### PR TITLE
allow file add to datasets with exisiting files #3454

### DIFF
--- a/scripts/database/upgrades/3405-filemetadata-directory-label.sql
+++ b/scripts/database/upgrades/3405-filemetadata-directory-label.sql
@@ -1,1 +1,0 @@
-ALTER TABLE filemetadata ADD COLUMN directorylabel character varying(255);

--- a/scripts/database/upgrades/upgrade_v4.5.1_to_v4.6.sql
+++ b/scripts/database/upgrades/upgrade_v4.5.1_to_v4.6.sql
@@ -5,3 +5,4 @@ ALTER TABLE datafile ALTER COLUMN checksumtype SET NOT NULL;
 -- note that in the database we use "SHA1" (no hyphen) but the GUI will show "SHA-1"
 --UPDATE datafile SET checksumtype = 'SHA1';
 ALTER TABLE datafile RENAME md5 TO checksumvalue;
+ALTER TABLE filemetadata ADD COLUMN directorylabel character varying(255);

--- a/src/main/java/edu/harvard/iq/dataverse/FileMetadata.java
+++ b/src/main/java/edu/harvard/iq/dataverse/FileMetadata.java
@@ -46,7 +46,7 @@ public class FileMetadata implements Serializable {
     @Pattern(regexp="|[^/\\\\]|^[^/\\\\]+.*[^/\\\\]+$",
             message = "Directory Name cannot contain leading or trailing file separators.")
     @Column ( nullable=true )
-    private String directoryLabel = "";
+    private String directoryLabel;
     @Column(columnDefinition = "TEXT")
     private String description = "";
     

--- a/src/main/java/edu/harvard/iq/dataverse/ingest/IngestServiceBeanHelper.java
+++ b/src/main/java/edu/harvard/iq/dataverse/ingest/IngestServiceBeanHelper.java
@@ -59,8 +59,8 @@ public class IngestServiceBeanHelper {
             if (fm.getId() != null) {
                 String existingName = fm.getLabel();
                 String existingDir = fm.getDirectoryLabel();
-                // add file separator to end of any non-empty directory label
-                if (!existingDir.isEmpty()) {
+                // add file separator to end of any non-null, non-empty directory label
+                if (existingDir != null && !existingDir.isEmpty()) {
                     existingDir = existingDir + File.separator;
                 }
                 String existingPath = existingDir + existingName;
@@ -87,7 +87,7 @@ public class IngestServiceBeanHelper {
             FileMetadata fm = dfIt.next().getFileMetadata();
             String fileName = fm.getLabel();
             String dirName = fm.getDirectoryLabel();
-            if (!dirName.isEmpty()) {
+            if (dirName != null && !dirName.isEmpty()) {
                 dirName = dirName + File.separator;
             }
             String pathName = dirName + fileName;

--- a/src/test/java/edu/harvard/iq/dataverse/api/FileMetadataIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/FileMetadataIT.java
@@ -32,7 +32,7 @@ import org.junit.Test;
 import java.util.UUID;
 
 import static com.jayway.restassured.RestAssured.given;
-import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+import static javax.ws.rs.core.Response.Status.FORBIDDEN;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.fail;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -150,7 +150,8 @@ public class FileMetadataIT {
             shouldFailDueToLeadingAndTrailingSeparators.then().assertThat()
                     // Note that the JSON under test actually exercises leading too but only the first (trailing) is exercised here.
                     .body("message", equalTo("Validation failed: Directory Name cannot contain leading or trailing file separators. Invalid value: 'data/subdir1/'."))
-                    .statusCode(BAD_REQUEST.getStatusCode());
+                    // not sure why this changed from BAD_REQUEST to FORBIDDEN, perhaps the "API cleanup" at https://github.com/IQSS/dataverse/pull/3381
+                    .statusCode(FORBIDDEN.getStatusCode());
 
             // create dataset and set id
             dsId = given()


### PR DESCRIPTION
# RFI Checklist

### 1. Related Issues

- connects #3454 If a dataset had files in 4.5.1 and earlier, you can't add files after upgrading to develop

---
### 2. Pull Request Checklist

- [x]  Functionality completed as described in FRD
- [x]  Dependencies, risks, assumptions in FRD addressed
- [x]  Unit tests completed
- [x] API tests completed (had to fix a bug in FileMetadataIT)
- [x]  Deployment requirements identified (e.g., SQL scripts, indexing) (3354-alt-checksum.sql and 3405-filemetadata-directory-label.sql have been consolidated into upgrade_v4.5.1_to_v4.6.sql)
- [x]  Documentation completed
- [x]  All code checkins completed

---
### 3. Review Checklist

_**After** the pull request has been submitted, fill out this section._

- [ ]  Code review completed or waived
- [ ]  Testing requirements completed
- [ ]  Usability testing completed or waived
- [ ]  Support testing completed or waived
- [ ]  Merged with develop branch and resolved conflicts

Also, consolidate SQL upgrade scripts and persist nulls rather than
empty strings for directoryLabel.