### PR TITLE
Splitting DCs into one per component

### DIFF
--- a/conf/openshift/openshift.json
+++ b/conf/openshift/openshift.json
@@ -33,13 +33,73 @@
       }
     },
     {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "dataverse-postgresql-service"
+      },
+      "spec": {
+        "selector": {
+          "name": "iqss-dataverse-postgresql"
+        },
+        "ports": [
+          {
+            "name": "database",
+            "protocol": "TCP",
+            "port": 5432,
+            "targetPort": 5432
+          }
+        ]
+      }
+    },
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "dataverse-solr-service"
+      },
+      "spec": {
+        "selector": {
+          "name": "iqss-dataverse-solr"
+        },
+        "ports": [
+          {
+            "name": "search",
+            "protocol": "TCP",
+            "port": 8983,
+            "targetPort": 8983
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "v1",
+      "kind": "Route",
+      "metadata": {
+        "annotations": {
+          "openshift.io/host.generated": "true"
+        },
+        "name": "dataverse"
+      },
+      "spec": {
+        "port": {
+          "targetPort": "web"
+        },
+        "to": {
+          "kind": "Service",
+          "name": "dataverse-glassfish-service",
+          "weight": 100
+        }
+      }
+    },
+    {
       "kind": "ImageStream",
       "apiVersion": "v1",
       "metadata": {
         "name": "dataverse-plus-glassfish"
       },
       "spec": {
-        "dockerImageRepository": "iqss/dataverse-glassfish"
+        "dockerImageRepository": "iqss/dataverse-glassfish:latest"
       }
     },
     {
@@ -49,7 +109,7 @@
         "name": "centos-postgresql-94-centos7"
       },
       "spec": {
-        "dockerImageRepository": "centos/postgresql-94-centos7"
+        "dockerImageRepository": "centos/postgresql-94-centos7:latest"
       }
     },
     {
@@ -59,14 +119,14 @@
         "name": "iqss-dataverse-solr"
       },
       "spec": {
-        "dockerImageRepository": "iqss/dataverse-solr"
+        "dockerImageRepository": "iqss/dataverse-solr:latest"
       }
     },
     {
       "kind": "DeploymentConfig",
       "apiVersion": "v1",
       "metadata": {
-        "name": "deploy-dataverse-glassfish",
+        "name": "dataverse-glassfish",
         "annotations": {
           "template.alpha.openshift.io/wait-for-ready": "true"
         }
@@ -91,6 +151,14 @@
                 ],
                 "env": [
                   {
+                    "name": "POSTGRES_SERVICE_HOST",
+                    "value": "dataverse-postgresql-service"
+                  },
+                  {
+                    "name": "SOLR_SERVICE_HOST",
+                    "value": "dataverse-solr-service"
+                  },
+                  {
                     "name": "ADMIN_PASSWORD",
                     "value": "admin"
                   },
@@ -104,7 +172,7 @@
                   },
                   {
                     "name": "POSTGRES_PASSWORD",
-                    "value": "dvnappPassword"
+                    "value": "secret"
                   },
                   {
                     "name": "POSTGRES_DATABASE",
@@ -116,7 +184,61 @@
                   "capabilities": {},
                   "privileged": false
                 }
-              },
+              }
+            ]
+          }
+        },
+        "strategy": {
+          "type": "Rolling",
+          "rollingParams": {
+            "updatePeriodSeconds": 1,
+            "intervalSeconds": 1,
+            "timeoutSeconds": 300
+          },
+          "resources": {}
+        },
+        "triggers": [
+          {
+            "type": "ImageChange",
+            "imageChangeParams": {
+              "automatic": true,
+              "containerNames": [
+                "dataverse-plus-glassfish"
+              ],
+              "from": {
+                "kind": "ImageStreamTag",
+                "name": "dataverse-plus-glassfish:latest"
+              }
+            }
+          },
+          {
+            "type": "ConfigChange"
+          }
+        ],
+        "replicas": 1,
+        "selector": {
+          "name": "iqss-dataverse-glassfish"
+        }
+      }
+    },
+    {
+      "kind": "DeploymentConfig",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "dataverse-postgresql",
+        "annotations": {
+          "template.alpha.openshift.io/wait-for-ready": "true"
+        }
+      },
+      "spec": {
+        "template": {
+          "metadata": {
+            "labels": {
+              "name": "iqss-dataverse-postgresql"
+            }
+          },
+          "spec": {
+            "containers": [
               {
                 "name": "centos-postgresql-94-centos7",
                 "image": "centos-postgresql-94-centos7",
@@ -129,16 +251,21 @@
                 "env": [
                   {
                     "name": "POSTGRESQL_USER",
-                    "value": "pgUserValue"
+                    "value": "dvnapp"
                   },
                   {
                     "name": "POSTGRESQL_PASSWORD",
-                    "value": "pgPasswordValue"
+                    "value": "secret"
                   },
                   {
                     "name": "POSTGRESQL_DATABASE",
-                    "value": "pgDatabaseValue"
+                    "value": "dvndb"
+                  },
+                  {
+                    "name": "POSTGRESQL_ADMIN_PASSWORD",
+                    "value": "secret"
                   }
+
                 ],
                 "resources": {
                   "limits": {
@@ -150,7 +277,61 @@
                   "capabilities": {},
                   "privileged": false
                 }
-              },
+              }
+            ]
+          }
+        },
+        "strategy": {
+          "type": "Rolling",
+          "rollingParams": {
+            "updatePeriodSeconds": 1,
+            "intervalSeconds": 1,
+            "timeoutSeconds": 300
+          },
+          "resources": {}
+        },
+        "triggers": [
+          {
+            "type": "ImageChange",
+            "imageChangeParams": {
+              "automatic": true,
+              "containerNames": [
+                "centos-postgresql-94-centos7"
+              ],
+              "from": {
+                "kind": "ImageStreamTag",
+                "name": "centos-postgresql-94-centos7:latest"
+              }
+            }
+          },
+          {
+            "type": "ConfigChange"
+          }
+        ],
+        "replicas": 1,
+        "selector": {
+          "name": "iqss-dataverse-postgresql"
+        }
+      }
+    },
+    {
+      "kind": "DeploymentConfig",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "dataverse-solr",
+        "annotations": {
+          "template.alpha.openshift.io/wait-for-ready": "true"
+        }
+      },
+      "spec": {
+        "template": {
+          "metadata": {
+            "labels": {
+              "name": "iqss-dataverse-solr"
+            }
+          },
+          "spec": {
+            "containers": [
               {
                 "name": "iqss-dataverse-solr",
                 "image": "iqss-dataverse-solr",
@@ -189,37 +370,11 @@
             "imageChangeParams": {
               "automatic": true,
               "containerNames": [
-                "dataverse-plus-glassfish"
-              ],
-              "from": {
-                "kind": "ImageStreamTag",
-                "name": "dataverse-plus-glassfish:kick-the-tires"
-              }
-            }
-          },
-          {
-            "type": "ImageChange",
-            "imageChangeParams": {
-              "automatic": true,
-              "containerNames": [
-                "centos-postgresql-94-centos7"
-              ],
-              "from": {
-                "kind": "ImageStreamTag",
-                "name": "centos-postgresql-94-centos7:latest"
-              }
-            }
-          },
-          {
-            "type": "ImageChange",
-            "imageChangeParams": {
-              "automatic": true,
-              "containerNames": [
                 "iqss-dataverse-solr"
               ],
               "from": {
                 "kind": "ImageStreamTag",
-                "name": "iqss-dataverse-solr:kick-the-tires"
+                "name": "iqss-dataverse-solr:latest"
               }
             }
           },
@@ -229,7 +384,7 @@
         ],
         "replicas": 1,
         "selector": {
-          "name": "iqss-dataverse-glassfish"
+          "name": "iqss-dataverse-solr"
         }
       }
     }

--- a/doc/sphinx-guides/source/developers/dev-environment.rst
+++ b/doc/sphinx-guides/source/developers/dev-environment.rst
@@ -436,9 +436,7 @@ Log into Minishift and Visit Dataverse in your Browser
 
 - https://192.168.99.100:8443
 - username: developer
-- password: developer
-
-Visit https://192.168.99.100:8443/console/project/project1/browse/routes and click http://dataverse-glassfish-service-project1.192.168.99.100.nip.io/ or whatever is shows under "Routes External Traffic" (the IP address may be different). This assumes you named your project ``project1``.
+- password: <any password>
 
 You should be able to log in with username "dataverseAdmin" and password "admin".
 
@@ -454,7 +452,7 @@ Making Changes
 
 If you're interested in using Minishift for development and want to change the Dataverse code, you will need to get set up to create Docker images based on your changes and push them to a Docker registry such as Docker Hub. See the section below on Docker for details.
 
-Runnning Containers to Run as Root in Minishift
+Running Containers to Run as Root in Minishift
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 It is **not** recommended to run containers as root in Minishift because for security reasons OpenShift doesn't support running containers as root. However, it's good to know how to allow containers to run as root in case you need to work on a Docker image to make it run as non-root.


### PR DESCRIPTION
Everything appears to be working in this config.  I would love someone else to validate it.

![screenshot from 2018-02-02 19-10-03](https://user-images.githubusercontent.com/492994/35760230-f70e5390-084c-11e8-867f-f6897756ddc9.png)

This PR moves from having Glassfish, postgres, and solr all installed in one pod to having a separate pod for each so you can potentially deploy/scale them separately.
