### PR TITLE
IQSS-5122 Fix NetBeans handling of test files.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,11 @@
         <project.timezone>UTC</project.timezone>
         <project.language>en</project.language>
         <project.region>US</project.region>
+        <!--
+            Moving this from plugin config to global config, because of GH-5122.
+            This seems to play well with NetBeans 8.2, IDEA 2018.1 and mvn including compatibility with JaCoCo.
+        -->
+        <argLine>-Duser.timezone=${project.timezone} -Dfile.encoding=${project.build.sourceEncoding} -Duser.language=${project.language} -Duser.region=${project.region}</argLine>
     
         <junit.version>4.12</junit.version>
         <junit.jupiter.version>5.3.1</junit.jupiter.version>
@@ -657,9 +662,8 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.22.0</version>
                 <configuration>
-                   <!-- testsToExclude come from the profile-->
-                   <excludedGroups>${testsToExclude}</excludedGroups>
-                    <argLine>${argLine} -Duser.timezone=${project.timezone} -Dfile.encoding=${project.build.sourceEncoding} -Duser.language=${project.language} -Duser.region=${project.region}</argLine>
+                    <!-- testsToExclude come from the profile-->
+                    <excludedGroups>${testsToExclude}</excludedGroups>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
By moving the `argLine` into `<properties>`, JaCoCo is happy, Maven is happy, Netbeans is happy and IDEA too. :tada: :birthday: :balloon: 

I tested all unit test and integration tests. There are test failures with IT tests, but these are just the same as `develop` branch has right now, thus unrelated to the change.

Please merge ASAP to make @pdurbin and potentially others happy :smile: 

## Related Issues

- connects to #5122 
- #5084 
- #4261 

## Pull Request Checklist

- [x] Unit [tests][] completed
- [x] Integration [tests][]: None
- [x] Merged latest from "develop" [branch][] and resolved conflicts

[tests]: http://guides.dataverse.org/en/latest/developers/testing.html
[SQL updates]: https://github.com/IQSS/dataverse/tree/develop/scripts/database/upgrades
[branch]: http://guides.dataverse.org/en/latest/developers/branching-strategy.html
