### PR TITLE
Removing incompatible links from dataset on move

### DIFF
--- a/doc/sphinx-guides/source/admin/dataverses-datasets.rst
+++ b/doc/sphinx-guides/source/admin/dataverses-datasets.rst
@@ -27,7 +27,7 @@ Datasets
 Move a Dataset
 ^^^^^^^^^^^^^^
 
-Moves a dataset whose id is passed to a dataverse whose alias is passed. If the moved dataset has a guestbook that is not compatible with the destination dataverse, you will be informed and given the option to force the move and remove the guestbook. Only accessible to superusers. ::
+Moves a dataset whose id is passed to a dataverse whose alias is passed. If the moved dataset has a guestbook or a dataverse link that is not compatible with the destination dataverse, you will be informed and given the option to force the move and remove the guestbook or link. Only accessible to superusers. ::
 
     curl -H "X-Dataverse-key: $API_TOKEN" -X POST http://$SERVER/api/datasets/$id/move/$alias
 

--- a/src/main/java/edu/harvard/iq/dataverse/api/Datasets.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Datasets.java
@@ -453,7 +453,6 @@ public class Datasets extends AbstractApiBean {
     @Path("{id}/move/{targetDataverseAlias}")
     public Response moveDataset(@PathParam("id") String id, @PathParam("targetDataverseAlias") String targetDataverseAlias, @QueryParam("forceMove") Boolean force) {        
         try{
-            System.out.print("force: " + force);
             User u = findUserOrDie();            
             Dataset ds = findDatasetOrDie(id);
             Dataverse target = dataverseService.findByAlias(targetDataverseAlias);

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/MoveDatasetCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/MoveDatasetCommand.java
@@ -6,6 +6,7 @@
 package edu.harvard.iq.dataverse.engine.command.impl;
 
 import edu.harvard.iq.dataverse.Dataset;
+import edu.harvard.iq.dataverse.DatasetLinkingDataverse;
 import edu.harvard.iq.dataverse.Dataverse;
 import edu.harvard.iq.dataverse.Guestbook;
 import edu.harvard.iq.dataverse.authorization.Permission;
@@ -17,6 +18,7 @@ import edu.harvard.iq.dataverse.engine.command.RequiredPermissions;
 import edu.harvard.iq.dataverse.engine.command.exception.CommandException;
 import edu.harvard.iq.dataverse.engine.command.exception.IllegalCommandException;
 import edu.harvard.iq.dataverse.engine.command.exception.PermissionException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.logging.Level;
@@ -47,7 +49,7 @@ public class MoveDatasetCommand extends AbstractVoidCommand {
 
     @Override
     public void executeImpl(CommandContext ctxt) throws CommandException {
-        
+        boolean removeGuestbook = false, removeLinkDs = false;
        // first check if  user is a superuser
         if ( (!(getUser() instanceof AuthenticatedUser) || !getUser().isSuperuser() ) ) {      
             throw new PermissionException("Move Dataset can only be called by superusers.",
@@ -73,17 +75,56 @@ public class MoveDatasetCommand extends AbstractVoidCommand {
             boolean inheritGuestbooksValue = !destination.isGuestbookRoot();
             if (inheritGuestbooksValue && destination.getOwner() != null) {
                 for (Guestbook pg : destination.getParentGuestbooks()) {
-
                     gbs.add(pg);
                 }
             }
             if (gbs == null || !gbs.contains(gb)) {
                 if (force == null  || !force){
-                    throw new IllegalCommandException("Dataset guestbook is not in target dataverse. Please use the parameter ?forceMove=true to complete the move. This will delete the guestbook from the Dataset", this);
+                    removeGuestbook = true;
+                } else {
+                    moved.setGuestbook(null);
                 }
-                moved.setGuestbook(null);
             }
         }
+        
+        // generate list of all possible parent dataverses to check against
+        List<Dataverse> ownersToCheck = new ArrayList<>();
+        ownersToCheck.add(destination);
+        if (destination.getOwners() != null) {
+            ownersToCheck.addAll(destination.getOwners());
+        }
+        
+        // if the dataset is linked to the new dataverse or any of 
+        // its parent dataverses then remove the link
+        List<DatasetLinkingDataverse> linkingDatasets = new ArrayList<>();
+        if (moved.getDatasetLinkingDataverses() != null) {
+            linkingDatasets.addAll(moved.getDatasetLinkingDataverses());
+        }
+        for (DatasetLinkingDataverse dsld : linkingDatasets) {
+            for (Dataverse owner : ownersToCheck){
+                if ((dsld.getLinkingDataverse()).equals(owner)){
+                    if (force == null || !force) {
+                        removeLinkDs = true;
+                        break;
+                    }
+                    boolean index = false;
+                    ctxt.engine().submit(new DeleteDatasetLinkingDataverseCommand(getRequest(), dsld.getDataset(), dsld, index));
+                    moved.getDatasetLinkingDataverses().remove(dsld);
+                }
+            }
+        }
+        
+        if (removeGuestbook || removeLinkDs) {
+            StringBuilder errorString = new StringBuilder();
+            if (removeGuestbook) {
+                errorString.append("Dataset guestbook is not in target dataverse. ");
+            }
+            if (removeLinkDs) {
+                errorString.append("Dataset is linked to target dataverse or one of its parents. ");
+            }
+            throw new IllegalCommandException(errorString + "Please use the parameter ?forceMove=true to complete the move. This will remove anything from the dataset that is not compatible with the target dataverse.", this);
+        }
+
 
         // OK, move
         moved.setOwner(destination);

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/MoveDataverseCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/MoveDataverseCommand.java
@@ -277,10 +277,10 @@ public class MoveDataverseCommand extends AbstractVoidCommand {
                errorString.append("Dataverse metadata block is not in target dataverse. ");
             }
             if (removeLinkDv) {
-                errorString.append("Dataverse is linked to target dataverse or one of its parents.");
+                errorString.append("Dataverse is linked to target dataverse or one of its parents. ");
             }
             if (removeLinkDs) {
-                errorString.append("Dataset is linked to target dataverse or one of its parents.");
+                errorString.append("Dataset is linked to target dataverse or one of its parents. ");
             }
             errorString.append("Please use the parameter ?forceMove=true to complete the move. This will remove anything from the dataverse that is not compatible with the target dataverse.");
             throw new IllegalCommandException(errorString.toString(), this);


### PR DESCRIPTION
## New Contributors
This issue fixes a bug which left unnecessary database entries in DatasetLinkingDataverse after a dataset move. 

A dataset link should be removed when a dataset is linked to the destination dataverse or any of its parents.

## Related Issues

- connects to #4596 : MoveDatasetCommand: Doesn't remove links 

## Pull Request Checklist

- [ ] Unit [tests][] completed
- [ ] Integration [tests][]: None
- [ ] Deployment requirements, [SQL updates][], [Solr updates][], etc.: None
- [x] [Documentation][docs] completed
- [x] Merged latest from "develop" [branch][] and resolved conflicts

[tests]: http://guides.dataverse.org/en/latest/developers/testing.html
[SQL updates]: https://github.com/IQSS/dataverse/tree/develop/scripts/database/upgrades
[Solr updates]: https://github.com/IQSS/dataverse/blob/develop/conf/solr/7.2.1/schema.xml
[docs]: http://guides.dataverse.org/en/latest/developers/documentation.html
[branch]: http://guides.dataverse.org/en/latest/developers/branching-strategy.html
