### PR TITLE
Support Shibboleth Federated Login Mode, Shibboleth no longer experimental

### DIFF
--- a/doc/sphinx-guides/source/_static/installation/files/etc/shibboleth/shibboleth2.xml
+++ b/doc/sphinx-guides/source/_static/installation/files/etc/shibboleth/shibboleth2.xml
@@ -9,6 +9,7 @@ https://wiki.shibboleth.net/confluence/display/SHIB2/NativeSPConfiguration
 -->
 
 <SPConfig xmlns="urn:mace:shibboleth:2.0:native:sp:config" xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"
+    xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
     clockSkew="1800">
 
     <!-- FIXME: change the entityID to your hostname. -->
@@ -54,6 +55,23 @@ https://wiki.shibboleth.net/confluence/display/SHIB2/NativeSPConfiguration
         <!-- Loads and trusts a metadata file that describes only the Testshib IdP and how to communicate with it. -->
         <!-- IdPs we want allow go in /etc/shibboleth/dataverse-idp-metadata.xml -->
         <MetadataProvider type="XML" file="dataverse-idp-metadata.xml" backingFilePath="local-idp-metadata.xml" legacyOrgNames="true" reloadInterval="7200"/>
+        <!-- Uncomment to enable all the Research & Scholarship IdPs from InCommon -->
+        <!--
+        <MetadataProvider type="XML" url="http://md.incommon.org/InCommon/InCommon-metadata.xml" backingFilePath="InCommon-metadata.xml" maxRefreshDelay="3600">
+            <DiscoveryFilter type="Whitelist" matcher="EntityAttributes">
+                <saml:Attribute
+                    Name="http://macedir.org/entity-category-support"
+                    NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+                    <saml:AttributeValue>http://id.incommon.org/category/research-and-scholarship</saml:AttributeValue>
+                </saml:Attribute>
+                <saml:Attribute
+                    Name="http://macedir.org/entity-category-support"
+                    NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+                    <saml:AttributeValue>http://refeds.org/category/research-and-scholarship</saml:AttributeValue>
+                </saml:Attribute>
+            </DiscoveryFilter>
+        </MetadataProvider>
+        -->
 
         <!-- Attribute and trust options you shouldn't need to change. -->
         <AttributeExtractor type="XML" validate="true" path="attribute-map.xml"/>

--- a/doc/sphinx-guides/source/installation/shibboleth.rst
+++ b/doc/sphinx-guides/source/installation/shibboleth.rst
@@ -177,7 +177,7 @@ Rather than or in addition to specifying individual Identity Provider(s) you may
 
 The details of how to register with an identity federation are out of scope for this document, but a good starting point may be this list of identity federations across the world: http://www.protectnetwork.org/support/faq/identity-federations
 
-One of the benefits of using ``shibd`` is that it can be configured to periodically poll your identify federation for updates as new Identity Providers (IdPs) join the federation you've registered with. For the InCommon federation, the following page describes how to download and verify signed InCommon metadata every hour: https://spaces.internet2.edu/display/InCFederation/Shibboleth+Metadata+Config#ShibbolethMetadataConfig-ConfiguretheShibbolethSP . You can also see an example of as ``maxRefreshDelay="3600"`` in the commented out section of the ``shibboleth2.xml`` file above.
+One of the benefits of using ``shibd`` is that it can be configured to periodically poll your identity federation for updates as new Identity Providers (IdPs) join the federation you've registered with. For the InCommon federation, the following page describes how to download and verify signed InCommon metadata every hour: https://spaces.internet2.edu/display/InCFederation/Shibboleth+Metadata+Config#ShibbolethMetadataConfig-ConfiguretheShibbolethSP . You can also see an example of this as ``maxRefreshDelay="3600"`` in the commented out section of the ``shibboleth2.xml`` file above.
 
 Once you've joined a federation the list of IdPs in the dropdown can be quite long! If you're curious how many are in the list you could try something like this: ``curl https://dataverse.example.edu/Shibboleth.sso/DiscoFeed | jq '.[].entityID' | wc -l``
 

--- a/doc/sphinx-guides/source/installation/shibboleth.rst
+++ b/doc/sphinx-guides/source/installation/shibboleth.rst
@@ -3,11 +3,6 @@ Shibboleth
 
 .. contents:: :local:
 
-Status: Experimental
---------------------
-
-Shibboleth support in Dataverse should be considered **experimental** until https://github.com/IQSS/dataverse/issues/2117 is closed (indicating that the feature has been in used in production at https://dataverse.harvard.edu for a while), but the `Dataverse development team <http://dataverse.org/about>`_ is eager to receive feedback on the Shibboleth feature (including these docs!) via any channel listed in the :doc:`intro` section.
-
 Introduction
 ------------
 
@@ -178,11 +173,13 @@ Most Dataverse installations will probably only want to authenticate users via S
 Identity Federation
 +++++++++++++++++++
 
-Rather than specifying individual Identity Provider(s) you may wish to broaden the number of users who can log into your Dataverse installation by registering your Dataverse installation as a Service Provider (SP) within an identity federation. For example, in the United States, users from `hundreds of institutions registered with the "InCommon" identity federation <https://incommon.org/federation/info/all-entities.html#IdPs>`_ will be able to log into your Dataverse installation if you register it as one of the `thousands of Service Providers registered with InCommon <https://incommon.org/federation/info/all-entities.html#SPs>`_.
+Rather than or in addition to specifying individual Identity Provider(s) you may wish to broaden the number of users who can log into your Dataverse installation by registering your Dataverse installation as a Service Provider (SP) within an identity federation. For example, in the United States, users from the `many institutions registered with the "InCommon" identity federation <https://incommon.org/federation/info/all-entities.html#IdPs>`_ that release the `"Research & Scholarship Attribute Bundle" <https://spaces.internet2.edu/display/InCFederation/Research+and+Scholarship+Attribute+Bundle>`_  will be able to log into your Dataverse installation if you register it as an `InCommon Service Provider <https://incommon.org/federation/info/all-entities.html#SPs>`_ that is part of the `Research & Scholarship (R&S) category <https://incommon.org/federation/info/all-entity-categories.html#SPs>`_.
 
 The details of how to register with an identity federation are out of scope for this document, but a good starting point may be this list of identity federations across the world: http://www.protectnetwork.org/support/faq/identity-federations
 
-One of the benefits of using ``shibd`` is that it can be configured to periodically poll your identify federation for updates as new Identity Providers (IdPs) join the federation you've registered with. For the InCommon federation, the following page describes how to download and verify signed InCommon metadata every hour: https://spaces.internet2.edu/display/InCFederation/Shibboleth+Metadata+Config#ShibbolethMetadataConfig-ConfiguretheShibbolethSP
+One of the benefits of using ``shibd`` is that it can be configured to periodically poll your identify federation for updates as new Identity Providers (IdPs) join the federation you've registered with. For the InCommon federation, the following page describes how to download and verify signed InCommon metadata every hour: https://spaces.internet2.edu/display/InCFederation/Shibboleth+Metadata+Config#ShibbolethMetadataConfig-ConfiguretheShibbolethSP . You can also see an example of as ``maxRefreshDelay="3600"`` in the commented out section of the ``shibboleth2.xml`` file above.
+
+Once you've joined a federation the list of IdPs in the dropdown can be quite long! If you're curious how many are in the list you could try something like this: ``curl https://dataverse.example.edu/Shibboleth.sso/DiscoFeed | jq '.[].entityID' | wc -l``
 
 .. _shibboleth-attributes:
 


### PR DESCRIPTION
Three Dataverse servers hosted by Harvard are now registered as Service Providers (SPs) as seen at https://incommon.org/federation/info/all-entities.html#SPs and the screenshot below:

- https://dataverse.harvard.edu
- https://demo.dataverse.org
- https://beta.dataverse.org

![screen shot 2016-08-02 at 8 44 17 am](https://cloud.githubusercontent.com/assets/21006/17328794/9d4cd6ee-588d-11e6-8169-af65c1b376a9.png)

We want all three servers to be in "Federated Login Mode". Yesterday I reconfigured the demo server for this mode and along the way improved the Shibboleth section of the Installation Guide, which is what this pull request is about. I also removed "experimental" from the top of the page since we're running Shibboleth in production at Harvard.

I would suggest reconfiguring beta then production using the updated template that's part of this pull request: https://github.com/IQSS/dataverse/blob/f0f5ac9de8e53ee9c5ca40a2c5243c0c1efb2a0c/doc/sphinx-guides/source/_static/installation/files/etc/shibboleth/shibboleth2.xml . If anything in the docs can be further clarified, please let me know and I'm happy to make more commits to this pull request.

# RFI Checklist

### 1. Related Issues

- #2937 Shibboleth: Support "Federated Login Mode" (i.e. feed of Identity Providers from InCommon)

---
### 2. Pull Request Checklist

- [x]  Functionality completed as described in FRD (Federated Login Mode is mentioned at [Remote Authentication Business Requirements Document](https://docs.google.com/document/d/1vcAmo2nkFYavAr7OwwXzxM0IFQbkRZYZrrX43q-wqGE/edit?usp=sharing) ) 
- [x]  Dependencies, risks, assumptions in FRD addressed
- [x]  Unit tests completed
- [x]  Deployment requirements identified (e.g., SQL scripts, indexing)
- [x]  Documentation completed
- [x]  All code checkins completed

---
### 3. Review Checklist

_**After** the pull request has been submitted, fill out this section._

- [x]  Code review completed or waived
- [ ]  Testing requirements completed
- [ ]  Usability testing completed or waived
- [ ]  Support testing completed or waived
- [ ]  Merged with develop branch and resolved conflicts

Also remove "experimental" since #2117 has been closed.