### PR TITLE
don't send notification when creating dataverseAdmin user #3894

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/api/BuiltinUsers.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/BuiltinUsers.java
@@ -1,5 +1,6 @@
 package edu.harvard.iq.dataverse.api;
 
+import edu.harvard.iq.dataverse.Dataverse;
 import edu.harvard.iq.dataverse.UserNotification;
 import edu.harvard.iq.dataverse.actionlogging.ActionLogRecord;
 import edu.harvard.iq.dataverse.authorization.UserRecordIdentifier;
@@ -129,9 +130,20 @@ public class BuiltinUsers extends AbstractApiBean {
              * @todo Move this to
              * AuthenticationServiceBean.createAuthenticatedUser
              */
-            userNotificationSvc.sendNotification(au,
-                    new Timestamp(new Date().getTime()),
-                    UserNotification.Type.CREATEACC, null);
+            boolean rootDataversePresent = false;
+            try {
+                Dataverse rootDataverse = dataverseSvc.findRootDataverse();
+                if (rootDataverse != null) {
+                    rootDataversePresent = true;
+                }
+            } catch (Exception e) {
+                logger.info("The root dataverse is not present. Don't send a notification to dataverseAdmin.");
+            }
+            if (rootDataversePresent) {
+                userNotificationSvc.sendNotification(au,
+                        new Timestamp(new Date().getTime()),
+                        UserNotification.Type.CREATEACC, null);
+            }
 
             ApiToken token = new ApiToken();
 

--- a/src/main/java/edu/harvard/iq/dataverse/api/Dataverses.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Dataverses.java
@@ -148,6 +148,9 @@ public class Dataverses extends AbstractApiBean {
         } catch ( WrappedResponse ww ) {
                     Throwable cause = ww.getCause();
                     StringBuilder sb = new StringBuilder();
+                    if (cause == null) {
+                        return ww.refineResponse("cause was null!");
+                    }
                     while (cause.getCause() != null) {
                         cause = cause.getCause();
                         if (cause instanceof ConstraintViolationException) {


### PR DESCRIPTION
The dataverseAdmin user creates the root dataverse. This user is created
by the installer.

Also included is a null check when creating a dataverse fails.

## New Contributors

Welcome! New contributors should at least glance at [CONTRIBUTING.md](/CONTRIBUTING.md), especially the section on pull requests where we encourage you to reach out to other developers before you start coding. Also, please note that we measure code coverage and prefer you write unit tests. Pull requests can still be reviewed without tests or completion of the checklist outlined below. Thanks!

## Related Issues

- connects to #3894 Installation: first "dataverseAdmin" user and root dataverse can't be created

## Pull Request Checklist

- [ ] Unit [tests][] completed
- [ ] Integration [tests][]: None
- [ ] Deployment requirements, [SQL updates][], [Solr updates][], etc.: None
- [ ] [Documentation][docs] completed
- [ ] Merged latest from "develop" [branch][] and resolved conflicts

[tests]: http://guides.dataverse.org/en/latest/developers/testing.html
[SQL updates]: https://github.com/IQSS/dataverse/tree/develop/scripts/database/upgrades
[Solr updates]: https://github.com/IQSS/dataverse/blob/develop/conf/solr/4.6.0/schema.xml
[docs]: http://guides.dataverse.org/en/latest/developers/documentation.html
[branch]: http://guides.dataverse.org/en/latest/developers/branching-strategy.html
