### PR TITLE
2888 create case insensitive emails

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/ManageFilePermissionsPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/ManageFilePermissionsPage.java
@@ -329,9 +329,8 @@ public class ManageFilePermissionsPage implements java.io.Serializable {
         List<RoleAssignee> returnList = new ArrayList();
         for (RoleAssignee ra : roleAssigneeList) {
             // @todo unsure if containsIgnore case will work for all locales
-            if ((StringUtils.containsIgnoreCase(ra.getDisplayInfo().getTitle(), query) 
-                    || StringUtils.containsIgnoreCase(ra.getIdentifier(), query))
-                    && (selectedRoleAssignees == null || !selectedRoleAssignees.contains(ra))) {
+            if (RoleAssignee.autocompleteMatch.apply(ra).test(query)
+            	&& (selectedRoleAssignees == null || !selectedRoleAssignees.contains(ra))) {
                 returnList.add(ra);
             }
         }

--- a/src/main/java/edu/harvard/iq/dataverse/ManageGroupsPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/ManageGroupsPage.java
@@ -273,7 +273,8 @@ public class ManageGroupsPage implements java.io.Serializable {
         for (RoleAssignee ra : roleAssigneeList) {
             // @todo unsure if containsIgnore case will work for all locales
             // @todo maybe add some solr/lucene style searching, did-you-mean style?
-            if (StringUtils.containsIgnoreCase(ra.getDisplayInfo().getTitle(), query)) {
+            if (StringUtils.containsIgnoreCase(ra.getDisplayInfo().getTitle(), query)
+               || StringUtils.containsIgnoreCase(ra.getIdentifier(), query)) {
                 filteredList.add(ra);
             }
         }

--- a/src/main/java/edu/harvard/iq/dataverse/ManageGroupsPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/ManageGroupsPage.java
@@ -273,8 +273,7 @@ public class ManageGroupsPage implements java.io.Serializable {
         for (RoleAssignee ra : roleAssigneeList) {
             // @todo unsure if containsIgnore case will work for all locales
             // @todo maybe add some solr/lucene style searching, did-you-mean style?
-            if (StringUtils.containsIgnoreCase(ra.getDisplayInfo().getTitle(), query)
-               || StringUtils.containsIgnoreCase(ra.getIdentifier(), query)) {
+            if (RoleAssignee.autocompleteMatch.apply(ra).test(query)) {
                 filteredList.add(ra);
             }
         }

--- a/src/main/java/edu/harvard/iq/dataverse/ManagePermissionsPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/ManagePermissionsPage.java
@@ -336,9 +336,8 @@ public class ManagePermissionsPage implements java.io.Serializable {
         for (RoleAssignee ra : roleAssigneeList) {
             // @todo unsure if containsIgnore case will work for all locales
             // @todo maybe add some solr/lucene style searching, did-you-mean style?
-            if ((StringUtils.containsIgnoreCase(ra.getDisplayInfo().getTitle(), query) 
-                    || StringUtils.containsIgnoreCase(ra.getIdentifier(), query))
-                    && (roleAssignSelectedRoleAssignees == null || !roleAssignSelectedRoleAssignees.contains(ra))) {
+            if (RoleAssignee.autocompleteMatch.apply(ra).test(query)
+                && (roleAssignSelectedRoleAssignees == null || !roleAssignSelectedRoleAssignees.contains(ra))) {
                 filteredList.add(ra);
             }
         }

--- a/src/main/java/edu/harvard/iq/dataverse/RolePermissionFragment.java
+++ b/src/main/java/edu/harvard/iq/dataverse/RolePermissionFragment.java
@@ -133,8 +133,9 @@ public class RolePermissionFragment implements java.io.Serializable {
         }
         List<RoleAssignee> returnList = new ArrayList();
         for (RoleAssignee ra : roleAssigneeList) {
+        	
             // @todo unsure if containsIgnore case will work for all locales
-            if (StringUtils.containsIgnoreCase(ra.getDisplayInfo().getTitle(),query)) {
+            if (RoleAssignee.autocompleteMatch.apply(ra).test(query)) {
                 returnList.add(ra);
             }
         }

--- a/src/main/java/edu/harvard/iq/dataverse/authorization/RoleAssignee.java
+++ b/src/main/java/edu/harvard/iq/dataverse/authorization/RoleAssignee.java
@@ -1,5 +1,10 @@
 package edu.harvard.iq.dataverse.authorization;
 
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import org.apache.commons.lang.StringUtils;
+
 import edu.harvard.iq.dataverse.authorization.groups.Group;
 import edu.harvard.iq.dataverse.authorization.groups.impl.builtin.AllUsers;
 import edu.harvard.iq.dataverse.authorization.users.GuestUser;
@@ -25,4 +30,17 @@ public interface RoleAssignee {
 
     public RoleAssigneeDisplayInfo getDisplayInfo();
 
+    static Function<RoleAssignee, Predicate<String>> autocompleteMatch = new Function<RoleAssignee, Predicate<String>>() {
+		@Override
+		public Predicate<String> apply(RoleAssignee ra) {
+			return new Predicate<String>() {
+				@Override
+				public boolean test(String query) {
+					return 	ra != null &&
+							((ra.getDisplayInfo() != null && StringUtils.containsIgnoreCase(ra.getDisplayInfo().getTitle(), query) )
+		                    || StringUtils.containsIgnoreCase(ra.getIdentifier(), query));
+				}
+			};
+		}
+	};
 }

--- a/src/main/java/edu/harvard/iq/dataverse/authorization/providers/builtin/BuiltinUser.java
+++ b/src/main/java/edu/harvard/iq/dataverse/authorization/providers/builtin/BuiltinUser.java
@@ -23,14 +23,14 @@ import org.hibernate.validator.constraints.NotBlank;
  * @author mbarsinai
  */
 @NamedQueries({
-		@NamedQuery( name="BuiltinUser.findAll",
-				query = "SELECT u FROM BuiltinUser u ORDER BY u.lastName"),
-		@NamedQuery( name="BuiltinUser.findByUserName",
-				query = "SELECT u FROM BuiltinUser u WHERE u.userName=:userName"),
-		@NamedQuery( name="BuiltinUser.findByEmail",
-				query = "SELECT o FROM BuiltinUser o WHERE o.email = :email"),
-		@NamedQuery( name="BuiltinUser.listByUserNameLike",
-				query = "SELECT u FROM BuiltinUser u WHERE u.userName LIKE :userNameLike")
+                @NamedQuery( name="BuiltinUser.findAll",
+                                query = "SELECT u FROM BuiltinUser u ORDER BY u.lastName"),
+                @NamedQuery( name="BuiltinUser.findByUserName",
+                                query = "SELECT u FROM BuiltinUser u WHERE u.userName=:userName"),
+                @NamedQuery( name="BuiltinUser.findByEmail",
+                                query = "SELECT o FROM BuiltinUser o WHERE LOWER(o.email) = LOWER(:email)"),
+                @NamedQuery( name="BuiltinUser.listByUserNameLike",
+                                query = "SELECT u FROM BuiltinUser u WHERE u.userName LIKE :userNameLike")
 })
 @Entity
 @Table(indexes = {@Index(columnList="lastName")})  // for sorting the NamedQuery BuiltinUser.findAll
@@ -44,12 +44,12 @@ public class BuiltinUser implements Serializable {
     @NotBlank(message = "Please enter a username.")
     @Size(min=2, max=60, message ="Username must be between 2 and 60 characters.")
     @Pattern(regexp = "[a-zA-Z0-9\\_\\-\\.]*", message = "Found an illegal character(s). Valid characters are a-Z, 0-9, '_', '-', and '.'.")
-    @Column(nullable = false, unique=true)  
+    @Column(nullable = false, unique=true)
     private String userName;
 
     @NotBlank(message = "Please enter a valid email address.")
     @ValidateEmail(message = "Please enter a valid email address.")
-    @Column(nullable = false, unique=true)    
+    @Column(nullable = false, unique=true)
     private String email;
 
     @NotBlank(message = "Please enter your first name.")
@@ -57,17 +57,17 @@ public class BuiltinUser implements Serializable {
 
     @NotBlank(message = "Please enter your last name.")
     private String lastName;
-    
-    private int passwordEncryptionVersion; 
+
+    private int passwordEncryptionVersion;
     private String encryptedPassword;
     private String affiliation;
     private String position;
-    
+
     public void updateEncryptedPassword( String encryptedPassword, int algorithmVersion ) {
         setEncryptedPassword(encryptedPassword);
         setPasswordEncryptionVersion(algorithmVersion);
     }
-    
+
     public Long getId() {
         return id;
     }
@@ -107,15 +107,15 @@ public class BuiltinUser implements Serializable {
     public void setLastName(String lastName) {
         this.lastName = lastName;
     }
-    
+
     public String getEncryptedPassword() {
         return encryptedPassword;
     }
-    
+
     /**
      * JPA-use only. Humans should call {@link #updateEncryptedPassword(java.lang.String, int)}
      * and update the password and the algorithm at the same time.
-     * 
+     *
      * @param encryptedPassword
      * @deprecated
      */
@@ -123,7 +123,7 @@ public class BuiltinUser implements Serializable {
     public void setEncryptedPassword(String encryptedPassword) {
         this.encryptedPassword = encryptedPassword;
     }
-    
+
     public String getAffiliation() {
         return affiliation;
     }
@@ -139,11 +139,11 @@ public class BuiltinUser implements Serializable {
     public void setPosition(String position) {
         this.position = position;
     }
-    
+
     public String getDisplayName(){
-        return this.getFirstName() + " " + this.getLastName(); 
+        return this.getFirstName() + " " + this.getLastName();
     }
-    
+
     public AuthenticatedUserDisplayInfo getDisplayInfo() {
         return new AuthenticatedUserDisplayInfo(getFirstName(), getLastName(), getEmail(), getAffiliation(), getPosition() );
     }
@@ -164,10 +164,10 @@ public class BuiltinUser implements Serializable {
         return !((this.id == null && other.id != null) || (this.id != null && !this.id.equals(other.id)));
     }
 
-	@Override
-	public String toString() {
-		return "BuiltinUser{" + "id=" + id + ", userName=" + userName + ", email=" + email + '}';
-	}
+        @Override
+        public String toString() {
+                return "BuiltinUser{" + "id=" + id + ", userName=" + userName + ", email=" + email + '}';
+        }
 
     public int getPasswordEncryptionVersion() {
         return passwordEncryptionVersion;
@@ -176,5 +176,5 @@ public class BuiltinUser implements Serializable {
     public void setPasswordEncryptionVersion(int passwordEncryptionVersion) {
         this.passwordEncryptionVersion = passwordEncryptionVersion;
     }
-    
+
 }

--- a/src/main/java/edu/harvard/iq/dataverse/authorization/users/AuthenticatedUser.java
+++ b/src/main/java/edu/harvard/iq/dataverse/authorization/users/AuthenticatedUser.java
@@ -31,15 +31,15 @@ import javax.validation.constraints.NotNull;
     @NamedQuery( name="AuthenticatedUser.findByIdentifier",
                 query="select au from AuthenticatedUser au WHERE au.userIdentifier=:identifier"),
     @NamedQuery( name="AuthenticatedUser.findByEmail",
-                query="select au from AuthenticatedUser au WHERE au.email=:email"),
+                query="select au from AuthenticatedUser au WHERE LOWER(au.email)=LOWER(:email)"),
     @NamedQuery( name="AuthenticatedUser.countOfIdentifier",
                 query="SELECT COUNT(a) FROM AuthenticatedUser a WHERE a.userIdentifier=:identifier")
 })
 @Entity
 public class AuthenticatedUser implements User, Serializable {
-    
+
     public static final String IDENTIFIER_PREFIX = "@";
-    
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     Long id;
@@ -79,12 +79,12 @@ public class AuthenticatedUser implements User, Serializable {
     public String getIdentifier() {
         return IDENTIFIER_PREFIX + userIdentifier;
     }
-    
-    
-    
+
+
+
     @OneToMany(mappedBy = "user", cascade={CascadeType.REMOVE, CascadeType.MERGE, CascadeType.PERSIST})
     private List<DatasetLock> datasetLocks;
-	
+
     public List<DatasetLock> getDatasetLocks() {
         return datasetLocks;
     }
@@ -92,12 +92,12 @@ public class AuthenticatedUser implements User, Serializable {
     public void setDatasetLocks(List<DatasetLock> datasetLocks) {
         this.datasetLocks = datasetLocks;
     }
-    
+
     @Override
     public RoleAssigneeDisplayInfo getDisplayInfo() {
         return new AuthenticatedUserDisplayInfo(firstName, lastName, email, affiliation, position);
     }
-    
+
     /**
      * Takes the passed info object and updated the internal fields according to it.
      * @param inf the info from which we update the fields.
@@ -110,7 +110,7 @@ public class AuthenticatedUser implements User, Serializable {
         setPosition( inf.getPosition());
 
     }
-    
+
     @Override
     public boolean isAuthenticated() { return true; }
 
@@ -192,7 +192,7 @@ public class AuthenticatedUser implements User, Serializable {
         if (authProviderString != null && authProviderString.equals(BuiltinAuthenticationProvider.PROVIDER_ID)) {
             return true;
         }
-        
+
         return false;
     }
 
@@ -206,14 +206,14 @@ public class AuthenticatedUser implements User, Serializable {
     public void setAuthenticatedUserLookup(AuthenticatedUserLookup authenticatedUserLookup) {
         this.authenticatedUserLookup = authenticatedUserLookup;
     }
-    
+
     @Override
     public int hashCode() {
         int hash = 0;
         hash += (id != null ? id.hashCode() : 0);
         return hash;
-    }    
-    
+    }
+
     @Override
     public boolean equals(Object object) {
         // TODO: Warning - this method won't work in the case the id fields are not set
@@ -222,7 +222,7 @@ public class AuthenticatedUser implements User, Serializable {
         }
         AuthenticatedUser other = (AuthenticatedUser) object;
         return Objects.equals(getId(), other.getId());
-    }    
+    }
 
     public String getShibIdentityProvider() {
         return shibIdentityProvider;
@@ -231,5 +231,5 @@ public class AuthenticatedUser implements User, Serializable {
     public void setShibIdentityProvider(String shibIdentityProvider) {
         this.shibIdentityProvider = shibIdentityProvider;
     }
-    
+
 }

--- a/src/test/java/edu/harvard/iq/dataverse/authorization/RoleAssigneeTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/authorization/RoleAssigneeTest.java
@@ -1,0 +1,60 @@
+package edu.harvard.iq.dataverse.authorization;
+
+import org.junit.Test;
+
+import junit.framework.Assert;
+
+public class RoleAssigneeTest {
+	@Test
+	public void autocompleteMatchHandlesNulls(){
+		RoleAssignee nullAssignee = null;
+		RoleAssignee nullDisplayInfo = new RoleAssignee() {
+			
+			@Override
+			public String getIdentifier() {
+				return null;
+			}
+			@Override
+			public RoleAssigneeDisplayInfo getDisplayInfo() {
+				return null;
+			}
+		};
+		String query = "test";
+		Assert.assertFalse("false match on null assignee",RoleAssignee.autocompleteMatch.apply(nullAssignee).test(query));
+		Assert.assertFalse("false match on null query",RoleAssignee.autocompleteMatch.apply(nullAssignee).test(query));
+		Assert.assertFalse("false match on null identifier",RoleAssignee.autocompleteMatch.apply(nullDisplayInfo).test(query));
+	}
+	@Test
+	public void autocompleteMatchesIdentifier(){
+		RoleAssignee ra = new RoleAssignee() {
+			
+			@Override
+			public String getIdentifier() {
+				return "testTube";
+			}
+			@Override
+			public RoleAssigneeDisplayInfo getDisplayInfo() {
+				return null;
+			}
+		};
+		String query = "test";
+		Assert.assertTrue("failed to match identifier",RoleAssignee.autocompleteMatch.apply(ra).test(query));
+	}
+	@Test
+	public void autocompleteDisplayInfo(){
+		RoleAssignee ra = new RoleAssignee() {
+			
+			@Override
+			public String getIdentifier() {
+				return "blah";
+			}
+			@Override
+			public RoleAssigneeDisplayInfo getDisplayInfo() {
+				return new RoleAssigneeDisplayInfo("testTube", "emailAddress");
+			}
+		};
+		String query = "test";
+		Assert.assertTrue("failed to match identifier",RoleAssignee.autocompleteMatch.apply(ra).test(query));
+	}
+	
+}


### PR DESCRIPTION
Switched queries to compare by lower case.
I profiled the queries on my machine and there were to few 
rows for the following indexes to be used.  I am not sure if
they are needed for the production instance.

CREATE UNIQUE INDEX lower_case_authenticated_user ON authenticateduser (lower(email));
CREATE UNIQUE INDEX lower_case_built_in_user ON builtinuser (lower(email));

