### PR TITLE
Fix psql_exec commands to work with different passwords.

### DIFF
--- a/scripts/installer/install
+++ b/scripts/installer/install
@@ -807,7 +807,7 @@ else
 	print TMPCMD $sql_command;
 	close TMPCMD;
 	    
-	my $psql_commandline = $psql_exec . "/psql -h " . $CONFIG_DEFAULTS{'POSTGRES_SERVER'} . " -U postgres -d postgres -f /tmp/pgcmd.$$.tmp >/dev/null 2>&1";
+	my $psql_commandline = $psql_admin_exec . "/psql -h " . $CONFIG_DEFAULTS{'POSTGRES_SERVER'} . " -U postgres -d postgres -f /tmp/pgcmd.$$.tmp >/dev/null 2>&1";
 
 	my $out      = qx($psql_commandline 2>&1);
 	my $exitcode = $?;
@@ -829,8 +829,8 @@ else
     print "\nCreating Postgres database:\n";
     
     my $psql_command =
-	$psql_admin_exec
-	. "/createdb -h " . $CONFIG_DEFAULTS{'POSTGRES_SERVER'} . " -U postgres "
+	$psql_exec
+	. "/createdb -h " . $CONFIG_DEFAULTS{'POSTGRES_SERVER'} . " -U dvnapp "
 	. $CONFIG_DEFAULTS{'POSTGRES_DATABASE'}
         . " --owner="
 	. $CONFIG_DEFAULTS{'POSTGRES_USER'};

--- a/scripts/installer/install
+++ b/scripts/installer/install
@@ -830,7 +830,7 @@ else
     
     my $psql_command =
 	$psql_exec
-	. "/createdb -h " . $CONFIG_DEFAULTS{'POSTGRES_SERVER'} . " -U dvnapp "
+	. "/createdb -h " . $CONFIG_DEFAULTS{'POSTGRES_SERVER'} . " -U $CONFIG_DEFAULTS{'POSTGRES_USER'} "
 	. $CONFIG_DEFAULTS{'POSTGRES_DATABASE'}
         . " --owner="
 	. $CONFIG_DEFAULTS{'POSTGRES_USER'};


### PR DESCRIPTION
# RFI Checklist

### 1. Related Issues

- #3291 Install script fails if postgres master password and user password differ

---
### 2. Pull Request Checklist

- [ ]  Functionality completed as described in FRD
- [ ]  Dependencies, risks, assumptions in FRD addressed
- [ ]  Unit tests completed
- [ ]  Deployment requirements identified (e.g., SQL scripts, indexing)
- [ ]  Documentation completed
- [ ]  All code checkins completed

---
### 3. Review Checklist

_**After** the pull request has been submitted, fill out this section._

- [ ]  Code review completed or waived
- [ ]  Testing requirements completed
- [ ]  Usability testing completed or waived
- [ ]  Support testing completed or waived
- [ ]  Merged with develop branch and resolved conflicts

Connects to #3291. 