### PR TITLE
trim whitespace for user email, identifier, etc. 

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/EMailValidator.java
+++ b/src/main/java/edu/harvard/iq/dataverse/EMailValidator.java
@@ -33,14 +33,7 @@ public class EMailValidator implements ConstraintValidator<ValidateEmail, String
             //we'll let someone else decide if it's required
             return true;
         }
-        /**
-         * @todo Why are we validating the trimmed value rather than the value
-         * itself? Which are we persisting to the database, the trimmed value or
-         * the non-trimmed value? See also
-         * https://github.com/IQSS/dataverse/issues/2945 and
-         * https://github.com/IQSS/dataverse/issues/3044
-         */
-        boolean isValid = EmailValidator.getInstance().isValid(value.trim());
+        boolean isValid = EmailValidator.getInstance().isValid(value);
         if (!isValid) {
             if (context != null) {
                 context.buildConstraintViolationWithTemplate(value + " is not a valid email address.").addConstraintViolation();

--- a/src/main/java/edu/harvard/iq/dataverse/Shib.java
+++ b/src/main/java/edu/harvard/iq/dataverse/Shib.java
@@ -357,21 +357,34 @@ public class Shib implements java.io.Serializable {
     }
 
     /**
-     * @return The value of a Shib attribute (if non-empty) or null.
+     * @return The trimmed value of a Shib attribute (if non-empty) or null.
+     *
+     * @todo Move this to ShibUtil
      */
     private String getValueFromAssertion(String key) {
         Object attribute = request.getAttribute(key);
         if (attribute != null) {
             String attributeValue = attribute.toString();
-            logger.fine("The SAML assertion for \"" + key + "\" (optional) was \"" + attributeValue + "\".");
-            if (!attributeValue.isEmpty()) {
-                return attributeValue;
+            String trimmedValue = attributeValue.trim();
+            if (!trimmedValue.isEmpty()) {
+                logger.fine("The SAML assertion for \"" + key + "\" (optional) was \"" + attributeValue + "\" and was trimmed to \"" + trimmedValue + "\".");
+                return trimmedValue;
+            } else {
+                logger.fine("The SAML assertion for \"" + key + "\" (optional) was \"" + attributeValue + "\" and was trimmed to \"" + trimmedValue + "\" (empty string). Returing null.");
+                return null;
             }
+        } else {
+            logger.fine("The SAML assertion for \"" + key + "\" (optional) was null.");
+            return null;
         }
-        logger.info("The SAML assertion for \"" + key + "\" (optional) was null.");
-        return null;
     }
 
+    /**
+     * @return The trimmed value of a Shib attribute (if non-empty) or null.
+     *
+     * @todo Move this to ShibUtil. More objects might be required since
+     * sometimes we want to show messages, etc.
+     */
     private String getRequiredValueFromAssertion(String key) throws Exception {
         Object attribute = request.getAttribute(key);
         if (attribute == null) {
@@ -390,8 +403,9 @@ public class Shib implements java.io.Serializable {
         if (attributeValue.isEmpty()) {
             throw new Exception(key + " was empty");
         }
-        logger.fine("The SAML assertion for \"" + key + "\" (required) was \"" + attributeValue + "\".");
-        return attributeValue;
+        String trimmedValue = attributeValue.trim();
+        logger.fine("The SAML assertion for \"" + key + "\" (required) was \"" + attributeValue + "\" and was trimmed to \"" + trimmedValue + "\".");
+        return trimmedValue;
     }
 
     public String getRootDataverseAlias() {

--- a/src/main/java/edu/harvard/iq/dataverse/authorization/AuthenticationServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/authorization/AuthenticationServiceBean.java
@@ -268,6 +268,11 @@ public class AuthenticationServiceBean {
             // yay! see if we already have this user.
             AuthenticatedUser user = lookupUser(authenticationProviderId, resp.getUserId());
 
+            /**
+             * @todo Why does a method called "authenticate" have the potential
+             * to call "createAuthenticatedUser"? Isn't the creation of a user a
+             * different action than authenticating?
+             */
             return ( user == null ) ?
                 AuthenticationServiceBean.this.createAuthenticatedUser(
                         new UserRecordIdentifier(authenticationProviderId, resp.getUserId()), resp.getUserId(), resp.getUserDisplayInfo(), true )
@@ -390,6 +395,7 @@ public class AuthenticationServiceBean {
      * @param userDisplayInfo
      * @param generateUniqueIdentifier if {@code true}, create a new, unique user identifier for the created user, if the suggested one exists.
      * @return the newly created user, or {@code null} if the proposed identifier exists and {@code generateUniqueIdentifier} was {@code false}.
+     * @throws EJBException which may wrap an ConstraintViolationException if the proposed user does not pass bean validation.
      */
     public AuthenticatedUser createAuthenticatedUser(UserRecordIdentifier userRecordId,
                                                      String proposedAuthenticatedUserIdentifier,
@@ -398,6 +404,10 @@ public class AuthenticationServiceBean {
         AuthenticatedUser authenticatedUser = new AuthenticatedUser();
         authenticatedUser.applyDisplayInfo(userDisplayInfo);
         
+        // we have no desire for leading or trailing whitespace in identifiers
+        if (proposedAuthenticatedUserIdentifier != null) {
+            proposedAuthenticatedUserIdentifier = proposedAuthenticatedUserIdentifier.trim();
+        }
         // we now select a username for the generated AuthenticatedUser, or give up
         String internalUserIdentifer = proposedAuthenticatedUserIdentifier;
         // TODO should lock table authenticated users for write here

--- a/src/main/java/edu/harvard/iq/dataverse/authorization/providers/shib/ShibServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/authorization/providers/shib/ShibServiceBean.java
@@ -62,6 +62,9 @@ public class ShibServiceBean {
         HARVARD2,
         TWO_EMAILS,
         INVALID_EMAIL,
+        EMAIL_WITH_LEADING_SPACE,
+        UID_WITH_LEADING_SPACE,
+        IDENTIFIER_WITH_LEADING_SPACE,
         MISSING_REQUIRED_ATTR,
     };
 
@@ -127,6 +130,18 @@ public class ShibServiceBean {
 
             case INVALID_EMAIL:
                 ShibUtil.mutateRequestForDevConstantInvalidEmail(request);
+                break;
+
+            case EMAIL_WITH_LEADING_SPACE:
+                ShibUtil.mutateRequestForDevConstantEmailWithLeadingSpace(request);
+                break;
+
+            case UID_WITH_LEADING_SPACE:
+                ShibUtil.mutateRequestForDevConstantUidWithLeadingSpace(request);
+                break;
+
+            case IDENTIFIER_WITH_LEADING_SPACE:
+                ShibUtil.mutateRequestForDevConstantIdentifierWithLeadingSpace(request);
                 break;
 
             case MISSING_REQUIRED_ATTR:

--- a/src/main/java/edu/harvard/iq/dataverse/authorization/providers/shib/ShibUtil.java
+++ b/src/main/java/edu/harvard/iq/dataverse/authorization/providers/shib/ShibUtil.java
@@ -199,8 +199,36 @@ public class ShibUtil {
         request.setAttribute(ShibUtil.uniquePersistentIdentifier, "invalidEmail");
         request.setAttribute(ShibUtil.firstNameAttribute, "Invalid");
         request.setAttribute(ShibUtil.lastNameAttribute, "Email");
-        request.setAttribute(ShibUtil.emailAttribute, "invalidEmail");
+        request.setAttribute(ShibUtil.emailAttribute, "elisah.da mota@example.com");
         request.setAttribute(ShibUtil.usernameAttribute, "invalidEmail");
+    }
+
+    static void mutateRequestForDevConstantEmailWithLeadingSpace(HttpServletRequest request) {
+        request.setAttribute(ShibUtil.shibIdpAttribute, "https://fake.example.com/idp/shibboleth");
+        request.setAttribute(ShibUtil.uniquePersistentIdentifier, "leadingWhitespace");
+        request.setAttribute(ShibUtil.firstNameAttribute, "leadingWhitespace");
+        request.setAttribute(ShibUtil.lastNameAttribute, "leadingWhitespace");
+        request.setAttribute(ShibUtil.emailAttribute, " leadingWhitespace@mailinator.com");
+        request.setAttribute(ShibUtil.usernameAttribute, "leadingWhitespace");
+    }
+
+    static void mutateRequestForDevConstantUidWithLeadingSpace(HttpServletRequest request) {
+        request.setAttribute(ShibUtil.shibIdpAttribute, "https://fake.example.com/idp/shibboleth");
+        request.setAttribute(ShibUtil.uniquePersistentIdentifier, "leadingWhitespace");
+        request.setAttribute(ShibUtil.firstNameAttribute, "leadingWhitespace");
+        request.setAttribute(ShibUtil.lastNameAttribute, "leadingWhitespace");
+        request.setAttribute(ShibUtil.emailAttribute, "leadingWhitespace@mailinator.com");
+        request.setAttribute(ShibUtil.usernameAttribute, " leadingWhitespace");
+    }
+
+    // the identifier is the IdP plus the eppn separated by a |
+    static void mutateRequestForDevConstantIdentifierWithLeadingSpace(HttpServletRequest request) {
+        request.setAttribute(ShibUtil.shibIdpAttribute, " https://fake.example.com/idp/shibboleth");
+        request.setAttribute(ShibUtil.uniquePersistentIdentifier, "leadingWhitespace");
+        request.setAttribute(ShibUtil.firstNameAttribute, "leadingWhitespace");
+        request.setAttribute(ShibUtil.lastNameAttribute, "leadingWhitespace");
+        request.setAttribute(ShibUtil.emailAttribute, "leadingWhitespace@mailinator.com");
+        request.setAttribute(ShibUtil.usernameAttribute, "leadingWhitespace");
     }
 
     static void mutateRequestForDevConstantMissingRequiredAttributes(HttpServletRequest request) {

--- a/src/main/java/edu/harvard/iq/dataverse/authorization/users/AuthenticatedUser.java
+++ b/src/main/java/edu/harvard/iq/dataverse/authorization/users/AuthenticatedUser.java
@@ -49,6 +49,15 @@ public class AuthenticatedUser implements User, Serializable {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     Long id;
 
+    /**
+     * @todo Shouldn't there be some constraints on what the userIdentifier is
+     * allowed to be? It can't be as restrictive as the "userName" field on
+     * BuiltinUser because we can't predict what Shibboleth Identity Providers
+     * (IdPs) will send (typically in the "eppn" SAML assertion) but perhaps
+     * spaces, for example, should be disallowed. Right now "elisah.da mota" can
+     * be persisted as a userIdentifier per
+     * https://github.com/IQSS/dataverse/issues/2945
+     */
     @NotNull
     @Column(nullable = false, unique=true)
     private String userIdentifier;

--- a/src/test/java/edu/harvard/iq/dataverse/EMailValidatorTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/EMailValidatorTest.java
@@ -8,6 +8,17 @@ public class EMailValidatorTest {
     @Test
     public void testIsEmailValid() {
         assertEquals(true, EMailValidator.isEmailValid("pete@mailinator.com", null));
+        /**
+         * @todo How can " leadingWhitespace@mailinator.com" be a valid email
+         * address?
+         */
+        assertEquals(true, EMailValidator.isEmailValid(" leadingWhitespace@mailinator.com", null));
+        /**
+         * @todo How can "trailingWhitespace@mailinator.com " be a valid email
+         * address?
+         */
+        assertEquals(true, EMailValidator.isEmailValid("trailingWhitespace@mailinator.com ", null));
+        assertEquals(false, EMailValidator.isEmailValid("elisah.da mota@example.com", null));
         assertEquals(false, EMailValidator.isEmailValid("pete1@mailinator.com;pete2@mailinator.com", null));
         boolean issue2998resolved = false;
         /**

--- a/src/test/java/edu/harvard/iq/dataverse/authorization/providers/shib/ShibUtilTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/authorization/providers/shib/ShibUtilTest.java
@@ -136,6 +136,7 @@ public class ShibUtilTest {
     public void testGenerateFriendlyLookingUserIdentifer() {
         int lengthOfUuid = UUID.randomUUID().toString().length();
         assertEquals("uid1", ShibUtil.generateFriendlyLookingUserIdentifer("uid1", null));
+        assertEquals(" leadingWhiteSpace", ShibUtil.generateFriendlyLookingUserIdentifer(" leadingWhiteSpace", null));
         assertEquals("uid1", ShibUtil.generateFriendlyLookingUserIdentifer("uid1", "email1@example.com"));
         assertEquals("email1", ShibUtil.generateFriendlyLookingUserIdentifer(null, "email1@example.com"));
         assertEquals(lengthOfUuid, ShibUtil.generateFriendlyLookingUserIdentifer(null, null).length());


### PR DESCRIPTION
# RFI Checklist

### 1. Related Issues

- #2945 Bug: spaces allowed in email and useridentifier in authenticateduser table
- #3044 Account Information: whitespace as part of fields, particularly email address is saved to db, should be trimmed.

---
### 2. Pull Request Checklist

- [ ]  Functionality completed as described in FRD
- [ ]  Dependencies, risks, assumptions in FRD addressed
- [ ]  Unit tests completed
- [ ]  Deployment requirements identified (e.g., SQL scripts, indexing)
- [ ]  Documentation completed
- [ ]  All code checkins completed

---
### 3. Review Checklist

_**After** the pull request has been submitted, fill out this section._

- [ ]  Code review completed or waived
- [ ]  Testing requirements completed
- [ ]  Usability testing completed or waived
- [ ]  Support testing completed or waived
- [ ]  Merged with develop branch and resolved conflicts

