### PR TITLE
allow sha-1 password during convert to shib #3287

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/api/Admin.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Admin.java
@@ -33,11 +33,14 @@ import javax.ws.rs.core.Response;
 
 import static edu.harvard.iq.dataverse.util.json.NullSafeJsonBuilder.jsonObjectBuilder;
 import static edu.harvard.iq.dataverse.util.json.JsonPrinter.*;
+import java.io.StringReader;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.ejb.EJB;
 import javax.ejb.Stateless;
+import javax.json.JsonObject;
+import javax.json.JsonReader;
 import javax.validation.ConstraintViolation;
 import javax.validation.ConstraintViolationException;
 import javax.ws.rs.Produces;
@@ -416,7 +419,11 @@ public class Admin extends AbstractApiBean {
             if (!knowsExistingPassword) {
                 String message = "User doesn't know password.";
                 problems.add(message);
-                return errorResponse(Status.BAD_REQUEST, message);
+                /**
+                 * @todo Someday we should make a errorResponse method that
+                 * takes JSON arrays and objects.
+                 */
+                return errorResponse(Status.BAD_REQUEST, problems.build().toString());
             }
 //            response.add("knows existing password", knowsExistingPassword);
         }
@@ -519,6 +526,22 @@ public class Admin extends AbstractApiBean {
             }
         }
         return okResponse(msg);
+    }
+
+    /**
+     * This method is used by an integration test in UsersIT.java to exercise
+     * bug https://github.com/IQSS/dataverse/issues/3287 . Not for use by users!
+     */
+    @Path("convertUserFromBcryptToSha1")
+    @POST
+    public Response convertUserFromBcryptToSha1(String json) {
+        JsonReader jsonReader = Json.createReader(new StringReader(json));
+        JsonObject object = jsonReader.readObject();
+        jsonReader.close();
+        BuiltinUser builtinUser  = builtinUserService.find(new Long(object.getInt("builtinUserId")));
+        builtinUser.updateEncryptedPassword("4G7xxL9z11/JKN4jHPn4g9iIQck=", 0); // password is "sha-1Pass", 0 means SHA-1
+        BuiltinUser savedUser = builtinUserService.save(builtinUser);
+        return okResponse("foo: " + savedUser);
     }
 
 }

--- a/src/test/java/edu/harvard/iq/dataverse/api/UsersIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/UsersIT.java
@@ -1,0 +1,80 @@
+package edu.harvard.iq.dataverse.api;
+
+import com.jayway.restassured.RestAssured;
+import static com.jayway.restassured.RestAssured.given;
+import com.jayway.restassured.http.ContentType;
+import com.jayway.restassured.response.Response;
+import java.util.UUID;
+import javax.json.Json;
+import javax.json.JsonObjectBuilder;
+import static javax.ws.rs.core.Response.Status.OK;
+import static junit.framework.Assert.assertEquals;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class UsersIT {
+
+    @BeforeClass
+    public static void setUp() {
+        RestAssured.baseURI = UtilIT.getRestAssuredBaseUri();
+    }
+
+    @Test
+    public void convertNonBcryptUserFromBuiltinToShib() {
+
+        Response createUserToConvert = UtilIT.createRandomUser();
+        createUserToConvert.prettyPrint();
+//
+        long AuthenticatedUserIdOfBcryptUserToConvert = createUserToConvert.body().jsonPath().getLong("data.authenticatedUser.id");
+        long BuiltinUserIdOfBcryptUserToConvert = createUserToConvert.body().jsonPath().getLong("data.user.id");
+        String emailOfNonBcryptUserToConvert = createUserToConvert.body().jsonPath().getString("data.user.email");
+        String usernameOfNonBcryptUserToConvert = UtilIT.getUsernameFromResponse(createUserToConvert);
+        System.out.println("usernameOfBcryptUserToConvert: " + usernameOfNonBcryptUserToConvert);
+        String newEmailAddressToUse = "builtin2shib." + UUID.randomUUID().toString().substring(0, 8) + "@mailinator.com";
+//        String password = "sha-1Pass";
+        String password = usernameOfNonBcryptUserToConvert;
+        Response convertToSha1 = convertUserFromBcryptToSha1(BuiltinUserIdOfBcryptUserToConvert, password);
+        convertToSha1.prettyPrint();
+        convertToSha1.then().assertThat()
+                .statusCode(OK.getStatusCode());
+
+        password = "sha-1Pass";
+        Response getApiTokenUsingUsername = getApiTokenUsingUsername(usernameOfNonBcryptUserToConvert, password);
+        assertEquals(200, getApiTokenUsingUsername.getStatusCode());
+
+        String data = emailOfNonBcryptUserToConvert + ":" + password + ":" + newEmailAddressToUse;
+        System.out.println("data: " + data);
+
+        Response createSuperuser = UtilIT.createRandomUser();
+        String superuserUsername = UtilIT.getUsernameFromResponse(createSuperuser);
+        String superuserApiToken = UtilIT.getApiTokenFromResponse(createSuperuser);
+        Response toggleSuperuser = UtilIT.makeSuperUser(superuserUsername);
+        toggleSuperuser.then().assertThat()
+                .statusCode(OK.getStatusCode());
+
+        Response makeShibUser = UtilIT.migrateBuiltinToShib(data, superuserApiToken);
+        makeShibUser.prettyPrint();
+        makeShibUser.then().assertThat()
+                .statusCode(OK.getStatusCode());
+
+    }
+
+    private Response getApiTokenUsingUsername(String username, String password) {
+        Response response = given()
+                .contentType(ContentType.JSON)
+                .get("/api/builtin-users/" + username + "/api-token?username=" + username + "&password=" + password);
+        return response;
+    }
+
+    private Response convertUserFromBcryptToSha1(long idOfBcryptUserToConvert, String password) {
+        JsonObjectBuilder data = Json.createObjectBuilder();
+        data.add("builtinUserId", idOfBcryptUserToConvert);
+        data.add("password", password);
+        Response response = given()
+                .contentType(ContentType.JSON)
+                .body(data.build().toString())
+                .post("/api/admin/convertUserFromBcryptToSha1");
+        return response;
+    }
+
+}


### PR DESCRIPTION
# RFI Checklist

### 1. Related Issues

- #3287 Upgraded (Bcrypt) password required for conversion from local to Shibboleth account 

---
### 2. Pull Request Checklist

- [x]  Functionality completed as described in FRD (no FRD)
- [x]  Dependencies, risks, assumptions in FRD addressed (no FRD)
- [x]  Unit tests completed (REST Assured tests)
- [x]  Deployment requirements identified (e.g., SQL scripts, indexing) (none)
- [x]  Documentation completed (none)
- [x]  All code checkins completed (none)

---
### 3. Review Checklist

_**After** the pull request has been submitted, fill out this section._

- [x]  Code review completed or waived
- [x]  Testing requirements completed
- [ ]  Usability testing completed or waived
- [ ]  Support testing completed or waived
- [ ]  Merged with develop branch and resolved conflicts

