### PR TITLE
Fixed #5340 delete auxiliary objects in Swift

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/dataaccess/SwiftAccessIO.java
+++ b/src/main/java/edu/harvard/iq/dataverse/dataaccess/SwiftAccessIO.java
@@ -518,13 +518,17 @@ public class SwiftAccessIO<T extends DvObject> extends StorageIO<T> {
                 Properties p = getSwiftProperties();
                 swiftEndPoint = p.getProperty("swift.default.endpoint");
 
+                // Swift uses this to create pseudo-hierarchical folders
+                String swiftPseudoFolderPathSeparator = "/";
+
                 //swiftFolderPath = dataFile.getOwner().getDisplayName();
                 String swiftFolderPathSeparator = "-";
                 String authorityNoSlashes = owner.getAuthority().replace("/", swiftFolderPathSeparator);
                 swiftFolderPath = owner.getProtocolForFileStorage() + swiftFolderPathSeparator
-                                  + authorityNoSlashes.replace(".", swiftFolderPathSeparator)
-                                  + swiftFolderPathSeparator + owner.getIdentifierForFileStorage();
-                swiftFileName = storageIdentifier;
+                                  + authorityNoSlashes.replace(".", swiftFolderPathSeparator);
+
+                swiftFileName = owner.getIdentifierForFileStorage() + swiftPseudoFolderPathSeparator
+                                + storageIdentifier;
                 //setSwiftContainerName(swiftFolderPath);
                 //swiftFileName = dataFile.getDisplayName();
                 //Storage Identifier is now updated after the object is uploaded on Swift.
@@ -569,10 +573,14 @@ public class SwiftAccessIO<T extends DvObject> extends StorageIO<T> {
                 Properties p = getSwiftProperties();
                 swiftEndPoint = p.getProperty("swift.default.endpoint");
                 String swiftFolderPathSeparator = "-";
+
+                // Swift uses this to create pseudo-hierarchical folders
+                String swiftPseudoFolderPathSeparator = "/";
+
                 String authorityNoSlashes = dataset.getAuthorityForFileStorage().replace("/", swiftFolderPathSeparator);
                 swiftFolderPath = dataset.getProtocolForFileStorage() + swiftFolderPathSeparator +
                     authorityNoSlashes.replace(".", swiftFolderPathSeparator) +
-                    swiftFolderPathSeparator + dataset.getIdentifierForFileStorage();
+                    swiftPseudoFolderPathSeparator + dataset.getIdentifierForFileStorage();
 
                 swiftFileName = auxItemTag;
                 dvObject.setStorageIdentifier("swift://" + swiftEndPoint + ":" + swiftFolderPath);


### PR DESCRIPTION
Change datafile storage identifier to work with joss
Change dataset storage identifier to reflect datafile storage identifier changes

## Related Issues

- connects to #5340 : deleteAllAuxObjects() fails on Swift due to malformed Swift REST API request

## Pull Request Checklist

- [x] Unit [tests][] completed
- [x] Integration [tests][]: None
- [x] Deployment requirements, [SQL updates][], [Solr updates][], etc.: None
- [x] [Documentation][docs] completed
- [x] Merged latest from "develop" [branch][] and resolved conflicts

[tests]: http://guides.dataverse.org/en/latest/developers/testing.html
[SQL updates]: http://guides.dataverse.org/en/latest/developers/sql-upgrade-scripts.html
[Solr updates]: https://github.com/IQSS/dataverse/blob/develop/conf/solr/7.3.0/schema.xml
[docs]: http://guides.dataverse.org/en/latest/developers/documentation.html
[branch]: http://guides.dataverse.org/en/latest/developers/branching-strategy.html