### PR TITLE
Fixes #5357

### DIFF
--- a/doc/sphinx-guides/source/index.rst
+++ b/doc/sphinx-guides/source/index.rst
@@ -60,11 +60,14 @@ We maintain an email based support service that's free of charge. We
 attempt to respond within one business day to all questions and if it
 cannot be resolved immediately, we'll let you know what to expect.
 
-The support email address is
-`support@dataverse.org <mailto:support@dataverse.org>`__.
+The support email address is `support@dataverse.org <mailto:support@dataverse.org>`__.
 
-This is the same address as the Report Issue link. We try to respond
-within one business day.
+**Reporting Issues and Contributing**
+
+Report bugs and add feature requests in `GitHub Issues <https://github.com/IQSS/dataverse/issues>`__
+or use `github pull requests <http://guides.dataverse.org/en/latest/developers/version-control.html#how-to-make-a-pull-request>`__,
+if you have some code, scripts or documentation that you'd like to share.
+If you have a **security issue** to report, please email `security@dataverse.org <mailto:security@dataverse.org>`__.
 
 
 Indices and tables

--- a/doc/sphinx-guides/source/index.rst
+++ b/doc/sphinx-guides/source/index.rst
@@ -65,7 +65,7 @@ The support email address is `support@dataverse.org <mailto:support@dataverse.or
 **Reporting Issues and Contributing**
 
 Report bugs and add feature requests in `GitHub Issues <https://github.com/IQSS/dataverse/issues>`__
-or use `github pull requests <http://guides.dataverse.org/en/latest/developers/version-control.html#how-to-make-a-pull-request>`__,
+or use `GitHub pull requests <http://guides.dataverse.org/en/latest/developers/version-control.html#how-to-make-a-pull-request>`__,
 if you have some code, scripts or documentation that you'd like to share.
 If you have a **security issue** to report, please email `security@dataverse.org <mailto:security@dataverse.org>`__.
 


### PR DESCRIPTION
Cleans up existing Support text on the front page of the guide and provides links to Issues, the PR section within the guide, and the security email address.

connects to #5357