### PR TITLE
Changed the comparison used in the auto-complete to

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/ManageGroupsPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/ManageGroupsPage.java
@@ -273,7 +273,8 @@ public class ManageGroupsPage implements java.io.Serializable {
         for (RoleAssignee ra : roleAssigneeList) {
             // @todo unsure if containsIgnore case will work for all locales
             // @todo maybe add some solr/lucene style searching, did-you-mean style?
-            if (StringUtils.containsIgnoreCase(ra.getDisplayInfo().getTitle(), query)) {
+            if (StringUtils.containsIgnoreCase(ra.getDisplayInfo().getTitle(), query)
+               || StringUtils.containsIgnoreCase(ra.getIdentifier(), query)) {
                 filteredList.add(ra);
             }
         }


### PR DESCRIPTION
Changed the comparison used in the auto-complete to include the identifier.
This is the behavior matches ManagePermissionsPage.completeRoleAssignee
which exhibits the expected behavior.