### PR TITLE
4460 dataset storage ids

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/dataaccess/FileAccessIO.java
+++ b/src/main/java/edu/harvard/iq/dataverse/dataaccess/FileAccessIO.java
@@ -153,9 +153,9 @@ public class FileAccessIO<T extends DvObject> extends StorageIO<T> {
               } else if (isWriteAccess) {
                 //this checks whether a directory for a dataset exists 
                 if (dataset.getFileSystemDirectory() != null && !Files.exists(dataset.getFileSystemDirectory())) {
-                Files.createDirectories(dataset.getFileSystemDirectory());
-                dataset.setStorageIdentifier("file://"+dataset.getAuthority()+dataset.getDoiSeparator()+dataset.getIdentifier());
+                    Files.createDirectories(dataset.getFileSystemDirectory());
                 }
+                dataset.setStorageIdentifier("file://"+dataset.getAuthority()+dataset.getDoiSeparator()+dataset.getIdentifier());
             }
 
         } else if (dvObject instanceof Dataverse) {

--- a/src/main/java/edu/harvard/iq/dataverse/dataaccess/S3AccessIO.java
+++ b/src/main/java/edu/harvard/iq/dataverse/dataaccess/S3AccessIO.java
@@ -593,10 +593,12 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
     }
 
     private String getDestinationKey(String auxItemTag) throws IOException {
-        open();
         if (dvObject instanceof DataFile) {
             return getMainFileKey() + "." + auxItemTag;
         } else if (dvObject instanceof Dataset) {
+            if (key == null) {
+                open();
+            }
             return key + "/" + auxItemTag;
         } else {
             throw new IOException("S3AccessIO: This operation is only supported for Datasets and DataFiles.");

--- a/src/main/java/edu/harvard/iq/dataverse/dataaccess/S3AccessIO.java
+++ b/src/main/java/edu/harvard/iq/dataverse/dataaccess/S3AccessIO.java
@@ -593,6 +593,7 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
     }
 
     private String getDestinationKey(String auxItemTag) throws IOException {
+        open();
         if (dvObject instanceof DataFile) {
             return getMainFileKey() + "." + auxItemTag;
         } else if (dvObject instanceof Dataset) {

--- a/src/main/java/edu/harvard/iq/dataverse/dataset/DatasetUtil.java
+++ b/src/main/java/edu/harvard/iq/dataverse/dataset/DatasetUtil.java
@@ -267,7 +267,7 @@ public class DatasetUtil {
         StorageIO<Dataset> dataAccess = null;
                 
         try{
-             dataAccess = DataAccess.createNewStorageIO(dataset,"file");
+             dataAccess = DataAccess.createNewStorageIO(dataset,"placeholder");
         }
         catch(IOException ioex){
             //TODO: Add a suitable waing message

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/CreateDatasetCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/CreateDatasetCommand.java
@@ -144,8 +144,8 @@ public class CreateDatasetCommand extends AbstractCommand<Dataset> {
                 // if setting the storage identifier through createNewStorageIO fails, dataset creation
                 // does not have to fail. we just set the storage id to a default -SF
                 String storageDriver = (System.getProperty("dataverse.files.storage-driver-id") != null) ? System.getProperty("dataverse.files.storage-driver-id") : "file://";
-                theDataset.setStorageIdentifier(storageDriver + theDataset.getAuthority()+theDataset.getDoiSeparator()+theDataset.getIdentifier());
-                logger.info("Failed to create StorageIO. StorageId set to default. Not fatal." + "(" + ioex.getMessage() + ")");
+                theDataset.setStorageIdentifier(storageDriver  + "://" + theDataset.getAuthority()+theDataset.getDoiSeparator()+theDataset.getIdentifier());
+                logger.info("Failed to create StorageIO. StorageIdentifier set to default. Not fatal." + "(" + ioex.getMessage() + ")");
             }
         }
         if (theDataset.getIdentifier()==null) {

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/CreateDatasetCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/CreateDatasetCommand.java
@@ -143,7 +143,7 @@ public class CreateDatasetCommand extends AbstractCommand<Dataset> {
             } catch (IOException ioex) {
                 // if setting the storage identifier through createNewStorageIO fails, dataset creation
                 // does not have to fail. we just set the storage id to a default -SF
-                String storageDriver = (System.getProperty("dataverse.files.storage-driver-id") != null) ? System.getProperty("dataverse.files.storage-driver-id") : "file://";
+                String storageDriver = (System.getProperty("dataverse.files.storage-driver-id") != null) ? System.getProperty("dataverse.files.storage-driver-id") : "file";
                 theDataset.setStorageIdentifier(storageDriver  + "://" + theDataset.getAuthority()+theDataset.getDoiSeparator()+theDataset.getIdentifier());
                 logger.info("Failed to create StorageIO. StorageIdentifier set to default. Not fatal." + "(" + ioex.getMessage() + ")");
             }

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/CreateDatasetCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/CreateDatasetCommand.java
@@ -139,7 +139,7 @@ public class CreateDatasetCommand extends AbstractCommand<Dataset> {
         if (theDataset.getDoiSeparator()==null) theDataset.setDoiSeparator(doiSeparator);
         if (theDataset.getStorageIdentifier() == null) {
             try {
-                DataAccess.createNewStorageIO(theDataset, "dataset");
+                DataAccess.createNewStorageIO(theDataset, "placeholder");
             } catch (IOException ioex) {
                 // if setting the storage identifier through createNewStorageIO fails, dataset creation
                 // does not have to fail. we just set the storage id to a default -SF

--- a/src/main/java/edu/harvard/iq/dataverse/export/ExportService.java
+++ b/src/main/java/edu/harvard/iq/dataverse/export/ExportService.java
@@ -252,6 +252,7 @@ public class ExportService {
                 tempFileRequired = true;
                 tempFile = File.createTempFile("tempFileToExport", ".tmp");
                 outputStream = new FileOutputStream(tempFile);
+                logger.info("ExportService: " + ioex.getMessage());
             }
 
             try {

--- a/src/main/java/edu/harvard/iq/dataverse/export/ExportService.java
+++ b/src/main/java/edu/harvard/iq/dataverse/export/ExportService.java
@@ -245,7 +245,7 @@ public class ExportService {
             Dataset dataset = version.getDataset();
             StorageIO<Dataset> storageIO = null;
             try {
-                storageIO = DataAccess.createNewStorageIO(dataset, "file");
+                storageIO = DataAccess.createNewStorageIO(dataset, "placeholder");
                 Channel outputChannel = storageIO.openAuxChannel("export_" + format + ".cached", DataAccessOption.WRITE_ACCESS);
                 outputStream = Channels.newOutputStream((WritableByteChannel) outputChannel);
             } catch (IOException ioex) {

--- a/src/main/java/edu/harvard/iq/dataverse/export/ExportService.java
+++ b/src/main/java/edu/harvard/iq/dataverse/export/ExportService.java
@@ -252,7 +252,6 @@ public class ExportService {
                 tempFileRequired = true;
                 tempFile = File.createTempFile("tempFileToExport", ".tmp");
                 outputStream = new FileOutputStream(tempFile);
-                logger.info("ExportService: " + ioex.getMessage());
             }
 
             try {


### PR DESCRIPTION
This PR fixes a bug which caused storage identifiers to be incorrect for datasets in Swift, File and S3 storage. It also fixes a bug which did not allow metadata export in S3 storage.

## Related Issues

- connects to #4460: StorageId: Dataset storage id for Swift/S3 is not accurate until publish

## Pull Request Checklist

- [ ] Unit [tests][] completed
- [ ] Integration [tests][]: None
- [ ] Deployment requirements, [SQL updates][], [Solr updates][], etc.: None
- [ ] [Documentation][docs] completed
- [ ] Merged latest from "develop" [branch][] and resolved conflicts

[tests]: http://guides.dataverse.org/en/latest/developers/testing.html
[SQL updates]: https://github.com/IQSS/dataverse/tree/develop/scripts/database/upgrades
[Solr updates]: https://github.com/IQSS/dataverse/blob/develop/conf/solr/4.6.0/schema.xml
[docs]: http://guides.dataverse.org/en/latest/developers/documentation.html
[branch]: http://guides.dataverse.org/en/latest/developers/branching-strategy.html
