### PR TITLE
Update POM version to 4.0.2 #2165

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>edu.harvard.iq</groupId>
     <artifactId>dataverse</artifactId>
-    <version>4.0.1</version>
+    <version>4.0.2</version>
     <packaging>war</packaging>
 
     <name>dataverse</name>


### PR DESCRIPTION
The installer expected `dataverse-4.0.2.war` because of the version number in VersionNumber.properties, but Maven built `dataverse-4.0.1.war` because of the version number in the pom.xml file. Fixed :)