### PR TITLE
5501 - Wrong scope for JUnit deps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,11 +134,13 @@
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
             <version>${junit.jupiter.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.vintage</groupId>
             <artifactId>junit-vintage-engine</artifactId>
             <version>${junit.vintage.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.glassfish</groupId>


### PR DESCRIPTION
Setting *test* scope for ALL JUnit dependencies properly excludes them and their transient deps form the WAR.

## Related Issues

- connects to #5501

## Pull Request Checklist
- [x] Merged latest from "develop" [branch][] and resolved conflicts