### PR TITLE
Allow configuration of Piwik Analytics tracker filenames #4497

### DIFF
--- a/doc/sphinx-guides/source/installation/config.rst
+++ b/doc/sphinx-guides/source/installation/config.rst
@@ -1045,6 +1045,16 @@ or
 
 ``curl -X PUT -d hostname.domain.tld/stats http://localhost:8080/api/admin/settings/:PiwikAnalyticsHost``
 
+:PiwikAnalyticsTrackerFileName
+++++++++++++++++++++++++++++++
+
+Filename for the 'php' and 'js' tracker files used in the piwik code (piwik.php and piwik.js).
+Sometimes these files are renamed in order to prevent ad-blockers (in the browser) to block the piwik tracking code.
+This sets the base name (without dot and extension), if not set it defaults to 'piwik'.
+
+``curl -X PUT -d domainstats http://localhost:8080/api/admin/settings/:PiwikAnalyticsTrackerFileName``
+
+
 :FileFixityChecksumAlgorithm
 ++++++++++++++++++++++++++++
 

--- a/src/main/webapp/piwik-analytics-snippet.xhtml
+++ b/src/main/webapp/piwik-analytics-snippet.xhtml
@@ -14,13 +14,14 @@
          _paq.push(['enableLinkTracking']);
          (function() {
              var u="//#{settingsWrapper.get(':PiwikAnalyticsHost')}/";
-             _paq.push(['setTrackerUrl', u+'piwik.php']);
+             var t="#{(empty settingsWrapper.get(':PiwikAnalyticsTrackerFileName'))?'piwik':settingsWrapper.get(':PiwikAnalyticsTrackerFileName')}";
+             _paq.push(['setTrackerUrl', u+t+'.php']);
              _paq.push(['setSiteId', #{settingsWrapper.get(':PiwikAnalyticsId')}]);
              var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-             g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+             g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+t+'.js'; s.parentNode.insertBefore(g,s);
          })();
          </script>
-         <noscript><p><img src="//#{settingsWrapper.get(':PiwikAnalyticsHost')}/piwik.php?idsite=#{settingsWrapper.get(':PiwikAnalyticsId')}" style="border:0;" alt="" /></p></noscript>
+         <noscript><p><img src="//#{settingsWrapper.get(':PiwikAnalyticsHost')}/#{(empty settingsWrapper.get(':PiwikAnalyticsTrackerFileName'))?'piwik':settingsWrapper.get(':PiwikAnalyticsTrackerFileName')}.php?idsite=#{settingsWrapper.get(':PiwikAnalyticsId')}" style="border:0;" alt="" /></p></noscript>
          <!-- End Piwik Code -->
     </c:if>
 </ui:composition>


### PR DESCRIPTION
Added the option to configure the piwik filenames by the ':PiwikAnalyticsTrackerFileName' setting.   
The hardcoded  use of the 'piwik.php' and 'piwik.js' filenames in the Javascript code was changed to use this new setting in piwik-analytics-snippet.xhtml.

## Related Issues

- connects to #4497 : Allow to set the Piwik Analytics tracker filenames if they are not the default 'piwik'
