### PR TITLE
Put dates in ISO 8601 format for easy sorting #4395

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/GuestbookResponseServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/GuestbookResponseServiceBean.java
@@ -282,7 +282,7 @@ public class GuestbookResponseServiceBean {
             if (guestbookResponseId != null) {
                 singleResult[0] = result[1];
                 if (result[2] != null) {
-                    singleResult[1] = new SimpleDateFormat("MMMM d, yyyy").format((Date) result[2]);
+                    singleResult[1] = new SimpleDateFormat("yyyy-MM-dd").format((Date) result[2]);
                 } else {
                     singleResult[1] = "N/A";
                 }


### PR DESCRIPTION
connects to #4395 Sorting guestbook responses by date doesn't sort chronologically