### PR TITLE
4240 - strange formatting in "to" field of Dataverse-sent email

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/MailServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/MailServiceBean.java
@@ -126,7 +126,7 @@ public class MailServiceBean implements java.io.Serializable {
                 InternetAddress[] recipients = new InternetAddress[recipientStrings.length];
                 for (int i = 0; i < recipients.length; i++) {
                     try {
-                        recipients[i] = new InternetAddress('"' + recipientStrings[i] + '"', "", charset);
+                        recipients[i] = new InternetAddress(recipientStrings[i], "", charset);
                     } catch (UnsupportedEncodingException ex) {
                         logger.severe(ex.getMessage());
                     }


### PR DESCRIPTION
remove double quotes around addresses in sendSystemMail()
now the same format as in line 94 in sendMail()

## New Contributors

Welcome! New contributors should at least glance at [CONTRIBUTING.md](/CONTRIBUTING.md), especially the section on pull requests where we encourage you to reach out to other developers before you start coding. Also, please note that we measure code coverage and prefer you write unit tests. Pull requests can still be reviewed without tests or completion of the checklist outlined below. Thanks!

## Related Issues

- connects to #4240:strange formatting in "to" field of Dataverse-sent email

## Pull Request Checklist

- [ ] Unit [tests][] completed
- [ ] Integration [tests][]: None
- [ ] Deployment requirements, [SQL updates][], [Solr updates][], etc.: None
- [ ] [Documentation][docs] completed
- [ ] Merged latest from "develop" [branch][] and resolved conflicts

[tests]: http://guides.dataverse.org/en/latest/developers/testing.html
[SQL updates]: https://github.com/IQSS/dataverse/tree/develop/scripts/database/upgrades
[Solr updates]: https://github.com/IQSS/dataverse/blob/develop/conf/solr/4.6.0/schema.xml
[docs]: http://guides.dataverse.org/en/latest/developers/documentation.html
[branch]: http://guides.dataverse.org/en/latest/developers/branching-strategy.html
