### PR TITLE
API for getting metadata blocks works again.

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/api/Dataverses.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Dataverses.java
@@ -256,10 +256,16 @@ public class Dataverses extends AbstractApiBean {
 	@GET
 	@Path("{identifier}/metadatablocks")
 	public Response listMetadataBlocks( @PathParam("identifier") String dvIdtf ) {
-        return response( req ->ok(
-                execCommand( new ListMetadataBlocksCommand(req, findDataverseOrDie(dvIdtf)))
-                .stream().map(brief::json).collect( toJsonArray() )
-        ));
+        try {
+            JsonArrayBuilder arr = Json.createArrayBuilder();
+            final List<MetadataBlock> blocks = execCommand( new ListMetadataBlocksCommand(createDataverseRequest(findUserOrDie()), findDataverseOrDie(dvIdtf)));
+            for ( MetadataBlock mdb : blocks) {
+                arr.add( brief.json(mdb) );
+            }
+            return ok(arr);
+        } catch (WrappedResponse we ){
+            return we.getResponse();
+        }
 	}
 	
     @POST


### PR DESCRIPTION
# RFI Checklist

_**Before** submitting the pull request, fill out sections (1.) Related Issues and (2.) Pull Request Checklist._

### 1. Related Issues

* [3425 API: Get metadablocks returns empty set in 4.6, worked in 4.5.1.](https://github.com/IQSS/dataverse/issues/3425)

---
### 2. Pull Request Checklist

- [x]  Functionality completed as described in FRD
- [ ]  Dependencies, risks, assumptions in FRD addressed
- [ ]  Unit tests completed
- [ ]  Deployment requirements identified (e.g., SQL scripts, indexing)
- [ ]  Documentation completed
- [ ]  All code checkins completed

---
### 3. Review Checklist

_**After** the pull request has been submitted, fill out this section._

- [ ]  Code review completed or waived
- [ ]  Testing requirements completed
- [ ]  Usability testing completed or waived
- [ ]  Support testing completed or waived
- [ ]  Merged with develop branch and resolved conflicts

connects to #3425