### PR TITLE
show URL for file on file landing page #3584

### DIFF
--- a/src/main/java/Bundle.properties
+++ b/src/main/java/Bundle.properties
@@ -1500,6 +1500,9 @@ file.metadataTab.fitsMetadata.header=FITS Metadata
 file.metadataTab.provenance.header=File Provenance
 file.metadataTab.provenance.body=File Provenance information coming in a later release...
 
+file.downloadUrl.label=Download URL
+file.downloadUrl.notPublic=This file cannot be downloaded publicly.
+
 # editdatafile.xhtml
 
 # editFilesFragment.xhtml

--- a/src/main/java/Bundle.properties
+++ b/src/main/java/Bundle.properties
@@ -1490,6 +1490,7 @@ file.lastupdated.label=Last Updated
 
 file.metadataTab.fileMetadata.header=File Metadata
 file.metadataTab.fileMetadata.persistentid.label=Data File Persistent ID
+file.metadataTab.fileMetadata.downloadUrl.label=Download URL
 file.metadataTab.fileMetadata.unf.label=UNF
 file.metadataTab.fileMetadata.size.label=Size
 file.metadataTab.fileMetadata.type.label=Type
@@ -1499,9 +1500,6 @@ file.metadataTab.fileMetadata.depositDate.label=Deposit Date
 file.metadataTab.fitsMetadata.header=FITS Metadata
 file.metadataTab.provenance.header=File Provenance
 file.metadataTab.provenance.body=File Provenance information coming in a later release...
-
-file.downloadUrl.label=Download URL
-file.downloadUrl.notPublic=This file cannot be downloaded publicly.
 
 # editdatafile.xhtml
 

--- a/src/main/java/edu/harvard/iq/dataverse/Dataset.java
+++ b/src/main/java/edu/harvard/iq/dataverse/Dataset.java
@@ -328,10 +328,14 @@ public class Dataset extends DvObjectContainer {
         }
     }
 
- public DatasetVersion getCreateVersion() {
+    /**
+     * @todo Investigate if this method should be deprecated in favor of
+     * createNewDatasetVersion.
+     */
+    public DatasetVersion getCreateVersion() {
         DatasetVersion dsv = new DatasetVersion();
         dsv.setVersionState(DatasetVersion.VersionState.DRAFT);
-        dsv.setDataset(this);        
+        dsv.setDataset(this);
         dsv.initDefaultValues();
         this.setVersions(new ArrayList());
         getVersions().add(0, dsv);

--- a/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
@@ -3311,7 +3311,7 @@ public class DatasetPage implements java.io.Serializable {
     }
 
     public boolean isDownloadPopupRequired() {
-        return fileDownloadService.isDownloadPopupRequired(workingVersion);
+        return FileUtil.isDownloadPopupRequired(workingVersion);
     }
     
        public String requestAccessMultipleFiles(String fileIdString) {

--- a/src/main/java/edu/harvard/iq/dataverse/DatasetVersion.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetVersion.java
@@ -444,7 +444,7 @@ public class DatasetVersion implements Serializable {
     }
 
     public boolean isReleased() {
-        return versionState.equals(VersionState.RELEASED);
+        return versionState != null && versionState.equals(VersionState.RELEASED);
     }
 
     public boolean isDraft() {

--- a/src/main/java/edu/harvard/iq/dataverse/DatasetVersion.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetVersion.java
@@ -131,6 +131,11 @@ public class DatasetVersion implements Serializable {
     @Column(length = VERSION_NOTE_MAX_LENGTH)
     private String versionNote;
     
+    /**
+     * @todo versionState should never be null so when we are ready, uncomment
+     * the `nullable = false` below.
+     */
+//    @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     private VersionState versionState;
 
@@ -444,7 +449,7 @@ public class DatasetVersion implements Serializable {
     }
 
     public boolean isReleased() {
-        return versionState != null && versionState.equals(VersionState.RELEASED);
+        return versionState.equals(VersionState.RELEASED);
     }
 
     public boolean isDraft() {

--- a/src/main/java/edu/harvard/iq/dataverse/FileDownloadServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/FileDownloadServiceBean.java
@@ -120,42 +120,15 @@ public class FileDownloadServiceBean implements java.io.Serializable {
 
         //return fileDownloadUrl;
     }
-    
-    //private String callDownloadServlet( String downloadType, Long fileId){
-    public void callDownloadServlet( String downloadType, Long fileId, Boolean gbRecordsWritten){
-        
-        String fileDownloadUrl = "/api/access/datafile/" + fileId;
-                    
-        if (downloadType != null && downloadType.equals("bundle")){
-            fileDownloadUrl = "/api/access/datafile/bundle/" + fileId;
-        }
-        if (downloadType != null && downloadType.equals("original")){
-            fileDownloadUrl = "/api/access/datafile/" + fileId + "?format=original";
-        }
-        if (downloadType != null && downloadType.equals("RData")){
-            fileDownloadUrl = "/api/access/datafile/" + fileId + "?format=RData";
-        }
-        if (downloadType != null && downloadType.equals("var")){
-            fileDownloadUrl = "/api/meta/datafile/" + fileId;
-        }
-        if (downloadType != null && downloadType.equals("tab")){
-            fileDownloadUrl = "/api/access/datafile/" + fileId+ "?format=tab";
-        }
-        if (gbRecordsWritten){
-            if(downloadType != null && ( downloadType.equals("original") || downloadType.equals("RData") || downloadType.equals("tab")) ){
-                fileDownloadUrl += "&gbrecs=true"; 
-            } else {
-                fileDownloadUrl += "?gbrecs=true"; 
-            }
-           
-        }
-        logger.fine("Returning file download url: " + fileDownloadUrl);
+
+    public void callDownloadServlet(String downloadType, Long fileId, boolean gbRecordsWritten) {
+        String fileDownloadUrl = FileUtil.getFileDownloadUrlPath(downloadType, fileId, gbRecordsWritten);
+        logger.fine("Redirecting to file download url: " + fileDownloadUrl);
         try {
             FacesContext.getCurrentInstance().getExternalContext().redirect(fileDownloadUrl);
         } catch (IOException ex) {
-            logger.info("Failed to issue a redirect to file download url.");
+            logger.info("Failed to issue a redirect to file download url (" + fileDownloadUrl + "): " + ex);
         }
-        //return fileDownloadUrl;       
     }
     
         //public String startFileDownload(FileMetadata fileMetadata, String format) {
@@ -229,39 +202,7 @@ public class FileDownloadServiceBean implements java.io.Serializable {
         }
         return retVal;
     }
-          
-    public boolean isDownloadPopupRequired(DatasetVersion datasetVersion) {
-        // Each of these conditions is sufficient reason to have to 
-        // present the user with the popup: 
-        if (datasetVersion == null){
-            return false;
-        }
-        //0. if version is draft then Popup "not required"    
-        if (!datasetVersion.isReleased()){
-            return false;
-        }
-        // 1. License and Terms of Use:
-        if (datasetVersion.getTermsOfUseAndAccess() != null) {
-            if (!TermsOfUseAndAccess.License.CC0.equals(datasetVersion.getTermsOfUseAndAccess().getLicense())
-                    && !(datasetVersion.getTermsOfUseAndAccess().getTermsOfUse() == null
-                    || datasetVersion.getTermsOfUseAndAccess().getTermsOfUse().equals(""))) {
-                return true;
-            }
 
-            // 2. Terms of Access:
-            if (!(datasetVersion.getTermsOfUseAndAccess().getTermsOfAccess() == null) && !datasetVersion.getTermsOfUseAndAccess().getTermsOfAccess().equals("")) {
-                return true;
-            }
-        }
-
-        // 3. Guest Book: 
-        if (datasetVersion.getDataset().getGuestbook() != null && datasetVersion.getDataset().getGuestbook().isEnabled() && datasetVersion.getDataset().getGuestbook().getDataverse() != null ) {
-            return true;
-        }
-
-        return false;
-    }
-    
     public Boolean canSeeTwoRavensExploreButton(){
         return false;
     }

--- a/src/main/java/edu/harvard/iq/dataverse/FilePage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/FilePage.java
@@ -19,6 +19,7 @@ import edu.harvard.iq.dataverse.export.ExportException;
 import edu.harvard.iq.dataverse.export.ExportService;
 import edu.harvard.iq.dataverse.export.spi.Exporter;
 import edu.harvard.iq.dataverse.settings.SettingsServiceBean;
+import edu.harvard.iq.dataverse.util.FileUtil;
 import edu.harvard.iq.dataverse.util.JsfHelper;
 import static edu.harvard.iq.dataverse.util.JsfHelper.JH;
 import edu.harvard.iq.dataverse.util.SystemConfig;
@@ -91,6 +92,8 @@ public class FilePage implements java.io.Serializable {
     TwoRavensHelper twoRavensHelper;
     @Inject WorldMapPermissionHelper worldMapPermissionHelper;
 
+    private static final Logger logger = Logger.getLogger(FilePage.class.getCanonicalName());
+
     public String init() {
      
         
@@ -157,7 +160,7 @@ public class FilePage implements java.io.Serializable {
         if(fileMetadata.getId() == null || fileMetadata.getDatasetVersion().getId() == null ){
             return false;
         }
-        return fileDownloadService.isDownloadPopupRequired(fileMetadata.getDatasetVersion());
+        return FileUtil.isDownloadPopupRequired(fileMetadata.getDatasetVersion());
     }
 
 
@@ -448,5 +451,13 @@ public class FilePage implements java.io.Serializable {
    
         return this.datafileService.isReplacementFile(this.getFile());
     }
-        
+
+    public boolean isPubliclyDownloadable() {
+        return FileUtil.isPubliclyDownloadable(fileMetadata);
+    }
+
+    public String getPublicDownloadUrl() {
+        return FileUtil.getPublicDownloadUrl(systemConfig.getDataverseSiteUrl(), fileId);
+    }
+
 }

--- a/src/main/java/edu/harvard/iq/dataverse/util/FileUtil.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/FileUtil.java
@@ -1241,10 +1241,6 @@ public class FileUtil implements java.io.Serializable  {
     }
 
     public static String getFileDownloadUrlPath(String downloadType, Long fileId, boolean gbRecordsWritten) {
-        /**
-         * @todo What happens when we bump the API version to v1.1 or v2? See
-         * also https://github.com/IQSS/dataverse/issues/3325
-         */
         String fileDownloadUrl = "/api/access/datafile/" + fileId;
         if (downloadType != null && downloadType.equals("bundle")) {
             fileDownloadUrl = "/api/access/datafile/bundle/" + fileId;

--- a/src/main/java/edu/harvard/iq/dataverse/util/FileUtil.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/FileUtil.java
@@ -1235,6 +1235,28 @@ public class FileUtil implements java.io.Serializable  {
         }
         boolean popupReasons = isDownloadPopupRequired(fileMetadata.getDatasetVersion());
         if (popupReasons == true) {
+            /**
+             * @todo The user clicking publish may have a bad "Dude, where did
+             * the file Download URL go" experience in the following scenario:
+             *
+             * - The user creates a dataset and uploads a file.
+             *
+             * - The user sets Terms of Use, which means a Download URL should
+             * not be displayed.
+             *
+             * - While the dataset is in draft, the Download URL is displayed
+             * due to the rule "Download popup required because datasetVersion
+             * has not been released."
+             *
+             * - Once the dataset is published the Download URL disappears due
+             * to the rule "Download popup required because of license or terms
+             * of use."
+             *
+             * In short, the Download URL disappears on publish in the scenario
+             * above, which is weird. We should probably attempt to see into the
+             * future to when the dataset is published to see if the file will
+             * be publicly downloadable or not.
+             */
             return false;
         }
         return true;

--- a/src/main/webapp/file.xhtml
+++ b/src/main/webapp/file.xhtml
@@ -219,33 +219,10 @@
                             </div>
                             <div id="fileMetadataBlock" class="col-xs-12">
                                 <div class="text-muted">
-                                    <div id="debugPopupAndDownloadUrl" style="background-color: lightgray" jsf:rendered="#{false}">
-                                        - license: #{FilePage.fileMetadata.datasetVersion.termsOfUseAndAccess.license}<br/>
-                                        - terms of use: #{FilePage.fileMetadata.datasetVersion.termsOfUseAndAccess.termsOfUse}<br/>
-                                        - terms of access: #{FilePage.fileMetadata.datasetVersion.termsOfUseAndAccess.termsOfAccess}<br/>
-                                        - guestbook name: #{FilePage.file.owner.guestbook.name}<br/>
-                                        - restricted: #{FilePage.fileMetadata.restricted}<br/>
-                                    </div>
-                                    <div id="file-public-download-url" jsf:rendered="#{FilePage.publiclyDownloadable}">
-                                        <h:outputText value="#{bundle['file.downloadUrl.label']}: "/>
-                                        <h:outputLink value="#{FilePage.publicDownloadUrl}">
-                                            <h:outputText value="#{FilePage.publicDownloadUrl}"/>
-                                        </h:outputLink>
-                                    <br/>
-                                    </div>
-                                    <div id="file-public-download-url" jsf:rendered="#{!FilePage.publiclyDownloadable}">
-                                        <h:outputText value="#{bundle['file.downloadUrl.label']}: "/>
-                                        <h:outputText value="#{bundle['file.downloadUrl.notPublic']}"/>
-                                    <br/>
-                                    </div>
                                     <h:outputText id="fileTypeOutputRegular" value="#{FilePage.fileMetadata.dataFile.friendlyType}" rendered="#{!(FilePage.fileMetadata.dataFile.tabularData)}"/>
                                     <h:outputText id="fileTypeOutputTabular" value="#{bundle['file.type.tabularData']}" rendered="#{FilePage.fileMetadata.dataFile.tabularData}"/>
                                     <h:outputText id="fileSize" value=" - #{FilePage.fileMetadata.dataFile.friendlySize}" />
-                                    
-                                    
                                     <h:outputText id="fileCreatePublishDate" value=" - #{bundle['file.lastupdated.label']}: #{FilePage.fileMetadata.fileDateToDisplay}" rendered="#{!(empty FilePage.fileMetadata.id)}"/>
-                                    
-                                    
                                     <div class="checksum-block" jsf:rendered="#{!FilePage.file.tabularData}">
                                         <h:outputText id="file-checksum" value="#{FilePage.file.tabularData ? FilePage.file.originalChecksumType : FilePage.file.checksumType}: #{FilePage.file.checksumValue}"
                                                       rendered="#{!(empty FilePage.file.checksumValue)}"/>
@@ -255,14 +232,6 @@
                                         <h:outputText id="fileNumObs" value="#{FilePage.file.dataTable.caseQuantity} #{bundle['file.metaData.dataFile.dataTab.observations']} #{!empty FilePage.file.unf ? ' - ' : ''}" rendered="#{FilePage.file.tabularData}"/>
                                         <h:outputText id="fileUNF" value="#{FilePage.file.unf}" rendered="#{!empty FilePage.file.unf}"/>
                                     </div>
-                                    
-                                    <!-- for dev/debugging purposes 
-                                    SEK TODO How do we want to indicate that a file is a replacement? -->
-                                    <ui:fragment rendered="#{false}">
-                                    <div>
-                                         <span class="label label-info">This is a Replacement File</span>
-                                    </div>
-                                    </ui:fragment>
                                 </div>
                             </div>
                             <div id="fileDescriptionBlock" class="col-xs-12" jsf:rendered="#{!empty FilePage.fileMetadata.description}">
@@ -325,6 +294,16 @@
                                     </div>
                                     <div id="panelCollapseFMD" class="collapse in">
                                         <div class="panel-body">
+                                            <div class="form-group" jsf:rendered="#{FilePage.publiclyDownloadable}">
+                                                <label class="col-sm-3 control-label">                                                   
+                                                   #{bundle['file.metadataTab.fileMetadata.downloadUrl.label']}
+                                                </label>
+                                                <div class="col-sm-9">
+                                                    <a href="#{FilePage.publicDownloadUrl}">
+                                                        <h:outputText value="#{FilePage.publicDownloadUrl}"/>
+                                                    </a>
+                                                </div>
+                                            </div>
                                             <div class="form-group" jsf:rendered="#{!(empty FilePage.file.checksumValue)}">
                                                 <label class="col-sm-3 control-label">                                                   
                                                    #{FilePage.file.tabularData ? FilePage.file.originalChecksumType : FilePage.file.checksumType}
@@ -341,8 +320,6 @@
                                                     <h:outputText value="#{FilePage.file.unf}"/>
                                                 </div>
                                             </div>
-                                            
-                                            
                                             <div class="form-group" jsf:rendered="#{FilePage.file.released}">
                                                 <label class="col-sm-3 control-label">
                                                    #{bundle['file.metadataTab.fileMetadata.publicationDate.label']}
@@ -351,8 +328,6 @@
                                                     <h:outputText value="#{FilePage.file.publicationDateFormattedYYYYMMDD}"/>
                                                 </div>
                                             </div>
-                                            
-                                            
                                             <div class="form-group" jsf:rendered="#{!(empty FilePage.file.friendlySize)}">
                                                 <label class="col-sm-3 control-label">
                                                    #{bundle['file.metadataTab.fileMetadata.size.label']}
@@ -393,8 +368,6 @@
                                                     <h:outputText value="#{FilePage.fileMetadata.description}"/>
                                                 </div>
                                             </div>
-                                            
-                                            
                                             <div class="form-group">
                                                 <label class="col-sm-3 control-label">
                                                    #{bundle['file.metadataTab.fileMetadata.depositDate.label']}
@@ -403,8 +376,6 @@
                                                     <h:outputText value="#{FilePage.file.createDateFormattedYYYYMMDD}"/> 
                                                 </div>
                                             </div>
-                                            
-                                            
                                         </div>
                                     </div>
                                 </div>

--- a/src/main/webapp/file.xhtml
+++ b/src/main/webapp/file.xhtml
@@ -219,6 +219,25 @@
                             </div>
                             <div id="fileMetadataBlock" class="col-xs-12">
                                 <div class="text-muted">
+                                    <div id="debugPopupAndDownloadUrl" style="background-color: lightgray" jsf:rendered="#{false}">
+                                        - license: #{FilePage.fileMetadata.datasetVersion.termsOfUseAndAccess.license}<br/>
+                                        - terms of use: #{FilePage.fileMetadata.datasetVersion.termsOfUseAndAccess.termsOfUse}<br/>
+                                        - terms of access: #{FilePage.fileMetadata.datasetVersion.termsOfUseAndAccess.termsOfAccess}<br/>
+                                        - guestbook name: #{FilePage.file.owner.guestbook.name}<br/>
+                                        - restricted: #{FilePage.fileMetadata.restricted}<br/>
+                                    </div>
+                                    <div id="file-public-download-url" jsf:rendered="#{FilePage.publiclyDownloadable}">
+                                        <h:outputText value="#{bundle['file.downloadUrl.label']}: "/>
+                                        <h:outputLink value="#{FilePage.publicDownloadUrl}">
+                                            <h:outputText value="#{FilePage.publicDownloadUrl}"/>
+                                        </h:outputLink>
+                                    <br/>
+                                    </div>
+                                    <div id="file-public-download-url" jsf:rendered="#{!FilePage.publiclyDownloadable}">
+                                        <h:outputText value="#{bundle['file.downloadUrl.label']}: "/>
+                                        <h:outputText value="#{bundle['file.downloadUrl.notPublic']}"/>
+                                    <br/>
+                                    </div>
                                     <h:outputText id="fileTypeOutputRegular" value="#{FilePage.fileMetadata.dataFile.friendlyType}" rendered="#{!(FilePage.fileMetadata.dataFile.tabularData)}"/>
                                     <h:outputText id="fileTypeOutputTabular" value="#{bundle['file.type.tabularData']}" rendered="#{FilePage.fileMetadata.dataFile.tabularData}"/>
                                     <h:outputText id="fileSize" value=" - #{FilePage.fileMetadata.dataFile.friendlySize}" />

--- a/src/test/java/edu/harvard/iq/dataverse/api/FilesIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/FilesIT.java
@@ -469,7 +469,7 @@ public class FilesIT {
                 .statusCode(OK.getStatusCode());
 
         // give file time to ingest
-        sleep(1000);
+        sleep(10000);
 
         Response publishDatasetResp = UtilIT.publishDatasetViaNativeApi(datasetId, "major", apiToken);
         publishDatasetResp.prettyPrint();

--- a/src/test/java/edu/harvard/iq/dataverse/util/FileUtilTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/util/FileUtilTest.java
@@ -36,15 +36,10 @@ public class FileUtilTest {
     }
 
     @Test
-    public void testIsDownloadPopupRequiredNoPopup() {
-        DatasetVersion dsv1 = new DatasetVersion();
-        assertEquals(false, FileUtil.isDownloadPopupRequired(dsv1));
-    }
-
-    @Test
     public void testIsDownloadPopupRequiredDraft() {
-        DatasetVersion dsv1 = new DatasetVersion();
-        dsv1.setVersionState(DatasetVersion.VersionState.DRAFT);
+        Dataset dataset = new Dataset();
+        DatasetVersion dsv1 = dataset.getEditVersion();
+        assertEquals(DatasetVersion.VersionState.DRAFT, dsv1.getVersionState());
         assertEquals(false, FileUtil.isDownloadPopupRequired(dsv1));
     }
 

--- a/src/test/java/edu/harvard/iq/dataverse/util/FileUtilTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/util/FileUtilTest.java
@@ -1,6 +1,11 @@
 package edu.harvard.iq.dataverse.util;
 
+import edu.harvard.iq.dataverse.Dataset;
+import edu.harvard.iq.dataverse.DatasetVersion;
+import edu.harvard.iq.dataverse.Dataverse;
 import edu.harvard.iq.dataverse.FileMetadata;
+import edu.harvard.iq.dataverse.Guestbook;
+import edu.harvard.iq.dataverse.TermsOfUseAndAccess;
 import static org.junit.Assert.assertEquals;
 import org.junit.Test;
 
@@ -23,6 +28,139 @@ public class FileUtilTest {
         assertEquals("50by1000-endnote.xml", FileUtil.getCiteDataFileFilename(tabular, FileUtil.FileCitationExtension.ENDNOTE));
         assertEquals("50by1000.ris", FileUtil.getCiteDataFileFilename(tabular, FileUtil.FileCitationExtension.RIS));
         assertEquals("50by1000.bib", FileUtil.getCiteDataFileFilename(tabular, FileUtil.FileCitationExtension.BIBTEX));
+    }
+
+    @Test
+    public void testIsDownloadPopupRequiredNull() {
+        assertEquals(false, FileUtil.isDownloadPopupRequired(null));
+    }
+
+    @Test
+    public void testIsDownloadPopupRequiredNoPopup() {
+        DatasetVersion dsv1 = new DatasetVersion();
+        assertEquals(false, FileUtil.isDownloadPopupRequired(dsv1));
+    }
+
+    @Test
+    public void testIsDownloadPopupRequiredDraft() {
+        DatasetVersion dsv1 = new DatasetVersion();
+        dsv1.setVersionState(DatasetVersion.VersionState.DRAFT);
+        assertEquals(false, FileUtil.isDownloadPopupRequired(dsv1));
+    }
+
+    @Test
+    public void testIsDownloadPopupRequiredLicenseCC0() {
+        DatasetVersion dsv1 = new DatasetVersion();
+        dsv1.setVersionState(DatasetVersion.VersionState.RELEASED);
+        TermsOfUseAndAccess termsOfUseAndAccess = new TermsOfUseAndAccess();
+        termsOfUseAndAccess.setLicense(TermsOfUseAndAccess.License.CC0);
+        dsv1.setTermsOfUseAndAccess(termsOfUseAndAccess);
+        assertEquals(false, FileUtil.isDownloadPopupRequired(dsv1));
+    }
+
+    @Test
+    public void testIsDownloadPopupRequiredHasTermsOfUseAndCc0License() {
+        DatasetVersion dsv1 = new DatasetVersion();
+        dsv1.setVersionState(DatasetVersion.VersionState.RELEASED);
+        TermsOfUseAndAccess termsOfUseAndAccess = new TermsOfUseAndAccess();
+        /**
+         * @todo Ask if setting the license to CC0 should be enough to not show
+         * the popup when the are Terms of Use. This feels like a bug since the
+         * Terms of Use should probably be shown.
+         */
+        termsOfUseAndAccess.setLicense(TermsOfUseAndAccess.License.CC0);
+        termsOfUseAndAccess.setTermsOfUse("be excellent to each other");
+        dsv1.setTermsOfUseAndAccess(termsOfUseAndAccess);
+        assertEquals(false, FileUtil.isDownloadPopupRequired(dsv1));
+    }
+
+    @Test
+    public void testIsDownloadPopupRequiredHasTermsOfUseAndNoneLicense() {
+        DatasetVersion dsv1 = new DatasetVersion();
+        dsv1.setVersionState(DatasetVersion.VersionState.RELEASED);
+        TermsOfUseAndAccess termsOfUseAndAccess = new TermsOfUseAndAccess();
+        termsOfUseAndAccess.setLicense(TermsOfUseAndAccess.License.NONE);
+        termsOfUseAndAccess.setTermsOfUse("be excellent to each other");
+        dsv1.setTermsOfUseAndAccess(termsOfUseAndAccess);
+        assertEquals(true, FileUtil.isDownloadPopupRequired(dsv1));
+    }
+
+    @Test
+    public void testIsDownloadPopupRequiredHasTermsOfAccess() {
+        DatasetVersion dsv1 = new DatasetVersion();
+        dsv1.setVersionState(DatasetVersion.VersionState.RELEASED);
+        TermsOfUseAndAccess termsOfUseAndAccess = new TermsOfUseAndAccess();
+        termsOfUseAndAccess.setTermsOfAccess("Terms of *Access* is different than Terms of Use");
+        dsv1.setTermsOfUseAndAccess(termsOfUseAndAccess);
+        assertEquals(true, FileUtil.isDownloadPopupRequired(dsv1));
+    }
+
+    @Test
+    public void testIsDownloadPopupRequiredHasGuestBook() {
+        DatasetVersion datasetVersion = new DatasetVersion();
+        datasetVersion.setVersionState(DatasetVersion.VersionState.RELEASED);
+        Dataset dataset = new Dataset();
+        datasetVersion.setDataset(dataset);
+        Guestbook guestbook = new Guestbook();
+        guestbook.setEnabled(true);
+        dataset.setGuestbook(guestbook);
+        Dataverse dataverse = new Dataverse();
+        guestbook.setDataverse(dataverse);
+        assertEquals(true, FileUtil.isDownloadPopupRequired(datasetVersion));
+    }
+
+    @Test
+    public void testIsPubliclyDownloadable() {
+        assertEquals(false, FileUtil.isPubliclyDownloadable(null));
+
+        FileMetadata restrictedFileMetadata = new FileMetadata();
+        restrictedFileMetadata.setRestricted(true);
+        assertEquals(false, FileUtil.isPubliclyDownloadable(restrictedFileMetadata));
+
+        FileMetadata nonRestrictedFileMetadata = new FileMetadata();
+        DatasetVersion dsv = new DatasetVersion();
+        dsv.setVersionState(DatasetVersion.VersionState.RELEASED);
+        nonRestrictedFileMetadata.setDatasetVersion(dsv);
+        Dataset dataset = new Dataset();
+        dsv.setDataset(dataset);
+        nonRestrictedFileMetadata.setRestricted(false);
+        assertEquals(true, FileUtil.isPubliclyDownloadable(nonRestrictedFileMetadata));
+    }
+
+    @Test
+    public void testIsPubliclyDownloadable2() {
+
+        FileMetadata nonRestrictedFileMetadata = new FileMetadata();
+        DatasetVersion dsv = new DatasetVersion();
+        TermsOfUseAndAccess termsOfUseAndAccess = new TermsOfUseAndAccess();
+        termsOfUseAndAccess.setTermsOfUse("be excellent to each other");
+        dsv.setTermsOfUseAndAccess(termsOfUseAndAccess);
+        dsv.setVersionState(DatasetVersion.VersionState.RELEASED);
+        nonRestrictedFileMetadata.setDatasetVersion(dsv);
+        Dataset dataset = new Dataset();
+        dsv.setDataset(dataset);
+        nonRestrictedFileMetadata.setRestricted(false);
+        assertEquals(false, FileUtil.isPubliclyDownloadable(nonRestrictedFileMetadata));
+    }
+
+    @Test
+    public void testgetFileDownloadUrl() {
+        Long fileId = 42l;
+        assertEquals("/api/access/datafile/42", FileUtil.getFileDownloadUrlPath(null, fileId, false));
+        assertEquals("/api/access/datafile/42", FileUtil.getFileDownloadUrlPath("", fileId, false));
+        assertEquals("/api/access/datafile/bundle/42", FileUtil.getFileDownloadUrlPath("bundle", fileId, false));
+        assertEquals("/api/access/datafile/42?format=original", FileUtil.getFileDownloadUrlPath("original", fileId, false));
+        assertEquals("/api/access/datafile/42?format=RData", FileUtil.getFileDownloadUrlPath("RData", fileId, false));
+        assertEquals("/api/meta/datafile/42", FileUtil.getFileDownloadUrlPath("var", fileId, false));
+        assertEquals("/api/access/datafile/42?format=tab", FileUtil.getFileDownloadUrlPath("tab", fileId, false));
+        assertEquals("/api/access/datafile/42?format=tab&gbrecs=true", FileUtil.getFileDownloadUrlPath("tab", fileId, true));
+        assertEquals("/api/access/datafile/42?gbrecs=true", FileUtil.getFileDownloadUrlPath(null, fileId, true));
+    }
+
+    @Test
+    public void testGetPublicDownloadUrl() {
+        assertEquals(null, FileUtil.getPublicDownloadUrl(null, null));
+        assertEquals("https://demo.dataverse.org/api/access/datafile/42", FileUtil.getPublicDownloadUrl("https://demo.dataverse.org", 42l));
     }
 
 }

--- a/src/test/java/edu/harvard/iq/dataverse/util/FileUtilTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/util/FileUtilTest.java
@@ -158,4 +158,16 @@ public class FileUtilTest {
         assertEquals("https://demo.dataverse.org/api/access/datafile/42", FileUtil.getPublicDownloadUrl("https://demo.dataverse.org", 42l));
     }
 
+    @Test
+    public void testGenerateOriginalExtension() {
+        assertEquals("", FileUtil.generateOriginalExtension("foo"));
+        // uh-oh, NullPointerException
+//        assertEquals("", FileUtil.generateOriginalExtension(null));
+        assertEquals(".sav", FileUtil.generateOriginalExtension("application/x-spss-sav"));
+        assertEquals(".por", FileUtil.generateOriginalExtension("application/x-spss-por"));
+        assertEquals(".dta", FileUtil.generateOriginalExtension("application/x-stata"));
+        assertEquals(".RData", FileUtil.generateOriginalExtension("application/x-rlang-transport"));
+        assertEquals(".csv", FileUtil.generateOriginalExtension("text/csv"));
+        assertEquals(".xlsx", FileUtil.generateOriginalExtension("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"));
+    }
 }


### PR DESCRIPTION
Refactor `isDownloadPopupRequired` and `callDownloadServlet` to make
them testable.

Tested from the GUI:

- Yes popup and no URL if Terms of Use is set.
- Yes popup and no URL if guestbook.
- No download button and no URL if Terms of Access is set.
- No download button and no URL if file restricted.
- No popup and yes URL given defaults (CC0, etc.)
- No popup and yes URL when Terms of Use is set and license is CC0. Bug.

Questions:

- Is the the bug identified above valid?
- What about tabular files? Which URL should be shown?

# RFI Checklist

### 1. Related Issues

- Connects to #3584 Provide Download URL for Public Files
- Connects to #2700 Files: Need Persistent Identifiers/URL's for Data Files

---
### 2. Pull Request Checklist

- [ ]  Functionality completed as described in FRD (no FRD)
- [ ]  Dependencies, risks, assumptions in FRD addressed (no FRD)
- [ ]  Unit tests completed (Yes)
- [ ]  Deployment requirements identified (e.g., SQL scripts, indexing) (None)
- [ ]  Documentation completed (None)
- [ ]  All code checkins completed (UI cleanup? Improved wording in bundle?)

---
### 3. Review Checklist

_**After** the pull request has been submitted, fill out this section._

- [ ]  Code review completed or waived
- [ ]  Testing requirements completed
- [ ]  Usability testing completed or waived
- [ ]  Support testing completed or waived
- [ ]  Merged with develop branch and resolved conflicts
