### PR TITLE
Typo fix - Corrected spelling of "official"

### DIFF
--- a/doc/sphinx-guides/source/api/client-libraries.rst
+++ b/doc/sphinx-guides/source/api/client-libraries.rst
@@ -22,6 +22,6 @@ It was created by `Thomas Leeper <http://thomasleeper.com>`_ whose dataverse can
 Java
 ----
 
-https://github.com/IQSS/dataverse-client-java is the offical Java library for Dataverse APIs.
+https://github.com/IQSS/dataverse-client-java is the official Java library for Dataverse APIs.
 
 `Richard Adams <http://www.researchspace.com/electronic-lab-notebook/about_us_team.html>`_ from `ResearchSpace <http://www.researchspace.com>`_ created and maintains this library.


### PR DESCRIPTION
This is a one-character typo fix (doing this with Phil as training)