### PR TITLE
support dataverseAdmin password during non-interactive installation; …

### DIFF
--- a/conf/docker-aio/install.bash
+++ b/conf/docker-aio/install.bash
@@ -4,7 +4,7 @@ sudo -u postgres createuser --superuser dvnapp
 unzip dvinstall.zip
 cd dvinstall/
 echo "beginning installer"
-./install -admin_email=dvAdmin@mailinator.com -y -f > install.out 2> install.err
+./install -admin_pass=admin0 -admin_email=dvAdmin@mailinator.com -y -f > install.out 2> install.err
 
 echo "installer complete"
 cat install.err

--- a/scripts/installer/install
+++ b/scripts/installer/install
@@ -19,6 +19,7 @@ my $skipdatabasesetup;
 my $force;
 my $nogfpasswd;
 my $admin_email;
+my $admin_pass;
 
 my ($rez) = GetOptions(
     #"length=i" => \$length,    # numeric
@@ -34,6 +35,7 @@ my ($rez) = GetOptions(
     "f|force"      => \$force,
     "nogfpasswd"   => \$nogfpasswd,
     "admin_email=s" => \$admin_email,
+    "admin_pass=s" => \$admin_pass,
 );
 
 # openshift/docker-specific - name of the "pod" executing the installer:
@@ -651,6 +653,13 @@ else
 	print "using default contact email for root dataverse\n";
 }
 
+# if there's an admin password from arguments, use it
+if ($admin_pass)
+{
+	printf("setting dataverseAdmin password to specified argument");
+	set_admin_pass( $admin_pass );
+}
+
 for my $script ( "setup-all.sh" ) {
     # (there's only 1 setup script to run now - it runs all the other required scripts)
     print "Executing post-deployment setup script " . $script . "... ";
@@ -1186,6 +1195,15 @@ sub set_root_contact_email
         search_replace_file($config_json,"\"email\":\"dataverse\@mailinator.com\"","\"email\":\"$contact_email\"",$config_json);
         return;
 }
+# if provided with a password for the dataverseAdmin account, use it
+sub set_admin_pass
+{
+        my ($p) = @_;
+        my $fn= "setup-all.sh"; # assume that we've got the path accurate
+        search_replace_file($fn,"password=admin&","password=$p&",$fn);
+        return;
+}
+
 
 
 sub setup_postgres {


### PR DESCRIPTION
…make use of this in docker-aio non-IT install

## New Contributors

Welcome! New contributors should at least glance at [CONTRIBUTING.md](/CONTRIBUTING.md), especially the section on pull requests where we encourage you to reach out to other developers before you start coding. Also, please note that we measure code coverage and prefer you write unit tests. Pull requests can still be reviewed without tests or completion of the checklist outlined below. Thanks!

## Related Issues

- connects to #4178 : update default dataverseAdmin password for new password complexity rules

## Pull Request Checklist

- [ ] Unit [tests][] completed
- [ ] Integration [tests][]: None
- [ ] Deployment requirements, [SQL updates][], [Solr updates][], etc.: None
- [ ] [Documentation][docs] completed
- [ ] Merged latest from "develop" [branch][] and resolved conflicts

[tests]: http://guides.dataverse.org/en/latest/developers/testing.html
[SQL updates]: https://github.com/IQSS/dataverse/tree/develop/scripts/database/upgrades
[Solr updates]: https://github.com/IQSS/dataverse/blob/develop/conf/solr/7.3.0/schema.xml
[docs]: http://guides.dataverse.org/en/latest/developers/documentation.html
[branch]: http://guides.dataverse.org/en/latest/developers/branching-strategy.html
