### PR TITLE
Replace System.out.print with logger.X in some files

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DatasetField.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetField.java
@@ -376,7 +376,7 @@ public class DatasetField implements Serializable {
             }
 
         }
-        // System.out.print("at return  " + this.datasetFieldType.getDisplayName() + " " + required);
+        // logger.fine("at return  " + this.datasetFieldType.getDisplayName() + " " + required);
         return required;
     }
     

--- a/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
@@ -707,8 +707,8 @@ public class DatasetPage implements java.io.Serializable {
      }
 
     public void handleChange() {
-        System.out.print("handle change");
-        System.out.print("new value " + selectedTemplate.getId());
+        logger.info("handle change");
+        logger.info("new value " + selectedTemplate.getId());
     }
 
     public void handleChangeButton() {
@@ -771,7 +771,7 @@ public class DatasetPage implements java.io.Serializable {
     }
 
     private void msg(String s){
-        //System.out.println(s);
+        //logger.fine(s);
     }
     
     /**
@@ -938,7 +938,7 @@ public class DatasetPage implements java.io.Serializable {
 
     
    public String init() {
-        // System.out.println("_YE_OLDE_QUERY_COUNTER_");  // for debug purposes
+        // logger.fine("_YE_OLDE_QUERY_COUNTER_");  // for debug purposes
         String nonNullDefaultIfKeyNotFound = "";
         
         guestbookResponse = new GuestbookResponse();
@@ -1600,7 +1600,6 @@ public class DatasetPage implements java.io.Serializable {
 
         } catch (CommandException ex) {
             String msg = "There was a problem linking this dataset to yours: " + ex;
-            System.out.print("in catch exception... " + ex);
             logger.severe(msg);
             /**
              * @todo how do we get this message to show up in the GUI?

--- a/src/main/java/edu/harvard/iq/dataverse/DatasetVersionServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetVersionServiceBean.java
@@ -62,8 +62,8 @@ public class DatasetVersionServiceBean implements java.io.Serializable {
             if (datasetVersion == null){
                 throw new IllegalArgumentException("datasetVersion cannot be null");
             }
-            //System.out.println("RetrieveDatasetVersionResponse: datasetVersion: " + datasetVersion.getSemanticVersion() + " requestedVersion: " + requestedVersion);
-            //System.out.println("chosenVersion id: " + datasetVersion.getId() + "  getFriendlyVersionNumber: " + datasetVersion.getFriendlyVersionNumber());
+            //logger.fine("RetrieveDatasetVersionResponse: datasetVersion: " + datasetVersion.getSemanticVersion() + " requestedVersion: " + requestedVersion);
+            //logger.fine("chosenVersion id: " + datasetVersion.getId() + "  getFriendlyVersionNumber: " + datasetVersion.getFriendlyVersionNumber());
             this.datasetVersionForResponse = datasetVersion;
             
             this.actualVersion = datasetVersion.getSemanticVersion();
@@ -97,7 +97,7 @@ public class DatasetVersionServiceBean implements java.io.Serializable {
             if (actualVersion==null){   // this shouldn't happen
                 return;
             }
-            //System.out.println("check version. requested: " + this.requestedVersion + " returned: " + actualVersion);
+            //logger.fine("check version. requested: " + this.requestedVersion + " returned: " + actualVersion);
             // This may often be the case if version is not specified
             //
             if (requestedVersion == null || requestedVersion.equals("")){
@@ -161,7 +161,7 @@ public class DatasetVersionServiceBean implements java.io.Serializable {
                 query.setParameter("minorVersionNumber", minorVersionNumber);
                 foundDatasetVersion = (DatasetVersion) query.getSingleResult();
             } catch (javax.persistence.NoResultException e) {
-                System.out.print("no ds version found: " + datasetId + " " + friendlyVersionNumber);
+                logger.warning("no ds version found: " + datasetId + " " + friendlyVersionNumber);
                 // DO nothing, just return null.
             }
             return foundDatasetVersion;
@@ -195,7 +195,7 @@ public class DatasetVersionServiceBean implements java.io.Serializable {
                 return retVal;
 
             } catch (javax.persistence.NoResultException e) {
-                System.out.print("no ds version found: " + datasetId + " " + friendlyVersionNumber);
+                logger.warning("no ds version found: " + datasetId + " " + friendlyVersionNumber);
                 // DO nothing, just return null.
             }
 
@@ -247,7 +247,7 @@ public class DatasetVersionServiceBean implements java.io.Serializable {
 
     
     private void msg(String s){
-        //System.out.println(s);
+        //logger.fine(s);
     }
     
     /**

--- a/src/main/java/edu/harvard/iq/dataverse/DataverseFieldTypeInputLevelServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DataverseFieldTypeInputLevelServiceBean.java
@@ -8,6 +8,7 @@ package edu.harvard.iq.dataverse;
 import edu.harvard.iq.dataverse.util.LruCache;
 import java.util.List;
 import java.util.Set;
+import java.util.logging.Logger;
 import javax.ejb.Stateless;
 import javax.inject.Named;
 import javax.persistence.EntityManager;
@@ -23,6 +24,7 @@ import javax.persistence.Query;
 @Named
 public class DataverseFieldTypeInputLevelServiceBean {
 
+//    private static final Logger logger = Logger.getLogger(DataverseFieldTypeInputLevelServiceBean.class.getCanonicalName());
     public static final LruCache<Long, List<DataverseFieldTypeInputLevel>> cache = new LruCache();
 
     @PersistenceContext(unitName = "VDCNet-ejbPU")
@@ -42,7 +44,7 @@ public class DataverseFieldTypeInputLevelServiceBean {
     }
     
     private void msg(String s){
-        //System.out.println(s);
+        //logger.fine(s);
     }
     
     /**


### PR DESCRIPTION
According to the [coding style guidelines](https://docs.google.com/document/d/1KTd3FpM1BI3HlBofaZjMmBiQEJtFf11jiiGpQeJzy7A/edit) and #775 `Logger`s should be used instead of `System.out`.

This commit does that for files whose names start with `Data`.