### PR TITLE
Change the meaning from forceCapitals in PasswordValidator

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/authorization/providers/builtin/BuiltinUserPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/authorization/providers/builtin/BuiltinUserPage.java
@@ -377,10 +377,10 @@ public class BuiltinUserPage implements java.io.Serializable {
         int minPasswordLength = 6;
         boolean forceNumber = true;
         boolean forceSpecialChar = false;
-        boolean forceCapitalLetter = false;
+        boolean forceMixedLetters = false;
         int maxPasswordLength = 255;
 
-        PasswordValidator validator = PasswordValidator.buildValidator(forceSpecialChar, forceCapitalLetter, forceNumber, minPasswordLength, maxPasswordLength);
+        PasswordValidator validator = PasswordValidator.buildValidator(forceSpecialChar, forceMixedLetters, forceNumber, minPasswordLength, maxPasswordLength);
         boolean passwordIsComplexEnough = password!= null && validator.validatePassword(password);
         if (!passwordIsComplexEnough) {
             ((UIInput) toValidate).setValid(false);

--- a/src/main/java/edu/harvard/iq/dataverse/passwordreset/PasswordResetServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/passwordreset/PasswordResetServiceBean.java
@@ -199,7 +199,7 @@ public class PasswordResetServiceBean {
         int minPasswordLength = 6;
         boolean forceNumber = true;
         boolean forceSpecialChar = false;
-        boolean forceCapitalLetter = false;
+        boolean forceMixedLetters = false;
         int maxPasswordLength = 255;
         /**
          *
@@ -213,7 +213,7 @@ public class PasswordResetServiceBean {
          * characters, max 255 characters, all other rules disabled that the
          * password "12345678" is not considered valid.
          */
-        PasswordValidator validator = PasswordValidator.buildValidator(forceSpecialChar, forceCapitalLetter, forceNumber, minPasswordLength, maxPasswordLength);
+        PasswordValidator validator = PasswordValidator.buildValidator(forceSpecialChar, forceMixedLetters, forceNumber, minPasswordLength, maxPasswordLength);
         boolean passwordIsComplexEnough = validator.validatePassword(newPassword);
         if (!passwordIsComplexEnough) {
             messageSummary = messageSummaryFail;

--- a/src/main/java/edu/harvard/iq/dataverse/passwordreset/PasswordValidator.java
+++ b/src/main/java/edu/harvard/iq/dataverse/passwordreset/PasswordValidator.java
@@ -24,19 +24,25 @@ public class PasswordValidator {
      * Force the user to build a validator using this way only
      *
      * @param forceSpecialChar
-     * @param forceCapitalLetter
+     * @param forceMixedLetters
      * @param forceNumber
      * @param minLength
      * @param maxLength
      * @return
      */
     public static PasswordValidator buildValidator(boolean forceSpecialChar,
-            boolean forceCapitalLetter,
+            boolean forceMixedLetters,
             boolean forceNumber,
             int minLength,
             int maxLength) {
-        // [a-z] is why one letter is required
-        StringBuilder patternBuilder = new StringBuilder("((?=.*[a-z])");
+
+        final StringBuilder patternBuilder = new StringBuilder("(");
+
+        if (forceMixedLetters) {
+            patternBuilder.append("(?=.*[A-Z])(?=.*[a-z])");
+        } else {
+            patternBuilder.append("(?=.*[A-Za-z])");
+        }
 
         /**
          * @todo should probably allow additional special characters
@@ -45,15 +51,11 @@ public class PasswordValidator {
             patternBuilder.append("(?=.*[@#$%])");
         }
 
-        if (forceCapitalLetter) {
-            patternBuilder.append("(?=.*[A-Z])");
-        }
-
         if (forceNumber) {
             patternBuilder.append("(?=.*\\d)");
         }
 
-        patternBuilder.append(".{" + minLength + "," + maxLength + "})");
+        patternBuilder.append(".{").append(minLength).append(",").append(maxLength).append("})");
         pattern = patternBuilder.toString();
 
         return INSTANCE;

--- a/src/test/java/edu/harvard/iq/dataverse/passwordreset/PasswordValidatorTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/passwordreset/PasswordValidatorTest.java
@@ -1,0 +1,59 @@
+package edu.harvard.iq.dataverse.passwordreset;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+/**
+ * PasswordValidatorTest
+ *
+ * Determine if the validator correctly handles limits applied to the password format.
+ */
+public class PasswordValidatorTest {
+
+    @Test
+    public void testPasswordValidatorNoForceMizedLetters() {
+
+        // All taken from edu.harvard.iq.dataverse.authorization.providers.builtin.BuiltinUserPage
+        int minPasswordLength = 6;
+        boolean forceNumber = true;
+        boolean forceSpecialChar = false;
+        boolean forceMixedLetters = false;
+        int maxPasswordLength = 255;
+        final PasswordValidator passwordValidator = PasswordValidator.buildValidator(forceSpecialChar, forceMixedLetters, forceNumber, minPasswordLength, maxPasswordLength);
+
+        boolean passwordIsComplexEnough = passwordValidator.validatePassword("short");
+        assertFalse(passwordIsComplexEnough);
+
+        passwordIsComplexEnough = passwordValidator.validatePassword("AAAaAA1");
+        assertTrue(passwordIsComplexEnough);
+
+        passwordIsComplexEnough = passwordValidator.validatePassword("aaaaaa1");
+        assertTrue(passwordIsComplexEnough);
+
+        passwordIsComplexEnough = passwordValidator.validatePassword("aaaaaa");
+        assertFalse(passwordIsComplexEnough);
+
+    }
+
+    @Test
+    public void testPasswordValidatorWithForceMizedLetters() {
+
+        int minPasswordLength = 6;
+        boolean forceNumber = true;
+        boolean forceSpecialChar = false;
+        boolean forceMixedLetters = true;
+        int maxPasswordLength = 255;
+        final PasswordValidator passwordValidator = PasswordValidator.buildValidator(forceSpecialChar, forceMixedLetters, forceNumber, minPasswordLength, maxPasswordLength);
+
+        boolean passwordIsComplexEnough = passwordValidator.validatePassword("AAAaAA1");
+        assertTrue(passwordIsComplexEnough);
+
+        passwordIsComplexEnough = passwordValidator.validatePassword("aaaaaa1");
+        assertFalse(passwordIsComplexEnough);
+
+        passwordIsComplexEnough = passwordValidator.validatePassword("AAAAA1");
+        assertFalse(passwordIsComplexEnough);
+
+    }
+
+}


### PR DESCRIPTION
One of our users could not set a password that had no lower case capitals in it.
So abcdefg12345 is valid, but ABCDEFG12345 is not, yet their complexity is equivalent.

I think this can be considered a bug, hence the PR. In it, the forceCapitalLetter (the password must have an uppercase letter) is replaced with forceMixedLetters (the password must have lower and upper case letters). This should not break the current behavior, but if unsure this can be falsified by adding to the unit tests.