### PR TITLE
update datafile state upon restriction change

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/CuratePublishedDatasetVersionCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/CuratePublishedDatasetVersionCommand.java
@@ -111,6 +111,8 @@ public class CuratePublishedDatasetVersionCommand extends AbstractDatasetCommand
                 if (!draftFmd.isRestricted() == publishedFmd.isRestricted()) {
                     publishedFmd.setRestricted(draftFmd.isRestricted());
                     metadataUpdated = true;
+                    //Must also update state of file
+                    dataFile.setRestricted(draftFmd.isRestricted());
                 }
                 String draftProv = draftFmd.getProvFreeForm();
                 String pubProv = publishedFmd.getProvFreeForm();


### PR DESCRIPTION
(the web app uses the info from the filemetadata associated with the
current dataset version to show the restricted/unrestricted state but
the state of the file itself controls download and api access.

## New Contributors

Welcome! New contributors should at least glance at [CONTRIBUTING.md](/CONTRIBUTING.md), especially the section on pull requests where we encourage you to reach out to other developers before you start coding. Also, please note that we measure code coverage and prefer you write unit tests. Pull requests can still be reviewed without tests or completion of the checklist outlined below. Thanks!

## Related Issues

- connects to #5607 Update Current Version doesn't change datafile.isRestricted

## Pull Request Checklist

- [ ] Unit [tests][] completed
- [ ] Integration [tests][]: None
- [ ] Deployment requirements, [SQL updates][], [Solr updates][], etc.: None
- [ ] [Documentation][docs] completed
- [ ] Merged latest from "develop" [branch][] and resolved conflicts

[tests]: http://guides.dataverse.org/en/latest/developers/testing.html
[SQL updates]: http://guides.dataverse.org/en/latest/developers/sql-upgrade-scripts.html
[Solr updates]: https://github.com/IQSS/dataverse/blob/develop/conf/solr/7.3.0/schema.xml
[docs]: http://guides.dataverse.org/en/latest/developers/documentation.html
[branch]: http://guides.dataverse.org/en/latest/developers/branching-strategy.html
