### PR TITLE
Added custom navbar support url #4504

### DIFF
--- a/doc/sphinx-guides/source/installation/config.rst
+++ b/doc/sphinx-guides/source/installation/config.rst
@@ -852,6 +852,14 @@ Set ``:GuidesVersion`` to override the version number in the URL of guides. For 
 
 ``curl -X PUT -d 1234-new-feature http://localhost:8080/api/admin/settings/:GuidesVersion``
 
+:NavbarSupportUrl
++++++++++++++++++
+Set ``:NavbarSupportUrl`` to a fully-qualified url which will be used for the "Support" link in the navbar.
+
+Note that this will override the default behaviour for the "Support" menu option, which is to display the dataverse 'feedback' dialog.
+
+``curl -X PUT -d http://dataverse.example.edu/supportpage.html http://localhost:8080/api/admin/settings/:NavbarSupportUrl``
+
 :MetricsUrl
 +++++++++++
 

--- a/src/main/java/edu/harvard/iq/dataverse/settings/SettingsServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/settings/SettingsServiceBean.java
@@ -295,7 +295,10 @@ public class SettingsServiceBean {
         
         // Option to override multiple guides with a single url
         NavbarGuidesUrl,
-        
+
+        // Option to overide the feedback dialog display with a link to an external page via its url
+        NavbarSupportUrl,
+
         /**
          * The theme for the root dataverse can get in the way when you try make
          * use of HeaderCustomizationFile and LogoCustomizationFile so this is a

--- a/src/main/webapp/dataverse_header.xhtml
+++ b/src/main/webapp/dataverse_header.xhtml
@@ -67,14 +67,24 @@
                             </h:outputLink>
                         </li>
 
-                        <o:form useRequestURI="true" class="navbar-form navbar-left navbar-form-link">
-                            <p:commandLink value="#{bundle['header.support']}" oncomplete="PF('contactForm').show()" update=":contactDialog" actionListener="#{sendFeedbackDialog.initUserInput}">
-                                <f:setPropertyActionListener target="#{sendFeedbackDialog.messageSubject}" value=""/>
-                                <f:setPropertyActionListener target="#{sendFeedbackDialog.recipient}" value="#{null}"/>
-                                <f:setPropertyActionListener target="#{sendFeedbackDialog.userMessage}" value=""/>
-                                <f:setPropertyActionListener target="#{sendFeedbackDialog.userEmail}" value=""/>
-                            </p:commandLink>
-                        </o:form>
+                        <ui:fragment rendered="#{!empty settingsWrapper.get(':NavbarSupportUrl')}">
+                            <li>
+                                <h:outputLink value="#{settingsWrapper.get(':NavbarSupportUrl')}" target="_blank">
+                                    #{bundle['header.support']}
+                                </h:outputLink>
+                            </li>
+                        </ui:fragment>
+                        <ui:fragment rendered="#{empty settingsWrapper.get(':NavbarSupportUrl')}">
+                            <o:form useRequestURI="true" class="navbar-form navbar-left navbar-form-link">
+                                <p:commandLink value="#{bundle['header.support']}" oncomplete="PF('contactForm').show()" update=":contactDialog" actionListener="#{sendFeedbackDialog.initUserInput}">
+                                    <f:setPropertyActionListener target="#{sendFeedbackDialog.messageSubject}" value=""/>
+                                    <f:setPropertyActionListener target="#{sendFeedbackDialog.recipient}" value="#{null}"/>
+                                    <f:setPropertyActionListener target="#{sendFeedbackDialog.userMessage}" value=""/>
+                                    <f:setPropertyActionListener target="#{sendFeedbackDialog.userEmail}" value=""/>
+                                </p:commandLink>
+                            </o:form>
+                        </ui:fragment>
+
                         <li jsf:rendered="#{dataverseSession.user.superuser}">
                             <h:outputLink value="/dashboard.xhtml?dataverseId=#{dataverseServiceBean.findRootDataverse().id}">
                                 <h:outputText value="#{bundle['header.dashboard']}" />


### PR DESCRIPTION
Added ":NavbarSupportUrl" setting to directly link to a given url from the navbar "Support" option instead of displaying the feedback dialog.

- connects to #4504: Allow custom navbar Support url
