### PR TITLE
DatasetServiceBean.findByGlobalId: return null rather than a RuntimeException (EJBException)

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DatasetServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetServiceBean.java
@@ -125,12 +125,14 @@ public class DatasetServiceBean implements java.io.Serializable {
         int index2 = globalId.indexOf(separator, index1 + 1);
         int index3 = 0;
         if (index1 == -1) {            
-            throw new EJBException("Error parsing identifier: " + globalId + ". ':' not found in string");
+            logger.info("Error parsing identifier: " + globalId + ". ':' not found in string");
+            return null;
         } else {
             protocol = globalId.substring(0, index1);
         }
         if (index2 == -1 ) {
-            throw new EJBException("Error parsing identifier: " + globalId + ". Second separator not found in string");
+            logger.info("Error parsing identifier: " + globalId + ". Second separator not found in string");
+            return null;
         } else {
             if (index2 != -1) {
                 authority = globalId.substring(index1 + 1, index2);


### PR DESCRIPTION
@sekmiller I'm giving this to you to review and merge if you think it's ok. I don't think DatasetServiceBean.findByGlobalId should throw a RuntimeException.