### PR TITLE
5246 bibtex closing bracket

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DataCitation.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DataCitation.java
@@ -256,17 +256,16 @@ public class DataCitation {
         out.write(publisher);
         out.write("},\r\n");
         if(getFileTitle() !=null && isDirect()) {
-        out.write("title = {");
-        out.write(fileTitle);
-        out.write("},\r\n");
-        out.write("booktitle = {");
-        out.write(title);
-        out.write("},\r\n");
+            out.write("title = {");
+            out.write(fileTitle);
+            out.write("},\r\n");
+            out.write("booktitle = {");
+            out.write(title);
+            out.write("},\r\n");
         } else {
             out.write("title = {");
             out.write(title);
             out.write("},\r\n");
-            
         }
         out.write("year = {");
         out.write(year);

--- a/src/main/java/edu/harvard/iq/dataverse/DataCitation.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DataCitation.java
@@ -279,6 +279,7 @@ public class DataCitation {
         out.write("url = {");
         out.write(persistentId.toURL().toString());
         out.write("}\r\n");
+        out.write("}\r\n");
         out.flush();
     }
 

--- a/src/test/java/edu/harvard/iq/dataverse/DataCitationTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/DataCitationTest.java
@@ -1,0 +1,70 @@
+package edu.harvard.iq.dataverse;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.sql.Timestamp;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author pkiraly@gwdg.de
+ */
+public class DataCitationTest {
+
+    /**
+     * Test that bibtex data export contains a closing bracket
+     * @throws ParseException
+     * @throws IOException
+     */
+    @Test
+    void testWriteAsBibtexCitation() throws ParseException, IOException {
+        DatasetVersion datasetVersion = createATestDatasetVersion();
+
+        DataCitation dataCitation = new DataCitation(datasetVersion);
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        dataCitation.writeAsBibtexCitation(os);
+        String out = new String(os.toByteArray(), "UTF-8");
+        assertEquals(
+            "@data{LK0D1H_1955,\r\n" +
+            "author = {},\r\n" +
+            "publisher = {LibraScholar},\r\n" +
+            "title = {},\r\n" +
+            "year = {1955},\r\n" +
+            "doi = {10.5072/FK2/LK0D1H},\r\n" +
+            "url = {https://doi.org/10.5072/FK2/LK0D1H}\r\n" +
+            "}\r\n",
+            out
+        );
+    }
+
+    private DatasetVersion createATestDatasetVersion() throws ParseException {
+        Dataverse dataverse = new Dataverse();
+        dataverse.setName("LibraScholar");
+
+        Dataset dataset = new Dataset();
+        dataset.setProtocol("doi");
+        dataset.setAuthority("10.5072/FK2");
+        dataset.setIdentifier("LK0D1H");
+        dataset.setOwner(dataverse);
+
+        DatasetVersion datasetVersion = new DatasetVersion();
+        datasetVersion.setDataset(dataset);
+        datasetVersion.setVersionState(DatasetVersion.VersionState.DRAFT);
+        datasetVersion.setVersionState(DatasetVersion.VersionState.RELEASED);
+        datasetVersion.setVersionNumber(1L);
+
+        SimpleDateFormat dateFmt = new SimpleDateFormat("yyyyMMdd");
+        Date publicationDate = dateFmt.parse("19551105");
+
+        datasetVersion.setReleaseTime(publicationDate);
+
+        dataset.setPublicationDate(new Timestamp(publicationDate.getTime()));
+
+        return datasetVersion;
+    }
+}


### PR DESCRIPTION
This fix adds a closing bracket to BibTeX export, and adds some indentation to the Java source code.
The code's starting point was master branch's v4.9.4 tag.

## Related Issues

- connects to #5246: bibtex closing bracket

## Pull Request Checklist

- [ ] Unit [tests][] completed
- [ ] Integration [tests][]: None
- [ ] Deployment requirements, [SQL updates][], [Solr updates][], etc.: None
- [ ] [Documentation][docs] completed
- [ ] Merged latest from "develop" [branch][] and resolved conflicts

[tests]: http://guides.dataverse.org/en/latest/developers/testing.html
[SQL updates]: http://guides.dataverse.org/en/latest/developers/sql-upgrade-scripts.html
[Solr updates]: https://github.com/IQSS/dataverse/blob/develop/conf/solr/7.3.0/schema.xml
[docs]: http://guides.dataverse.org/en/latest/developers/documentation.html
[branch]: http://guides.dataverse.org/en/latest/developers/branching-strategy.html
