### PR TITLE
5552 - obey file PID flag in UpdateDvObjectPIDMetadataCommand

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/UpdateDvObjectPIDMetadataCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/UpdateDvObjectPIDMetadataCommand.java
@@ -11,6 +11,7 @@ import edu.harvard.iq.dataverse.engine.command.DataverseRequest;
 import edu.harvard.iq.dataverse.engine.command.RequiredPermissions;
 import edu.harvard.iq.dataverse.engine.command.exception.CommandException;
 import edu.harvard.iq.dataverse.engine.command.exception.PermissionException;
+import edu.harvard.iq.dataverse.settings.SettingsServiceBean;
 import edu.harvard.iq.dataverse.util.BundleUtil;
 import java.sql.Timestamp;
 import java.util.Collections;
@@ -52,12 +53,29 @@ public class UpdateDvObjectPIDMetadataCommand extends AbstractVoidCommand {
                 target.setGlobalIdCreateTime(new Timestamp(new Date().getTime()));
                 ctxt.em().merge(target);
                 ctxt.em().flush();
+                // When updating, we want to traverse through files even if the dataset itself
+                // didn't need updating.
+                String currentGlobalIdProtocol = ctxt.settings().getValueForKey(SettingsServiceBean.Key.Protocol, "");
+                String dataFilePIDFormat = ctxt.settings().getValueForKey(SettingsServiceBean.Key.DataFilePIDFormat, "DEPENDENT");
+                boolean isFilePIDsEnabled = ctxt.systemConfig().isFilePIDsEnabled();
+                // We will skip trying to update the global identifiers for datafiles if they
+                // aren't being used.
+                // If they are, we need to assure that there's an existing PID or, as when
+                // creating PIDs, that the protocol matches that of the dataset DOI if
+                // we're going to create a DEPENDENT file PID.
+                String protocol = target.getProtocol();
                 for (DataFile df : target.getFiles()) {
-                    doiRetString = idServiceBean.publicizeIdentifier(df);
-                    if (doiRetString) {
-                        df.setGlobalIdCreateTime(new Timestamp(new Date().getTime()));
-                        ctxt.em().merge(df);
-                        ctxt.em().flush();
+                    if (isFilePIDsEnabled && // using file PIDs and
+                            (!(df.getIdentifier() == null || df.getIdentifier().isEmpty()) || // identifier exists, or
+                                    currentGlobalIdProtocol.equals(protocol) || // right protocol to create dependent DOIs, or
+                                    dataFilePIDFormat.equals("INDEPENDENT"))// or independent. TODO(pm) - check authority too
+                    ) {
+                        doiRetString = idServiceBean.publicizeIdentifier(df);
+                        if (doiRetString) {
+                            df.setGlobalIdCreateTime(new Timestamp(new Date().getTime()));
+                            ctxt.em().merge(df);
+                            ctxt.em().flush();
+                        }
                     }
                 }
             } else {


### PR DESCRIPTION
## New Contributors

Welcome! New contributors should at least glance at [CONTRIBUTING.md](/CONTRIBUTING.md), especially the section on pull requests where we encourage you to reach out to other developers before you start coding. Also, please note that we measure code coverage and prefer you write unit tests. Pull requests can still be reviewed without tests or completion of the checklist outlined below. Thanks!

## Related Issues

- connects to #5552 - modifyRegistrationMetadata api and UpdateDvObjectPIDMetadataCommand will create filePIDs even if they are not in use

## Pull Request Checklist

- [ ] Unit [tests][] completed
- [ ] Integration [tests][]: None
- [ ] Deployment requirements, [SQL updates][], [Solr updates][], etc.: None
- [ ] [Documentation][docs] completed
- [ ] Merged latest from "develop" [branch][] and resolved conflicts

[tests]: http://guides.dataverse.org/en/latest/developers/testing.html
[SQL updates]: http://guides.dataverse.org/en/latest/developers/sql-upgrade-scripts.html
[Solr updates]: https://github.com/IQSS/dataverse/blob/develop/conf/solr/7.3.0/schema.xml
[docs]: http://guides.dataverse.org/en/latest/developers/documentation.html
[branch]: http://guides.dataverse.org/en/latest/developers/branching-strategy.html
