### PR TITLE
Fixed in password resetting email link.

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/passwordreset/PasswordResetInitResponse.java
+++ b/src/main/java/edu/harvard/iq/dataverse/passwordreset/PasswordResetInitResponse.java
@@ -11,7 +11,7 @@ public class PasswordResetInitResponse {
      * null or not instead?
      */
     private boolean emailFound;
-    private String resetUrl;
+    private String resetUrlPart;
     private PasswordResetData passwordResetData;
 
     public PasswordResetInitResponse(boolean emailFound) {
@@ -21,32 +21,15 @@ public class PasswordResetInitResponse {
     public PasswordResetInitResponse(boolean emailFound, PasswordResetData passwordResetData) {
         this.emailFound = emailFound;
         this.passwordResetData = passwordResetData;
-        // default to localhost
-        String finalHostname = "localhost";
-        String configuredHostname = System.getProperty(SystemConfig.FQDN);
-        if (configuredHostname != null) {
-            if (configuredHostname.equals("localhost")) {
-                // must be a dev environment
-                finalHostname = "localhost:8181";
-            } else {
-                finalHostname = configuredHostname;
-            }
-        } else {
-            try {
-                finalHostname = InetAddress.getLocalHost().getHostName();
-            } catch (UnknownHostException ex) {
-                // just use the dev address
-            }
-        }
-        this.resetUrl = "https://" + finalHostname + "/passwordreset.xhtml?token=" + passwordResetData.getToken();
+        this.resetUrlPart = "/passwordreset.xhtml?token=" + passwordResetData.getToken();
     }
 
     public boolean isEmailFound() {
         return emailFound;
     }
 
-    public String getResetUrl() {
-        return resetUrl;
+    public String getResetUrl(String prefix) {
+        return prefix + resetUrlPart;
     }
 
     public PasswordResetData getPasswordResetData() {

--- a/src/main/java/edu/harvard/iq/dataverse/passwordreset/PasswordResetPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/passwordreset/PasswordResetPage.java
@@ -56,6 +56,9 @@ public class PasswordResetPage implements java.io.Serializable {
     @EJB
     PasswordValidatorServiceBean passwordValidatorService;
     
+    @EJB
+    SystemConfig systemConfig;
+
     /**
      * The unique string used to look up a user and continue the password reset
      * process.
@@ -113,7 +116,7 @@ public class PasswordResetPage implements java.io.Serializable {
             PasswordResetData passwordResetData = passwordResetInitResponse.getPasswordResetData();
             if (passwordResetData != null) {
                 BuiltinUser foundUser = passwordResetData.getBuiltinUser();
-                passwordResetUrl = passwordResetInitResponse.getResetUrl();
+                passwordResetUrl = passwordResetInitResponse.getResetUrl(systemConfig.getDataverseSiteUrl());
                 actionLogSvc.log( new ActionLogRecord(ActionLogRecord.ActionType.BuiltinUser, "passwordResetSent")
                             .setInfo("Email Address: " + emailAddress) );
             } else {

--- a/src/main/java/edu/harvard/iq/dataverse/passwordreset/PasswordResetServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/passwordreset/PasswordResetServiceBean.java
@@ -42,6 +42,9 @@ public class PasswordResetServiceBean {
     @EJB
     AuthenticationServiceBean authService;
 
+    @EJB
+    SystemConfig systemConfig;
+
     @PersistenceContext(unitName = "VDCNet-ejbPU")
     private EntityManager em;
 
@@ -81,7 +84,7 @@ public class PasswordResetServiceBean {
             em.persist(passwordResetData);
             PasswordResetInitResponse passwordResetInitResponse = new PasswordResetInitResponse(true, passwordResetData);
             if ( sendEmail ) {
-                sendPasswordResetEmail(aUser, passwordResetInitResponse.getResetUrl());
+                sendPasswordResetEmail(aUser, passwordResetInitResponse.getResetUrl(systemConfig.getDataverseSiteUrl()));
             }
 
             return passwordResetInitResponse;


### PR DESCRIPTION
Use `siteUrl` to generate correct password resetting link instead of hard-coded 'https://...'
So that password resetting works if the site runs without https.
