### PR TITLE
SWORD: more tests around deleting files #1784 #2222

### DIFF
--- a/src/test/java/edu/harvard/iq/dataverse/api/SwordIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/SwordIT.java
@@ -4,6 +4,7 @@ import com.jayway.restassured.RestAssured;
 import com.jayway.restassured.path.json.JsonPath;
 import com.jayway.restassured.response.Response;
 import edu.harvard.iq.dataverse.api.datadeposit.SwordConfigurationImpl;
+import java.util.List;
 import java.util.logging.Logger;
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static javax.ws.rs.core.Response.Status.CREATED;
@@ -26,8 +27,10 @@ public class SwordIT {
     private static String apiToken1;
     private static String dataverseAlias1;
     private static String dataverseAlias2;
+    private static String dataverseAlias3;
     private static String datasetPersistentId1;
     private static String datasetPersistentId2;
+    private static String datasetPersistentId3;
 
     @BeforeClass
     public static void setUpClass() {
@@ -37,6 +40,8 @@ public class SwordIT {
 //        createUser1.prettyPrint();
         username1 = UtilIT.getUsernameFromResponse(createUser1);
         apiToken1 = UtilIT.getApiTokenFromResponse(createUser1);
+        Response makeSuperuser = UtilIT.makeSuperUser(username1);
+        makeSuperuser.prettyPrint();
     }
 
     @Test
@@ -136,6 +141,15 @@ public class SwordIT {
         title = UtilIT.getTitleFromSwordStatementResponse(swordStatement);
         assertEquals(newTitle, title);
         logger.info("Title updated from \"" + initialDatasetTitle + "\" to \"" + newTitle + "\".");
+
+        Response deleteDatasetResponse = UtilIT.deleteLatestDatasetVersionViaSwordApi(datasetPersistentId1, apiToken1);
+        deleteDatasetResponse.prettyPrint();
+        assertEquals(204, deleteDatasetResponse.getStatusCode());
+
+        Response deleteDataverse1Response = UtilIT.deleteDataverse(dataverseAlias1, apiToken1);
+        deleteDataverse1Response.prettyPrint();
+        assertEquals(200, deleteDataverse1Response.getStatusCode());
+
     }
 
     @Test
@@ -153,8 +167,6 @@ public class SwordIT {
         attemptToPublishDatasetInUnpublishedDataverse.prettyPrint();
         attemptToPublishDatasetInUnpublishedDataverse.then().assertThat()
                 .statusCode(BAD_REQUEST.getStatusCode());
-        Response makeSuperuser = UtilIT.makeSuperUser(username1);
-        makeSuperuser.prettyPrint();
 
         String rootDataverseAlias = "root";
         Response publishRootDataverse = UtilIT.publishDataverseViaSword(rootDataverseAlias, apiToken1);
@@ -176,7 +188,7 @@ public class SwordIT {
         publishDataset.then().assertThat()
                 .statusCode(OK.getStatusCode());
 
-        Response attemptToDeletePublishedDataset = UtilIT.deleteDatasetViaSwordApi(datasetPersistentId2, apiToken1);
+        Response attemptToDeletePublishedDataset = UtilIT.deleteLatestDatasetVersionViaSwordApi(datasetPersistentId2, apiToken1);
         attemptToDeletePublishedDataset.prettyPrint();
         attemptToDeletePublishedDataset.then().assertThat()
                 .statusCode(METHOD_NOT_ALLOWED.getStatusCode());
@@ -196,6 +208,149 @@ public class SwordIT {
         destroyDataset.prettyPrint();
         destroyDataset.then().assertThat()
                 .statusCode(OK.getStatusCode());
+
+        Response atomEntryDestroyed = UtilIT.getSwordAtomEntry(datasetPersistentId2, apiToken1);
+        atomEntryDestroyed.prettyPrint();
+        atomEntryDestroyed.then().statusCode(400);
+
+        Response deleteDataverse2Response = UtilIT.deleteDataverse(dataverseAlias2, apiToken1);
+        deleteDataverse2Response.prettyPrint();
+        assertEquals(200, deleteDataverse2Response.getStatusCode());
+
+    }
+
+    /**
+     * Test the following issues:
+     *
+     * - https://github.com/IQSS/dataverse/issues/1784
+     *
+     * - https://github.com/IQSS/dataverse/issues/2222
+     */
+    @Test
+    public void testDeleteFiles() {
+
+        Response createDataverse = UtilIT.createRandomDataverse(apiToken1);
+        createDataverse.prettyPrint();
+        dataverseAlias3 = UtilIT.getAliasFromResponse(createDataverse);
+
+        Response createDataset = UtilIT.createRandomDatasetViaSwordApi(dataverseAlias3, apiToken1);
+        createDataset.prettyPrint();
+        datasetPersistentId3 = UtilIT.getDatasetPersistentIdFromResponse(createDataset);
+
+        Response uploadZip = UtilIT.uploadFile(datasetPersistentId3, "3files.zip", apiToken1);
+        uploadZip.prettyPrint();
+        assertEquals(CREATED.getStatusCode(), uploadZip.getStatusCode());
+        Response statement1 = UtilIT.getSwordStatement(datasetPersistentId3, apiToken1);
+        statement1.prettyPrint();
+        String index0a = statement1.getBody().xmlPath().get("feed.entry[0].id").toString().split("/")[10];
+        String index1a = statement1.getBody().xmlPath().get("feed.entry[1].id").toString().split("/")[10];
+        String index2a = statement1.getBody().xmlPath().get("feed.entry[2].id").toString().split("/")[10];
+
+        List<String> fileList = statement1.getBody().xmlPath().getList("feed.entry.id");
+        logger.info("Dataset contains file ids: " + index0a + " " + index1a + " " + index2a + " (" + fileList.size() + ") files");
+
+        Response deleteIndex0a = UtilIT.deleteFile(Integer.parseInt(index0a), apiToken1);
+//        deleteIndex0a.prettyPrint();
+        deleteIndex0a.then().assertThat()
+                .statusCode(NO_CONTENT.getStatusCode());
+        logger.info("Deleted file id " + index0a + " from draft of unpublished dataset.");
+
+        Response statement2 = UtilIT.getSwordStatement(datasetPersistentId3, apiToken1);
+        statement2.prettyPrint();
+        String index0b = statement2.getBody().xmlPath().get("feed.entry[0].id").toString().split("/")[10];
+        String index1b = statement2.getBody().xmlPath().get("feed.entry[1].id").toString().split("/")[10];
+        try {
+            String index2b = statement2.getBody().xmlPath().get("feed.entry[2].id").toString().split("/")[10];
+        } catch (ArrayIndexOutOfBoundsException ex) {
+            // expected since file has been deleted
+        }
+        logger.info("Dataset contains file ids: " + index0b + " " + index1b);
+        List<String> twoFilesLeftInV2Draft = statement2.getBody().xmlPath().getList("feed.entry.id");
+        logger.info("Number of files remaining in this draft:" + twoFilesLeftInV2Draft.size());
+        assertEquals(2, twoFilesLeftInV2Draft.size());
+
+        Response publishDataverse = UtilIT.publishDataverseViaSword(dataverseAlias3, apiToken1);
+//        publishDataverse.prettyPrint();
+        publishDataverse.then().assertThat()
+                .statusCode(OK.getStatusCode());
+
+        logger.info("dataset has not yet been published:");
+        Response atomEntryUnpublished = UtilIT.getSwordAtomEntry(datasetPersistentId3, apiToken1);
+        atomEntryUnpublished.prettyPrint();
+
+        Response publishDataset = UtilIT.publishDatasetViaSword(datasetPersistentId3, apiToken1);
+//        publishDataset.prettyPrint();
+        publishDataset.then().assertThat()
+                .statusCode(OK.getStatusCode());
+
+        logger.info("dataset has been published:");
+        Response atomEntryPublishedV1 = UtilIT.getSwordAtomEntry(datasetPersistentId3, apiToken1);
+        atomEntryPublishedV1.prettyPrint();
+
+        Response deleteIndex0b = UtilIT.deleteFile(Integer.parseInt(index0b), apiToken1);
+//        deleteIndex0b.prettyPrint();
+        deleteIndex0b.then().assertThat()
+                .statusCode(NO_CONTENT.getStatusCode());
+        logger.info("Deleted file id " + index0b + " from published dataset (should create draft).");
+        Response statement3 = UtilIT.getSwordStatement(datasetPersistentId3, apiToken1);
+        statement3.prettyPrint();
+
+        logger.info("draft created from published dataset because a file was deleted:");
+        Response atomEntryDraftV2 = UtilIT.getSwordAtomEntry(datasetPersistentId3, apiToken1);
+        atomEntryDraftV2.prettyPrint();
+        String citation = atomEntryDraftV2.body().xmlPath().getString("entry.bibliographicCitation");
+        logger.info("citation (should contain 'DRAFT'): " + citation);
+        boolean draftStringFoundInCitation = citation.matches(".*DRAFT.*");
+        assertEquals(true, draftStringFoundInCitation);
+
+        List<String> oneFileLeftInV2Draft = statement3.getBody().xmlPath().getList("feed.entry.id");
+        logger.info("Number of files remaining in this post version 1 draft:" + oneFileLeftInV2Draft.size());
+        assertEquals(1, oneFileLeftInV2Draft.size());
+
+        Response deleteIndex1b = UtilIT.deleteFile(Integer.parseInt(index1b), apiToken1);
+        deleteIndex1b.then().assertThat()
+                .statusCode(NO_CONTENT.getStatusCode());
+        logger.info("Deleted file id " + index1b + " from draft version of a published dataset.");
+
+        Response statement4 = UtilIT.getSwordStatement(datasetPersistentId3, apiToken1);
+        statement4.prettyPrint();
+
+        List<String> fileListEmpty = statement4.getBody().xmlPath().getList("feed.entry.id");
+        logger.info("Number of files remaining:" + fileListEmpty.size());
+        assertEquals(0, fileListEmpty.size());
+
+        Response deleteDatasetDraft = UtilIT.deleteLatestDatasetVersionViaSwordApi(datasetPersistentId3, apiToken1);
+        deleteDatasetDraft.prettyPrint();
+
+        Response statement5 = UtilIT.getSwordStatement(datasetPersistentId3, apiToken1);
+        statement5.prettyPrint();
+        List<String> twoFilesinV1published = statement5.getBody().xmlPath().getList("feed.entry.id");
+        logger.info("Number of files in V1 (draft has been deleted)" + twoFilesinV1published.size());
+        assertEquals(2, twoFilesinV1published.size());
+
+        /**
+         * @todo The "destroy" endpoint should accept a persistentId:
+         * https://github.com/IQSS/dataverse/issues/1837
+         */
+        Response reindexDatasetToFindDatabaseId = UtilIT.reindexDataset(datasetPersistentId3);
+        reindexDatasetToFindDatabaseId.prettyPrint();
+        reindexDatasetToFindDatabaseId.then().assertThat()
+                .statusCode(OK.getStatusCode());
+        Integer datasetId3 = JsonPath.from(reindexDatasetToFindDatabaseId.asString()).getInt("data.id");
+        Response destroyDataset = UtilIT.destroyDataset(datasetId3, apiToken1);
+        destroyDataset.prettyPrint();
+        destroyDataset.then().assertThat()
+                .statusCode(OK.getStatusCode());
+        logger.info("Dataset has been destroyed: " + datasetPersistentId3 + " id " + datasetId3 + " but let's double check we can't access it...");
+
+        Response atomEntryDestroyed = UtilIT.getSwordAtomEntry(datasetPersistentId3, apiToken1);
+        atomEntryDestroyed.prettyPrint();
+        atomEntryDestroyed.then().statusCode(400);
+
+        Response deleteDataverse3Response = UtilIT.deleteDataverse(dataverseAlias3, apiToken1);
+        deleteDataverse3Response.prettyPrint();
+        assertEquals(200, deleteDataverse3Response.getStatusCode());
+
     }
 
     @AfterClass
@@ -205,18 +360,6 @@ public class SwordIT {
         if (disabled) {
             return;
         }
-
-        Response deleteDatasetResponse = UtilIT.deleteDatasetViaSwordApi(datasetPersistentId1, apiToken1);
-        deleteDatasetResponse.prettyPrint();
-        assertEquals(204, deleteDatasetResponse.getStatusCode());
-
-        Response deleteDataverse1Response = UtilIT.deleteDataverse(dataverseAlias1, apiToken1);
-        deleteDataverse1Response.prettyPrint();
-        assertEquals(200, deleteDataverse1Response.getStatusCode());
-
-        Response deleteDataverse2Response = UtilIT.deleteDataverse(dataverseAlias2, apiToken1);
-        deleteDataverse2Response.prettyPrint();
-        assertEquals(200, deleteDataverse2Response.getStatusCode());
 
         Response deleteUser1Response = UtilIT.deleteUser(username1);
         deleteUser1Response.prettyPrint();

--- a/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
@@ -223,6 +223,10 @@ public class UtilIT {
 
     public static Response uploadRandomFile(String persistentId, String apiToken) {
         String zipfilename = "trees.zip";
+        return uploadFile(persistentId, zipfilename, apiToken);
+    }
+
+    public static Response uploadFile(String persistentId, String zipfilename, String apiToken) {
         String pathToFileName = "scripts/search/data/binary/" + zipfilename;
         byte[] bytes = null;
         try {
@@ -294,11 +298,11 @@ public class UtilIT {
     }
 
     static String getFilenameFromSwordStatementResponse(Response swordStatement) {
-        String filename = getFilenameFromSwordStatementResponse(swordStatement.body().asString());
+        String filename = getFirstFilenameFromSwordStatementResponse(swordStatement.body().asString());
         return filename;
     }
 
-    private static String getFilenameFromSwordStatementResponse(String swordStatement) {
+    private static String getFirstFilenameFromSwordStatementResponse(String swordStatement) {
         XmlPath xmlPath = new XmlPath(swordStatement);
         try {
             String filename = xmlPath.get("feed.entry[0].id").toString().split("/")[11];
@@ -332,7 +336,7 @@ public class UtilIT {
                 .delete("/api/datasets/" + datasetId);
     }
 
-    static Response deleteDatasetViaSwordApi(String persistentId, String apiToken) {
+    static Response deleteLatestDatasetVersionViaSwordApi(String persistentId, String apiToken) {
         return given()
                 .auth().basic(apiToken, EMPTY_STRING)
                 .relaxedHTTPSValidation()
@@ -342,7 +346,7 @@ public class UtilIT {
     static Response destroyDataset(Integer datasetId, String apiToken) {
         return given()
                 .header(API_TOKEN_HTTP_HEADER, apiToken)
-                .delete("/api/datasets/" + datasetId);
+                .delete("/api/datasets/" + datasetId + "/destroy");
     }
 
     static Response deleteFile(Integer fileId, String apiToken) {


### PR DESCRIPTION
Also made the following fixes to testing code:

- upload arbitrary file (assuming same path)
- call "destroy" method properly
- clarify that SWORD delete operates latest version
- more accurate names for old methods

Related: #1784 #2222