### PR TITLE
2901 disable google analytics

### DIFF
--- a/src/main/webapp/google-analytics-snippet.xhtml
+++ b/src/main/webapp/google-analytics-snippet.xhtml
@@ -7,7 +7,7 @@
      xmlns:o="http://omnifaces.org/ui"
      xmlns:jsf="http://xmlns.jcp.org/jsf">
     <script><!-- Google Analytics Snippet -->
-               
+        <c:if test="#{not empty settingsWrapper.get(':GoogleAnalyticsCode')}">
         (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
          (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
          m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
@@ -28,5 +28,6 @@
             'socialTarget': '#{systemConfig.dataverseSiteUrl}',
             'page': '#{systemConfig.pageURLWithQueryString}'
           });
+        </c:if>
 	</script>
 </ui:composition>


### PR DESCRIPTION
Addressing #2901 

Added a check to see if the google analytics code was empty (null or empty string).

Tested by running the following command
curl -X PUT -d Ub7NoNgo9V "$SERVER/admin/settings/:GoogleAnalyticsCode"
The random string Ub7NoNgo9V was displayed as the analytics code.

The following command removed the analytics code from the page
curl -X PUT -d "" "$SERVER/admin/settings/:GoogleAnalyticsCode"
