### PR TITLE
2221 harvested file cards

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
@@ -21,10 +21,7 @@ import edu.harvard.iq.dataverse.engine.command.impl.UpdateDatasetCommand;
 import edu.harvard.iq.dataverse.ingest.IngestRequest;
 import edu.harvard.iq.dataverse.ingest.IngestServiceBean;
 import edu.harvard.iq.dataverse.metadataimport.ForeignMetadataImportServiceBean;
-import edu.harvard.iq.dataverse.search.FacetCategory;
-import edu.harvard.iq.dataverse.search.FileView;
 import edu.harvard.iq.dataverse.search.SearchFilesServiceBean;
-import edu.harvard.iq.dataverse.search.SolrSearchResult;
 import edu.harvard.iq.dataverse.search.SortBy;
 import edu.harvard.iq.dataverse.settings.SettingsServiceBean;
 import edu.harvard.iq.dataverse.util.BundleUtil;
@@ -37,9 +34,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.StringReader;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
@@ -62,27 +57,20 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import org.primefaces.event.FileUploadEvent;
 import org.primefaces.model.UploadedFile;
-import javax.json.Json;
-import javax.json.JsonObject;
-import javax.json.JsonArray;
-import javax.json.JsonReader;
 import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.ConstraintViolation;
 import org.apache.commons.httpclient.HttpClient;
-import org.apache.commons.httpclient.methods.GetMethod;
 import org.primefaces.context.RequestContext;
 import java.text.DateFormat;
 import java.util.HashSet;
-import java.util.LinkedHashMap;
 import javax.faces.model.SelectItem;
 import java.util.logging.Level;
 import javax.faces.component.UIComponent;
 import javax.faces.component.UIInput;
+import javax.faces.event.AjaxBehaviorEvent;
 import org.primefaces.component.tabview.TabView;
 import org.primefaces.event.TabChangeEvent;
-import org.primefaces.model.LazyDataModel;
-import org.primefaces.model.SortOrder;
 
 /**
  *
@@ -3332,6 +3320,12 @@ public class DatasetPage implements java.io.Serializable {
     }
 
     private String[] selectedTags = {};
+    
+    public void handleSelection(final AjaxBehaviorEvent event) {
+        if (selectedTags != null) {
+            selectedTags = selectedTags.clone();
+        }
+    }
     
     private void refreshSelectedTags() {
         selectedTags = null;

--- a/src/main/webapp/dataset.xhtml
+++ b/src/main/webapp/dataset.xhtml
@@ -873,23 +873,44 @@
                     <p:dialog id="fileTagsPopup" styleClass="smallPopUp" header="#{bundle['file.editTags']}" widgetVar="fileTagsPopup" modal="true">
                         <p class="help-block"><span class="glyphicon glyphicon-info-sign"/> #{bundle['file.editTagsDialog.tip']}</p>
                         <div class="form-horizontal" jsf:rendered="#{!(empty DatasetPage.selectedFiles)}">
-                            <div class="form-group">
-                                <label for="fileTagsMenuDS" class="col-sm-3 control-label">
+                            <div class="form-group text-left">
+                                <label for="selectedTagsList" class="col-sm-4 control-label">
+                                    Selected Tags
+                                </label>
+                                <div class="col-sm-7">
+                                    <p:outputPanel id="selectedTagsList" style="padding-top:.5em;">
+                                        <h:outputText value="No tags selected" rendered="#{empty DatasetPage.selectedTags}" />
+                                       
+                                        <ui:repeat value="#{DatasetPage.selectedTags}" var="tags" rendered="#{!empty DatasetPage.selectedTags}">
+                                            <h:outputText value="#{tags}" styleClass="label label-info" style="margin-right:.5em;display:inline-block;"/>
+                                        </ui:repeat>
+                                        <ui:repeat value="#{DatasetPage.selectedTabFileTags}" var="tags" rendered="#{!empty DatasetPage.selectedTabFileTags}">
+                                            <h:outputText value="#{tags}" styleClass="label label-info" style="margin-right:.5em;display:inline-block;"/>
+                                        </ui:repeat>
+                                    </p:outputPanel>
+                                </div>
+                            </div>
+                            <div class="form-group text-left">
+                                <label for="fileTagsMenuDS" class="col-sm-4 control-label">
                                     #{bundle['file.editTagsDialog.select']}
                                 </label>
-                                <div class="col-sm-8">
+                                <div class="col-sm-7">
                                     <p:selectCheckboxMenu id="fileTagsMenuDS" styleClass="form-control"
                                                           value="#{DatasetPage.selectedTags}" label="#{bundle.select}">
+                                       
+                                        <p:ajax event="toggleSelect" listener="#{DatasetPage.handleSelection}" update="selectedTagsList" />
+                                        <p:ajax event="change" listener="#{DatasetPage.handleSelection}" update="selectedTagsList" />
+                                       
                                         <f:selectItems value="#{DatasetPage.dataset.categoriesByName}"/>
                                     </p:selectCheckboxMenu>
                                     <p:message for="fileTagsMenuDS" display="text" />
                                 </div>
                             </div>
-                            <div class="form-group">
-                                <label for="fileTagAddNewDS" class="col-sm-3 control-label">
+                            <div class="form-group text-left">
+                                <label for="fileTagAddNewDS" class="col-sm-4 control-label">
                                     #{bundle['file.editTagsDialog.add']}
                                 </label>
-                                <div class="col-sm-8">
+                                <div class="col-sm-7">
                                     <p:inputText id="fileTagAddNewDS" styleClass="form-control"
                                                  type="text" value="#{DatasetPage.newCategoryName}"
                                                  placeholder="#{bundle['file.editTagsDialog.newName']}"
@@ -899,21 +920,25 @@
                                     <p:message for="fileTagAddNewDS" display="text" />
                                 </div>
                             </div>
-                        </div>
-                        <div class="form-group" jsf:rendered="#{DatasetPage.tabularDataSelected}">
-                            <label for="tabularDataTagsDsPAge" class="col-sm-3 control-label">
-                                <span data-toggle="tooltip" data-placement="auto right" class="tooltiplabel text-info" data-original-title="#{bundle['file.tabularDataTags.title']}">
-                                    #{bundle['file.tabularDataTags']}
-                                </span>
-                            </label>
-                            <div class="col-sm-8">
-                                <p class="help-block">#{bundle['file.tabularDataTags.tip']}</p>
-                                <p:selectCheckboxMenu id="tabularDataTagsDSPage" styleClass="form-control"
-                                                      value="#{DatasetPage.selectedTabFileTags}" label="#{bundle.select}"
-                                                      filter="false">
-                                    <f:selectItems value="#{DatasetPage.tabFileTags}" />
-                                </p:selectCheckboxMenu>
-                                <p:message for="tabularDataTagsDSPage" display="text" />
+                            <div class="form-group text-left" jsf:rendered="#{DatasetPage.tabularDataSelected}">
+                                <label for="tabularDataTagsDsPAge" class="col-sm-4 control-label">
+                                    <span data-toggle="tooltip" data-placement="auto right" class="tooltiplabel text-info" data-original-title="#{bundle['file.tabularDataTags.title']}">
+                                        #{bundle['file.tabularDataTags']}
+                                    </span>
+                                </label>
+                                <div class="col-sm-7">
+                                    <p class="help-block">#{bundle['file.tabularDataTags.tip']}</p>
+                                    <p:selectCheckboxMenu id="tabularDataTagsDSPage" styleClass="form-control"
+                                                          value="#{DatasetPage.selectedTabFileTags}" label="#{bundle.select}"
+                                                          filter="false">
+
+                                        <p:ajax event="toggleSelect" listener="#{DatasetPage.handleSelection}" update="selectedTagsList" />
+                                        <p:ajax event="change" listener="#{DatasetPage.handleSelection}" update="selectedTagsList" />
+
+                                        <f:selectItems value="#{DatasetPage.tabFileTags}" />
+                                    </p:selectCheckboxMenu>
+                                    <p:message for="tabularDataTagsDSPage" display="text" />
+                                </div>
                             </div>
                         </div>
                         <div class="button-block">
@@ -1347,7 +1372,7 @@
                             PF('selectFilesForEditTags').show();
                         } else {
                            refreshTagsCommand();
-                        }                       
+                        }
                     }
                     
                     function testFilesSelectedForDelete(){

--- a/src/main/webapp/search-include-fragment.xhtml
+++ b/src/main/webapp/search-include-fragment.xhtml
@@ -591,28 +591,27 @@
                             <span class="icon-#{dataFileServiceBean.getFileClass(result.entity)} text-muted h1"
                                   jsf:rendered="#{!result.displayImage}"/>
                         </div>
-
-                        <h:outputText styleClass="text-muted" value="#{result.dateToDisplayOnCard} - "/>
-                        <a href="#{result.fileDatasetUrl}" target="#{showFacets == true ? '_self' : '_blank'}">
-                            <h:outputText value="#{result.parent.get('name')}"/></a>
-
-                        <ui:fragment>
-                            <br/>
+                        
+                        <div>
+                            <h:outputText styleClass="text-muted" value="#{result.dateToDisplayOnCard} - "/>
+                            <a href="#{result.fileDatasetUrl}" target="#{showFacets == true ? '_self' : '_blank'}">
+                                <h:outputText value="#{result.parent.get('name')}"/></a>
+                        </div>
+                        
+                        <div>
                             <h:outputText value="#{bundle['dataverse.results.cards.files.tabularData']}" styleClass="text-muted" rendered="#{!empty SearchIncludeFragment.tabularDataDisplayInfo(result.entity)}"/>
                             <h:outputText value="#{result.filetype}" styleClass="text-muted" rendered="#{empty SearchIncludeFragment.tabularDataDisplayInfo(result.entity) and result.fileTypeHighlightSnippet == null}"/>
                             <h:outputText value="#{result.fileTypeHighlightSnippet}" styleClass="text-muted" rendered="#{empty SearchIncludeFragment.tabularDataDisplayInfo(result.entity) and result.fileTypeHighlightSnippet != null}" escape="false"/>
 
-                            <h:outputText styleClass="text-muted" value=" - #{SearchIncludeFragment.dataFileSizeDisplay(result.entity)} - "/>
+                            <h:outputText styleClass="text-muted" value=" - #{SearchIncludeFragment.dataFileSizeDisplay(result.entity)}" rendered="#{!result.harvested}" />
 
-                            <h:outputText styleClass="text-muted" value="#{SearchIncludeFragment.dataFileMD5Display(result.entity)}" rendered="#{!SearchIncludeFragment.isTabular(result.entity)}"/>
+                            <h:outputText styleClass="text-muted" value=" - #{SearchIncludeFragment.dataFileMD5Display(result.entity)}" rendered="#{!result.harvested and !SearchIncludeFragment.isTabular(result.entity)}"/>
 
                             <!-- if this is a tabular data file, extra information, such as the numbers of variables and observations and the unf, is displayed: -->
-                            <h:outputText styleClass="text-muted" value="#{SearchIncludeFragment.tabularDataDisplayInfo(result.entity)}"
+                            <h:outputText styleClass="text-muted" value=" - #{SearchIncludeFragment.tabularDataDisplayInfo(result.entity)}"
                                             rendered="#{!empty SearchIncludeFragment.tabularDataDisplayInfo(result.entity)}"/>
-
-                            <br/>
-                        </ui:fragment>
-
+                        </div>
+                        
                         <div class="file-tags-block" jsf:rendered="#{(!empty result.fileCategories) or (!empty result.tabularDataTags)}">
                             <ui:repeat value="#{result.fileCategories}" var="cat">
                                 <h:outputText value="#{cat}" styleClass="label label-default"/>


### PR DESCRIPTION
Added render logic to hide empty metadata fields for harvested files in the dataverse result cards. [ref #2221]