### PR TITLE
Refactor superuser API endpoint to migrate Shib user to builtin/local account

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/api/Admin.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Admin.java
@@ -286,8 +286,14 @@ public class Admin extends AbstractApiBean {
             output.add("email", builtinUser.getEmail());
             output.add("username", builtinUser.getUserName());
             return okResponse(output);
-        } catch (Exception ex) {
-            String msg = "User id " + id + " could not be converted from Shibboleth to BuiltIn. Details from Exception: " + ex;
+        } catch (Throwable ex) {
+            StringBuilder sb = new StringBuilder();
+            sb.append(ex + " ");
+            while (ex.getCause() != null) {
+                ex = ex.getCause();
+                sb.append(ex + " ");
+            }
+            String msg = "User id " + id + " could not be converted from Shibboleth to BuiltIn. Details from Exception: " + sb;
             logger.info(msg);
             return errorResponse(Response.Status.BAD_REQUEST, msg);
         }


### PR DESCRIPTION
I had coder's remorse over the quality of work I put into the superuser API endpoint to migrate Shib user to builtin/local account in #2915 and confessed to @scolapasta at https://github.com/IQSS/dataverse/pull/3025#issuecomment-218758445 . We agreed that the code should be refactored, which I did in this pull request. Nothing changes in terms of how the API works. Docs at http://guides.dataverse.org/en/2939-shib/installation/shibboleth.html#converting-shibboleth-users-to-local are still accurate. The code was cleaned up and centralized, which means it will be easier to build a GUI around this feature in the future. I'm reopening #2915 since it hasn't shipped yet.

### 1. Related Issues

-  #2915 Shibboleth: Add superuser API endpoint to migrate Shib user to builtin/local account  

---
### 2. Pull Request Checklist

- [x]  Functionality completed as described in FRD
- [x]  Dependencies, risks, assumptions in FRD addressed
- [x]  Unit tests completed
- [x]  Deployment requirements identified (e.g., SQL scripts, indexing)
- [x]  Documentation completed
- [x]  All code checkins completed

---
### 3. Review Checklist

_**After** the pull request has been submitted, fill out this section._

- [x]  Code review completed or waived
- [ ]  Testing requirements completed
- [ ]  Usability testing completed or waived
- [ ]  Support testing completed or waived
- [ ]  Merged with develop branch and resolved conflicts
