### PR TITLE
don't attempt to index null values #4229

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DatasetField.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetField.java
@@ -299,7 +299,10 @@ public class DatasetField implements Serializable {
         List returnList = new ArrayList();
         if (!datasetFieldValues.isEmpty()) {
             for (DatasetFieldValue dsfv : datasetFieldValues) {
-                returnList.add(dsfv.getValue());
+                String value = dsfv.getValue();
+                if (value != null) {
+                    returnList.add(value);
+                }
             }
         } else {
             for (ControlledVocabularyValue cvv : controlledVocabularyValues) {


### PR DESCRIPTION
- connects to #4229 Dataset Metadata: At least two types of "bad metadata" exist in production db and need investigation/correction 
- connects to #4179 NULL values in TextBox-type metadata fields cause a parser exception. Bug introduced when we switched to indexing values, instead of DisplayValues