### PR TITLE
API: remove "meta" (deprecated) and document "subset" #4687

### DIFF
--- a/doc/sphinx-guides/source/api/dataaccess.rst
+++ b/doc/sphinx-guides/source/api/dataaccess.rst
@@ -34,6 +34,7 @@ Value           Description
 original        "Saved Original", the proprietary (SPSS, Stata, R, etc.) file from which the tabular data was ingested;
 RData           Tabular data as an R Data frame (generated; unless the "original" file was in R);
 prep		"Pre-processed data", in JSON.
+subset          Column-wise subsetting. You must also supply a comma separated list of variables in the "variables" query parameter. In this example, 123 and 127 are the ids of data variables that belong to the data file with the id 6: ``curl 'http://localhost:8080/api/access/datafile/6?format=subset&variables=123,127'``.
 ==============  ===========
 
 ---------------------------
@@ -48,18 +49,6 @@ Value           Description
 true            Generates a thumbnail image, by rescaling to the default thumbnail size (64 pixels)
 ``N``           Rescales the image to ``N`` pixels.
 ==============  ===========
-
----------------------------
-
-``vars``
-
-For column-wise subsetting (available for tabular data files only).
-
-Example: 
-
-``http://localhost:8080/api/meta/datafile/6?vars=123,127``
-
-where 123 and 127 are the ids of data variables that belong to the data file with the id 6.
 
 Multiple File ("bundle") download
 ---------------------------------

--- a/doc/sphinx-guides/source/api/dataaccess.rst
+++ b/doc/sphinx-guides/source/api/dataaccess.rst
@@ -34,7 +34,7 @@ Value           Description
 original        "Saved Original", the proprietary (SPSS, Stata, R, etc.) file from which the tabular data was ingested;
 RData           Tabular data as an R Data frame (generated; unless the "original" file was in R);
 prep		"Pre-processed data", in JSON.
-subset          Column-wise subsetting. You must also supply a comma separated list of variables in the "variables" query parameter. In this example, 123 and 127 are the ids of data variables that belong to the data file with the id 6: ``curl 'http://localhost:8080/api/access/datafile/6?format=subset&variables=123,127'``.
+subset          Column-wise subsetting. You must also supply a comma separated list of variables in the "variables" query parameter. In this example, 123 and 127 are the database ids of data variables that belong to the data file with the id 6: ``curl 'http://localhost:8080/api/access/datafile/6?format=subset&variables=123,127'``.
 ==============  ===========
 
 ---------------------------
@@ -88,17 +88,15 @@ Data Variable Metadata Access
 ``/api/access/datafile/$id/metadata/ddi``
 
 In its basic form the verb above returns a DDI fragment that describes the file and the data variables in it. 
-The DDI XML is the only format supported so far. In the future, support for formatting the output in JSON will 
-(may?) be added.
 
-The DDI returned will only have 2 top-level sections: 
+The DDI returned will only have two top-level sections:
 
 * a single ``fileDscr``, with the basic file information plus the numbers of variables and observations and the UNF of the file.  
 * a single ``dataDscr`` section, with one ``var`` section for each variable. 
 
 Example: 
 
-``http://localhost:8080/api/meta/datafile/6``
+``http://localhost:8080/api/access/datafile/6/metadata/ddi``
 
 .. code-block:: xml
 
@@ -154,24 +152,22 @@ Example:
       </dataDscr>
    </codeBook>
 
-
-
-More information on the DDI is available at (TODO). 
+More information on DDI is available in the :doc:`/user/tabulardataingest/ingestprocess` section of the User Guide.
 
 Advanced options/Parameters: 
 
 It is possible to request only specific subsets of, rather than the
 full file-level DDI record. This can be a useful optimization, in
 cases such as when an application needs to look up a single variable;
-especially with data files with large numbers of variables.
+especially with data files with large numbers of variables. See
+``variables=123,127`` in the example above.
 
-Partial record parameters: 
-
-(TODO). 
+Preprocessed Data
+-----------------
 
 ``/api/access/datafile/$id/metadata/preprocessed``
 
-This method provides the "Pre-processed Data" - a summary record that describes the values of the data vectors in the tabular file, in JSON. These metadata values are used by TwoRavens, the companion data exploration utility of the Dataverse application. 
+This method provides the "preprocessed data" - a summary record that describes the values of the data vectors in the tabular file, in JSON. These metadata values are used by TwoRavens, the companion data exploration utility of the Dataverse application. Please note that this format might change in the future.
 
 Authentication and Authorization
 -------------------------------- 
@@ -179,4 +175,4 @@ Authentication and Authorization
 Data Access API supports both session- and API key-based authentication. 
 
 If a session is available, and it is already associated with an authenticated user, it will be used for access authorization. If not, or if the user in question is not authorized to access the requested object, an attempt will be made to authorize based on an API key, if supplied. 
-All of the API verbs above support the key parameter ``key=...``.
+All of the API verbs above support the key parameter ``key=...`` as well as the newer ``X-Dataverse-key`` header. For more details, see "Authentication" in the :doc:`intro` section.

--- a/doc/sphinx-guides/source/user/tabulardataingest/ingestprocess.rst
+++ b/doc/sphinx-guides/source/user/tabulardataingest/ingestprocess.rst
@@ -56,7 +56,4 @@ The structure of the metadata defining tabular data variables used in
 Dataverse was originally based on the `DDI Codebook
 <http://www.ddialliance.org/Specification/DDI-Codebook/2.5/>`_ format.
 
-[TODO: a brief explanation of the DataVariable and related objects? A
-link to a more technical documentation writeup in the developers
-guide?]
-
+You can see an example of DDI output under the "Data Variable Metadata Access" section of the :doc:`/api/dataaccess` section of the API Guide.

--- a/src/main/java/edu/harvard/iq/dataverse/api/Meta.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Meta.java
@@ -40,13 +40,13 @@ import edu.harvard.iq.dataverse.api.exceptions.AuthorizationRequiredException;
 /**
  *
  * PLEASE NOTE that the "/api/meta" endpoints are deprecated! All code should
- * point to the newer "/api/access/datafile/.../access" endpoints instead.
+ * point to the newer "/api/access/datafile/..." endpoints instead.
  *
  * @author Leonid Andreev
  * 
  * The metadata access API is based on the DVN metadata API v.1.0 (that came 
  * with the v.3.* of the DVN app) and extended for DVN 4.0 to include more
- * granular access to subsets of the metatada that describe the dataaset: 
+ * granular access to subsets of the metadata that describe the dataset:
  * access to individual datafile and datavariable sections, as well as  
  * specific fragments of these sections. 
  */

--- a/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
@@ -510,6 +510,12 @@ public class UtilIT {
                 .get("/api/access/datafile/" + fileId + "?key=" + apiToken);
     }
 
+    static Response subset(String fileId, String variables, String apiToken) {
+        return given()
+                .header(API_TOKEN_HTTP_HEADER, apiToken)
+                .get("/api/access/datafile/" + fileId + "?format=subset&variables=" + variables);
+    }
+
     static Response getFileMetadata(String fileIdOrPersistentId, String optionalFormat, String apiToken) {
         String idInPath = fileIdOrPersistentId; // Assume it's a number.
         String optionalQueryParam = ""; // If idOrPersistentId is a number we'll just put it in the path.


### PR DESCRIPTION
connects to #4687 Documentation: Need to correct api endpoint for tabular column-wise subsetting.