### PR TITLE
fix SQL upgrade script to match JPA (unlimited) #4353

### DIFF
--- a/scripts/database/upgrades/upgrade_v4.8.3_to_v4.8.4.sql
+++ b/scripts/database/upgrades/upgrade_v4.8.3_to_v4.8.4.sql
@@ -1,2 +1,2 @@
--- Hopefully, 255 characters is enough. Google login has used 131 characters.
-ALTER TABLE oauth2tokendata ALTER COLUMN accesstoken TYPE character varying(255);
+-- Google login has used 131 characters. 64 is not enough.
+ALTER TABLE oauth2tokendata ALTER COLUMN accesstoken TYPE text;

--- a/src/main/java/edu/harvard/iq/dataverse/authorization/providers/oauth2/OAuth2TokenData.java
+++ b/src/main/java/edu/harvard/iq/dataverse/authorization/providers/oauth2/OAuth2TokenData.java
@@ -49,9 +49,7 @@ public class OAuth2TokenData implements Serializable {
     private Timestamp expiryDate;
     
     /**
-     * "TEXT" is 255 characters, which is enough for Google at 131 characters.
-     * Facebook says, "Please don't put a maximum size on the storage for an
-     * access token" at
+     * "Please don't put a maximum size on the storage for an access token" at
      * https://stackoverflow.com/questions/4408945/what-is-the-length-of-the-access-token-in-facebook-oauth2/16365828#16365828
      */
     @Column(columnDefinition = "TEXT")


### PR DESCRIPTION
connects to #4353 4.8.4 SQL upgrade script doesn't match change in code for `oauth2tokendata` table in pull request 4342 