### PR TITLE
5457-provide dataset/version/filemetadata to External tools

### DIFF
--- a/doc/sphinx-guides/source/installation/external-tools.rst
+++ b/doc/sphinx-guides/source/installation/external-tools.rst
@@ -36,6 +36,8 @@ In the example above, a mix of required and optional reserved words appear that 
 - ``{fileId}`` (required) - The Dataverse database ID of a file the external tool has been launched on.
 - ``{siteUrl}`` (optional) - The URL of the Dataverse installation that hosts the file with the fileId above.
 - ``{apiToken}`` (optional) - The Dataverse API token of the user launching the external tool, if available.
+- ``{datasetId}`` (optional) - The ID of the dataset containing the file.
+- ``{datasetVersion}`` (optional) - The friendly version number ( or \:draft ) of the dataset version the tool is being launched from.
 
 Making an External Tool Available in Dataverse
 ----------------------------------------------

--- a/src/main/java/edu/harvard/iq/dataverse/FileDownloadServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/FileDownloadServiceBean.java
@@ -235,6 +235,10 @@ public class FileDownloadServiceBean implements java.io.Serializable {
                 dataFile = guestbookResponse.getDataFile();
             }
         }
+        //For tools to get the dataset and datasetversion ids, we need a full DataFile object (not a findCheapAndEasy() copy)
+        if(dataFile.getFileMetadata()==null) {
+            dataFile=datafileService.find(dataFile.getId());
+        }
         ExternalToolHandler externalToolHandler = new ExternalToolHandler(externalTool, dataFile, apiToken);
         // Back when we only had TwoRavens, the downloadType was always "Explore". Now we persist the name of the tool (i.e. "TwoRavens", "Data Explorer", etc.)
         guestbookResponse.setDownloadtype(externalTool.getDisplayName());

--- a/src/main/java/edu/harvard/iq/dataverse/externaltools/ExternalTool.java
+++ b/src/main/java/edu/harvard/iq/dataverse/externaltools/ExternalTool.java
@@ -174,7 +174,9 @@ public class ExternalTool implements Serializable {
         // from https://swagger.io/specification/#fixed-fields-29 but that's for URLs.
         FILE_ID("fileId"),
         SITE_URL("siteUrl"),
-        API_TOKEN("apiToken");
+        API_TOKEN("apiToken"),
+        DATASET_ID("datasetId"),
+        DATASET_VERSION("datasetVersion");
 
         private final String text;
         private final String START = "{";

--- a/src/main/java/edu/harvard/iq/dataverse/externaltools/ExternalToolHandler.java
+++ b/src/main/java/edu/harvard/iq/dataverse/externaltools/ExternalToolHandler.java
@@ -1,6 +1,9 @@
 package edu.harvard.iq.dataverse.externaltools;
 
 import edu.harvard.iq.dataverse.DataFile;
+import edu.harvard.iq.dataverse.Dataset;
+import edu.harvard.iq.dataverse.DatasetVersion;
+import edu.harvard.iq.dataverse.FileMetadata;
 import edu.harvard.iq.dataverse.authorization.users.ApiToken;
 import edu.harvard.iq.dataverse.externaltools.ExternalTool.ReservedWord;
 import edu.harvard.iq.dataverse.util.SystemConfig;
@@ -24,6 +27,7 @@ public class ExternalToolHandler {
 
     private final ExternalTool externalTool;
     private final DataFile dataFile;
+    private final Dataset dataset;
 
     private final ApiToken apiToken;
 
@@ -42,6 +46,7 @@ public class ExternalToolHandler {
         }
         this.dataFile = dataFile;
         this.apiToken = apiToken;
+        dataset = getDataFile().getFileMetadata().getDatasetVersion().getDataset();
     }
 
     public DataFile getDataFile() {
@@ -90,6 +95,20 @@ public class ExternalToolHandler {
                     return key + "=" + apiTokenString;
                 }
                 break;
+            case DATASET_ID:
+                return key + "=" + dataset.getId();
+            case DATASET_VERSION:
+                String version = null;
+                if (getApiToken() != null) {
+                    version = dataset.getLatestVersion().getFriendlyVersionNumber();
+                } else {
+                    version = dataset.getLatestVersionForCopy().getFriendlyVersionNumber();
+                }
+                if (("DRAFT").equals(version)) {
+                    version = ":draft"; // send the token needed in api calls that can be substituted for a numeric
+                                        // version.
+                }
+                return key + "=" + version;
             default:
                 break;
         }

--- a/src/test/java/edu/harvard/iq/dataverse/externaltools/ExternalToolHandlerTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/externaltools/ExternalToolHandlerTest.java
@@ -1,10 +1,18 @@
 package edu.harvard.iq.dataverse.externaltools;
 
 import edu.harvard.iq.dataverse.DataFile;
+import edu.harvard.iq.dataverse.DataFileServiceBean;
+import edu.harvard.iq.dataverse.Dataset;
+import edu.harvard.iq.dataverse.DatasetVersion;
+import edu.harvard.iq.dataverse.FileMetadata;
 import edu.harvard.iq.dataverse.authorization.users.ApiToken;
 import javax.json.Json;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
 import org.junit.Test;
 
 public class ExternalToolHandlerTest {
@@ -68,6 +76,14 @@ public class ExternalToolHandlerTest {
                 .build().toString());
         DataFile dataFile = new DataFile();
         dataFile.setId(42l);
+        FileMetadata fmd = new FileMetadata();
+        DatasetVersion dv = new DatasetVersion();
+        Dataset ds = new Dataset();
+        dv.setDataset(ds);
+        fmd.setDatasetVersion(dv);
+        List<FileMetadata> fmdl = new ArrayList<FileMetadata>();
+        fmdl.add(fmd);
+        dataFile.setFileMetadatas(fmdl);
         ApiToken apiToken = new ApiToken();
         apiToken.setTokenString("7196b5ce-f200-4286-8809-03ffdbc255d7");
         ExternalToolHandler externalToolHandler3 = new ExternalToolHandler(externalTool, dataFile, apiToken);

--- a/src/test/java/edu/harvard/iq/dataverse/externaltools/ExternalToolServiceBeanTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/externaltools/ExternalToolServiceBeanTest.java
@@ -2,6 +2,9 @@ package edu.harvard.iq.dataverse.externaltools;
 
 import edu.harvard.iq.dataverse.DataFile;
 import edu.harvard.iq.dataverse.DataTable;
+import edu.harvard.iq.dataverse.Dataset;
+import edu.harvard.iq.dataverse.DatasetVersion;
+import edu.harvard.iq.dataverse.FileMetadata;
 import edu.harvard.iq.dataverse.authorization.users.ApiToken;
 import java.util.ArrayList;
 import java.util.List;
@@ -20,6 +23,14 @@ public class ExternalToolServiceBeanTest {
     public void testfindAll() {
         DataFile dataFile = new DataFile();
         dataFile.setId(42l);
+        FileMetadata fmd = new FileMetadata();
+        DatasetVersion dv = new DatasetVersion();
+        Dataset ds = new Dataset();
+        dv.setDataset(ds);
+        fmd.setDatasetVersion(dv);
+        List<FileMetadata> fmdl = new ArrayList<FileMetadata>();
+        fmdl.add(fmd);
+        dataFile.setFileMetadatas(fmdl);
         List<DataTable> dataTables = new ArrayList<DataTable>();
         dataTables.add(new DataTable());
         dataFile.setDataTables(dataTables);
@@ -57,6 +68,14 @@ public class ExternalToolServiceBeanTest {
         assertEquals("AwesomeTool", externalTool.getDisplayName());
         DataFile dataFile = new DataFile();
         dataFile.setId(42l);
+        FileMetadata fmd = new FileMetadata();
+        DatasetVersion dv = new DatasetVersion();
+        Dataset ds = new Dataset();
+        dv.setDataset(ds);
+        fmd.setDatasetVersion(dv);
+        List<FileMetadata> fmdl = new ArrayList<FileMetadata>();
+        fmdl.add(fmd);
+        dataFile.setFileMetadatas(fmdl);
         ApiToken apiToken = new ApiToken();
         apiToken.setTokenString("7196b5ce-f200-4286-8809-03ffdbc255d7");
         ExternalToolHandler externalToolHandler = new ExternalToolHandler(externalTool, dataFile, apiToken);


### PR DESCRIPTION
## New Contributors

Welcome! New contributors should at least glance at [CONTRIBUTING.md](/CONTRIBUTING.md), especially the section on pull requests where we encourage you to reach out to other developers before you start coding. Also, please note that we measure code coverage and prefer you write unit tests. Pull requests can still be reviewed without tests or completion of the checklist outlined below. Thanks!

## Related Issues

- connects to #5457 External tools can't see the dataset context

## Pull Request Checklist

- [ ] Unit [tests][] completed
- [ ] Integration [tests][]: None
- [ ] Deployment requirements, [SQL updates][], [Solr updates][], etc.: None
- [ ] [Documentation][docs] completed
- [ ] Merged latest from "develop" [branch][] and resolved conflicts

[tests]: http://guides.dataverse.org/en/latest/developers/testing.html
[SQL updates]: http://guides.dataverse.org/en/latest/developers/sql-upgrade-scripts.html
[Solr updates]: https://github.com/IQSS/dataverse/blob/develop/conf/solr/7.3.0/schema.xml
[docs]: http://guides.dataverse.org/en/latest/developers/documentation.html
[branch]: http://guides.dataverse.org/en/latest/developers/branching-strategy.html
