### PR TITLE
don't expect "Dataverse" in name/brand in test #3897

### DIFF
--- a/src/test/java/edu/harvard/iq/dataverse/api/DataversesIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/DataversesIT.java
@@ -81,7 +81,7 @@ public class DataversesIT {
                 .body("data.dataverseType", equalTo("UNCATEGORIZED"))
                 .statusCode(Status.CREATED.getStatusCode());
 
-        String alias1 = UtilIT.getRandomIdentifier();
+        String alias1 = UtilIT.getRandomDvAlias();
         String category1 = Dataverse.DataverseType.LABORATORY.toString();
         Response createDataverseWithCategory = UtilIT.createDataverse(alias1, category1, apiToken);
         createDataverseWithCategory.prettyPrint();
@@ -89,7 +89,7 @@ public class DataversesIT {
                 .body("data.dataverseType", equalTo("LABORATORY"))
                 .statusCode(Status.CREATED.getStatusCode());
 
-        String alias2 = UtilIT.getRandomIdentifier();
+        String alias2 = UtilIT.getRandomDvAlias();
         String madeUpCategory = "madeUpCategory";
         Response createDataverseWithInvalidCategory = UtilIT.createDataverse(alias2, madeUpCategory, apiToken);
         createDataverseWithInvalidCategory.prettyPrint();
@@ -97,7 +97,7 @@ public class DataversesIT {
                 .body("data.dataverseType", equalTo("UNCATEGORIZED"))
                 .statusCode(Status.CREATED.getStatusCode());
 
-        String alias3 = UtilIT.getRandomIdentifier();
+        String alias3 = UtilIT.getRandomDvAlias();
         String category3 = Dataverse.DataverseType.LABORATORY.toString().toLowerCase();
         Response createDataverseWithLowerCaseCategory = UtilIT.createDataverse(alias3, category3, apiToken);
         createDataverseWithLowerCaseCategory.prettyPrint();

--- a/src/test/java/edu/harvard/iq/dataverse/api/SwordIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/SwordIT.java
@@ -239,13 +239,13 @@ public class SwordIT {
 
         Response attemptToDownloadUnpublishedFileWithoutApiToken = UtilIT.downloadFile(fileId);
         attemptToDownloadUnpublishedFileWithoutApiToken.then().assertThat()
-                .body("html.head.title", equalTo("403 Not Authorized - Root Dataverse"))
+                .body("html.head.title", equalTo("403 Not Authorized - Root"))
                 .statusCode(FORBIDDEN.getStatusCode());
 
         Response attemptToDownloadUnpublishedFileUnauthApiToken = UtilIT.downloadFile(fileId, apiTokenNoPrivs);
         attemptToDownloadUnpublishedFileUnauthApiToken.prettyPrint();
         attemptToDownloadUnpublishedFileUnauthApiToken.then().assertThat()
-                .body("html.head.title", equalTo("403 Not Authorized - Root Dataverse"))
+                .body("html.head.title", equalTo("403 Not Authorized - Root"))
                 .statusCode(FORBIDDEN.getStatusCode());
 
         Response downloadUnpublishedFileWithValidApiToken = UtilIT.downloadFile(fileId, apiToken);

--- a/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
@@ -121,6 +121,10 @@ public class UtilIT {
         return UUID.randomUUID().toString().substring(0, 8);
     }
 
+    public static String getRandomDvAlias() {
+        return "dv" + getRandomIdentifier();
+    }
+
     static String getUsernameFromResponse(Response createUserResponse) {
         JsonPath createdUser = JsonPath.from(createUserResponse.body().asString());
         String username = createdUser.getString("data.user." + USERNAME_KEY);


### PR DESCRIPTION
Also add "dv" to dataverse aliases so they aren't just numbers, which
aren't allowed.

## New Contributors

Welcome! New contributors should at least glance at [CONTRIBUTING.md](/CONTRIBUTING.md), especially the section on pull requests where we encourage you to reach out to other developers before you start coding. Also, please note that we measure code coverage and prefer you write unit tests. Pull requests can still be reviewed without tests or completion of the checklist outlined below. Thanks!

## Related Issues

- connects to #3897 API tests failing due to dropping "Dataverse" from dataverse names

## Pull Request Checklist

- [ ] Unit [tests][] completed
- [ ] Integration [tests][]: None
- [ ] Deployment requirements, [SQL updates][], [Solr updates][], etc.: None
- [ ] [Documentation][docs] completed
- [ ] Merged latest from "develop" [branch][] and resolved conflicts

[tests]: http://guides.dataverse.org/en/latest/developers/testing.html
[SQL updates]: https://github.com/IQSS/dataverse/tree/develop/scripts/database/upgrades
[Solr updates]: https://github.com/IQSS/dataverse/blob/develop/conf/solr/4.6.0/schema.xml
[docs]: http://guides.dataverse.org/en/latest/developers/documentation.html
[branch]: http://guides.dataverse.org/en/latest/developers/branching-strategy.html
