### PR TITLE
Remove the codes which create a new HttpSolrServer for each method invocation. Create a HttpSolrServer for each EJB and reuse it for each method call.

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/AutoCompleteBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/AutoCompleteBean.java
@@ -24,11 +24,20 @@ public class AutoCompleteBean implements java.io.Serializable {
 
     @EJB
     SystemConfig systemConfig;
+    
+    private static SolrServer solrServer;
+    
+    public SolrServer getSolrServer(){
+        if(solrServer == null){
+            solrServer = new HttpSolrServer("http://" + systemConfig.getSolrHostColonPort() + "/solr");
+        }
+        return solrServer;
+    }
 
     public List<String> complete(String query) {
         List<String> results = new ArrayList<>();
 
-        SolrServer solrServer = new HttpSolrServer("http://" + systemConfig.getSolrHostColonPort() + "/solr");
+        solrServer = getSolrServer();
         SolrQuery solrQuery = new SolrQuery();
         solrQuery.setParam("qt", "/terms");
         solrQuery.setTermsLower(query);

--- a/src/main/java/edu/harvard/iq/dataverse/search/SearchServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/search/SearchServiceBean.java
@@ -31,6 +31,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
 import javax.ejb.EJB;
 import javax.ejb.EJBTransactionRolledbackException;
 import javax.ejb.Stateless;
@@ -81,6 +83,20 @@ public class SearchServiceBean {
     SystemConfig systemConfig;
 
     public static final JsfHelper JH = new JsfHelper();
+    private SolrServer solrServer;
+    
+    @PostConstruct
+    public void init(){
+        solrServer = new HttpSolrServer("http://" + systemConfig.getSolrHostColonPort() + "/solr");
+    }
+    
+    @PreDestroy
+    public void close(){
+        if(solrServer != null){
+            solrServer.shutdown();
+            solrServer = null;
+        }
+    }
 
     /**
      * Import note: "onlyDatatRelatedToMe" relies on filterQueries for providing
@@ -110,7 +126,6 @@ public class SearchServiceBean {
             throw new IllegalArgumentException("numResultsPerPage must be 1 or greater");
         }
 
-        SolrServer solrServer = new HttpSolrServer("http://" + systemConfig.getSolrHostColonPort() + "/solr");
         SolrQuery solrQuery = new SolrQuery();
         query = SearchUtil.sanitizeQuery(query);
         solrQuery.setQuery(query);


### PR DESCRIPTION
In the class of edu.harvard.iq.dataverse.search.SearchServiceBean, every search request create a HttpSolrServer object. However, HttpSolrServer has a method named shutdown() which releases some resources. So the code must invoke the shutdown method.

Besides, when construct the HttpSolrServer object, it will create a HttpClient. This process is expensive and there is no need to create a new HttpSolrServer for every search request.