### PR TITLE
Add simple tests for DataFileServiceBean

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DataFileServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DataFileServiceBean.java
@@ -227,11 +227,11 @@ public class DataFileServiceBean implements java.io.Serializable {
     }
     
     public boolean isSpssPorFile (DataFile file) {
-        return MIME_TYPE_SPSS_POR.equalsIgnoreCase(file.getContentType());
+        return (file != null) ? MIME_TYPE_SPSS_POR.equalsIgnoreCase(file.getContentType()) : false;
     }
     
     public boolean isSpssSavFile (DataFile file) {
-        return MIME_TYPE_SPSS_SAV.equalsIgnoreCase(file.getContentType());
+        return (file != null) ? MIME_TYPE_SPSS_SAV.equalsIgnoreCase(file.getContentType()) : false;
     }
     
     /*

--- a/src/test/java/edu/harvard/iq/dataverse/DataFileServiceBeanTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/DataFileServiceBeanTest.java
@@ -1,0 +1,204 @@
+package edu.harvard.iq.dataverse;
+
+import org.junit.Before;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+/**
+ * Test that the DataFileServiceBean classifies DataFiles correctly.
+ * @author bencomp
+ */
+public class DataFileServiceBeanTest {
+    
+    public DataFileServiceBeanTest() {
+    }
+    
+    /**
+     * A DataFile without content type.
+     */
+    private DataFile fileWoContentType = null;
+    /**
+     * A DataFile with bogus content type "foo/bar".
+     */
+    private DataFile fileWithBogusContentType = null;
+    /**
+     * The Bean Under Test.
+     */
+    private DataFileServiceBean dataFileServiceBean;
+            
+    
+    @Before
+    public void setUp() {
+        fileWoContentType = new DataFile();
+        fileWithBogusContentType = new DataFile("foo/bar");
+        dataFileServiceBean = new DataFileServiceBean();
+    }
+
+    /**
+     * Expect that {@code null}, a DataFile without content type and a DataFile
+     * with bogus content type are not astro files.
+     * @throws Exception when the test is in error.
+     */
+    @Test
+    public void testIsFileClassAstro() throws Exception {
+        assertFalse(dataFileServiceBean.isFileClassAstro(null));
+        assertFalse(dataFileServiceBean.isFileClassAstro(fileWoContentType));
+        assertFalse(dataFileServiceBean.isFileClassAstro(fileWithBogusContentType));
+    }
+
+    /**
+     * Expect that {@code null}, a DataFile without content type and a DataFile
+     * with bogus content type are not audio files.
+     * @throws Exception when the test is in error.
+     */
+    @Test
+    public void testIsFileClassAudio() throws Exception {
+        assertFalse(dataFileServiceBean.isFileClassAudio(null));
+        assertFalse(dataFileServiceBean.isFileClassAudio(fileWoContentType));
+        assertFalse(dataFileServiceBean.isFileClassAudio(fileWithBogusContentType));
+    }
+
+    /**
+     * Expect that {@code null}, a DataFile without content type and a DataFile
+     * with bogus content type are not code files.
+     * @throws Exception when the test is in error.
+     */
+    @Test
+    public void testIsFileClassCode() throws Exception {
+        assertFalse(dataFileServiceBean.isFileClassCode(null));
+        assertFalse(dataFileServiceBean.isFileClassCode(fileWoContentType));
+        assertFalse(dataFileServiceBean.isFileClassCode(fileWithBogusContentType));
+    }
+
+    /**
+     * Expect that {@code null}, a DataFile without content type and a DataFile
+     * with bogus content type are not document files.
+     * @throws Exception when the test is in error.
+     */
+    @Test
+    public void testIsFileClassDocument() throws Exception {
+        assertFalse(dataFileServiceBean.isFileClassDocument(null));
+        assertFalse(dataFileServiceBean.isFileClassDocument(fileWoContentType));
+        assertFalse(dataFileServiceBean.isFileClassDocument(fileWithBogusContentType));
+    }
+
+    /**
+     * Expect that {@code null}, a DataFile without content type and a DataFile
+     * with bogus content type are not geo files.
+     * @throws Exception when the test is in error.
+     */
+    @Test
+    public void testIsFileClassGeo() throws Exception {
+        assertFalse(dataFileServiceBean.isFileClassGeo(null));
+        assertFalse(dataFileServiceBean.isFileClassGeo(fileWoContentType));
+        assertFalse(dataFileServiceBean.isFileClassGeo(fileWithBogusContentType));
+    }
+
+    /**
+     * Expect that {@code null}, a DataFile without content type and a DataFile
+     * with bogus content type are not image files.
+     * @throws Exception when the test is in error.
+     */
+    @Test
+    public void testIsFileClassImage() throws Exception {
+        assertFalse(dataFileServiceBean.isFileClassImage(null));
+        assertFalse(dataFileServiceBean.isFileClassImage(fileWoContentType));
+        assertFalse(dataFileServiceBean.isFileClassImage(fileWithBogusContentType));
+    }
+
+    /**
+     * Expect that {@code null}, a DataFile without content type and a DataFile
+     * with bogus content type are not network files.
+     * @throws Exception when the test is in error.
+     */
+    @Test
+    public void testIsFileClassNetwork() throws Exception {
+        assertFalse(dataFileServiceBean.isFileClassNetwork(null));
+        assertFalse(dataFileServiceBean.isFileClassNetwork(fileWoContentType));
+        assertFalse(dataFileServiceBean.isFileClassNetwork(fileWithBogusContentType));
+    }
+
+    /**
+     * Expect that {@code null}, a DataFile without content type and a DataFile
+     * with bogus content type are not tabular files.
+     * @throws Exception when the test is in error.
+     */
+    @Test
+    public void testIsFileClassTabularData() throws Exception {
+        assertFalse(dataFileServiceBean.isFileClassTabularData(null));
+        assertFalse(dataFileServiceBean.isFileClassTabularData(fileWoContentType));
+        assertFalse(dataFileServiceBean.isFileClassTabularData(fileWithBogusContentType));
+    }
+
+    /**
+     * Expect that {@code null}, a DataFile without content type and a DataFile
+     * with bogus content type are not video files.
+     * @throws Exception when the test is in error.
+     */
+    @Test
+    public void testIsFileClassVideo() throws Exception {
+        assertFalse(dataFileServiceBean.isFileClassVideo(null));
+        assertFalse(dataFileServiceBean.isFileClassVideo(fileWoContentType));
+        assertFalse(dataFileServiceBean.isFileClassVideo(fileWithBogusContentType));
+    }
+
+    /**
+     * Expect that {@code null}, a DataFile without content type and a DataFile
+     * with bogus content type are not SPSS portable files.
+     * @throws Exception when the test is in error.
+     */
+    @Test
+    public void testIsSpssPorFile() throws Exception {
+        assertFalse(dataFileServiceBean.isSpssPorFile(null));
+        assertFalse(dataFileServiceBean.isSpssPorFile(fileWoContentType));
+        assertFalse(dataFileServiceBean.isSpssPorFile(fileWithBogusContentType));
+    }
+
+    /**
+     * Expect that {@code null}, a DataFile without content type and a DataFile
+     * with bogus content type are not SPSS .sav files.
+     * @throws Exception when the test is in error.
+     */
+    @Test
+    public void testIsSpssSavFile() throws Exception {
+        assertFalse(dataFileServiceBean.isSpssSavFile(null));
+        assertFalse(dataFileServiceBean.isSpssSavFile(fileWoContentType));
+        assertFalse(dataFileServiceBean.isSpssSavFile(fileWithBogusContentType));
+    }
+
+    /**
+     * Expect that {@code null}, a DataFile without content type and a DataFile
+     * with bogus content type are not files that thumbnails can be created for.
+     * @throws Exception when the test is in error.
+     */
+    @Test
+    public void testIsThumbnailSupported() throws Exception {
+        assertFalse(dataFileServiceBean.thumbnailSupported(null));
+        assertFalse(dataFileServiceBean.thumbnailSupported(fileWoContentType));
+        assertFalse(dataFileServiceBean.thumbnailSupported(fileWithBogusContentType));
+    }
+
+    /**
+     * Expect that {@code null}, a DataFile without content type and a DataFile
+     * with bogus content type are not files that thumbnails can be created for.
+     * @throws Exception when the test is in error.
+     */
+    @Test
+    public void testIsThumbnailSupportedForSize() throws Exception {
+        assertFalse(dataFileServiceBean.isThumbnailAvailableForSize(null));
+        assertFalse(dataFileServiceBean.isThumbnailAvailableForSize(fileWoContentType));
+        assertFalse(dataFileServiceBean.isThumbnailAvailableForSize(fileWithBogusContentType));
+    }
+    
+    /**
+     * Expect that files without content type or with a bogus content type are
+     * classed as "other". Note that the file classes are not coded as constants!
+     * @throws Exception when the test is in error.
+     */
+    @Test
+    public void testGetFileClass() throws Exception {
+        assertEquals("other", dataFileServiceBean.getFileClass(fileWoContentType));
+        assertEquals("other", dataFileServiceBean.getFileClass(fileWithBogusContentType));
+    }
+    
+}


### PR DESCRIPTION
This adds test expecting that `null` DataFiles, DataFiles without content type
and DataFiles with a bogus content type (`"foo/bar"`) are *not* classed as files
of types that Dataverse handles in specific ways. Also, for these files the tests
expect that no thumbnail can be generated.

In my PR #2422 I changed the behaviour of `DataFileServiceBean.getFileClass` to
return `null` when the input is `null`. This is still discussed, so I don't test for
this behaviour. The same goes for `DataFileServiceBean.ingestableAsTabular`; this
method is not tested at all at the moment.

To make the tests pass, I changed the `isSpssPorFile` and `isSpssSavFile` methods
to return `false` when the input is `null`. Hopefully this makes sense to you too :)

@scolapasta, @landreev and @michbarsinai, I'll happily discuss these suggestions.