### PR TITLE
centralize 'MockDatasetFieldSvc' to remove code duplication #5732

### DIFF
--- a/src/test/java/edu/harvard/iq/dataverse/export/DDIExporterTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/export/DDIExporterTest.java
@@ -5,6 +5,7 @@ import edu.harvard.iq.dataverse.Dataset;
 import edu.harvard.iq.dataverse.DatasetFieldServiceBean;
 import edu.harvard.iq.dataverse.DatasetFieldType;
 import edu.harvard.iq.dataverse.DatasetFieldType.FieldType;
+import edu.harvard.iq.dataverse.mocks.MockDatasetFieldSvc;
 import edu.harvard.iq.dataverse.DatasetVersion;
 import edu.harvard.iq.dataverse.Dataverse;
 import edu.harvard.iq.dataverse.util.json.JsonParser;
@@ -186,39 +187,6 @@ public class DDIExporterTest {
 
         System.out.println(XmlPrinter.prettyPrintXml(byteArrayOutputStream.toString()));
         assertFalse(byteArrayOutputStream.toString().contains("finch@mailinator.com"));
-
-    }
-
-    static class MockDatasetFieldSvc extends DatasetFieldServiceBean {
-
-        Map<String, DatasetFieldType> fieldTypes = new HashMap<>();
-        long nextId = 1;
-
-        public DatasetFieldType add(DatasetFieldType t) {
-            if (t.getId() == null) {
-                t.setId(nextId++);
-            }
-            fieldTypes.put(t.getName(), t);
-            return t;
-        }
-
-        @Override
-        public DatasetFieldType findByName(String name) {
-            return fieldTypes.get(name);
-        }
-
-        @Override
-        public DatasetFieldType findByNameOpt(String name) {
-            return findByName(name);
-        }
-
-        @Override
-        public ControlledVocabularyValue findControlledVocabularyValueByDatasetFieldTypeAndStrValue(DatasetFieldType dsft, String strValue, boolean lenient) {
-            ControlledVocabularyValue cvv = new ControlledVocabularyValue();
-            cvv.setDatasetFieldType(dsft);
-            cvv.setStrValue(strValue);
-            return cvv;
-        }
 
     }
 

--- a/src/test/java/edu/harvard/iq/dataverse/export/SchemaDotOrgExporterTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/export/SchemaDotOrgExporterTest.java
@@ -8,6 +8,8 @@ import edu.harvard.iq.dataverse.DatasetVersion;
 import edu.harvard.iq.dataverse.Dataverse;
 import edu.harvard.iq.dataverse.FileMetadata;
 import edu.harvard.iq.dataverse.TermsOfUseAndAccess;
+import edu.harvard.iq.dataverse.mocks.MockDatasetFieldSvc;
+
 import static edu.harvard.iq.dataverse.util.SystemConfig.SITE_URL;
 import static edu.harvard.iq.dataverse.util.SystemConfig.FILES_HIDE_SCHEMA_DOT_ORG_DOWNLOAD_URLS;
 import edu.harvard.iq.dataverse.util.json.JsonParser;
@@ -42,7 +44,7 @@ import static org.junit.Assert.*;
 public class SchemaDotOrgExporterTest {
 
     private final SchemaDotOrgExporter schemaDotOrgExporter;
-    DDIExporterTest.MockDatasetFieldSvc datasetFieldTypeSvc = null;
+    MockDatasetFieldSvc datasetFieldTypeSvc = null;
 
     public SchemaDotOrgExporterTest() {
         schemaDotOrgExporter = new SchemaDotOrgExporter();
@@ -58,7 +60,7 @@ public class SchemaDotOrgExporterTest {
 
     @Before
     public void setUp() {
-        datasetFieldTypeSvc = new DDIExporterTest.MockDatasetFieldSvc();
+        datasetFieldTypeSvc = new MockDatasetFieldSvc();
 
         DatasetFieldType titleType = datasetFieldTypeSvc.add(new DatasetFieldType("title", DatasetFieldType.FieldType.TEXTBOX, false));
         DatasetFieldType authorType = datasetFieldTypeSvc.add(new DatasetFieldType("author", DatasetFieldType.FieldType.TEXT, true));

--- a/src/test/java/edu/harvard/iq/dataverse/feedback/FeedbackUtilTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/feedback/FeedbackUtilTest.java
@@ -14,6 +14,7 @@ import edu.harvard.iq.dataverse.DataverseSession;
 import edu.harvard.iq.dataverse.DvObject;
 import edu.harvard.iq.dataverse.FileMetadata;
 import edu.harvard.iq.dataverse.authorization.users.AuthenticatedUser;
+import edu.harvard.iq.dataverse.mocks.MockDatasetFieldSvc;
 import edu.harvard.iq.dataverse.mocks.MocksFactory;
 import edu.harvard.iq.dataverse.util.json.JsonParseException;
 import edu.harvard.iq.dataverse.util.json.JsonParser;
@@ -478,40 +479,6 @@ public class FeedbackUtilTest {
         assertEquals("Help!", feedback.getBody());
         assertEquals("support@librascholar.edu", feedback.getToEmail());
         assertEquals("First.Last@someU.edu", feedback.getFromEmail());
-    }
-
-    // We are starting to accumulate a lot of these. See DDIExporterTest, SchemaDotOrgExporterTest, JsonParserTest, and JsonPrinterTest.
-    static class MockDatasetFieldSvc extends DatasetFieldServiceBean {
-
-        Map<String, DatasetFieldType> fieldTypes = new HashMap<>();
-        long nextId = 1;
-
-        public DatasetFieldType add(DatasetFieldType t) {
-            if (t.getId() == null) {
-                t.setId(nextId++);
-            }
-            fieldTypes.put(t.getName(), t);
-            return t;
-        }
-
-        @Override
-        public DatasetFieldType findByName(String name) {
-            return fieldTypes.get(name);
-        }
-
-        @Override
-        public DatasetFieldType findByNameOpt(String name) {
-            return findByName(name);
-        }
-
-        @Override
-        public ControlledVocabularyValue findControlledVocabularyValueByDatasetFieldTypeAndStrValue(DatasetFieldType dsft, String strValue, boolean lenient) {
-            ControlledVocabularyValue cvv = new ControlledVocabularyValue();
-            cvv.setDatasetFieldType(dsft);
-            cvv.setStrValue(strValue);
-            return cvv;
-        }
-
     }
 
 }

--- a/src/test/java/edu/harvard/iq/dataverse/mocks/MockDatasetFieldSvc.java
+++ b/src/test/java/edu/harvard/iq/dataverse/mocks/MockDatasetFieldSvc.java
@@ -1,0 +1,42 @@
+package edu.harvard.iq.dataverse.mocks;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import edu.harvard.iq.dataverse.ControlledVocabularyValue;
+import edu.harvard.iq.dataverse.DatasetFieldServiceBean;
+import edu.harvard.iq.dataverse.DatasetFieldType;
+
+public class MockDatasetFieldSvc extends DatasetFieldServiceBean {
+
+    Map<String, DatasetFieldType> fieldTypes = new HashMap<>();
+    long nextId = 1;
+
+    public DatasetFieldType add(DatasetFieldType t) {
+        if (t.getId() == null) {
+            t.setId(nextId++);
+        }
+        fieldTypes.put(t.getName(), t);
+        return t;
+    }
+
+    @Override
+    public DatasetFieldType findByName(String name) {
+        return fieldTypes.get(name);
+    }
+
+    @Override
+    public DatasetFieldType findByNameOpt(String name) {
+        return findByName(name);
+    }
+
+    @Override
+    public ControlledVocabularyValue findControlledVocabularyValueByDatasetFieldTypeAndStrValue(DatasetFieldType dsft,
+            String strValue, boolean lenient) {
+        ControlledVocabularyValue cvv = new ControlledVocabularyValue();
+        cvv.setDatasetFieldType(dsft);
+        cvv.setStrValue(strValue);
+        return cvv;
+    }
+
+}

--- a/src/test/java/edu/harvard/iq/dataverse/util/json/JsonParserTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/util/json/JsonParserTest.java
@@ -22,6 +22,7 @@ import edu.harvard.iq.dataverse.DataverseTheme.Alignment;
 import edu.harvard.iq.dataverse.FileMetadata;
 import edu.harvard.iq.dataverse.authorization.users.GuestUser;
 import edu.harvard.iq.dataverse.engine.command.DataverseRequest;
+import edu.harvard.iq.dataverse.mocks.MockDatasetFieldSvc;
 import edu.harvard.iq.dataverse.settings.SettingsServiceBean;
 import java.io.FileReader;
 import java.io.IOException;
@@ -634,36 +635,5 @@ public class JsonParserTest {
              return null;
         }
     }
-    
-    static class MockDatasetFieldSvc extends DatasetFieldServiceBean {
-        
-        Map<String, DatasetFieldType> fieldTypes = new HashMap<>();
-        long nextId = 1;
-        public DatasetFieldType add( DatasetFieldType t ) {
-            if ( t.getId()==null ) {
-                t.setId( nextId++ );
-            }
-            fieldTypes.put( t.getName(), t);
-            return t;
-        }
-        
-        @Override
-        public DatasetFieldType findByName( String name ) {
-            return fieldTypes.get(name);
-        }
-        
-        @Override
-        public DatasetFieldType findByNameOpt(String name) {
-           return findByName(name);
-        }
-        
-        @Override
-        public ControlledVocabularyValue findControlledVocabularyValueByDatasetFieldTypeAndStrValue(DatasetFieldType dsft, String strValue, boolean lenient) {
-            ControlledVocabularyValue cvv = new ControlledVocabularyValue();
-            cvv.setDatasetFieldType(dsft);
-            cvv.setStrValue(strValue);
-            return cvv;
-        }
- 
-    }
+
 }

--- a/src/test/java/edu/harvard/iq/dataverse/util/json/JsonPrinterTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/util/json/JsonPrinterTest.java
@@ -20,6 +20,7 @@ import edu.harvard.iq.dataverse.RoleAssignment;
 import edu.harvard.iq.dataverse.authorization.DataverseRole;
 import edu.harvard.iq.dataverse.authorization.RoleAssignee;
 import edu.harvard.iq.dataverse.authorization.users.PrivateUrlUser;
+import edu.harvard.iq.dataverse.mocks.MockDatasetFieldSvc;
 import edu.harvard.iq.dataverse.privateurl.PrivateUrl;
 import edu.harvard.iq.dataverse.settings.SettingsServiceBean;
 import java.util.ArrayList;
@@ -38,12 +39,11 @@ import static org.junit.Assert.assertNotNull;
 
 public class JsonPrinterTest {
 
-    // Centralize JsonParserTest.MockDatasetFieldSvc? See also https://github.com/IQSS/dataverse/issues/3413 and https://github.com/IQSS/dataverse/issues/3777
-    JsonParserTest.MockDatasetFieldSvc datasetFieldTypeSvc = null;
+    MockDatasetFieldSvc datasetFieldTypeSvc = null;
 
     @Before
     public void setUp() {
-        datasetFieldTypeSvc = new JsonParserTest.MockDatasetFieldSvc();
+        datasetFieldTypeSvc = new MockDatasetFieldSvc();
 
         DatasetFieldType titleType = datasetFieldTypeSvc.add(new DatasetFieldType("title", FieldType.TEXTBOX, false));
         DatasetFieldType authorType = datasetFieldTypeSvc.add(new DatasetFieldType("author", FieldType.TEXT, true));


### PR DESCRIPTION
As mentioned in #5732, the class `MockDatasetFieldSvc` is declared three times (copy&paste). I moved it into a separate file in the existing `mocks` folder, removed remaining declarations and imported the class where it is needed.

## Related Issues

- connects to #5732

## Pull Request Checklist

- [x] Unit [tests][] completed
- [x] Integration [tests][]: None
- [x] Deployment requirements, [SQL updates][], [Solr updates][], etc.: None
- [x] [Documentation][docs] completed: None
- [x] Merged latest from "develop" [branch][] and resolved conflicts

[tests]: http://guides.dataverse.org/en/latest/developers/testing.html
[SQL updates]: http://guides.dataverse.org/en/latest/developers/sql-upgrade-scripts.html
[Solr updates]: https://github.com/IQSS/dataverse/blob/develop/conf/solr/7.3.0/schema.xml
[docs]: http://guides.dataverse.org/en/latest/developers/documentation.html
[branch]: http://guides.dataverse.org/en/latest/developers/branching-strategy.html
