### PR TITLE
Skip bothering to register the global identifiers for datafiles...

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/FinalizeDatasetPublicationCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/FinalizeDatasetPublicationCommand.java
@@ -186,7 +186,7 @@ public class FinalizeDatasetPublicationCommand extends AbstractPublishDatasetCom
             try {
                 String currentGlobalIdProtocol = ctxt.settings().getValueForKey(SettingsServiceBean.Key.Protocol, "");
                 String dataFilePIDFormat = ctxt.settings().getValueForKey(SettingsServiceBean.Key.DataFilePIDFormat, "DEPENDENT");
-                // We will skip trying to regiester the global identifiers for datafiles 
+                // We will skip trying to register the global identifiers for datafiles 
                 // if "dependent" file-level identifiers are requested, AND the naming 
                 // protocol of the dataset global id is different from the
                 // one currently configured for the Dataverse. This is to specifically 

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/FinalizeDatasetPublicationCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/FinalizeDatasetPublicationCommand.java
@@ -185,12 +185,14 @@ public class FinalizeDatasetPublicationCommand extends AbstractPublishDatasetCom
             List<String> args = idServiceBean.getProviderInformation();
             try {
                 String currentGlobalIdProtocol = ctxt.settings().getValueForKey(SettingsServiceBean.Key.Protocol, "");
+                String dataFilePIDFormat = ctxt.settings().getValueForKey(SettingsServiceBean.Key.DataFilePIDFormat, "DEPENDENT");
                 // We will skip trying to regiester the global identifiers for datafiles 
-                // if the naming protocol of the dataset global id is different from the 
+                // if "dependent" file-level identifiers are requested, AND the naming 
+                // protocol of the dataset global id is different from the
                 // one currently configured for the Dataverse. This is to specifically 
                 // address the issue with the datasets with handle ids registered, 
                 // that are currently configured to use DOI.
-                if (currentGlobalIdProtocol.equals(protocol)) {
+                if (currentGlobalIdProtocol.equals(protocol) || dataFilePIDFormat.equals("INDEPENDENT")) {
                     //A false return value indicates a failure in calling the service
                     for (DataFile df : dataset.getFiles()) {
                         logger.log(Level.FINE, "registering global id for file {0}", df.getId());

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/PublishDatasetCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/PublishDatasetCommand.java
@@ -89,7 +89,7 @@ public class PublishDatasetCommand extends AbstractPublishDatasetCommand<Publish
             return new PublishDatasetResult(theDataset, false);
             
         } else {
-            // We will skip trying to regiester the global identifiers for datafiles 
+            // We will skip trying to register the global identifiers for datafiles 
             // if "dependent" file-level identifiers are requested, AND the naming 
             // protocol of the dataset global id is different from the 
             // one currently configured for the Dataverse. This is to specifically 

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/PublishDatasetCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/PublishDatasetCommand.java
@@ -89,8 +89,18 @@ public class PublishDatasetCommand extends AbstractPublishDatasetCommand<Publish
             return new PublishDatasetResult(theDataset, false);
             
         } else {
-            //if there are more than required size files  then call Finalize asychronously (default is 10)
-            if (theDataset.getFiles().size() > ctxt.systemConfig().getPIDAsynchRegFileCount()) {     
+            // We will skip trying to regiester the global identifiers for datafiles 
+            // if the naming protocol of the dataset global id is different from the 
+            // one currently configured for the Dataverse. This is to specifically 
+            // address the issue with the datasets with handle ids registered, 
+            // that are currently configured to use DOI.
+            // If we are registering file-level identifiers, and there are more 
+            // than the configured limit number of files, then call Finalize 
+            // asychronously (default is 10)
+            String currentGlobalIdProtocol = ctxt.settings().getValueForKey(SettingsServiceBean.Key.Protocol, "");
+            boolean registerGlobalIdsForFiles = currentGlobalIdProtocol.equals(theDataset.getProtocol());
+
+            if (theDataset.getFiles().size() > ctxt.systemConfig().getPIDAsynchRegFileCount() && registerGlobalIdsForFiles) {     
                 String info = "Adding File PIDs asynchronously";
                 AuthenticatedUser user = request.getAuthenticatedUser();
                 

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/PublishDatasetCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/PublishDatasetCommand.java
@@ -90,7 +90,8 @@ public class PublishDatasetCommand extends AbstractPublishDatasetCommand<Publish
             
         } else {
             // We will skip trying to regiester the global identifiers for datafiles 
-            // if the naming protocol of the dataset global id is different from the 
+            // if "dependent" file-level identifiers are requested, AND the naming 
+            // protocol of the dataset global id is different from the 
             // one currently configured for the Dataverse. This is to specifically 
             // address the issue with the datasets with handle ids registered, 
             // that are currently configured to use DOI.
@@ -98,7 +99,8 @@ public class PublishDatasetCommand extends AbstractPublishDatasetCommand<Publish
             // than the configured limit number of files, then call Finalize 
             // asychronously (default is 10)
             String currentGlobalIdProtocol = ctxt.settings().getValueForKey(SettingsServiceBean.Key.Protocol, "");
-            boolean registerGlobalIdsForFiles = currentGlobalIdProtocol.equals(theDataset.getProtocol());
+            String dataFilePIDFormat = ctxt.settings().getValueForKey(SettingsServiceBean.Key.DataFilePIDFormat, "DEPENDENT");
+            boolean registerGlobalIdsForFiles = currentGlobalIdProtocol.equals(theDataset.getProtocol()) || dataFilePIDFormat.equals("INDEPENDENT");
 
             if (theDataset.getFiles().size() > ctxt.systemConfig().getPIDAsynchRegFileCount() && registerGlobalIdsForFiles) {     
                 String info = "Adding File PIDs asynchronously";

--- a/src/main/java/edu/harvard/iq/dataverse/settings/SettingsServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/settings/SettingsServiceBean.java
@@ -350,9 +350,9 @@ public class SettingsServiceBean {
          */
         PVCustomPasswordResetAlertMessage,
         /*
-        String to describe DOI format for data files. Default is INDEPENDENT. (That is independent 
-        from the Dataset DOI
-        If 'DEPENEDENT' then the DOI will be the Dataset DOI plus a file DOI with a slash in between.
+        String to describe DOI format for data files. Default is DEPENDENT. 
+        'DEPENEDENT' means the DOI will be the Dataset DOI plus a file DOI with a slash in between.
+        'INDEPENDENT' means a new global id, completely independent from the dataset-level global id.
         */
         DataFilePIDFormat, 
         /*


### PR DESCRIPTION
…if the dataset level naming protocol is different from the one currently configured for the Dataverse. (#4941)

## New Contributors

Welcome! New contributors should at least glance at [CONTRIBUTING.md](/CONTRIBUTING.md), especially the section on pull requests where we encourage you to reach out to other developers before you start coding. Also, please note that we measure code coverage and prefer you write unit tests. Pull requests can still be reviewed without tests or completion of the checklist outlined below. Thanks!

## Related Issues

- connects to #4941: PID provider doesn't match dataset PID provider, skip

## Pull Request Checklist

- [ ] Unit [tests][] completed
- [ ] Integration [tests][]: None
- [ ] Deployment requirements, [SQL updates][], [Solr updates][], etc.: None
- [ ] [Documentation][docs] completed
- [ ] Merged latest from "develop" [branch][] and resolved conflicts

[tests]: http://guides.dataverse.org/en/latest/developers/testing.html
[SQL updates]: https://github.com/IQSS/dataverse/tree/develop/scripts/database/upgrades
[Solr updates]: https://github.com/IQSS/dataverse/blob/develop/conf/solr/7.3.0/schema.xml
[docs]: http://guides.dataverse.org/en/latest/developers/documentation.html
[branch]: http://guides.dataverse.org/en/latest/developers/branching-strategy.html
