### PR TITLE
2998 Updated apache commons-validator to 1.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -198,7 +198,7 @@
         <dependency>
             <groupId>commons-validator</groupId>
             <artifactId>commons-validator</artifactId>
-            <version>1.4.0</version>
+            <version>1.5.0</version>
         </dependency>
         <dependency>
             <groupId>colt</groupId>
@@ -319,10 +319,10 @@
             <artifactId>jacoco-maven-plugin</artifactId>
             <version>0.7.5.201505241946</version>
         </dependency>
-        <!-- Added specific versionf of SLF4J jars; otherwise we end up with 
+        <!-- Added specific versionf of SLF4J jars; otherwise we end up with
         conflicting versions of slf4j-api and slf4j-log4j12, loaded as
         dependencies for different packages; which was causing some incompatibility
-        issues -L.A. 4.3 -->  
+        issues -L.A. 4.3 -->
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
@@ -435,7 +435,7 @@
            <groupId>org.glassfish.jersey.containers</groupId>
            <artifactId>jersey-container-servlet</artifactId>
            <version>2.23.2</version>
-       </dependency>                
+       </dependency>
         <!-- For API File Upload: 2 of 2 -->
        <dependency>
            <groupId>org.glassfish.jersey.media</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -195,6 +195,7 @@
             <artifactId>commons-math</artifactId>
             <version>2.2</version>
         </dependency>
+	<!-- commons-validator 1.5.1 & 1.6.0 gave errors and did not provide needed functionality, so 1.5.0 was used -->
         <dependency>
             <groupId>commons-validator</groupId>
             <artifactId>commons-validator</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -195,11 +195,10 @@
             <artifactId>commons-math</artifactId>
             <version>2.2</version>
         </dependency>
-	<!-- commons-validator 1.5.1 & 1.6.0 gave errors and did not provide needed functionality, so 1.5.0 was used -->
         <dependency>
             <groupId>commons-validator</groupId>
             <artifactId>commons-validator</artifactId>
-            <version>1.5.0</version>
+            <version>1.6</version>
         </dependency>
         <dependency>
             <groupId>colt</groupId>

--- a/src/main/java/edu/harvard/iq/dataverse/MailServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/MailServiceBean.java
@@ -39,8 +39,6 @@ import javax.mail.internet.AddressException;
 import javax.mail.internet.InternetAddress;
 import javax.mail.internet.MimeMessage;
 import org.apache.commons.lang.StringUtils;
-import java.net.IDN;
-import java.util.logging.Level;
 
 /**
  *
@@ -70,7 +68,8 @@ public class MailServiceBean implements java.io.Serializable {
     ConfirmEmailServiceBean confirmEmailService;
     
     private static final Logger logger = Logger.getLogger(MailServiceBean.class.getCanonicalName());
-    
+
+    private static final String charset = "UTF-8";
     private static final String EMAIL_PATTERN = "^[_A-Za-z0-9-\\+]+(\\.[_A-Za-z0-9-]+)*@"
     + "[A-Za-z0-9-]+(\\.[A-Za-z0-9]+)*(\\.[A-Za-z]{2,})$";
     
@@ -90,17 +89,17 @@ public class MailServiceBean implements java.io.Serializable {
             String[] recipientStrings = to.split(",");
             InternetAddress[] recipients = new InternetAddress[recipientStrings.length];
             try {
-                msg.setFrom(new InternetAddress(from, "UTF-8"));
+                msg.setFrom(new InternetAddress(from, charset));
                 for (int i = 0; i < recipients.length; i++) {
-                    recipients[i] = new InternetAddress(recipientStrings[i], "", "UTF-8");
+                    recipients[i] = new InternetAddress(recipientStrings[i], "", charset);
                 }
             } catch (UnsupportedEncodingException ex) {
                 logger.severe(ex.getMessage());
             }
             msg.setRecipients(Message.RecipientType.TO, recipients);
-            msg.setSubject(subject, "UTF-8");
-            msg.setText(messageText, "UTF-8");
-            Transport.send(msg);
+            msg.setSubject(subject, charset);
+            msg.setText(messageText, charset);
+            Transport.send(msg, recipients);
         } catch (AddressException ae) {
             ae.printStackTrace(System.out);
         } catch (MessagingException me) {
@@ -127,14 +126,14 @@ public class MailServiceBean implements java.io.Serializable {
                 InternetAddress[] recipients = new InternetAddress[recipientStrings.length];
                 for (int i = 0; i < recipients.length; i++) {
                     try {
-                        recipients[i] = new InternetAddress('"' + recipientStrings[i] + '"', "", "UTF-8");
+                        recipients[i] = new InternetAddress('"' + recipientStrings[i] + '"', "", charset);
                     } catch (UnsupportedEncodingException ex) {
                         logger.severe(ex.getMessage());
                     }
                 }
                 msg.setRecipients(Message.RecipientType.TO, recipients);
-                msg.setSubject(subject, "UTF-8");
-                msg.setText(body, "UTF-8");
+                msg.setSubject(subject, charset);
+                msg.setText(body, charset);
                 try {
                     Transport.send(msg, recipients);
                     sent = true;
@@ -178,8 +177,8 @@ public class MailServiceBean implements java.io.Serializable {
             msg.setSentDate(new Date());
             msg.setRecipients(Message.RecipientType.TO,
                     InternetAddress.parse(to, false));
-            msg.setSubject(subject, "UTF-8");
-            msg.setText(messageText, "UTF-8");
+            msg.setSubject(subject, charset);
+            msg.setText(messageText, charset);
 
             if (extraHeaders != null) {
                 for (Object key : extraHeaders.keySet()) {

--- a/src/test/java/edu/harvard/iq/dataverse/EMailValidatorTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/EMailValidatorTest.java
@@ -31,6 +31,7 @@ public class EMailValidatorTest {
         assertEquals(true, EMailValidator.isEmailValid("begüm.vriezen@example.com", null));
         assertEquals(true, EMailValidator.isEmailValid("lótus.gonçalves@example.com", null));
         assertEquals(true, EMailValidator.isEmailValid("lótus.gonçalves@éxample.com", null));
+        assertEquals(true, EMailValidator.isEmailValid("begüm.vriezen@example.cologne", null));
         assertEquals(true, EMailValidator.isEmailValid("رونیکا.محمدخان@example.com", null));
         assertEquals(false, EMailValidator.isEmailValid("lótus.gonçalves@example.cóm", null));
         assertEquals(false, EMailValidator.isEmailValid("dora@.com", null));

--- a/src/test/java/edu/harvard/iq/dataverse/EMailValidatorTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/EMailValidatorTest.java
@@ -20,7 +20,6 @@ public class EMailValidatorTest {
         assertEquals(true, EMailValidator.isEmailValid("trailingWhitespace@mailinator.com ", null));
         assertEquals(false, EMailValidator.isEmailValid("elisah.da mota@example.com", null));
         assertEquals(false, EMailValidator.isEmailValid("pete1@mailinator.com;pete2@mailinator.com", null));
-        boolean issue2998resolved = false;
         /**
          * @todo Evaluate if we should upgrade to commons-validator 1.5 or
          * newer, which seems to allow these non-ASCII email addresses to pass
@@ -38,10 +37,11 @@ public class EMailValidatorTest {
          *
          * See https://github.com/IQSS/dataverse/issues/2998
          */
-        assertEquals(issue2998resolved, EMailValidator.isEmailValid("michélle.pereboom@example.com", null));
-        assertEquals(issue2998resolved, EMailValidator.isEmailValid("begüm.vriezen@example.com", null));
-        assertEquals(issue2998resolved, EMailValidator.isEmailValid("lótus.gonçalves@example.com", null));
-        assertEquals(issue2998resolved, EMailValidator.isEmailValid("رونیکا.محمدخان@example.com", null));
+        assertEquals(true, EMailValidator.isEmailValid("michélle.pereboom@example.com", null));
+        assertEquals(true, EMailValidator.isEmailValid("begüm.vriezen@example.com", null));
+        assertEquals(true, EMailValidator.isEmailValid("lótus.gonçalves@example.com", null));
+        assertEquals(true, EMailValidator.isEmailValid("رونیکا.محمدخان@example.com", null));
+        assertEquals(false, EMailValidator.isEmailValid("dora@.com", null));
         assertEquals(false, EMailValidator.isEmailValid("", null));
         /**
          * @todo How can null as an email address be valid?!?

--- a/src/test/java/edu/harvard/iq/dataverse/EMailValidatorTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/EMailValidatorTest.java
@@ -21,26 +21,18 @@ public class EMailValidatorTest {
         assertEquals(false, EMailValidator.isEmailValid("elisah.da mota@example.com", null));
         assertEquals(false, EMailValidator.isEmailValid("pete1@mailinator.com;pete2@mailinator.com", null));
         /**
-         * @todo Evaluate if we should upgrade to commons-validator 1.5 or
-         * newer, which seems to allow these non-ASCII email addresses to pass
-         * validation.
-         *
-         * "In addition to the above ASCII characters, international characters
-         * above U+007F, encoded as UTF-8, are permitted by RFC 6531, though
-         * mail systems may restrict which characters to use when assigning
-         * local parts." https://en.wikipedia.org/wiki/Email_address
-         *
          * These examples are all from https://randomuser.me and seem to be
          * valid according to
          * http://sphinx.mythic-beasts.com/~pdw/cgi-bin/emailvalidate (except
          * رونیکا.محمدخان@example.com).
          *
-         * See https://github.com/IQSS/dataverse/issues/2998
          */
         assertEquals(true, EMailValidator.isEmailValid("michélle.pereboom@example.com", null));
         assertEquals(true, EMailValidator.isEmailValid("begüm.vriezen@example.com", null));
         assertEquals(true, EMailValidator.isEmailValid("lótus.gonçalves@example.com", null));
+        assertEquals(true, EMailValidator.isEmailValid("lótus.gonçalves@éxample.com", null));
         assertEquals(true, EMailValidator.isEmailValid("رونیکا.محمدخان@example.com", null));
+        assertEquals(false, EMailValidator.isEmailValid("lótus.gonçalves@example.cóm", null));
         assertEquals(false, EMailValidator.isEmailValid("dora@.com", null));
         assertEquals(false, EMailValidator.isEmailValid("", null));
         /**


### PR DESCRIPTION
Upgrades commons-validator to allow unicode characters in email addresses.

- connects to #2998: Be more permissive in what we consider a valid email address to be

## Pull Request Checklist

- [z] Unit [tests][] completed
- [x] Integration [tests][]: None
- [x] Deployment requirements, [SQL updates][], [Solr updates][], etc.: None
- [ ] [Documentation][docs] completed
- [ ] Merged latest from "develop" [branch][] and resolved conflicts
