### PR TITLE
Refactor use of DataverseServiceBean.getApplicationVersion (fixes #1579)

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DataverseServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DataverseServiceBean.java
@@ -221,17 +221,6 @@ public class DataverseServiceBean implements java.io.Serializable {
     
     public List<DataverseFacet> findAllDataverseFacets() {
         return em.createQuery("select object(o) from DataverseFacet as o order by o.display").getResultList();
-    }  
-   
-    private String appVersionString;
-
-    /**
-     * @todo Remove this method, and make all the (a couple of) xhtml pages 
-     * call the SystemConfig.getVersion method directly 
-     * (I don't have time to do it now -- L.A. 4.0.2)
-     */
-    public String getApplicationVersion() { 
-        return systemConfig.getVersion(true);
     }
     
     public String getDataverseLogoThumbnailAsBase64(Dataverse dataverse, User user) {

--- a/src/main/java/edu/harvard/iq/dataverse/util/SystemConfig.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/SystemConfig.java
@@ -66,10 +66,6 @@ public class SystemConfig {
      */
     private static final int defaultZipUploadFilesLimit = 1000; 
 
-    /**
-     * @todo Reconcile with getApplicationVersion on DataverseServiceBean.java
-     * which we'd like to move to this class.
-     */
     private static String appVersionString = null; 
     private static String buildNumberString = null; 
     

--- a/src/main/webapp/dataverse_template.xhtml
+++ b/src/main/webapp/dataverse_template.xhtml
@@ -51,7 +51,7 @@
                     <div class="poweredbylogo">
                         <span>#{bundle['footer.poweredby']}</span>
                         <a href="http://dataverse.org/" title="#{bundle['footer.dataverseProject']}" target="_blank"><img src="/resources/images/dataverseproject_logo.jpg" alt="#{bundle['footer.dataverseProject']}" /></a>
-                        <span class="version">v. #{dataverseServiceBean.applicationVersion}</span>
+                        <span class="version">v. #{systemConfig.getVersion()}</span>
                     </div>
                 </div>
             </div>

--- a/src/main/webapp/dataverse_template.xhtml
+++ b/src/main/webapp/dataverse_template.xhtml
@@ -51,7 +51,7 @@
                     <div class="poweredbylogo">
                         <span>#{bundle['footer.poweredby']}</span>
                         <a href="http://dataverse.org/" title="#{bundle['footer.dataverseProject']}" target="_blank"><img src="/resources/images/dataverseproject_logo.jpg" alt="#{bundle['footer.dataverseProject']}" /></a>
-                        <span class="version">v. #{systemConfig.getVersion()}</span>
+                        <span class="version">v. #{systemConfig.getVersion(true)}</span>
                     </div>
                 </div>
             </div>

--- a/src/main/webapp/passwordreset.xhtml
+++ b/src/main/webapp/passwordreset.xhtml
@@ -99,8 +99,8 @@
                         <div class="row" jsf:rendered="#{PasswordResetPage.isAccountUpgrade()}">
                             <div class="col-sm-12">
                                 <h:outputFormat styleClass="h2 text-info show" value="#{bundle['user.updatePassword.welcome']}">
-                                        <f:param value="#{dataverseServiceBean.applicationVersion}"/>
-                                        <f:param value="#{PasswordResetPage.user.displayInfo.title}"/>
+                                    <f:param value="#{systemConfig.getVersion(true)}"/>
+                                    <f:param value="#{PasswordResetPage.user.displayInfo.title}"/>
                                 </h:outputFormat>
                                 <p class="help-block"><span class="text-danger"><span class="glyphicon glyphicon-warning-sign"/> #{bundle['user.updatePassword.warning']}</span></p>
                             </div>


### PR DESCRIPTION
Updated all calls to `DataverseServiceBean.getApplicationVersion` to
use `SystemConfig.getVersion`. Removed the now unused method and an
already unused field `appversion` from DataverseServiceBean, as well
as comments about the reconciliation.

I searched for references in the code and HTML templates, and verified that the application version is displayed correctly in the places that is was used before the changes.