### PR TITLE
5479 close file descriptor on listing cached files

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/dataaccess/FileAccessIO.java
+++ b/src/main/java/edu/harvard/iq/dataverse/dataaccess/FileAccessIO.java
@@ -565,6 +565,8 @@ public class FileAccessIO<T extends DvObject> extends StorageIO<T> {
             }
         }   
 
+        dirStream.close();
+        
         return auxItems;
     }
 


### PR DESCRIPTION
## Related Issues

- connects to #5479 Deleting files keeps 2 file descriptors on dataset directory 
