### PR TITLE
Fixes the constraint violation error in DestroyDataseCommand (3875)

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/DestroyDatasetCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/DestroyDatasetCommand.java
@@ -53,12 +53,17 @@ public class DestroyDatasetCommand extends AbstractVoidCommand {
                 this,  Collections.singleton(Permission.DeleteDatasetDraft), doomed);                
         }
         
+        // If there is a dedicated thumbnail DataFile, it needs to be reset
+        // explicitly, or we'll get a constraint violation when deleting:
+        doomed.setThumbnailFile(null);
         final Dataset managedDoomed = ctxt.em().merge(doomed);
 
         
         List<String> datasetAndFileSolrIdsToDelete = new ArrayList<>();
         // files need to iterate through and remove 'by hand' to avoid
-        // optimistic lock issues....        
+        // optimistic lock issues... (plus the physical files need to be 
+        // deleted too!)
+        
         Iterator <DataFile> dfIt = doomed.getFiles().iterator();
         while (dfIt.hasNext()){
             DataFile df = dfIt.next();


### PR DESCRIPTION

## New Contributors

Welcome! New contributors should at least glance at [CONTRIBUTING.md](/CONTRIBUTING.md), especially the section on pull requests where we encourage you to reach out to other developers before you start coding. Also, please note that we measure code coverage and prefer you write unit tests. Pull requests can still be reviewed without tests or completion of the checklist outlined below. Thanks!

## Related Issues

- connects to #3875: Internal Server Error (500) when destroying a dataset: foreign key constraint "fk_dataset_thumbnailfile_id" on table "dataset"

## Pull Request Checklist

- [ ] Unit [tests][] completed
- [ ] Integration [tests][]: None
- [ ] Deployment requirements, [SQL updates][], [Solr updates][], etc.: None
- [ ] [Documentation][docs] completed
- [ ] Merged latest from "develop" [branch][] and resolved conflicts

[tests]: http://guides.dataverse.org/en/latest/developers/testing.html
[SQL updates]: https://github.com/IQSS/dataverse/tree/develop/scripts/database/upgrades
[Solr updates]: https://github.com/IQSS/dataverse/blob/develop/conf/solr/4.6.0/schema.xml
[docs]: http://guides.dataverse.org/en/latest/developers/documentation.html
[branch]: http://guides.dataverse.org/en/latest/developers/branching-strategy.html
