### PR TITLE
glassfish.service file: correct breaking problems

### DIFF
--- a/doc/sphinx-guides/source/_static/installation/files/etc/systemd/glassfish.service
+++ b/doc/sphinx-guides/source/_static/installation/files/etc/systemd/glassfish.service
@@ -3,13 +3,14 @@ Description = GlassFish Server v4.1
 After = syslog.target network.target
 
 [Service]
-User=glassfish
+Type = forking
 ExecStart = /usr/bin/java -jar /usr/local/glassfish4/glassfish/lib/client/appserver-cli.jar start-domain
 ExecStop = /usr/bin/java -jar /usr/local/glassfish4/glassfish/lib/client/appserver-cli.jar stop-domain
 ExecReload = /usr/bin/java -jar /usr/local/glassfish4/glassfish/lib/client/appserver-cli.jar restart-domain
+User=glassfish
 LimitNOFILE=32768
-DefaultTimeoutStartSec=120s # current default is 90s
-Type = forking
+Environment="LANG=en_US.UTF-8"
+TimeoutStartSec=120s
 
 [Install]
 WantedBy = multi-user.target


### PR DESCRIPTION
systemctl does not accept the file as-is. There is one major error, and second, the LANG setting should be enforce, per documentation.

Note: systemctl does only allows `#` comments that are on their own line.

connects to #5168