### PR TITLE
4406 dataverse move api

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DataverseServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DataverseServiceBean.java
@@ -550,4 +550,40 @@ public class DataverseServiceBean implements java.io.Serializable {
             }
         }
     }
+    
+    // function to recursively find all children of a dataverse that 
+    // are also of type dataverse
+    public List<Dataverse> findAllDataverseDataverseChildren(Dataverse dv) {
+        // get list of Dataverse children
+        List<Dataverse> dataverseChildren = findByOwnerId(dv.getId());
+        
+        if (dataverseChildren == null) {
+            return dataverseChildren;
+        } else {
+            List<Dataverse> newChildren = new ArrayList<>();
+            for (Dataverse childDv : dataverseChildren) {
+                newChildren.addAll(findAllDataverseDataverseChildren(childDv));
+            }
+            dataverseChildren.addAll(newChildren);
+            return dataverseChildren;
+        }
+    }
+    
+    // function to recursively find all children of a dataverse that are 
+    // of type dataset
+    public List<Dataset> findAllDataverseDatasetChildren(Dataverse dv) {
+        // get list of Dataverse children
+        List<Dataverse> dataverseChildren = findByOwnerId(dv.getId());
+        // get list of Dataset children
+        List<Dataset> datasetChildren = datasetService.findByOwnerId(dv.getId());
+        
+        if (dataverseChildren == null) {
+            return datasetChildren;
+        } else {
+            for (Dataverse childDv : dataverseChildren) {
+                datasetChildren.addAll(findAllDataverseDatasetChildren(childDv));
+            }
+            return datasetChildren;
+        }
+    }
 }  

--- a/src/main/java/edu/harvard/iq/dataverse/api/Dataverses.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Dataverses.java
@@ -39,6 +39,7 @@ import edu.harvard.iq.dataverse.engine.command.impl.ListFacetsCommand;
 import edu.harvard.iq.dataverse.engine.command.impl.ListMetadataBlocksCommand;
 import edu.harvard.iq.dataverse.engine.command.impl.ListRoleAssignments;
 import edu.harvard.iq.dataverse.engine.command.impl.ListRolesCommand;
+import edu.harvard.iq.dataverse.engine.command.impl.MoveDataverseCommand;
 import edu.harvard.iq.dataverse.engine.command.impl.PublishDataverseCommand;
 import edu.harvard.iq.dataverse.engine.command.impl.RemoveRoleAssigneesFromExplicitGroupCommand;
 import edu.harvard.iq.dataverse.engine.command.impl.RevokeRoleCommand;
@@ -759,6 +760,25 @@ public class Dataverses extends AbstractApiBean {
 
         } catch (WrappedResponse wr) {
             return wr.getResponse();
+        }
+    }
+    
+    @POST
+    @Path("{id}/move/{targetDataverseAlias}") 
+    public Response moveDataverse(@PathParam("id") String id, @PathParam("targetDataverseAlias") String targetDataverseAlias, @QueryParam("forceMove") Boolean force) {        
+        try{
+            User u = findUserOrDie();            
+            Dataverse dv = findDataverseOrDie(id);
+            Dataverse target = findDataverseOrDie(targetDataverseAlias);
+            if (target == null){
+                return error(Response.Status.BAD_REQUEST, "Target Dataverse not found.");
+            }            
+            execCommand(new MoveDataverseCommand(
+                    createDataverseRequest(u), dv, target, force
+                    ));
+            return ok("Dataverse moved successfully");
+        } catch (WrappedResponse ex) {
+            return ex.getResponse();
         }
     }
 

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/MoveDataverseCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/MoveDataverseCommand.java
@@ -1,6 +1,8 @@
 package edu.harvard.iq.dataverse.engine.command.impl;
 
+import edu.harvard.iq.dataverse.Dataset;
 import edu.harvard.iq.dataverse.Dataverse;
+import edu.harvard.iq.dataverse.DataverseFeaturedDataverse;
 import edu.harvard.iq.dataverse.Guestbook;
 import static edu.harvard.iq.dataverse.IdServiceBean.logger;
 import edu.harvard.iq.dataverse.MetadataBlock;
@@ -15,6 +17,7 @@ import edu.harvard.iq.dataverse.engine.command.RequiredPermissionsMap;
 import edu.harvard.iq.dataverse.engine.command.exception.CommandException;
 import edu.harvard.iq.dataverse.engine.command.exception.IllegalCommandException;
 import edu.harvard.iq.dataverse.engine.command.exception.PermissionException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -103,18 +106,7 @@ public class MoveDataverseCommand extends AbstractVoidCommand {
                 }
             }
         }
-        
-        // metadata blocks
-        if (moved.getMetadataBlocks() != null) {
-            List<MetadataBlock> movedMbs = moved.getMetadataBlocks();
-            List<MetadataBlock> destinationMbs = destination.getMetadataBlocks();
-            boolean inheritMetadataBlockValue = destination.isMetadataBlockRoot();
-            if (inheritMetadataBlockValue && destination.getOwner() != null) {
-                // todo
-            }
-            
-        }
-        
+                
         // if all the dataverses TEMPLATES are not contained in the new dataverse then remove the
         // ones that aren't
         if (moved.getTemplates() != null) {
@@ -144,7 +136,17 @@ public class MoveDataverseCommand extends AbstractVoidCommand {
                 } 
             }
         }
-        // what else?
+
+        // if the dataverse is featured, remove it
+        List<DataverseFeaturedDataverse> ownerFeaturedDv = moved.getOwner().getDataverseFeaturedDataverses();
+        if (ownerFeaturedDv != null) {
+            for (DataverseFeaturedDataverse dfdv: ownerFeaturedDv) {
+                if (moved.equals(dfdv.getFeaturedDataverse())) {
+                    ctxt.featuredDataverses().delete(dfdv);
+                }
+            }
+        }
+        
         
         // OK, move
         moved.setOwner(destination);

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/MoveDataverseCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/MoveDataverseCommand.java
@@ -1,6 +1,9 @@
 package edu.harvard.iq.dataverse.engine.command.impl;
 
+import edu.harvard.iq.dataverse.Dataset;
 import edu.harvard.iq.dataverse.Dataverse;
+import edu.harvard.iq.dataverse.DataverseServiceBean;
+import static edu.harvard.iq.dataverse.IdServiceBean.logger;
 import edu.harvard.iq.dataverse.authorization.Permission;
 import edu.harvard.iq.dataverse.engine.command.AbstractVoidCommand;
 import edu.harvard.iq.dataverse.engine.command.CommandContext;
@@ -9,6 +12,8 @@ import edu.harvard.iq.dataverse.engine.command.RequiredPermissions;
 import edu.harvard.iq.dataverse.engine.command.RequiredPermissionsMap;
 import edu.harvard.iq.dataverse.engine.command.exception.CommandException;
 import edu.harvard.iq.dataverse.engine.command.exception.IllegalCommandException;
+import java.util.List;
+import java.util.logging.Level;
 
 /**
  * A command to move a {@link Dataverse} between two {@link Dataverse}s.
@@ -28,29 +33,74 @@ public class MoveDataverseCommand extends AbstractVoidCommand {
 	
 	final Dataverse moved;
 	final Dataverse destination;
+        final Boolean force;
 
-	public MoveDataverseCommand( DataverseRequest aRequest, Dataverse moved, Dataverse destination ) {
+	public MoveDataverseCommand( DataverseRequest aRequest, Dataverse moved, Dataverse destination, Boolean force ) {
 		super(aRequest, dv("moved", moved),
 					 dv("source",moved.getOwner()),
 					 dv("destination",destination) );
 		this.moved = moved;
 		this.destination = destination;
+                this.force = force;
 	}
 	
 	@Override
 	public void executeImpl(CommandContext ctxt) throws CommandException {
         
-        // NOTE placeholder, more logic due
         
 		// validate the move makes sense
 		if ( destination.getOwners().contains(moved) ) {
-			throw new IllegalCommandException("Can't move a dataverse to its descendant", this);
+			throw new IllegalCommandException("Can't move a Dataverse to its descendant", this);
 		}
+                if (moved.getOwner().equals(destination)) {
+                    throw new IllegalCommandException("Dataverse already in this Dataverse ", this);
+                }
+                if (moved.equals(destination)) {
+                    throw new IllegalCommandException("Cannot move a Dataverse into itself", this);
+                }
+                // if dataverse is published make sure that its destination is published
+                if (moved.isReleased() && !destination.isReleased()){
+                    throw new IllegalCommandException("Published Dataverse may not be moved to unpublished Dataverse. You may publish " + destination.getDisplayName() + " and re-try the move.", this);
+                }
 		
 		// OK, move
 		moved.setOwner(destination);
 		ctxt.dataverses().save(moved);
-		
+                try {
+                    indexDataverses(ctxt, moved);
+                } catch (CommandException e) {
+                    logger.log(Level.WARNING, "Exception while indexing:" + e.getMessage()); //, e);
+                    throw new CommandException("Dataverse could not be moved. Indexing failed: (" + e.getMessage() + ")", this);
+                }
 	}
+        
+        public void indexDataverses(CommandContext ctxt, Dataverse dataverse) throws CommandException{
+            // index the Dataverse of current recursion
+            try {
+                ctxt.index().indexDataverse(dataverse);
+            } catch (Exception e) {
+                throw new CommandException("Dataverse could not be moved. Indexing failed on " + dataverse.getName() + ": (" + e.getMessage() + ")", this);
+            }
+            // get list of Dataverse children
+            List<Dataverse> dataverseChildren = ctxt.dataverses().findByOwnerId(dataverse.getId());
+            
+            // get list of Dataset children
+            List<Dataset> datasetChildren = ctxt.datasets().findByOwnerId(dataverse.getId());
+
+            // index the Dataset children
+            for (Dataset child : datasetChildren) {
+                try {
+                    boolean doNormalSolrDocCleanUp = true;
+                    ctxt.index().indexDataset(child, doNormalSolrDocCleanUp);
+                } catch (Exception e){
+                    throw new CommandException("Dataset could not be moved. Indexing failed on " + child.getId() +": (" + e.getMessage() + ")", this);
+                }
+            }
+            
+            // recursively index the Dataverse children
+            for (Dataverse child : dataverseChildren) {
+                indexDataverses(ctxt, child);
+            }
+        }
 	
 }

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/MoveDataverseCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/MoveDataverseCommand.java
@@ -27,19 +27,20 @@ import java.util.logging.Level;
 
 /**
  * A command to move a {@link Dataverse} between two {@link Dataverse}s.
+ *
  * @author michael
  */
-
 //@todo We will need to revist the permissions for move, once we add this 
 //(will probably need different move commands for unplublished which checks add,
 //versus published which checks publish 
-
 // since the current implementation is superuser only, we can ignore these permission
 // checks that would need to be revisited if regular users were able to use this
 @RequiredPermissionsMap({
-	@RequiredPermissions( dataverseName = "moved",       value = {Permission.ManageDataversePermissions, Permission.EditDataverse} ),
-	@RequiredPermissions( dataverseName = "source",      value = Permission.DeleteDataverse ),
-	@RequiredPermissions( dataverseName = "destination", value = Permission.AddDataverse )
+    @RequiredPermissions(dataverseName = "moved", value = {Permission.ManageDataversePermissions, Permission.EditDataverse})
+    ,
+	@RequiredPermissions(dataverseName = "source", value = Permission.DeleteDataverse)
+    ,
+	@RequiredPermissions(dataverseName = "destination", value = Permission.AddDataverse)
 })
 public class MoveDataverseCommand extends AbstractVoidCommand {
 
@@ -47,10 +48,10 @@ public class MoveDataverseCommand extends AbstractVoidCommand {
     final Dataverse destination;
     final Boolean force;
 
-    public MoveDataverseCommand( DataverseRequest aRequest, Dataverse moved, Dataverse destination, Boolean force ) {
+    public MoveDataverseCommand(DataverseRequest aRequest, Dataverse moved, Dataverse destination, Boolean force) {
         super(aRequest, dv("moved", moved),
-                                 dv("source",moved.getOwner()),
-                                 dv("destination",destination) );
+                dv("source", moved.getOwner()),
+                dv("destination", destination));
         this.moved = moved;
         this.destination = destination;
         this.force = force;
@@ -59,14 +60,14 @@ public class MoveDataverseCommand extends AbstractVoidCommand {
     @Override
     public void executeImpl(CommandContext ctxt) throws CommandException {
         // first check if user is a superuser
-        if ( (!(getUser() instanceof AuthenticatedUser) || !getUser().isSuperuser() ) ) {      
+        if ((!(getUser() instanceof AuthenticatedUser) || !getUser().isSuperuser())) {
             throw new PermissionException("Move Dataset can only be called by superusers.",
-                this,  Collections.singleton(Permission.DeleteDataverse), moved);                
+                    this, Collections.singleton(Permission.DeleteDataverse), moved);
         }
 
         // validate the move makes sense
-        if ( destination.getOwners().contains(moved) ) {
-                throw new IllegalCommandException("Can't move a Dataverse to its descendant", this);
+        if (destination.getOwners().contains(moved)) {
+            throw new IllegalCommandException("Can't move a Dataverse to its descendant", this);
         }
         if (moved.getOwner().equals(destination)) {
             throw new IllegalCommandException("Dataverse already in this Dataverse ", this);
@@ -75,15 +76,14 @@ public class MoveDataverseCommand extends AbstractVoidCommand {
             throw new IllegalCommandException("Cannot move a Dataverse into itself", this);
         }
         // if dataverse is published make sure that its destination is published
-        if (moved.isReleased() && !destination.isReleased()){
+        if (moved.isReleased() && !destination.isReleased()) {
             throw new IllegalCommandException("Published Dataverse may not be moved to unpublished Dataverse. You may publish " + destination.getDisplayName() + " and re-try the move.", this);
         }
-        
-        List<Dataset> datasetChildren = findAllDataverseDatasetChildren(moved, ctxt.datasets(), ctxt.dataverses());
-        System.out.println("datasetChildren: " + datasetChildren);
-        
-        List<Dataverse> dataverseChildren = findAllDataverseDataverseChildren(moved, ctxt.datasets(), ctxt.dataverses());
-        System.out.println("dataverseChildren: " + dataverseChildren);
+
+        List<Dataset> datasetChildren = ctxt.dataverses().findAllDataverseDatasetChildren(moved);
+
+        List<Dataverse> dataverseChildren = ctxt.dataverses().findAllDataverseDataverseChildren(moved);
+        dataverseChildren.add(moved); // include the root of the children
 
         // if all the dataverse's datasets GUESTBOOKS are not contained in the new dataverse then remove the
         // ones that aren't
@@ -92,47 +92,37 @@ public class MoveDataverseCommand extends AbstractVoidCommand {
             List<Guestbook> destinationGbs = destination.getGuestbooks();
             boolean inheritGuestbooksValue = !destination.isGuestbookRoot();
             if (inheritGuestbooksValue && destination.getOwner() != null) {
-                for (Guestbook pg : destination.getParentGuestbooks()) {
-                    destinationGbs.add(pg);
-                }
+                destinationGbs.addAll(destination.getParentGuestbooks());
             }
             // include guestbooks in moved dataverse since they will also be there
             // in the destination
-            for (Guestbook pg : movedGbs) {
-                destinationGbs.add(pg);
-            }
-            
-            for (Dataset ds : datasetChildren) { 
+            destinationGbs.addAll(movedGbs);
+            for (Dataset ds : datasetChildren) {
                 Guestbook dsgb = ds.getGuestbook();
                 if (dsgb != null && (destinationGbs == null || !destinationGbs.contains(dsgb))) {
-                    if (force == null  || !force) {
+                    if (force == null || !force) {
                         throw new IllegalCommandException("Dataset guestbook is not in target dataverse. Please use the parameter ?forceMove=true to complete the move. This will delete the guestbook from the Dataverse", this);
                     }
                     ds.setGuestbook(null);
                 }
             }
         }
-                
+
         // if the dataverses default TEMPLATE is not contained in the new dataverse then remove it
         if (moved.getTemplates() != null) {
             List<Template> movedTemplates = moved.getTemplates();
             List<Template> destinationTemplates = destination.getTemplates();
             boolean inheritTemplateValue = !destination.isTemplateRoot();
             if (inheritTemplateValue && destination.getOwner() != null) {
-                for (Template t : destination.getParentTemplates()) {
-                    destinationTemplates.add(t);
-                }
+                destinationTemplates.addAll(destination.getParentTemplates());
             }
             // include templates in moved dataverse since they will also be there
             // in the destination
-            for (Template t : movedTemplates) {
-                destinationTemplates.add(t);
-            }
-            dataverseChildren.add(moved);
+            destinationTemplates.addAll(movedTemplates);
             for (Dataverse dv : dataverseChildren) {
                 Template dvt = dv.getDefaultTemplate();
                 if (dvt != null && (destinationTemplates == null || !destinationTemplates.contains(dvt))) {
-                    if (force == null  || !force) {
+                    if (force == null || !force) {
                         throw new IllegalCommandException("Dataverse template is not in target dataverse. Please use the parameter ?forceMove=true to complete the move. This will delete the template from the Dataverse", this);
                     }
                     logger.info("Removing template: " + moved.getDefaultTemplate().getName());
@@ -140,101 +130,71 @@ public class MoveDataverseCommand extends AbstractVoidCommand {
                 }
             }
         }
-        
+
         // if the dataverse is FEATURED by its parent, remove it
         List<DataverseFeaturedDataverse> ownerFeaturedDv = moved.getOwner().getDataverseFeaturedDataverses();
         if (ownerFeaturedDv != null) {
-            for (DataverseFeaturedDataverse dfdv: ownerFeaturedDv) {
+            for (DataverseFeaturedDataverse dfdv : ownerFeaturedDv) {
+                System.out.println(dfdv);
+                System.out.println(dfdv.getFeaturedDataverse());
                 if (moved.equals(dfdv.getFeaturedDataverse())) {
+                    if (force == null || !force) {
+                        throw new IllegalCommandException("Dataverse is featured in current dataverse. Please use the parameter ?forceMove=true to complete the move. This will unfeature the Dataverse", this);
+                    }
                     ctxt.featuredDataverses().delete(dfdv);
                 }
             }
         }
-        
+
         // if all the dataverses METADATA BLOCKS are not contained in the new dataverse then remove the
         // ones that aren't available in the destination
         // i.e. the case where a custom metadata block is available through a parent 
         // but then the dataverse is moved outside of that parent-child structure
         if (moved.getMetadataBlocks() != null) {
-            List<MetadataBlock> movedMbs = moved.getMetadataBlocks();
             boolean inheritMbValue = !destination.isMetadataBlockRoot();
-            
             // generate list of all possible metadata block owner dataverses to check against
             List<Dataverse> ownersToCheck = new ArrayList<>();
             ownersToCheck.add(destination);
             ownersToCheck.add(moved);
-            if (inheritMbValue && destination.getOwners() != null) {
-                for (Dataverse owner : destination.getOwners()) {
-                    ownersToCheck.add(owner);
-                }
+            ownersToCheck.addAll(dataverseChildren);
+            if (destination.getOwners() != null) {
+                ownersToCheck.addAll(destination.getOwners());
             }
 
             // determine which metadata blocks to keep selected 
-            // on the moved dataverse 
-            List<MetadataBlock> metadataBlocksToKeep = new ArrayList<>();
-            Iterator<MetadataBlock> iter = movedMbs.iterator();
-            while (iter.hasNext()) {
-                MetadataBlock mb = iter.next();
-                // if the owner is null, it means that the owner is the root dataverse
-                // because technically only custom metadata blocks have owners
-                Dataverse mbOwner = (mb.getOwner() != null) ? mb.getOwner() : ctxt.dataverses().findByAlias(":root");
-                System.out.println("mbOwner: " + mbOwner);
-                System.out.println("ownersToCheck: " + ownersToCheck);
-                if (!ownersToCheck.contains(mbOwner)) {
-                    if (force == null  || !force) {
-                        throw new IllegalCommandException("Dataverse metadata block is not in target dataverse. Please use the parameter ?forceMove=true to complete the move. This will disassociate the metadata block from the Dataverse", this);
+            // on the moved dataverse and its children 
+            for (Dataverse dv : dataverseChildren) {
+                List<MetadataBlock> metadataBlocksToKeep = new ArrayList<>();
+                List<MetadataBlock> movedMbs = dv.getMetadataBlocks(true);
+                Iterator<MetadataBlock> iter = movedMbs.iterator();
+                while (iter.hasNext()) {
+                    MetadataBlock mb = iter.next();
+                    // if the owner is null, it means that the owner is the root dataverse
+                    // because technically only custom metadata blocks have owners
+                    Dataverse mbOwner = (mb.getOwner() != null) ? mb.getOwner() : ctxt.dataverses().findByAlias(":root");
+                    if (!ownersToCheck.contains(mbOwner)) {
+                        if (force == null || !force) {
+                            throw new IllegalCommandException("Dataverse metadata block is not in target dataverse. Please use the parameter ?forceMove=true to complete the move. This will disassociate the metadata block from the Dataverse", this);
+                        }
+                    } else if (ownersToCheck.contains(mbOwner) || inheritMbValue) {
+                        // only keep metadata block if
+                        // it is being inherited from its parent
+                        metadataBlocksToKeep.add(mb);
                     }
                 }
-                else if (ownersToCheck.contains(mbOwner) || !moved.isMetadataBlockRoot()) {
-                    // only keep metadata block if
-                    // it is being inherited from its parent
-                     metadataBlocksToKeep.add(mb);
-                }
+                dv.setMetadataBlocks(metadataBlocksToKeep);
             }
-            moved.setMetadataBlocks(metadataBlocksToKeep);
         }
-        
+
         // OK, move
         moved.setOwner(destination);
-        ctxt.dataverses().save(moved);        
+        ctxt.dataverses().save(moved);
         try {
             boolean doNormalSolrDocCleanUp = true;
             ctxt.index().indexDataverseRecursively(moved, doNormalSolrDocCleanUp);
         } catch (Exception e) {
             logger.log(Level.WARNING, "Exception while indexing:" + e.getMessage()); //, e);
             throw new CommandException("Dataverse could not be moved. Indexing failed: (" + e.getMessage() + ")", this);
-        }
-    }
-    
-    public List<Dataset> findAllDataverseDatasetChildren(Dataverse dv, DatasetServiceBean datasetService, DataverseServiceBean dataverseService) {
-        // get list of Dataverse children
-        List<Dataverse> dataverseChildren = dataverseService.findByOwnerId(dv.getId());
-        // get list of Dataset children
-        List<Dataset> datasetChildren = datasetService.findByOwnerId(dv.getId());
-        
-        if (dataverseChildren == null) {
-            return datasetChildren;
-        } else {
-            for (Dataverse childDv : dataverseChildren) {
-                datasetChildren.addAll(findAllDataverseDatasetChildren(childDv, datasetService, dataverseService));
-            }
-            return datasetChildren;
-        }
-    }
-    
-    public List<Dataverse> findAllDataverseDataverseChildren(Dataverse dv, DatasetServiceBean datasetService, DataverseServiceBean dataverseService) {
-        // get list of Dataverse children
-        List<Dataverse> dataverseChildren = dataverseService.findByOwnerId(dv.getId());
-        
-        if (dataverseChildren == null) {
-            return dataverseChildren;
-        } else {
-            List<Dataverse> newChildren = new ArrayList<>();
-            for (Dataverse childDv : dataverseChildren) {
-                newChildren.addAll(findAllDataverseDataverseChildren(childDv, datasetService, dataverseService));
-            }
-            dataverseChildren.addAll(newChildren);
-            return dataverseChildren;
         }
     }
 }

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/MoveDataverseCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/MoveDataverseCommand.java
@@ -5,6 +5,7 @@ import edu.harvard.iq.dataverse.Dataverse;
 import edu.harvard.iq.dataverse.DataverseServiceBean;
 import static edu.harvard.iq.dataverse.IdServiceBean.logger;
 import edu.harvard.iq.dataverse.authorization.Permission;
+import edu.harvard.iq.dataverse.authorization.users.AuthenticatedUser;
 import edu.harvard.iq.dataverse.engine.command.AbstractVoidCommand;
 import edu.harvard.iq.dataverse.engine.command.CommandContext;
 import edu.harvard.iq.dataverse.engine.command.DataverseRequest;
@@ -12,6 +13,8 @@ import edu.harvard.iq.dataverse.engine.command.RequiredPermissions;
 import edu.harvard.iq.dataverse.engine.command.RequiredPermissionsMap;
 import edu.harvard.iq.dataverse.engine.command.exception.CommandException;
 import edu.harvard.iq.dataverse.engine.command.exception.IllegalCommandException;
+import edu.harvard.iq.dataverse.engine.command.exception.PermissionException;
+import java.util.Collections;
 import java.util.List;
 import java.util.logging.Level;
 
@@ -30,77 +33,55 @@ import java.util.logging.Level;
 	@RequiredPermissions( dataverseName = "destination", value = Permission.AddDataverse )
 })
 public class MoveDataverseCommand extends AbstractVoidCommand {
-	
-	final Dataverse moved;
-	final Dataverse destination;
-        final Boolean force;
 
-	public MoveDataverseCommand( DataverseRequest aRequest, Dataverse moved, Dataverse destination, Boolean force ) {
-		super(aRequest, dv("moved", moved),
-					 dv("source",moved.getOwner()),
-					 dv("destination",destination) );
-		this.moved = moved;
-		this.destination = destination;
-                this.force = force;
-	}
-	
-	@Override
-	public void executeImpl(CommandContext ctxt) throws CommandException {
-        
-        
-		// validate the move makes sense
-		if ( destination.getOwners().contains(moved) ) {
-			throw new IllegalCommandException("Can't move a Dataverse to its descendant", this);
-		}
-                if (moved.getOwner().equals(destination)) {
-                    throw new IllegalCommandException("Dataverse already in this Dataverse ", this);
-                }
-                if (moved.equals(destination)) {
-                    throw new IllegalCommandException("Cannot move a Dataverse into itself", this);
-                }
-                // if dataverse is published make sure that its destination is published
-                if (moved.isReleased() && !destination.isReleased()){
-                    throw new IllegalCommandException("Published Dataverse may not be moved to unpublished Dataverse. You may publish " + destination.getDisplayName() + " and re-try the move.", this);
-                }
-		
-		// OK, move
-		moved.setOwner(destination);
-		ctxt.dataverses().save(moved);
-                try {
-                    indexDataverses(ctxt, moved);
-                } catch (CommandException e) {
-                    logger.log(Level.WARNING, "Exception while indexing:" + e.getMessage()); //, e);
-                    throw new CommandException("Dataverse could not be moved. Indexing failed: (" + e.getMessage() + ")", this);
-                }
-	}
-        
-        public void indexDataverses(CommandContext ctxt, Dataverse dataverse) throws CommandException{
-            // index the Dataverse of current recursion
-            try {
-                ctxt.index().indexDataverse(dataverse);
-            } catch (Exception e) {
-                throw new CommandException("Dataverse could not be moved. Indexing failed on " + dataverse.getName() + ": (" + e.getMessage() + ")", this);
-            }
-            // get list of Dataverse children
-            List<Dataverse> dataverseChildren = ctxt.dataverses().findByOwnerId(dataverse.getId());
-            
-            // get list of Dataset children
-            List<Dataset> datasetChildren = ctxt.datasets().findByOwnerId(dataverse.getId());
+    final Dataverse moved;
+    final Dataverse destination;
+    final Boolean force;
 
-            // index the Dataset children
-            for (Dataset child : datasetChildren) {
-                try {
-                    boolean doNormalSolrDocCleanUp = true;
-                    ctxt.index().indexDataset(child, doNormalSolrDocCleanUp);
-                } catch (Exception e){
-                    throw new CommandException("Dataset could not be moved. Indexing failed on " + child.getId() +": (" + e.getMessage() + ")", this);
-                }
-            }
-            
-            // recursively index the Dataverse children
-            for (Dataverse child : dataverseChildren) {
-                indexDataverses(ctxt, child);
-            }
+    public MoveDataverseCommand( DataverseRequest aRequest, Dataverse moved, Dataverse destination, Boolean force ) {
+        super(aRequest, dv("moved", moved),
+                                 dv("source",moved.getOwner()),
+                                 dv("destination",destination) );
+        this.moved = moved;
+        this.destination = destination;
+        this.force = force;
+    }
+
+    @Override
+    public void executeImpl(CommandContext ctxt) throws CommandException {
+        // first check if user is a superuser
+//        if ( (!(getUser() instanceof AuthenticatedUser) || !getUser().isSuperuser() ) ) {      
+//            throw new PermissionException("Move Dataset can only be called by superusers.",
+//                this,  Collections.singleton(Permission.DeleteDataverse), moved);                
+//        }
+
+        // validate the move makes sense
+        if ( destination.getOwners().contains(moved) ) {
+                throw new IllegalCommandException("Can't move a Dataverse to its descendant", this);
         }
-	
+        if (moved.getOwner().equals(destination)) {
+            throw new IllegalCommandException("Dataverse already in this Dataverse ", this);
+        }
+        if (moved.equals(destination)) {
+            throw new IllegalCommandException("Cannot move a Dataverse into itself", this);
+        }
+        // if dataverse is published make sure that its destination is published
+        if (moved.isReleased() && !destination.isReleased()){
+            throw new IllegalCommandException("Published Dataverse may not be moved to unpublished Dataverse. You may publish " + destination.getDisplayName() + " and re-try the move.", this);
+        }
+
+        // guestbook
+        
+        
+        // OK, move
+        moved.setOwner(destination);
+        ctxt.dataverses().save(moved);
+        try {
+            boolean doNormalSolrDocCleanUp = true;
+            ctxt.index().indexDataverseRecursively(moved, doNormalSolrDocCleanUp);
+        } catch (Exception e) {
+            logger.log(Level.WARNING, "Exception while indexing:" + e.getMessage()); //, e);
+            throw new CommandException("Dataverse could not be moved. Indexing failed: (" + e.getMessage() + ")", this);
+        }
+    }
 }

--- a/src/main/java/edu/harvard/iq/dataverse/search/IndexServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/search/IndexServiceBean.java
@@ -128,6 +128,27 @@ public class IndexServiceBean {
     public Future<String> indexDataverseInNewTransaction(Dataverse dataverse) {
         return indexDataverse(dataverse);
     }
+    
+    public void indexDataverseRecursively(Dataverse dataverse, boolean doNormalSolrDocCleanUp) {
+        // index the Dataverse of current recursion
+        indexDataverse(dataverse);
+
+        // get list of Dataverse children
+        List<Dataverse> dataverseChildren = dataverseService.findByOwnerId(dataverse.getId());
+
+        // get list of Dataset children
+        List<Dataset> datasetChildren = datasetService.findByOwnerId(dataverse.getId());
+
+        // index the Dataset children
+        for (Dataset child : datasetChildren) {
+            indexDataset(child, doNormalSolrDocCleanUp);
+        }
+
+        // recursively index the Dataverse children
+        for (Dataverse child : dataverseChildren) {
+            indexDataverseRecursively(child, doNormalSolrDocCleanUp);
+        }
+    }
 
     public Future<String> indexDataverse(Dataverse dataverse) {
         logger.fine("indexDataverse called on dataverse id " + dataverse.getId() + "(" + dataverse.getAlias() + ")");

--- a/src/test/java/edu/harvard/iq/dataverse/api/DataversesIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/DataversesIT.java
@@ -231,4 +231,31 @@ public class DataversesIT {
         assertTrue(htmlStr4.contains(expectedErrMsg));
 
     }
+    
+    @Test
+    public void testMoveDataverse() throws FileNotFoundException {
+        Response createUser = UtilIT.createRandomUser();
+        
+        createUser.prettyPrint();
+        String username = UtilIT.getUsernameFromResponse(createUser);
+        String apiToken = UtilIT.getApiTokenFromResponse(createUser);
+        
+        Response superuserResponse = UtilIT.makeSuperUser(username);
+        
+        Response createDataverseResponse = UtilIT.createRandomDataverse(apiToken);
+        createDataverseResponse.prettyPrint();
+        String dataverseAlias = UtilIT.getAliasFromResponse(createDataverseResponse);
+        
+        
+        Response createDataverseResponse2 = UtilIT.createRandomDataverse(apiToken);
+        createDataverseResponse2.prettyPrint();
+        String dataverseAlias2 = UtilIT.getAliasFromResponse(createDataverseResponse2);
+        Response moveResponse = UtilIT.moveDataverse(dataverseAlias, dataverseAlias2, true, apiToken);
+        
+        moveResponse.prettyPrint();
+        moveResponse.then().assertThat().statusCode(OK.getStatusCode());
+    }
+    
+    
+    
 }

--- a/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
@@ -850,6 +850,13 @@ public class UtilIT {
                 .put("/api/files/" + datafileId + "/restrict");
         return response;
     }
+    
+    static Response moveDataverse(String movedDataverseAlias, String targetDataverseAlias, Boolean force, String apiToken) {
+        Response response = given()
+                .header(API_TOKEN_HTTP_HEADER, apiToken)
+                .post("api/dataverses/" + movedDataverseAlias + "/move/" + targetDataverseAlias + "?forceMove=" + force + "&key=" + apiToken);
+        return response;
+    }
 
     static Response nativeGet(Integer datasetId, String apiToken) {
         Response response = given()

--- a/src/test/java/edu/harvard/iq/dataverse/engine/command/impl/MoveDataverseCommandTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/engine/command/impl/MoveDataverseCommandTest.java
@@ -5,15 +5,21 @@ import edu.harvard.iq.dataverse.DatasetServiceBean;
 import edu.harvard.iq.dataverse.engine.command.impl.MoveDataverseCommand;
 import edu.harvard.iq.dataverse.Dataverse;
 import edu.harvard.iq.dataverse.DataverseServiceBean;
+import edu.harvard.iq.dataverse.authorization.users.AuthenticatedUser;
 import edu.harvard.iq.dataverse.engine.DataverseEngine;
+import edu.harvard.iq.dataverse.engine.NoOpTestEntityManager;
 import edu.harvard.iq.dataverse.engine.TestCommandContext;
 import edu.harvard.iq.dataverse.engine.TestDataverseEngine;
+import edu.harvard.iq.dataverse.engine.command.DataverseRequest;
 import edu.harvard.iq.dataverse.engine.command.exception.IllegalCommandException;
+import static edu.harvard.iq.dataverse.mocks.MocksFactory.makeAuthenticatedUser;
 import edu.harvard.iq.dataverse.search.IndexServiceBean;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.Future;
+import javax.persistence.EntityManager;
+import javax.servlet.http.HttpServletRequest;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import org.junit.Before;
@@ -24,99 +30,110 @@ import org.junit.Test;
  * @author michael
  */
 public class MoveDataverseCommandTest {
-	
-	Dataverse root, childA, childB, grandchildAA;
-	DataverseEngine testEngine;
-        Boolean force;
-	
-	@Before
-	public void setUp() {
-		root = new Dataverse();
-		root.setName("root");
-		root.setId(1l);
-		childA = new Dataverse();
-		childA.setName( "childA" );
-		childA.setId(2l);
-		childB = new Dataverse();
-		childB.setName( "childB" );
-		childB.setId(3l);
-		grandchildAA = new Dataverse();
-		grandchildAA.setName( "grandchildAA" );
-		grandchildAA.setId(4l);
-		
-		childA.setOwner( root );
-		childB.setOwner( root );
-		grandchildAA.setOwner( childA );
-		force = false;
-		
-		testEngine = new TestDataverseEngine( new TestCommandContext(){
-			@Override
-			public DataverseServiceBean dataverses() {
-                            return new DataverseServiceBean(){
-                                @Override
-                                public Dataverse save(Dataverse dataverse) {
-                                        // no-op. The superclass accesses databases which we don't have.
-                                        return dataverse;
-                                }
-                                @Override
-                                public List<Dataverse> findByOwnerId(Long ownerId) {
-                                    return new ArrayList<>();
-                                }
-                            };
-                        }
-                        @Override
-                        public IndexServiceBean index(){
-                            return new IndexServiceBean(){
-                                @Override
-                                public Future<String> indexDataverse(Dataverse dataverse){
-                                    return null;
-                                }
-                                
-                                @Override
-                                public Future<String> indexDataset(Dataset dataset, boolean doNormalSolrDocCleanUp){
-                                    return null;
-                                }
-                                
-                                @Override
-                                public void indexDataverseRecursively(Dataverse datverse, boolean doNormalSolrDocCleanUp) {
-                                    
-                                }
-                            };
-     
-                        }
-                        @Override
-                        public DatasetServiceBean datasets() {
-                            return new DatasetServiceBean() {
-                                @Override
-                                public List<Dataset> findByOwnerId(Long ownerId) {
-                                    return new ArrayList<>();
-                                }
-                            };
-                        }
-                });
-	}
-	
-	/**
-	 * Moving ChildB to ChildA
-	 * @throws Exception - should not throw an exception
-	 */
-	@Test
-	public void testValidMove() throws Exception {
-		testEngine.submit(
-				new MoveDataverseCommand(null, childB, childA, force));
-		
-		assertEquals( childA, childB.getOwner() );
-		assertEquals( Arrays.asList(root, childA), childB.getOwners() );
-	}
-	
-	/**
-	 * Moving ChildA to its child (illegal).
-	 */
-	@Test( expected=IllegalCommandException.class )
-	public void testInvalidMove() throws Exception {
-		testEngine.submit(
-				new MoveDataverseCommand(null, childA, grandchildAA, force));
-		fail();
-	}
-	
+
+    Dataverse root, childA, childB, grandchildAA;
+    DataverseEngine testEngine;
+    Boolean force;
+    AuthenticatedUser auth;
+    protected HttpServletRequest httpRequest;
+
+    @Before
+    public void setUp() {
+        auth = makeAuthenticatedUser("Super", "User");
+        auth.setSuperuser(true);
+        root = new Dataverse();
+        root.setName("root");
+        root.setId(1l);
+        childA = new Dataverse();
+        childA.setName( "childA" );
+        childA.setId(2l);
+        childB = new Dataverse();
+        childB.setName( "childB" );
+        childB.setId(3l);
+        grandchildAA = new Dataverse();
+        grandchildAA.setName( "grandchildAA" );
+        grandchildAA.setId(4l);
+
+        childA.setOwner( root );
+        childB.setOwner( root );
+        grandchildAA.setOwner( childA );
+        force = false;
+
+        testEngine = new TestDataverseEngine( new TestCommandContext(){
+            @Override
+            public DataverseServiceBean dataverses() {
+                return new DataverseServiceBean(){
+                    @Override
+                    public Dataverse save(Dataverse dataverse) {
+                            // no-op. The superclass accesses databases which we don't have.
+                            return dataverse;
+                    }
+                    @Override
+                    public List<Dataverse> findByOwnerId(Long ownerId) {
+                        return new ArrayList<>();
+                    }
+                };
+            }
+            @Override
+            public IndexServiceBean index(){
+                return new IndexServiceBean(){
+                    @Override
+                    public Future<String> indexDataverse(Dataverse dataverse){
+                        return null;
+                    }
+
+                    @Override
+                    public Future<String> indexDataset(Dataset dataset, boolean doNormalSolrDocCleanUp){
+                        return null;
+                    }
+
+                    @Override
+                    public void indexDataverseRecursively(Dataverse datverse, boolean doNormalSolrDocCleanUp) {
+
+                    }
+                };
+
+            }
+            @Override
+            public DatasetServiceBean datasets() {
+                return new DatasetServiceBean() {
+                    @Override
+                    public List<Dataset> findByOwnerId(Long ownerId) {
+                        return new ArrayList<>();
+                    }
+                };
+            }
+            @Override
+            public EntityManager em() {
+                return new NoOpTestEntityManager();
+            }
+        });
+    }
+
+    /**
+     * Moving ChildB to ChildA
+     * @throws Exception - should not throw an exception
+     */
+    @Test
+    public void testValidMove() throws Exception {
+            DataverseRequest aRequest = new DataverseRequest(auth, httpRequest);
+
+            testEngine.submit(
+                            new MoveDataverseCommand(aRequest, childB, childA, force));
+
+            assertEquals( childA, childB.getOwner() );
+            assertEquals( Arrays.asList(root, childA), childB.getOwners() );
+    }
+
+    /**
+     * Moving ChildA to its child (illegal).
+     */
+    @Test( expected=IllegalCommandException.class )
+    public void testInvalidMove() throws Exception {
+            DataverseRequest aRequest = new DataverseRequest(auth, httpRequest);
+            testEngine.submit(
+                            new MoveDataverseCommand(aRequest, childA, grandchildAA, force));
+            fail();
+    }
+
 }

--- a/src/test/java/edu/harvard/iq/dataverse/engine/command/impl/MoveDataverseCommandTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/engine/command/impl/MoveDataverseCommandTest.java
@@ -2,29 +2,31 @@ package edu.harvard.iq.dataverse.engine.command.impl;
 
 import edu.harvard.iq.dataverse.Dataset;
 import edu.harvard.iq.dataverse.DatasetServiceBean;
-import edu.harvard.iq.dataverse.engine.command.impl.MoveDataverseCommand;
 import edu.harvard.iq.dataverse.Dataverse;
-import edu.harvard.iq.dataverse.DataverseFeaturedDataverse;
 import edu.harvard.iq.dataverse.DataverseServiceBean;
 import edu.harvard.iq.dataverse.Guestbook;
+import edu.harvard.iq.dataverse.MetadataBlock;
+import edu.harvard.iq.dataverse.Template;
 import edu.harvard.iq.dataverse.authorization.users.AuthenticatedUser;
 import edu.harvard.iq.dataverse.engine.DataverseEngine;
 import edu.harvard.iq.dataverse.engine.NoOpTestEntityManager;
 import edu.harvard.iq.dataverse.engine.TestCommandContext;
 import edu.harvard.iq.dataverse.engine.TestDataverseEngine;
-import edu.harvard.iq.dataverse.engine.TestEntityManager;
 import edu.harvard.iq.dataverse.engine.command.DataverseRequest;
 import edu.harvard.iq.dataverse.engine.command.exception.IllegalCommandException;
 import edu.harvard.iq.dataverse.engine.command.exception.PermissionException;
 import static edu.harvard.iq.dataverse.mocks.MocksFactory.makeAuthenticatedUser;
 import edu.harvard.iq.dataverse.search.IndexServiceBean;
+import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.List;
 import java.util.concurrent.Future;
 import javax.persistence.EntityManager;
 import javax.servlet.http.HttpServletRequest;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 import org.junit.Before;
@@ -36,35 +38,133 @@ import org.junit.Test;
  */
 public class MoveDataverseCommandTest {
 
-    Dataverse root, childA, childB, grandchildAA, childC, childD, grandchildDD;
+    Dataverse root, childA, childB, grandchildAA, childC, grandchildCC, childD, grandchildDD, childE, grandchildEE, childF;
+    Dataset datasetC, datasetCC;
+    Guestbook gbA;
+    Template templateA;
+    MetadataBlock mbA, mbB;
     DataverseEngine testEngine;
     AuthenticatedUser auth, nobody;
     protected HttpServletRequest httpRequest;
 
     @Before
     public void setUp() {
+        // authentication 
         auth = makeAuthenticatedUser("Super", "User");
         auth.setSuperuser(true);
         nobody = makeAuthenticatedUser("Nick", "Nobody");
         nobody.setSuperuser(false);
 
+        // Dataverses
         root = new Dataverse();
         root.setName("root");
         root.setId(1l);
+        root.setPublicationDate(new Timestamp(new Date().getTime()));
+        
         childA = new Dataverse();
-        childA.setName( "childA" );
+        childA.setOwner( root );
         childA.setId(2l);
+        
         childB = new Dataverse();
-        childB.setName( "childB" );
+        childB.setOwner( root );
         childB.setId(3l);
+        
         grandchildAA = new Dataverse();
-        grandchildAA.setName( "grandchildAA" );
+        grandchildAA.setOwner( childA );
         grandchildAA.setId(4l);
 
-        childA.setOwner( root );
-        childB.setOwner( root );
-        grandchildAA.setOwner( childA );
+        childC = new Dataverse();
+        childC.setOwner(root);
+        childC.setId(5l);
         
+        grandchildCC = new Dataverse();
+        grandchildCC.setOwner(childC);
+        grandchildCC.setId(6l);
+        
+        childD = new Dataverse();
+        childD.setOwner(root);
+        childD.setId(7l);
+        
+        grandchildDD = new Dataverse();
+        grandchildDD.setOwner(childD);
+        grandchildDD.setId(8l);
+        
+        childE = new Dataverse();
+        childE.setOwner(root);
+        childE.setId(9l);
+        
+        grandchildEE = new Dataverse();
+        grandchildEE.setOwner(childE);
+        grandchildEE.setId(10l);
+                
+        // Datasets
+        datasetC = new Dataset();
+        datasetC.setOwner(childC);
+        datasetC.setId(1l);
+        
+        datasetCC = new Dataset();
+        datasetCC.setOwner(grandchildCC);
+        datasetCC.setId(2l);
+        
+        // Guestbooks
+        gbA= new Guestbook();
+        gbA.setId(1l);
+        gbA.setDataverse(childC);
+        
+        List<Guestbook> gbs = new ArrayList<>();
+        gbs.add(gbA);
+        childC.setGuestbooks(gbs);
+        childC.setGuestbookRoot(true);
+        grandchildCC.setGuestbookRoot(false);
+        datasetC.setGuestbook(gbA);
+        datasetCC.setGuestbook(gbA);
+        
+        List<Guestbook> noneGb = new ArrayList();
+        root.setGuestbooks(noneGb);
+        childA.setGuestbooks(noneGb);
+        grandchildAA.setGuestbooks(noneGb);
+        childB.setGuestbooks(noneGb);
+        grandchildCC.setGuestbooks(noneGb);
+        childD.setGuestbooks(noneGb);
+        grandchildDD.setGuestbooks(noneGb);
+        
+        // Templates
+        List<Template> ts = new ArrayList<>();
+        templateA = new Template();
+        templateA.setName("TemplateA");
+        templateA.setDataverse(childD);
+        ts.add(templateA);
+        childD.setTemplates(ts);
+        childD.setTemplateRoot(true);
+        grandchildDD.setTemplateRoot(false);
+        grandchildDD.setDefaultTemplate(templateA);
+        
+        List<Template> noneT = new ArrayList<>();
+        root.setTemplates(noneT);
+        childA.setTemplates(noneT);
+        grandchildAA.setTemplates(noneT);
+        childB.setTemplates(noneT);
+        childC.setTemplates(noneT);
+        grandchildCC.setTemplates(noneT);
+        grandchildDD.setTemplates(noneT);
+        
+        // Metadata blocks
+        List<MetadataBlock> mbsE = new ArrayList<>();
+        List<MetadataBlock> mbsEE = new ArrayList<>();
+        mbA = new MetadataBlock();
+        mbA.setOwner(root);
+        mbA.setId(1l);
+        mbB = new MetadataBlock();
+        mbB.setOwner(childE);
+        mbB.setId(2l);
+        mbsE.add(mbB);
+        mbsEE.add(mbA);
+        mbsEE.add(mbB);
+        childE.setMetadataBlocks(mbsE);
+        childE.setMetadataBlockRoot(true);
+        grandchildEE.setMetadataBlockRoot(false);
+        grandchildEE.setMetadataBlocks(mbsEE);
+            
         testEngine = new TestDataverseEngine( new TestCommandContext(){
             @Override
             public DataverseServiceBean dataverses() {
@@ -77,6 +177,24 @@ public class MoveDataverseCommandTest {
                     @Override
                     public List<Dataverse> findByOwnerId(Long ownerId) {
                         return new ArrayList<>();
+                    }
+                    @Override
+                    public List<Dataverse> findAllDataverseDataverseChildren(Dataverse dv) {
+                        // fake this for what we need 
+                        List<Dataverse> fakeChildren = new ArrayList<>();
+                        if (dv.getId() == 9){ 
+                            fakeChildren.add(grandchildEE);
+                        }
+                        return fakeChildren;
+                    }
+                    @Override
+                    public List<Dataset> findAllDataverseDatasetChildren(Dataverse dv) {
+                        // fake this for what we need
+                        List<Dataset> fakeChildren = new ArrayList<>();
+                        if (dv.getId() == 6) {
+                            fakeChildren.add(datasetCC);
+                        }
+                        return fakeChildren;
                     }
                 };
             }
@@ -122,6 +240,7 @@ public class MoveDataverseCommandTest {
      */
     @Test
     public void testValidMove() throws Exception {
+        System.out.println("testValidMove");
         DataverseRequest aRequest = new DataverseRequest(auth, httpRequest);
 
         testEngine.submit(
@@ -129,6 +248,13 @@ public class MoveDataverseCommandTest {
 
         assertEquals( childA, childB.getOwner() );
         assertEquals( Arrays.asList(root, childA), childB.getOwners() );
+        
+        // move back
+        testEngine.submit(
+                        new MoveDataverseCommand(aRequest, childB, root, null));
+        
+        assertEquals( root, childB.getOwner() );
+        assertEquals( Arrays.asList(root), childB.getOwners() );
     }
 
     /**
@@ -136,6 +262,7 @@ public class MoveDataverseCommandTest {
      */
     @Test( expected=IllegalCommandException.class )
     public void testInvalidMove() throws Exception {
+        System.out.println("testInvalidMove");
         DataverseRequest aRequest = new DataverseRequest(auth, httpRequest);
         testEngine.submit(
                         new MoveDataverseCommand(aRequest, childA, grandchildAA, null));
@@ -147,6 +274,7 @@ public class MoveDataverseCommandTest {
      */
     @Test(expected = PermissionException.class)
     public void testNotSuperUser() throws Exception {
+        System.out.println("testNotSuperUser");
         DataverseRequest aRequest = new DataverseRequest(nobody, httpRequest);
         testEngine.submit(
                         new MoveDataverseCommand(aRequest, childB, childA, null));
@@ -155,6 +283,7 @@ public class MoveDataverseCommandTest {
     
     @Test( expected=IllegalCommandException.class )
     public void testMoveIntoSelf() throws Exception {
+        System.out.println("testMoveIntoSelf");
         DataverseRequest aRequest = new DataverseRequest(auth, httpRequest);
         testEngine.submit(
                         new MoveDataverseCommand(aRequest, childB, childB, null));
@@ -163,10 +292,121 @@ public class MoveDataverseCommandTest {
     
     @Test( expected=IllegalCommandException.class )
     public void testMoveIntoParent() throws Exception {
+        System.out.println("testMoveIntoParent");
         DataverseRequest aRequest = new DataverseRequest(auth, httpRequest);
         testEngine.submit(
                         new MoveDataverseCommand(aRequest, grandchildAA, childA, null));
         fail();
     }
-
+    
+    @Test
+    public void testKeepGuestbook() throws Exception {
+        System.out.println("testKeepGuestbook");
+        DataverseRequest aRequest = new DataverseRequest(auth, httpRequest);
+        testEngine.submit(
+                        new MoveDataverseCommand(aRequest, childC, childB, null));
+        assertNotNull(datasetC.getGuestbook());
+        
+        // move back
+        testEngine.submit(
+                        new MoveDataverseCommand(aRequest, childC, root, null));
+        assertEquals( root, childC.getOwner() );
+    }
+    
+    @Test(expected = IllegalCommandException.class)
+    public void testRemoveGuestbookWithoutForce() throws Exception {
+        System.out.println("testRemoveGuestbookWithoutForce");
+        DataverseRequest aRequest = new DataverseRequest(auth, httpRequest);
+        testEngine.submit(
+                        new MoveDataverseCommand(aRequest, grandchildCC, root, null));
+        fail();
+    }
+    
+    @Test
+    public void testRemoveGuestbook() throws Exception {
+        System.out.println("testRemoveGuestbook");
+        DataverseRequest aRequest = new DataverseRequest(auth, httpRequest);
+        testEngine.submit(
+                        new MoveDataverseCommand(aRequest, grandchildCC, root, true));
+        assertNull( datasetCC.getGuestbook());
+        
+        // move back
+        testEngine.submit(
+                        new MoveDataverseCommand(aRequest, grandchildCC, childC, true));
+        assertEquals( childC, grandchildCC.getOwner() );
+    }
+    
+    @Test
+    public void testKeepTemplate() throws Exception {
+        System.out.println("testKeepTemplate");
+        DataverseRequest aRequest = new DataverseRequest(auth, httpRequest);
+        testEngine.submit(
+                        new MoveDataverseCommand(aRequest, childD, childB, null));
+        assertNotNull(grandchildDD.getDefaultTemplate());
+        
+        // move back
+        testEngine.submit(
+                        new MoveDataverseCommand(aRequest, childD, root, null));
+        assertEquals( root, childD.getOwner() );
+        
+    }
+    
+    @Test(expected = IllegalCommandException.class)
+    public void testRemoveTemplateWithoutForce() throws Exception {
+        System.out.println("testRemoveTemplateWithoutForce");
+        DataverseRequest aRequest = new DataverseRequest(auth, httpRequest);
+        testEngine.submit(
+                        new MoveDataverseCommand(aRequest, grandchildDD, root, null));
+        fail();
+    }
+    
+    @Test
+    public void testRemoveTemplate() throws Exception {
+        System.out.println("testRemoveTemplate");
+        DataverseRequest aRequest = new DataverseRequest(auth, httpRequest);
+        testEngine.submit(
+                        new MoveDataverseCommand(aRequest, grandchildDD, root, true));
+        assertNull( grandchildDD.getDefaultTemplate());
+        
+        // move back
+        testEngine.submit(
+                        new MoveDataverseCommand(aRequest, grandchildDD, childD, true));
+        assertEquals( childD, grandchildDD.getOwner() );
+    }
+    
+    @Test
+    public void testKeepMetadataBlock() throws Exception {
+        System.out.println("testKeepMetadataBlock");
+        DataverseRequest aRequest = new DataverseRequest(auth, httpRequest);
+        testEngine.submit(
+                        new MoveDataverseCommand(aRequest, childE, childB, null));
+        assertEquals(Arrays.asList(mbB), childE.getMetadataBlocks());
+        
+        // move back
+        testEngine.submit(
+                        new MoveDataverseCommand(aRequest, childE, root, null));
+        assertEquals( root, childE.getOwner() );
+    }
+    
+    @Test(expected = IllegalCommandException.class)
+    public void testRemoveMetadataBlockWithoutForce() throws Exception {
+        System.out.println("testRemoveMetadataBlockWithoutForce");
+        DataverseRequest aRequest = new DataverseRequest(auth, httpRequest);
+        testEngine.submit(
+                        new MoveDataverseCommand(aRequest, grandchildEE, root, null));
+        fail();
+    }
+    
+    @Test
+    public void testRemoveMetadataBlock() throws Exception {
+        System.out.println("testRemoveMetadataBlock");
+        DataverseRequest aRequest = new DataverseRequest(auth, httpRequest);
+        testEngine.submit(
+                        new MoveDataverseCommand(aRequest, grandchildEE, root, true));
+        assertEquals(Arrays.asList(mbA), grandchildEE.getMetadataBlocks(true));
+        // move back
+        testEngine.submit(
+                        new MoveDataverseCommand(aRequest, grandchildEE, childE, true));
+        assertEquals( childE, grandchildEE.getOwner() );
+    }
 }

--- a/src/test/java/edu/harvard/iq/dataverse/engine/command/impl/MoveDataverseCommandTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/engine/command/impl/MoveDataverseCommandTest.java
@@ -76,6 +76,11 @@ public class MoveDataverseCommandTest {
                                 public Future<String> indexDataset(Dataset dataset, boolean doNormalSolrDocCleanUp){
                                     return null;
                                 }
+                                
+                                @Override
+                                public void indexDataverseRecursively(Dataverse datverse, boolean doNormalSolrDocCleanUp) {
+                                    
+                                }
                             };
      
                         }


### PR DESCRIPTION
This pull request extends the Native API to allow a superuser to move a dataverse. 

If a move is forced, the functionality is as follows:

- If a dataverse's dataset uses a guestbook that was inherited from a parent and is moving to a dataverse without that guestbook, the guestbook is removed from the dataset 
- If a dataverse's default template is one that was inherited from a parent and is moving to a dataverse without that template, the default template is removed
- If a dataverse is featured in its parent, that feature association is removed
- If a metadata field is selected on a dataverse and the metadata block does not exist in the destination dataverse, it is disassociated with the moved dataverse

These rules should also follow for any children of the moved dataverse.

## Related Issues

- connects to #4406 : New API: Add api end point to move dataverses

## Pull Request Checklist

- [x] Unit [tests][] completed
- [x] Integration [tests][]: 
- [x] Deployment requirements, [SQL updates][], [Solr updates][], etc.: None
- [ ] [Documentation][docs] completed
- [ ] Merged latest from "develop" [branch][] and resolved conflicts

[tests]: http://guides.dataverse.org/en/latest/developers/testing.html
[SQL updates]: https://github.com/IQSS/dataverse/tree/develop/scripts/database/upgrades
[Solr updates]: https://github.com/IQSS/dataverse/blob/develop/conf/solr/4.6.0/schema.xml
[docs]: http://guides.dataverse.org/en/latest/developers/documentation.html
[branch]: http://guides.dataverse.org/en/latest/developers/branching-strategy.html
