### PR TITLE
4524 s3 redirects utf8 filenames

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/dataaccess/S3AccessIO.java
+++ b/src/main/java/edu/harvard/iq/dataverse/dataaccess/S3AccessIO.java
@@ -39,6 +39,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URL;
+import java.net.URLEncoder;
 import java.nio.channels.Channel;
 import java.nio.channels.Channels;
 import java.nio.channels.WritableByteChannel;
@@ -650,7 +651,10 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
             generatePresignedUrlRequest.setMethod(HttpMethod.GET); // Default.
             generatePresignedUrlRequest.setExpiration(expiration);
             ResponseHeaderOverrides responseHeaders = new ResponseHeaderOverrides();
-            responseHeaders.setContentDisposition("attachment; filename="+this.getDataFile().getDisplayName());
+            //responseHeaders.setContentDisposition("attachment; filename="+this.getDataFile().getDisplayName());
+            // Encode the file name explicitly specifying the encoding as UTF-8:
+            // (otherwise S3 may not like non-ASCII characters!)
+            responseHeaders.setContentDisposition("attachment; filename="+URLEncoder.encode(this.getDataFile().getDisplayName(), "UTF-8"));
             responseHeaders.setContentType(this.getDataFile().getContentType());
             generatePresignedUrlRequest.setResponseHeaders(responseHeaders);
 

--- a/src/main/java/edu/harvard/iq/dataverse/dataaccess/S3AccessIO.java
+++ b/src/main/java/edu/harvard/iq/dataverse/dataaccess/S3AccessIO.java
@@ -654,7 +654,16 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
             //responseHeaders.setContentDisposition("attachment; filename="+this.getDataFile().getDisplayName());
             // Encode the file name explicitly specifying the encoding as UTF-8:
             // (otherwise S3 may not like non-ASCII characters!)
-            responseHeaders.setContentDisposition("attachment; filename="+URLEncoder.encode(this.getDataFile().getDisplayName(), "UTF-8"));
+            // Most browsers are happy with just "filename="+URLEncoder.encode(this.getDataFile().getDisplayName(), "UTF-8") 
+            // in the header. But Firefox appears to require that "UTF8" is 
+            // specified explicitly, as below:
+            responseHeaders.setContentDisposition("attachment; filename*=UTF-8''"+URLEncoder.encode(this.getDataFile().getDisplayName(), "UTF-8"));
+            // - without it, download will work, but Firefox will leave the special
+            // characters in the file name encoded. For example, the file name 
+            // will look like "1976%E2%80%932016.txt" instead of "1976–2016.txt", 
+            // where the dash is the "long dash", represented by a 3-byte UTF8 
+            // character "\xE2\x80\x93"
+            
             responseHeaders.setContentType(this.getDataFile().getContentType());
             generatePresignedUrlRequest.setResponseHeaders(responseHeaders);
 


### PR DESCRIPTION
## New Contributors

Welcome! New contributors should at least glance at [CONTRIBUTING.md](/CONTRIBUTING.md), especially the section on pull requests where we encourage you to reach out to other developers before you start coding. Also, please note that we measure code coverage and prefer you write unit tests. Pull requests can still be reviewed without tests or completion of the checklist outlined below. Thanks!

## Related Issues

- connects to #4524: S3 redirect for file downloads: UTF8 characters in filenames cause problems

## Pull Request Checklist

- [ ] Unit [tests][] completed
- [ ] Integration [tests][]: None
- [ ] Deployment requirements, [SQL updates][], [Solr updates][], etc.: None
- [ ] [Documentation][docs] completed
- [ ] Merged latest from "develop" [branch][] and resolved conflicts

[tests]: http://guides.dataverse.org/en/latest/developers/testing.html
[SQL updates]: https://github.com/IQSS/dataverse/tree/develop/scripts/database/upgrades
[Solr updates]: https://github.com/IQSS/dataverse/blob/develop/conf/solr/4.6.0/schema.xml
[docs]: http://guides.dataverse.org/en/latest/developers/documentation.html
[branch]: http://guides.dataverse.org/en/latest/developers/branching-strategy.html
