### PR TITLE
Add Postgresql statefulsets with master/slave replication on OpenShift.

### DIFF
--- a/conf/docker/build.sh
+++ b/conf/docker/build.sh
@@ -1,10 +1,15 @@
 #!/bin/sh
 # Creates images and pushes them to Docker Hub.
-# The "latest" tag should be relatively stable. Don't push breaking changes there.
+# The "latest" tag under "iqss" should be relatively stable. Don't push breaking changes there.
 # None of the tags are suitable for production use. See https://github.com/IQSS/dataverse/issues/4040
-# Push to custom tags or tags based on branch names to iterate on the images.
+# To interate on images, push to custom tags or tags based on branch names or a non-iqss Docker Hub org/username.
+# Docker Hub organization or username
+HUBORG=iqss
+# The most stable tag we have.
+STABLE=latest
+#FIXME: Use a real flag/argument parser. download-files.sh uses "getopts" for example.
 if [ -z "$1" ]; then
-  echo "No argument supplied. Please specify \"branch\" or \"custom my-custom-tag\" for experiments or \"stable\" if your change won't break anything."
+  echo "No argument supplied. For experiments, specify \"branch\" or \"custom my-custom-tag\" or \"huborg <USERNAME/ORG>\". Specify \"stable\" to push to the \"$STABLE\" tag under \"$HUBORG\" if your change won't break anything."
   exit 1
 fi
 
@@ -14,23 +19,32 @@ if [ "$1" == 'branch' ]; then
   TAG=$GIT_BRANCH
 elif [ "$1" == 'stable' ]; then
   echo "We'll push a tag to the most stable tag (which isn't saying much!)."
-  TAG=kick-the-tires
+  TAG=$STABLE
 elif [ "$1" == 'custom' ]; then
-  if [ -z "$1" ]; then
-    echo "You must provide a custom tag as the second argument."
+  if [ -z "$2" ]; then
+    echo "You must provide a custom tag as the second argument. Something other than \"$STABLE\"."
     exit 1
   else
     echo "We'll push a custom tag."
     TAG=$2
   fi
+elif [ "$1" == 'huborg' ]; then
+  if [ -z "$2" ]; then
+    echo "You must provide your Docker Hub organization or username as the second argument. \"$USER\" or whatever."
+    exit 1
+  else
+    HUBORG=$2
+    TAG=$STABLE
+    echo "We'll push to the Docker Hub organization or username you specified: $HUBORG."
+  fi
 else
   echo "Unexpected argument: $1. Exiting. Run with no arguments for help."
   exit 1
 fi
-echo Images will be pushed to Docker Hub with the tag \"$TAG\".
+echo Images will be pushed to Docker Hub org/username \"$HUBORG\" with the tag \"$TAG\".
 # Use "conf" directory as context so we can copy schema.xml into Solr image.
-docker build -t iqss/dataverse-solr:$TAG -f solr/Dockerfile ../../conf
-docker push iqss/dataverse-solr:$TAG
+docker build -t $HUBORG/dataverse-solr:$TAG -f solr/Dockerfile ../../conf
+docker push $HUBORG/dataverse-solr:$TAG
 # TODO: Think about if we really need dataverse.war because it's in dvinstall.zip.
 cd ../..
 mvn clean
@@ -58,6 +72,6 @@ if [[ "$?" -ne 0 ]]; then
 fi
 # We'll assume at this point that the download script has been run.
 cp ../../downloads/weld-osgi-bundle-2.2.10.Final-glassfish4.jar dataverse-glassfish
-docker build -t iqss/dataverse-glassfish:$TAG dataverse-glassfish
+docker build -t $HUBORG/dataverse-glassfish:$TAG dataverse-glassfish
 # FIXME: Check the output of `docker build` and only push on success.
-docker push iqss/dataverse-glassfish:$TAG
+docker push $HUBORG/dataverse-glassfish:$TAG

--- a/conf/docker/dataverse-glassfish/default.config
+++ b/conf/docker/dataverse-glassfish/default.config
@@ -3,7 +3,7 @@ GLASSFISH_DIRECTORY	/usr/local/glassfish4
 ADMIN_EMAIL	 
 MAIL_SERVER	mail.hmdc.harvard.edu
 POSTGRES_ADMIN_PASSWORD	secret
-POSTGRES_SERVER	dataverse-postgresql-service
+POSTGRES_SERVER	dataverse-postgresql-0.dataverse-postgresql-service
 POSTGRES_PORT	5432
 POSTGRES_DATABASE	dvndb
 POSTGRES_USER	dvnapp

--- a/conf/openshift/openshift.json
+++ b/conf/openshift/openshift.json
@@ -42,6 +42,7 @@
         "selector": {
           "name": "iqss-dataverse-postgresql"
         },
+        "clusterIP": "None",
         "ports": [
           {
             "name": "database",
@@ -151,6 +152,10 @@
                 ],
                 "env": [
                   {
+                    "name": "POSTGRES_SERVER",
+                    "value": "dataverse-postgresql-0"
+                  },
+                  {
                     "name": "POSTGRES_SERVICE_HOST",
                     "value": "dataverse-postgresql-service"
                   },
@@ -222,8 +227,8 @@
       }
     },
     {
-      "kind": "DeploymentConfig",
-      "apiVersion": "v1",
+      "kind": "StatefulSet",
+      "apiVersion": "apps/v1beta1",
       "metadata": {
         "name": "dataverse-postgresql",
         "annotations": {
@@ -231,6 +236,8 @@
         }
       },
       "spec": {
+        "serviceName" : "dataverse-postgresql-service",
+        "replicas" : 1,
         "template": {
           "metadata": {
             "labels": {
@@ -241,7 +248,10 @@
             "containers": [
               {
                 "name": "centos-postgresql-94-centos7",
-                "image": "centos-postgresql-94-centos7",
+                "image": "centos/postgresql-94-centos7",
+                "command": [
+                "sh", "-c", "echo 'Setting up Postgres Master/Slave replication...'; [[ `hostname` =~ -([0-9]+)$ ]] || exit 1; ordinal=${BASH_REMATCH[1]}; if [[ $ordinal -eq 0 ]]; then run-postgresql-master; else run-postgresql-slave; fi;"
+                ],
                 "ports": [
                   {
                     "containerPort": 5432,
@@ -254,8 +264,32 @@
                     "value": "dvnapp"
                   },
                   {
+                    "name": "POSTGRESQL_MASTER_USER",
+                    "value": "master"
+                  },
+                  {
                     "name": "POSTGRESQL_PASSWORD",
                     "value": "secret"
+                  },
+                  {
+                    "name": "POSTGRESQL_MASTER_PASSWORD",
+                    "value": "master"
+                  },
+                  {
+                    "name": "POSTGRESQL_MASTER_SERVICE_NAME",
+                    "value": "dataverse-postgresql-service"
+                  },
+                  {
+                    "name": "POSTGRESQL_MASTER_IP",
+                    "value": "dataverse-postgresql-0.dataverse-postgresql-service"
+                  },
+                  {
+                    "name": "postgresql_master_addr",
+                    "value": "dataverse-postgresql-0.dataverse-postgresql-service"
+                  },
+                  {
+                    "name": "master_fqdn",
+                    "value": "dataverse-postgresql-0.dataverse-postgresql-service"
                   },
                   {
                     "name": "POSTGRESQL_DATABASE",
@@ -281,6 +315,7 @@
             ]
           }
         },
+
         "strategy": {
           "type": "Rolling",
           "rollingParams": {
@@ -300,7 +335,7 @@
               ],
               "from": {
                 "kind": "ImageStreamTag",
-                "name": "centos-postgresql-94-centos7:latest"
+                "name": "centos/postgresql-94-centos7:latest"
               }
             }
           },
@@ -308,9 +343,11 @@
             "type": "ConfigChange"
           }
         ],
-        "replicas": 1,
         "selector": {
-          "name": "iqss-dataverse-postgresql"
+          "name": "iqss-dataverse-postgresql",
+          "matchLabels" : {
+            "name" : "iqss-dataverse-postgresql"
+          }
         }
       }
     },


### PR DESCRIPTION
This pull requests modifies openshift.json to set up a postgres statefulset with master/slave replication.

This pull request requires that the dataverse glassfish image be rebuilt with the small tweak I committed in default.config (pointing to the master postgres pod). To test, perhaps before rebuilding the image, you can point to my docker image by changing line 113 in openshift.json to         `"dockerImageRepository": "patrickdillon/dataverse-glassfish"`

No changes have been made to run dv on openshift:
`oc new-project [name]`
 `oc new-app openshift.json`

Once you have started, you can test with the psql client in each container. From the terminal in each postgres container, you can login and check that the tables were created. That should be enough to show changes from master have been replicated:
`psql -d dvndb`
 ` \dt`

You can also make a change, such as changing the name of the dataverse from root to something else and then checking that with `select * from dataverse;`

I still need to update my Dockerhub image to incorporate the fixes to solr.  I will do that soon and update if there are problems.

## Related Issues

- connects to #4598 

