### PR TITLE
#3505 - Fix permissions gathering for Dataset Page

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/FileDownloadHelper.java
+++ b/src/main/java/edu/harvard/iq/dataverse/FileDownloadHelper.java
@@ -32,7 +32,7 @@ public class FileDownloadHelper implements java.io.Serializable {
 
     
     private final Map<Long, Boolean> fileDownloadPermissionMap = new HashMap<>(); // { FileMetadata.id : Boolean } 
-    private final Map<String, Boolean> datasetPermissionMap = new HashMap<>(); // { Permission human_name : Boolean }
+
 
     
     
@@ -169,24 +169,8 @@ public class FileDownloadHelper implements java.io.Serializable {
             return false;
         }
         
-        
-               
-        String permName = permissionToCheck.getHumanName();
-       
-        // Has this check already been done? 
-        // 
-        if (this.datasetPermissionMap.containsKey(permName)){
-            // Yes, return previous answer
-            return this.datasetPermissionMap.get(permName);
-        }
-        
-        // Check the permission
-        //
         boolean hasPermission = this.permissionService.userOn(this.session.getUser(), objectToCheck).has(permissionToCheck);
-
-        // Save the permission
-        this.datasetPermissionMap.put(permName, hasPermission);
-        
+       
         // return true/false
         return hasPermission;
     }

--- a/src/main/webapp/filesFragment.xhtml
+++ b/src/main/webapp/filesFragment.xhtml
@@ -212,10 +212,10 @@
                 </ui:fragment>
 
                 <!-- Restricted File Icon -->
-                <div class="file-icon-restricted-block" jsf:rendered="#{fileMetadata.restricted and ((empty fileMetadata.dataFile.id) or !(fileDownloadHelper.canDownloadFile(fileMetadata)) )}">
+                <div class="file-icon-restricted-block" jsf:rendered="#{fileMetadata.restricted and !fileDownloadHelper.canDownloadFile(fileMetadata)}">                  
                     <span class="glyphicon glyphicon-lock text-danger"/>
                 </div>
-                <div class="file-icon-restricted-block" jsf:rendered="#{!(empty fileMetadata.dataFile.id) and fileMetadata.restricted and fileDownloadHelper.canDownloadFile(fileMetadata) }">
+                <div class="file-icon-restricted-block" jsf:rendered="#{fileMetadata.restricted and fileDownloadHelper.canDownloadFile(fileMetadata) }">
                     <span class="icon-unlock text-success"/>
                 </div>
             </div>


### PR DESCRIPTION
# RFI Checklist

_**Before** submitting the pull request, fill out sections (1.) Related Issues and (2.) Pull Request Checklist._

### 1. Related Issues

_List and [link](https://guides.github.com/features/issues/#notifications) to the issues in this Pull Request._

- [3505 + Restricting a second file after granting access to first shows open lock and removes req access button on second]

---
### 2. Pull Request Checklist

- [X]  Functionality completed as described in FRD
- [NA]  Dependencies, risks, assumptions in FRD addressed
- [NA]  Unit tests completed
- [NA]  Deployment requirements identified (e.g., SQL scripts, indexing)
- [NA]  Documentation completed
- [X]  All code checkins completed

---
### 3. Review Checklist

_**After** the pull request has been submitted, fill out this section._

- [X]  Code review completed or waived
- [ ]  Testing requirements completed
- [ ]  Usability testing completed or waived
- [ ]  Support testing completed or waived
- [ ]  Merged with develop branch and resolved conflicts

Connects to #3505.
