### PR TITLE
stop confusingly using CC0 example in Terms of Use #1849

### DIFF
--- a/doc/sphinx-guides/source/api/sword.rst
+++ b/doc/sphinx-guides/source/api/sword.rst
@@ -110,7 +110,7 @@ Example Atom entry (XML)::
        <dcterms:source>Stumptown, Jane. 2011. Home Roasting. Coffeemill Press.</dcterms:source>
        <!-- license and restrictions -->
        <dcterms:license>NONE</dcterms:license>
-       <dcterms:rights>Creative Commons CC-BY 3.0 (unported) http://creativecommons.org/licenses/by/3.0/</dcterms:rights>
+       <dcterms:rights>Downloader will not use the Materials in any way prohibited by applicable laws.</dcterms:rights>
        <!-- related materials -->
        <dcterms:relation>Peets, John. 2010. Roasting Coffee at the Coffee Shop. Coffeemill Press</dcterms:relation>
        <dcterms:contributor type="Funder">CaffeineForAll</dcterms:contributor>

--- a/scripts/search/tests/data/dataset-trees1.xml
+++ b/scripts/search/tests/data/dataset-trees1.xml
@@ -3,11 +3,11 @@
    <dcterms:title>Spruce Goose</dcterms:title>
    <dcterms:creator>Spruce, Sabrina</dcterms:creator>
    <dcterms:description>What the Spruce Goose was really made of.</dcterms:description>
-   <dcterms:rights>Creative Commons CC-BY 3.0 (unported) http://creativecommons.org/licenses/by/3.0/</dcterms:rights>
+   <dcterms:rights>Downloader will not use the Materials in any way prohibited by applicable laws.</dcterms:rights>
    <!--
    <dcterms:license>CC0</dcterms:license>
    <dcterms:license>NONE</dcterms:license>
-   <dcterms:rights>Creative Commons CC-BY 3.0 (unported) http://creativecommons.org/licenses/by/3.0/</dcterms:rights>
+   <dcterms:rights>Downloader will not use the Materials in any way prohibited by applicable laws.</dcterms:rights>
    -->
    <!--
    <dcterms:subject>Chemistry</dcterms:subject>


### PR DESCRIPTION
@scolapasta this is a fix for #1849 where sample datasets in the SWORD docs and at https://apitest.dataverse.org are confusingly using Terms of Use mentioning CC0 for dataset with a non-CC0 license.

I changed the Terms of Use to have nothing to do with CC0: "Downloader will not use the Materials in any way prohibited by applicable laws." 