### PR TITLE
A small change per Gustavo's review: if a datafile is assigned as the…

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DatasetVersionServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetVersionServiceBean.java
@@ -703,6 +703,7 @@ public class DatasetVersionServiceBean implements java.io.Serializable {
                     + "AND df.id = o.id "
                     + "AND fm.datasetversion_id = dv.id "
                     + "AND fm.datafile_id = df.id "
+                    + "AND df.restricted = false "
                     + "AND o.previewImageAvailable = true "
                     + "ORDER BY df.id LIMIT 1;").getSingleResult();
         } catch (Exception ex) {
@@ -727,6 +728,7 @@ public class DatasetVersionServiceBean implements java.io.Serializable {
                         + "AND fm.datasetversion_id = dv.id "
                         + "AND fm.datafile_id = df.id "
                         // + "AND o.previewImageAvailable = false "
+                        + "AND df.restricted = false "
                         + "AND df.contenttype LIKE 'image/%' "
                         + "AND NOT df.contenttype = 'image/fits' "
                         + "AND df.filesize < " + imageThumbnailSizeLimit + " "
@@ -759,6 +761,7 @@ public class DatasetVersionServiceBean implements java.io.Serializable {
                         + "AND fm.datasetversion_id = dv.id "
                         + "AND fm.datafile_id = df.id "
                         // + "AND o.previewImageAvailable = false "
+                        + "AND df.restricted = false "
                         + "AND df.contenttype = 'application/pdf' "
                         + "AND df.filesize < " + imageThumbnailSizeLimit + " "
                         + "ORDER BY df.filesize ASC LIMIT 1;").getSingleResult();

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/PublishDatasetCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/PublishDatasetCommand.java
@@ -205,6 +205,10 @@ public class PublishDatasetCommand extends AbstractCommand<Dataset> {
                 }
                
             }
+            
+            if (dataFile.isRestricted() && dataFile.equals(theDataset.getThumbnailFile())) {
+                theDataset.setThumbnailFile(null);
+            }
         }
 
         theDataset.setFileAccessRequest(theDataset.getLatestVersion().getTermsOfUseAndAccess().isFileAccessRequest());

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/PublishDatasetCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/PublishDatasetCommand.java
@@ -177,37 +177,55 @@ public class PublishDatasetCommand extends AbstractCommand<Dataset> {
             if (dataFile.getFileMetadata() != null && dataFile.getFileMetadata().getDatasetVersion().equals(theDataset.getLatestVersion())) {
                 dataFile.setRestricted(dataFile.getFileMetadata().isRestricted());
             }
-            if (dataFile.isRestricted() && ctxt.mapLayerMetadata().findMetadataByDatafile(dataFile) != null){
-                // (We need an AuthenticatedUser in order to produce a WorldMap token!)
-                String id = getUser().getIdentifier();
-                id = id.startsWith("@") ? id.substring(1) : id;
-                AuthenticatedUser authenticatedUser = ctxt.authentication().getAuthenticatedUser(id);
-                try {
-                    logger.fine("(1 of 2) PublishDatasetCommand: delete MapLayer From *WorldMap*");
-                    ctxt.mapLayerMetadata().deleteMapLayerFromWorldMap(dataFile, authenticatedUser);
-                    
-                    // If that was successful, delete the layer on the Dataverse side as well:
-                    //SEK 4/20/2017                
-                    //Command to delete from Dataverse side
-                    logger.fine("(2 of 2) PublishDatasetCommand: Delete MapLayerMetadata From *Dataverse*");
-                    boolean deleteMapSuccess = ctxt.engine().submit(new DeleteMapLayerMetadataCommand(this.getRequest(), dataFile));  
-                    
-                    // RP - Bit of hack, update the datafile here b/c the reference to the datafile 
-                    // is not being passed all the way up/down the chain.   
-                    //
-                    dataFile.setPreviewImageAvailable(false);
-                   
-                } catch (IOException ioex) {
-                    // We are not going to treat it as a fatal condition and bail out, 
-                    // but we will send a notification to the user, warning them about
-                    // the layer still being out there, un-deleted:
-                    ctxt.notifications().sendNotification(authenticatedUser, new Timestamp(new Date().getTime()), UserNotification.Type.MAPLAYERDELETEFAILED, dataFile.getFileMetadata().getId());
-                }
-               
-            }
             
-            if (dataFile.isRestricted() && dataFile.equals(theDataset.getThumbnailFile())) {
-                theDataset.setThumbnailFile(null);
+            
+            if (dataFile.isRestricted()) {
+                // A couple things need to happen if the file has been restricted: 
+                // 1. If there's a map layer associated with this shape file, or 
+                //    tabular-with-geo-tag file, all that map layer data (that 
+                //    includes most of the actual data in the file!) need to be
+                //    removed from WorldMap and GeoConnect, since anyone can get 
+                //    download the data from there;
+                // 2. If this (image) file has been assigned as the dedicated 
+                //    thumbnail for the dataset, we need to remove that assignment, 
+                //    now that the file is restricted. 
+
+                // Map layer: 
+                
+                if (ctxt.mapLayerMetadata().findMetadataByDatafile(dataFile) != null) {
+                    // (We need an AuthenticatedUser in order to produce a WorldMap token!)
+                    String id = getUser().getIdentifier();
+                    id = id.startsWith("@") ? id.substring(1) : id;
+                    AuthenticatedUser authenticatedUser = ctxt.authentication().getAuthenticatedUser(id);
+                    try {
+                        logger.fine("(1 of 2) PublishDatasetCommand: delete MapLayer From *WorldMap*");
+                        ctxt.mapLayerMetadata().deleteMapLayerFromWorldMap(dataFile, authenticatedUser);
+
+                        // If that was successful, delete the layer on the Dataverse side as well:
+                        //SEK 4/20/2017                
+                        //Command to delete from Dataverse side
+                        logger.fine("(2 of 2) PublishDatasetCommand: Delete MapLayerMetadata From *Dataverse*");
+                        boolean deleteMapSuccess = ctxt.engine().submit(new DeleteMapLayerMetadataCommand(this.getRequest(), dataFile));
+
+                        // RP - Bit of hack, update the datafile here b/c the reference to the datafile 
+                        // is not being passed all the way up/down the chain.   
+                        //
+                        dataFile.setPreviewImageAvailable(false);
+
+                    } catch (IOException ioex) {
+                        // We are not going to treat it as a fatal condition and bail out, 
+                        // but we will send a notification to the user, warning them about
+                        // the layer still being out there, un-deleted:
+                        ctxt.notifications().sendNotification(authenticatedUser, new Timestamp(new Date().getTime()), UserNotification.Type.MAPLAYERDELETEFAILED, dataFile.getFileMetadata().getId());
+                    }
+
+                }
+                
+                // Dataset thumbnail assignment: 
+                
+                if (dataFile.equals(theDataset.getThumbnailFile())) {
+                    theDataset.setThumbnailFile(null);
+                }
             }
         }
 


### PR DESCRIPTION
… thumbnail for a dataset, but

has been restricted since then, the assignment will be removed *when the dataset gets published*.
(somewhat similarly to how the map layer for a restricted file gets removed inside PublishDatasetCommand).

## New Contributors

Welcome! New contributors should at least glance at [CONTRIBUTING.md](/CONTRIBUTING.md), especially the section on pull requests where we encourage you to reach out to other developers before you start coding. Also, please note that we measure code coverage and prefer you write unit tests. Pull requests can still be reviewed without tests or completion of the checklist outlined below. Thanks!

## Related Issues

- connects to #3852: 4.6.2 regression issue
## Pull Request Checklist

- [ ] Unit [tests][] completed
- [ ] Integration [tests][]: None
- [ ] Deployment requirements, [SQL updates][], [Solr updates][], etc.: None
- [ ] [Documentation][docs] completed
- [ ] Merged latest from "develop" [branch][] and resolved conflicts

[tests]: http://guides.dataverse.org/en/latest/developers/testing.html
[SQL updates]: https://github.com/IQSS/dataverse/tree/develop/scripts/database/upgrades
[Solr updates]: https://github.com/IQSS/dataverse/blob/develop/conf/solr/4.6.0/schema.xml
[docs]: http://guides.dataverse.org/en/latest/developers/documentation.html
[branch]: http://guides.dataverse.org/en/latest/developers/branching-strategy.html
