### PR TITLE
Issue #4563: remove link to a SWORD video which is not available anym…

### DIFF
--- a/doc/sphinx-guides/source/api/sword.rst
+++ b/doc/sphinx-guides/source/api/sword.rst
@@ -11,7 +11,7 @@ About
 
 Introduced in Dataverse Network (DVN) `3.6 <http://guides.dataverse.org/en/3.6.2/dataverse-api-main.html#data-deposit-api>`_, the SWORD API was formerly known as the "Data Deposit API" and ``data-deposit/v1`` appeared in the URLs. For backwards compatibility these URLs continue to work (with deprecation warnings). Due to architectural changes and security improvements (especially the introduction of API tokens) in Dataverse 4.0, a few backward incompatible changes were necessarily introduced and for this reason the version has been increased to ``v1.1``. For details, see :ref:`incompatible`.
 
-Dataverse implements most of SWORDv2_, which is specified at http://swordapp.github.io/SWORDv2-Profile/SWORDProfile.html . Please reference the `SWORDv2 specification`_ for expected HTTP status codes (i.e. 201, 204, 404, etc.), headers (i.e. "Location"), etc. For a quick introduction to SWORD, the two minute video at http://cottagelabs.com/news/intro-to-sword-2 is recommended.
+Dataverse implements most of SWORDv2_, which is specified at http://swordapp.github.io/SWORDv2-Profile/SWORDProfile.html . Please reference the `SWORDv2 specification`_ for expected HTTP status codes (i.e. 201, 204, 404, etc.), headers (i.e. "Location"), etc.
 
 As a profile of AtomPub, XML is used throughout SWORD. As of Dataverse 4.0 datasets can also be created via JSON using the "native" API. SWORD is limited to the dozen or so fields listed below in the crosswalk, but the native API allows you to populate all metadata fields available in Dataverse.
 


### PR DESCRIPTION
This pull request removes a sentence from SWORD documentation which contains a link to a video which is not available any more. Not even the publisher of the video (Cottage Lab LLP) has any information about the video or about an alternative location.

## Related Issues

- connects to #4563: Invalid SWORD tutorial link in documentation

## Pull Request Checklist

- [ ] Unit [tests][] completed
- [ ] Integration [tests][]: None
- [ ] Deployment requirements, [SQL updates][], [Solr updates][], etc.: None
- [ ] [Documentation][docs] completed
- [ ] Merged latest from "develop" [branch][] and resolved conflicts

[tests]: http://guides.dataverse.org/en/latest/developers/testing.html
[SQL updates]: http://guides.dataverse.org/en/latest/developers/sql-upgrade-scripts.html
[Solr updates]: https://github.com/IQSS/dataverse/blob/develop/conf/solr/7.3.0/schema.xml
[docs]: http://guides.dataverse.org/en/latest/developers/documentation.html
[branch]: http://guides.dataverse.org/en/latest/developers/branching-strategy.html
