### PR TITLE
5785 test smell refactoring

### DIFF
--- a/src/test/java/edu/harvard/iq/dataverse/privateurl/PrivateUrlUtilTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/privateurl/PrivateUrlUtilTest.java
@@ -71,6 +71,37 @@ public class PrivateUrlUtilTest {
 
     }
 
+    private RoleAssignment createTestRoleAssignment(DvObject dvObject) {
+        DataverseRole role = null;
+        PrivateUrlUser user = new PrivateUrlUser(42);
+        RoleAssignee assignee = user;
+        String urlToken = null;
+
+        return new RoleAssignment(role, assignee, dvObject, urlToken);
+    }
+
+    private RoleAssignment createTestRoleAssignmentWithVersion(Dataset dataset, DatasetVersion.VersionState versionState) {
+        RoleAssignment ra = createTestRoleAssignment(dataset);
+
+        List<DatasetVersion> versions = new ArrayList<>();
+        DatasetVersion datasetVersion = new DatasetVersion();
+        datasetVersion.setVersionState(versionState);
+        versions.add(datasetVersion);
+        dataset.setVersions(versions);
+        ra.setDefinitionPoint(dataset);
+
+        return ra;
+    }
+
+    private RoleAssignment createTestRoleAssignmentWithDvObjectId(DvObject dvObject, Long datasetId) {
+        RoleAssignment ra = createTestRoleAssignment(dvObject);
+
+        dvObject.setId(123l);
+        ra.setDefinitionPoint(dvObject);
+
+        return ra;
+    }
+
     @Test
     public void testGetDatasetFromRoleAssignmentNullRoleAssignment() {
         assertNull(PrivateUrlUtil.getDatasetFromRoleAssignment(null));
@@ -78,34 +109,25 @@ public class PrivateUrlUtilTest {
 
     @Test
     public void testGetDatasetFromRoleAssignmentNullDefinitionPoint() {
-        DataverseRole aRole = null;
-        PrivateUrlUser privateUrlUser = new PrivateUrlUser(42);
-        RoleAssignee anAssignee = privateUrlUser;
         DvObject nullDefinitionPoint = null;
-        String privateUrlToken = null;
-        RoleAssignment ra = new RoleAssignment(aRole, anAssignee, nullDefinitionPoint, privateUrlToken);
+        RoleAssignment ra = this.createTestRoleAssignment(nullDefinitionPoint);
+
         assertNull(PrivateUrlUtil.getDatasetFromRoleAssignment(ra));
     }
 
     @Test
     public void testGetDatasetFromRoleAssignmentNonDataset() {
-        DataverseRole aRole = null;
-        PrivateUrlUser privateUrlUser = new PrivateUrlUser(42);
-        RoleAssignee anAssignee = privateUrlUser;
         DvObject nonDataset = new Dataverse();
-        String privateUrlToken = null;
-        RoleAssignment ra = new RoleAssignment(aRole, anAssignee, nonDataset, privateUrlToken);
+        RoleAssignment ra = this.createTestRoleAssignment(nonDataset);
+
         assertNull(PrivateUrlUtil.getDatasetFromRoleAssignment(ra));
     }
 
     @Test
     public void testGetDatasetFromRoleAssignmentSuccess() {
-        DataverseRole aRole = null;
-        PrivateUrlUser privateUrlUser = new PrivateUrlUser(42);
-        RoleAssignee anAssignee = privateUrlUser;
         DvObject dataset = new Dataset();
-        String privateUrlToken = null;
-        RoleAssignment ra = new RoleAssignment(aRole, anAssignee, dataset, privateUrlToken);
+        RoleAssignment ra = this.createTestRoleAssignment(dataset);
+
         assertNotNull(PrivateUrlUtil.getDatasetFromRoleAssignment(ra));
         assertEquals("#42", ra.getAssigneeIdentifier());
     }
@@ -117,46 +139,29 @@ public class PrivateUrlUtilTest {
 
     @Test
     public void testGetDraftDatasetVersionFromRoleAssignmentNullDataset() {
-        DataverseRole aRole = null;
-        PrivateUrlUser privateUrlUser = new PrivateUrlUser(42);
-        RoleAssignee anAssignee = privateUrlUser;
         DvObject dataset = null;
-        String privateUrlToken = null;
-        RoleAssignment ra = new RoleAssignment(aRole, anAssignee, dataset, privateUrlToken);
+        RoleAssignment ra = this.createTestRoleAssignment(dataset);
+
         DatasetVersion datasetVersion = PrivateUrlUtil.getDraftDatasetVersionFromRoleAssignment(ra);
         assertNull(datasetVersion);
     }
 
     @Test
     public void testGetDraftDatasetVersionFromRoleAssignmentLastestIsNotDraft() {
-        DataverseRole aRole = null;
-        PrivateUrlUser privateUrlUser = new PrivateUrlUser(42);
-        RoleAssignee anAssignee = privateUrlUser;
         Dataset dataset = new Dataset();
-        List<DatasetVersion> versions = new ArrayList<>();
-        DatasetVersion datasetVersionIn = new DatasetVersion();
-        datasetVersionIn.setVersionState(DatasetVersion.VersionState.RELEASED);
-        versions.add(datasetVersionIn);
-        dataset.setVersions(versions);
-        String privateUrlToken = null;
-        RoleAssignment ra = new RoleAssignment(aRole, anAssignee, dataset, privateUrlToken);
+        DatasetVersion.VersionState versionState = DatasetVersion.VersionState.RELEASED;
+        RoleAssignment ra = this.createTestRoleAssignmentWithVersion(dataset, versionState);
+
         DatasetVersion datasetVersionOut = PrivateUrlUtil.getDraftDatasetVersionFromRoleAssignment(ra);
         assertNull(datasetVersionOut);
     }
 
     @Test
     public void testGetDraftDatasetVersionFromRoleAssignmentSuccess() {
-        DataverseRole aRole = null;
-        PrivateUrlUser privateUrlUser = new PrivateUrlUser(42);
-        RoleAssignee anAssignee = privateUrlUser;
         Dataset dataset = new Dataset();
-        List<DatasetVersion> versions = new ArrayList<>();
-        DatasetVersion datasetVersionIn = new DatasetVersion();
-        datasetVersionIn.setVersionState(DatasetVersion.VersionState.DRAFT);
-        versions.add(datasetVersionIn);
-        dataset.setVersions(versions);
-        String privateUrlToken = null;
-        RoleAssignment ra = new RoleAssignment(aRole, anAssignee, dataset, privateUrlToken);
+        DatasetVersion.VersionState versionState = DatasetVersion.VersionState.DRAFT;
+        RoleAssignment ra = this.createTestRoleAssignmentWithVersion(dataset, versionState);
+
         DatasetVersion datasetVersionOut = PrivateUrlUtil.getDraftDatasetVersionFromRoleAssignment(ra);
         assertNotNull(datasetVersionOut);
         assertEquals("#42", ra.getAssigneeIdentifier());
@@ -169,39 +174,27 @@ public class PrivateUrlUtilTest {
 
     @Test
     public void testGetUserFromRoleAssignmentNonDataset() {
-        DataverseRole aRole = null;
-        PrivateUrlUser privateUrlUserIn = new PrivateUrlUser(42);
-        RoleAssignee anAssignee = privateUrlUserIn;
         DvObject nonDataset = new Dataverse();
-        nonDataset.setId(123l);
-        String privateUrlToken = null;
-        RoleAssignment ra = new RoleAssignment(aRole, anAssignee, nonDataset, privateUrlToken);
+        RoleAssignment ra = this.createTestRoleAssignmentWithDvObjectId(nonDataset, 123l);
+
         PrivateUrlUser privateUrlUserOut = PrivateUrlUtil.getPrivateUrlUserFromRoleAssignment(ra);
         assertNull(privateUrlUserOut);
     }
 
     @Test
     public void testGetUserFromRoleAssignmentSucess() {
-        DataverseRole aRole = null;
-        PrivateUrlUser privateUrlUserIn = new PrivateUrlUser(42);
-        RoleAssignee anAssignee = privateUrlUserIn;
         DvObject dataset = new Dataset();
-        dataset.setId(123l);
-        String privateUrlToken = null;
-        RoleAssignment ra = new RoleAssignment(aRole, anAssignee, dataset, privateUrlToken);
+        RoleAssignment ra = this.createTestRoleAssignmentWithDvObjectId(dataset, 123l);
+
         PrivateUrlUser privateUrlUserOut = PrivateUrlUtil.getPrivateUrlUserFromRoleAssignment(ra);
         assertNotNull(privateUrlUserOut);
     }
 
     @Test
     public void testGetPrivateUrlRedirectDataFail() {
-        DataverseRole aRole = null;
-        long datasetId = 42;
-        PrivateUrlUser privateUrlUser = new PrivateUrlUser(datasetId);
-        RoleAssignee anAssignee = privateUrlUser;
         Dataset dataset = new Dataset();
-        String privateUrlToken = null;
-        RoleAssignment ra = new RoleAssignment(aRole, anAssignee, dataset, privateUrlToken);
+        RoleAssignment ra = this.createTestRoleAssignment(dataset);
+
         ra.setDefinitionPoint(null);
         PrivateUrlRedirectData privateUrlRedirectData = null;
         privateUrlRedirectData = PrivateUrlUtil.getPrivateUrlRedirectData(ra);

--- a/src/test/java/edu/harvard/iq/dataverse/util/shapefile/ShapefileHandlerTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/util/shapefile/ShapefileHandlerTest.java
@@ -154,14 +154,9 @@ public class ShapefileHandlerTest {
         // get file_groups Map
         Map<String, List<String>> file_groups = shp_handler.getFileGroups();
         
-        // The dict should not be empty
-        assertEquals(file_groups.isEmpty(), false);
-
-        // Verify the key
-        assertEquals(file_groups.containsKey("not-quite-a-shape"), true);
-        
-        // Verify the value
-        assertEquals(file_groups.get("not-quite-a-shape"), Arrays.asList("shp", "shx", "dbf", "pdf"));
+        assertEquals("verify that the dict is not empty", file_groups.isEmpty(), false);
+        assertEquals("verify key existance", file_groups.containsKey("not-quite-a-shape"), true);
+        assertEquals("verify value of key", file_groups.get("not-quite-a-shape"), Arrays.asList("shp", "shx", "dbf", "pdf"));
         
         this.showFilesInTempFolder(this.tempFolder.getRoot().getAbsolutePath());
 
@@ -190,9 +185,8 @@ public class ShapefileHandlerTest {
         ShapefileHandler shp_handler = new ShapefileHandler(new FileInputStream(zipfile_obj));
         shp_handler.DEBUG= true;
         
-        // Contains shapefile?
-        assertEquals(shp_handler.containsShapefile(), true);
-        assertEquals(shp_handler.errorFound, false);
+        assertEquals("verify shapefile existance", shp_handler.containsShapefile(), true);
+        assertEquals("verify that no error was found", shp_handler.errorFound, false);
         
         shp_handler.showFileGroups();
        // if (true){
@@ -201,16 +195,15 @@ public class ShapefileHandlerTest {
         // get file_groups Map
         Map<String, List<String>> file_groups = shp_handler.getFileGroups();
         
-        // The dict should not be empty
-        assertEquals(file_groups.isEmpty(), false);
+        assertEquals("verify that the dict is not empty", file_groups.isEmpty(), false);
 
         // Verify the keys
-        assertEquals(file_groups.containsKey("shape1"), true);      
-        assertEquals(file_groups.containsKey("shape2"), true);
+        assertEquals("verify key existance of 'shape1'", file_groups.containsKey("shape1"), true);
+        assertEquals("verify key existance of 'shape2'", file_groups.containsKey("shape2"), true);
 
         // Verify the values
-        assertEquals(file_groups.get("shape1"), Arrays.asList("shp", "shx", "dbf", "prj", "fbn", "fbx"));
-        assertEquals(file_groups.get("shape2"), Arrays.asList("shp", "shx", "dbf", "prj", "txt", "pdf", ShapefileHandler.BLANK_EXTENSION));
+        assertEquals("verify value of key 'shape1'", file_groups.get("shape1"), Arrays.asList("shp", "shx", "dbf", "prj", "fbn", "fbx"));
+        assertEquals("verify value of key 'shape2'", file_groups.get("shape2"), Arrays.asList("shp", "shx", "dbf", "prj", "txt", "pdf", ShapefileHandler.BLANK_EXTENSION));
         
         this.showFilesInTempFolder(this.tempFolder.getRoot().getAbsolutePath());
 
@@ -227,7 +220,7 @@ public class ShapefileHandlerTest {
         msg("rezipped_filenames: " + rezipped_filenames);
         List<String> expected_filenames = Arrays.asList("shape1.zip", "shape2.zip", "shape2.txt", "shape2.pdf", "shape2", "README.MD", "shp_dictionary.xls", "notes");  
 
-        assertEquals(rezipped_filenames.containsAll(rezipped_filenames), true);
+        assertEquals("verify that all files exist", rezipped_filenames.containsAll(rezipped_filenames), true);
         
         // Delete .zip
         zipfile_obj.delete();
@@ -248,23 +241,20 @@ public class ShapefileHandlerTest {
         ShapefileHandler shp_handler = new ShapefileHandler(new FileInputStream(zipfile_obj));
         shp_handler.DEBUG= true;
 
-        
-        // Contains shapefile?
-        assertEquals(shp_handler.containsShapefile(), true);
+        assertEquals("verify shapefile existance", shp_handler.containsShapefile(), true);
 
         // get file_groups Map
         Map<String, List<String>> file_groups = shp_handler.getFileGroups();
-        
-        // The dict should not be empty
-        assertEquals(file_groups.isEmpty(), false);
+
+        assertEquals("verify that the dict is not empty", file_groups.isEmpty(), false);
 
         // Verify the keys
-        assertEquals(file_groups.containsKey("shape1"), true);      
+        assertEquals("verify key existance of 'shape1'", file_groups.containsKey("shape1"), true);
 
         // Verify the values
-        assertEquals(file_groups.get("shape1"), Arrays.asList("shp", "shx", "dbf", "prj", "pdf", "cpg", SHP_XML_EXTENSION));
-        assertEquals(file_groups.get("README"), Arrays.asList("md"));
-        assertEquals(file_groups.get("shape_notes"), Arrays.asList("txt"));
+        assertEquals("verify value of key 'shape1'", file_groups.get("shape1"), Arrays.asList("shp", "shx", "dbf", "prj", "pdf", "cpg", SHP_XML_EXTENSION));
+        assertEquals("verify value of key 'README'", file_groups.get("README"), Arrays.asList("md"));
+        assertEquals("verify value of key 'shape_notes'", file_groups.get("shape_notes"), Arrays.asList("txt"));
         
         File unzip2Folder = this.tempFolder.newFolder("test_unzip2").getAbsoluteFile();
         // Rezip/Reorder the files
@@ -279,7 +269,7 @@ public class ShapefileHandlerTest {
         msg("rezipped_filenames: " + rezipped_filenames);
         List<String> expected_filenames = Arrays.asList("shape1.zip", "scratch-for-unzip-12345", "shape1.pdf", "README.md", "shape_notes.txt");  
 
-        assertEquals(expected_filenames.containsAll(rezipped_filenames), true);
+        assertEquals("verify that all files exist", expected_filenames.containsAll(rezipped_filenames), true);
         
         // Delete .zip
         zipfile_obj.delete();

--- a/src/test/java/edu/harvard/iq/dataverse/validation/PasswordValidatorUtilTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/validation/PasswordValidatorUtilTest.java
@@ -94,7 +94,6 @@ public class PasswordValidatorUtilTest {
     @Test
     public void testGetRequiredCharacters() {
         int numberOfCharacteristics = 2; //influences use of # or "each" in text generation
-        String textBeforeList = BundleUtil.getStringFromBundle("passwdVal.passwdReq.characteristicsReq" , Arrays.asList(Integer.toString(numberOfCharacteristics)))+ " " ;
         List<CharacterRule> characterRules = PasswordValidatorUtil.getCharacterRulesDefault();
         String reqString = PasswordValidatorUtil.getRequiredCharacters(characterRules,numberOfCharacteristics);
         System.out.println("Character rules string for default: ");

--- a/src/test/java/edu/harvard/iq/dataverse/validation/PasswordValidatorUtilTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/validation/PasswordValidatorUtilTest.java
@@ -9,12 +9,19 @@ import edu.harvard.iq.dataverse.util.BundleUtil;
 import edu.harvard.iq.dataverse.util.xml.html.HtmlPrinter;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
 import static org.junit.Assert.*;
 import org.passay.CharacterRule;
 import org.passay.EnglishCharacterData;
@@ -23,106 +30,132 @@ import org.passay.EnglishCharacterData;
  *
  * @author pdurbin
  */
+@RunWith(Enclosed.class)
 public class PasswordValidatorUtilTest {
 
-    /**
-     * Test of getPasswordRequirements method, of class PasswordValidatorUtil.
-     */
-    @Test
-    public void testGetPasswordRequirements() {
-        System.out.println("getPasswordRequirements");
-        int minLength = 6;
-        int maxLength = 0;
-        List<CharacterRule> characterRules = PasswordValidatorUtil.getCharacterRulesDefault();
-        int numberOfCharacteristics = 2;
-        int numberOfRepeatingCharactersAllowed = 4;
-        int goodStrength = 21;
-        boolean dictionaryEnabled = true;
-        List<String> errors = new ArrayList<>();
-        System.out.println("---Show all");
-        String req1 = PasswordValidatorUtil.getPasswordRequirements(minLength, maxLength, characterRules, numberOfCharacteristics, numberOfRepeatingCharactersAllowed, goodStrength, dictionaryEnabled, errors);
-        System.out.println(HtmlPrinter.prettyPrint(req1));
-        System.out.println("---Hide all");
-        String req2 = PasswordValidatorUtil.getPasswordRequirements(minLength, maxLength, characterRules, numberOfCharacteristics, 0, 0, false, errors);
-        System.out.println(HtmlPrinter.prettyPrint(req2));
-        System.out.println("---Show may not include sequence");
-        String req3 = PasswordValidatorUtil.getPasswordRequirements(minLength, maxLength, characterRules, numberOfCharacteristics, numberOfRepeatingCharactersAllowed, goodStrength, false, errors);
-        System.out.println(HtmlPrinter.prettyPrint(req3));
-        System.out.println("---Show may not dictionary");
-        String req4 = PasswordValidatorUtil.getPasswordRequirements(minLength, maxLength, characterRules, numberOfCharacteristics, 0, goodStrength, true, errors);
-        System.out.println(HtmlPrinter.prettyPrint(req4));
-    }
-    
-    /**
-     * Test of parseConfigString method, of class PasswordValidatorUtil.
-     */
-    @Test
-    public void testParseConfigString() {
-        String configString = "UpperCase:1,LowerCase:4,Digit:1,Special:1";
-        List<CharacterRule> rules = PasswordValidatorUtil.parseConfigString(configString);
-
-        System.out.println("Uppercase valid chars: " + rules.get(0).getValidCharacters());
-        System.out.println("Lowercase valid chars: " + rules.get(1).getValidCharacters());
-        System.out.println("Special valid chars: " + rules.get(3).getValidCharacters());
-
-        assertEquals(4, rules.size());
-        assertEquals(EnglishCharacterData.UpperCase.getCharacters(), rules.get(0).getValidCharacters());
-        assertEquals(EnglishCharacterData.LowerCase.getCharacters(), rules.get(1).getValidCharacters());
-        assertEquals(EnglishCharacterData.Digit.getCharacters(), rules.get(2).getValidCharacters());
-        assertEquals(EnglishCharacterData.Special.getCharacters(), rules.get(3).getValidCharacters());
-    }
-
-    private void executeTestOfGetRequiredCharacters(int numberOfCharacteristics, String characterRulesConfigString, String expectedValue) {
-        List<CharacterRule> characterRules;
-        String message = "Character rules string for ";
-        if (characterRulesConfigString != null) {
-            characterRules = PasswordValidatorUtil.getCharacterRules(characterRulesConfigString);
-            message += characterRulesConfigString;
-        } else {
-            characterRules = PasswordValidatorUtil.getCharacterRulesDefault();
-            message += "default";
+    public static class PasswordValidatorUtilNoParamTest {
+        /**
+         * Test of getPasswordRequirements method, of class PasswordValidatorUtil.
+         */
+        @Test
+        public void testGetPasswordRequirements() {
+            System.out.println("getPasswordRequirements");
+            int minLength = 6;
+            int maxLength = 0;
+            List<CharacterRule> characterRules = PasswordValidatorUtil.getCharacterRulesDefault();
+            int numberOfCharacteristics = 2;
+            int numberOfRepeatingCharactersAllowed = 4;
+            int goodStrength = 21;
+            boolean dictionaryEnabled = true;
+            List<String> errors = new ArrayList<>();
+            System.out.println("---Show all");
+            String req1 = PasswordValidatorUtil.getPasswordRequirements(minLength, maxLength, characterRules, numberOfCharacteristics, numberOfRepeatingCharactersAllowed, goodStrength, dictionaryEnabled, errors);
+            System.out.println(HtmlPrinter.prettyPrint(req1));
+            System.out.println("---Hide all");
+            String req2 = PasswordValidatorUtil.getPasswordRequirements(minLength, maxLength, characterRules, numberOfCharacteristics, 0, 0, false, errors);
+            System.out.println(HtmlPrinter.prettyPrint(req2));
+            System.out.println("---Show may not include sequence");
+            String req3 = PasswordValidatorUtil.getPasswordRequirements(minLength, maxLength, characterRules, numberOfCharacteristics, numberOfRepeatingCharactersAllowed, goodStrength, false, errors);
+            System.out.println(HtmlPrinter.prettyPrint(req3));
+            System.out.println("---Show may not dictionary");
+            String req4 = PasswordValidatorUtil.getPasswordRequirements(minLength, maxLength, characterRules, numberOfCharacteristics, 0, goodStrength, true, errors);
+            System.out.println(HtmlPrinter.prettyPrint(req4));
         }
         
-        String reqString = PasswordValidatorUtil.getRequiredCharacters(characterRules, numberOfCharacteristics);
-        assertEquals(message + ": " + reqString, expectedValue, reqString);
+        /**
+         * Test of parseConfigString method, of class PasswordValidatorUtil.
+         */
+        @Test
+        public void testParseConfigString() {
+            String configString = "UpperCase:1,LowerCase:4,Digit:1,Special:1";
+            List<CharacterRule> rules = PasswordValidatorUtil.parseConfigString(configString);
+
+            System.out.println("Uppercase valid chars: " + rules.get(0).getValidCharacters());
+            System.out.println("Lowercase valid chars: " + rules.get(1).getValidCharacters());
+            System.out.println("Special valid chars: " + rules.get(3).getValidCharacters());
+
+            assertEquals(4, rules.size());
+            assertEquals(EnglishCharacterData.UpperCase.getCharacters(), rules.get(0).getValidCharacters());
+            assertEquals(EnglishCharacterData.LowerCase.getCharacters(), rules.get(1).getValidCharacters());
+            assertEquals(EnglishCharacterData.Digit.getCharacters(), rules.get(2).getValidCharacters());
+            assertEquals(EnglishCharacterData.Special.getCharacters(), rules.get(3).getValidCharacters());
+        }
+
     }
 
-    @Test
-    public void testGetRequiredCharacters() {
-        int numberOfCharacteristics = 2; // influences use of # or "each" in text generation
-        String characterRulesConfigString = null;
-        String expectedValue = "At least 1 character from each of the following types: letter, numeral";
-        this.executeTestOfGetRequiredCharacters(numberOfCharacteristics, characterRulesConfigString, expectedValue);
+    @RunWith(Parameterized.class)
+    public static class PasswordValidatorUtilParamTest {
 
-        numberOfCharacteristics = 2;
-        characterRulesConfigString = "UpperCase:1,LowerCase:1,Digit:1,Special:1";
-        expectedValue = "At least 1 character from 2 of the following types: uppercase, lowercase, numeral, special";
-        this.executeTestOfGetRequiredCharacters(numberOfCharacteristics, characterRulesConfigString, expectedValue);
-        
-        numberOfCharacteristics = 4;
-        characterRulesConfigString = "UpperCase:1,LowerCase:1,Digit:1,Special:1";
-        expectedValue = "At least 1 character from each of the following types: uppercase, lowercase, numeral, special";
-        this.executeTestOfGetRequiredCharacters(numberOfCharacteristics, characterRulesConfigString, expectedValue);
-        
-        numberOfCharacteristics = 2; // Should say each, even if more characteristics set than possible
-        characterRulesConfigString = "Digit:1";
-        expectedValue = "At least 1 character from each of the following types: numeral";
-        this.executeTestOfGetRequiredCharacters(numberOfCharacteristics, characterRulesConfigString, expectedValue);
-        
-        numberOfCharacteristics = 2;
-        characterRulesConfigString = "Digit:2";
-        expectedValue = "Fufill 2: At least 2 numeral characters";
-        this.executeTestOfGetRequiredCharacters(numberOfCharacteristics, characterRulesConfigString, expectedValue);
-        
-        numberOfCharacteristics = 2;
-        characterRulesConfigString = "LowerCase:1,Digit:2,Special:3";
-        expectedValue = "Fufill 2: At least 1 lowercase characters, 2 numeral characters, 3 special characters";
-        this.executeTestOfGetRequiredCharacters(numberOfCharacteristics, characterRulesConfigString, expectedValue);
-        
-        // letter is mentioned even though that configuration is discouraged
-        numberOfCharacteristics = 2;
-        characterRulesConfigString = "UpperCase:1,LowerCase:1,Digit:1,Special:1,Alphabetical:1";
-        expectedValue = "At least 1 character from 2 of the following types: uppercase, lowercase, letter, numeral, special";
-        this.executeTestOfGetRequiredCharacters(numberOfCharacteristics, characterRulesConfigString, expectedValue);
+        // influences use of # or "each" in text generation
+        @Parameter(0)
+        public int numberOfCharacteristics;
+
+        @Parameter(1)
+        public String characterRulesConfigString;
+
+        @Parameter(2)
+        public String expectedValue;
+
+        @Parameters
+        public static Collection data() {
+            return Arrays.asList(new Object[][] {
+                {
+                    2,
+                    null,
+                    "At least 1 character from each of the following types: letter, numeral"
+                },
+                {
+                    2,
+                    "UpperCase:1,LowerCase:1,Digit:1,Special:1",
+                    "At least 1 character from 2 of the following types: uppercase, lowercase, numeral, special"
+                },
+                {
+                    4,
+                    "UpperCase:1,LowerCase:1,Digit:1,Special:1",
+                    "At least 1 character from each of the following types: uppercase, lowercase, numeral, special"
+                },
+
+                // Should say each, even if more characteristics set than possible
+                {
+                    2,
+                    "Digit:1",
+                    "At least 1 character from each of the following types: numeral"
+                },
+
+                {
+                    2,
+                    "Digit:2",
+                    "Fufill 2: At least 2 numeral characters"
+                },
+                {
+                    2,
+                    "LowerCase:1,Digit:2,Special:3",
+                    "Fufill 2: At least 1 lowercase characters, 2 numeral characters, 3 special characters"
+                },
+
+                // letter is mentioned even though that configuration is discouraged
+                {
+                    2,
+                    "UpperCase:1,LowerCase:1,Digit:1,Special:1,Alphabetical:1",
+                    "At least 1 character from 2 of the following types: uppercase, lowercase, letter, numeral, special"
+                }
+            });
+        }
+
+        @Test
+        public void testGetRequiredCharacters() {
+            List<CharacterRule> characterRules;
+            String message = "Character rules string for ";
+            if (characterRulesConfigString != null) {
+                characterRules = PasswordValidatorUtil.getCharacterRules(characterRulesConfigString);
+                message += characterRulesConfigString;
+            } else {
+                characterRules = PasswordValidatorUtil.getCharacterRulesDefault();
+                message += "default";
+            }
+
+            String reqString = PasswordValidatorUtil.getRequiredCharacters(characterRules, numberOfCharacteristics);
+            assertEquals(message + ": " + reqString, expectedValue, reqString);
+        }
     }
 }

--- a/src/test/java/edu/harvard/iq/dataverse/validation/PasswordValidatorUtilTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/validation/PasswordValidatorUtilTest.java
@@ -25,25 +25,6 @@ import org.passay.EnglishCharacterData;
  */
 public class PasswordValidatorUtilTest {
 
-    public PasswordValidatorUtilTest() {
-    }
-
-    @BeforeClass
-    public static void setUpClass() {
-    }
-
-    @AfterClass
-    public static void tearDownClass() {
-    }
-
-    @Before
-    public void setUp() {
-    }
-
-    @After
-    public void tearDown() {
-    }
-
     /**
      * Test of getPasswordRequirements method, of class PasswordValidatorUtil.
      */

--- a/src/test/java/edu/harvard/iq/dataverse/validation/PasswordValidatorUtilTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/validation/PasswordValidatorUtilTest.java
@@ -115,22 +115,6 @@ public class PasswordValidatorUtilTest {
         System.out.println(reqString);
         assertEquals("At least 1 character from each of the following types: uppercase, lowercase, numeral, special", reqString);
         
-        numberOfCharacteristics = 4;
-        characterRulesConfigString = "UpperCase:1,LowerCase:1,Digit:1,Special:1";
-        characterRules = PasswordValidatorUtil.getCharacterRules(characterRulesConfigString);
-        reqString = PasswordValidatorUtil.getRequiredCharacters(characterRules,numberOfCharacteristics);
-        System.out.println("Character rules string for '" + characterRulesConfigString );
-        System.out.println(reqString);
-        assertEquals("At least 1 character from each of the following types: uppercase, lowercase, numeral, special", reqString);
-        
-        numberOfCharacteristics = 2;
-        characterRulesConfigString = "UpperCase:1,LowerCase:1,Digit:1,Special:1";
-        characterRules = PasswordValidatorUtil.getCharacterRules(characterRulesConfigString);
-        reqString = PasswordValidatorUtil.getRequiredCharacters(characterRules,numberOfCharacteristics);
-        System.out.println("Character rules string for '" + characterRulesConfigString );
-        System.out.println(reqString);
-        assertEquals("At least 1 character from 2 of the following types: uppercase, lowercase, numeral, special", reqString);
-        
         numberOfCharacteristics = 2; //Should say each, even if more characteristics set than possible
         characterRulesConfigString = "Digit:1";
         characterRules = PasswordValidatorUtil.getCharacterRules(characterRulesConfigString);

--- a/src/test/java/edu/harvard/iq/dataverse/validation/PasswordValidatorUtilTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/validation/PasswordValidatorUtilTest.java
@@ -91,58 +91,57 @@ public class PasswordValidatorUtilTest {
         assertEquals(EnglishCharacterData.Special.getCharacters(), rules.get(3).getValidCharacters());
     }
 
+    private void executeTestOfGetRequiredCharacters(int numberOfCharacteristics, String characterRulesConfigString, String expectedValue) {
+        List<CharacterRule> characterRules;
+        String message = "Character rules string for ";
+        if (characterRulesConfigString != null) {
+            characterRules = PasswordValidatorUtil.getCharacterRules(characterRulesConfigString);
+            message += characterRulesConfigString;
+        } else {
+            characterRules = PasswordValidatorUtil.getCharacterRulesDefault();
+            message += "default";
+        }
+        
+        String reqString = PasswordValidatorUtil.getRequiredCharacters(characterRules, numberOfCharacteristics);
+        assertEquals(message + ": " + reqString, expectedValue, reqString);
+    }
+
     @Test
     public void testGetRequiredCharacters() {
-        int numberOfCharacteristics = 2; //influences use of # or "each" in text generation
-        List<CharacterRule> characterRules = PasswordValidatorUtil.getCharacterRulesDefault();
-        String reqString = PasswordValidatorUtil.getRequiredCharacters(characterRules,numberOfCharacteristics);
-        System.out.println("Character rules string for default: ");
-        System.out.println(reqString);
-        assertEquals("At least 1 character from each of the following types: letter, numeral", reqString);
-          
-        String characterRulesConfigString = "UpperCase:1,LowerCase:1,Digit:1,Special:1";
-        characterRules = PasswordValidatorUtil.getCharacterRules(characterRulesConfigString);
-        reqString = PasswordValidatorUtil.getRequiredCharacters(characterRules,numberOfCharacteristics);
-        System.out.println("Character rules string for '" + characterRulesConfigString + "': ");
-        System.out.println(reqString);
-        assertEquals("At least 1 character from 2 of the following types: uppercase, lowercase, numeral, special", reqString);
+        int numberOfCharacteristics = 2; // influences use of # or "each" in text generation
+        String characterRulesConfigString = null;
+        String expectedValue = "At least 1 character from each of the following types: letter, numeral";
+        this.executeTestOfGetRequiredCharacters(numberOfCharacteristics, characterRulesConfigString, expectedValue);
+
+        numberOfCharacteristics = 2;
+        characterRulesConfigString = "UpperCase:1,LowerCase:1,Digit:1,Special:1";
+        expectedValue = "At least 1 character from 2 of the following types: uppercase, lowercase, numeral, special";
+        this.executeTestOfGetRequiredCharacters(numberOfCharacteristics, characterRulesConfigString, expectedValue);
         
         numberOfCharacteristics = 4;
         characterRulesConfigString = "UpperCase:1,LowerCase:1,Digit:1,Special:1";
-        characterRules = PasswordValidatorUtil.getCharacterRules(characterRulesConfigString);
-        reqString = PasswordValidatorUtil.getRequiredCharacters(characterRules,numberOfCharacteristics);
-        System.out.println("Character rules string for '" + characterRulesConfigString + "': ");
-        System.out.println(reqString);
-        assertEquals("At least 1 character from each of the following types: uppercase, lowercase, numeral, special", reqString);
+        expectedValue = "At least 1 character from each of the following types: uppercase, lowercase, numeral, special";
+        this.executeTestOfGetRequiredCharacters(numberOfCharacteristics, characterRulesConfigString, expectedValue);
         
-        numberOfCharacteristics = 2; //Should say each, even if more characteristics set than possible
+        numberOfCharacteristics = 2; // Should say each, even if more characteristics set than possible
         characterRulesConfigString = "Digit:1";
-        characterRules = PasswordValidatorUtil.getCharacterRules(characterRulesConfigString);
-        reqString = PasswordValidatorUtil.getRequiredCharacters(characterRules,numberOfCharacteristics);
-        System.out.println("Character rules string for '" + characterRulesConfigString + "': ");
-        System.out.println(reqString);
-        assertEquals("At least 1 character from each of the following types: numeral", reqString);
-        
-        characterRulesConfigString = "Digit:2";
-        characterRules = PasswordValidatorUtil.getCharacterRules(characterRulesConfigString);
-        reqString = PasswordValidatorUtil.getRequiredCharacters(characterRules,numberOfCharacteristics);
-        System.out.println("Character rules string for '" + characterRulesConfigString + "': ");
-        System.out.println(reqString);
-        assertEquals("Fufill 2: At least 2 numeral characters", reqString);
-        
-        characterRulesConfigString = "LowerCase:1,Digit:2,Special:3";
-        characterRules = PasswordValidatorUtil.getCharacterRules(characterRulesConfigString);
-        reqString = PasswordValidatorUtil.getRequiredCharacters(characterRules,numberOfCharacteristics);
-        System.out.println("Character rules string for '" + characterRulesConfigString + "': ");
-        System.out.println(reqString);
-        assertEquals("Fufill 2: At least 1 lowercase characters, 2 numeral characters, 3 special characters", reqString);
+        expectedValue = "At least 1 character from each of the following types: numeral";
+        this.executeTestOfGetRequiredCharacters(numberOfCharacteristics, characterRulesConfigString, expectedValue);
         
         numberOfCharacteristics = 2;
+        characterRulesConfigString = "Digit:2";
+        expectedValue = "Fufill 2: At least 2 numeral characters";
+        this.executeTestOfGetRequiredCharacters(numberOfCharacteristics, characterRulesConfigString, expectedValue);
+        
+        numberOfCharacteristics = 2;
+        characterRulesConfigString = "LowerCase:1,Digit:2,Special:3";
+        expectedValue = "Fufill 2: At least 1 lowercase characters, 2 numeral characters, 3 special characters";
+        this.executeTestOfGetRequiredCharacters(numberOfCharacteristics, characterRulesConfigString, expectedValue);
+        
+        // letter is mentioned even though that configuration is discouraged
+        numberOfCharacteristics = 2;
         characterRulesConfigString = "UpperCase:1,LowerCase:1,Digit:1,Special:1,Alphabetical:1";
-        characterRules = PasswordValidatorUtil.getCharacterRules(characterRulesConfigString);
-        reqString = PasswordValidatorUtil.getRequiredCharacters(characterRules,numberOfCharacteristics);
-        System.out.println("Character rules string for '" + characterRulesConfigString + "', letter is mentioned even though that configuration is discouraged: ");
-        System.out.println(reqString);
-        assertEquals("At least 1 character from 2 of the following types: uppercase, lowercase, letter, numeral, special", reqString);
+        expectedValue = "At least 1 character from 2 of the following types: uppercase, lowercase, letter, numeral, special";
+        this.executeTestOfGetRequiredCharacters(numberOfCharacteristics, characterRulesConfigString, expectedValue);
     }
 }


### PR DESCRIPTION
This PR refactors existing unit tests regarding test smells. The following changes were made:
- a508034: refactor 'test code duplication' test smell in PrivateUrlUtilTest #5775
Move duplicated test code into private methods to ensure that every test runs exactly the same and changes to the tests do not need to be duplicated for each test.
- 11d9c28:  refactor 'assertion roulette' test smell in ShapefileHandlerTest #5732
Print description of assertion if the test fails, so that it immediately becomes clear which assertion failed and what was tested.
- e8d0362: remove unused variable in PasswordValidatorUtilTest #5732
The variable `textBeforeList` was never used in the tests, so I removed it.
- 2f5ae92: remove duplicated test cases in PasswordValidatorUtilTest #5732
The two deleted test cases were duplicates, so I removed them.
- cc8b6d9:  refactor 'assertion roulette' and 'test code duplication' test smells in PasswordValidatorUtilTest #5732
Move duplicated test code into a private method an annotate assertions with error descriptions.
- 398bb6c: remove empty setUp and tearDown methods in PasswordValidatorUtilTest #5732
- 33bb11e: parameterize refactored test cases in PasswordValidatorUtilTest #5732

## Related Issues

- connects to #5785: Unit Testing (Test Smells Refactoring)

## Pull Request Checklist

- [x] Unit [tests][] completed
- [x] Integration [tests][]: None
- [x] Deployment requirements, [SQL updates][], [Solr updates][], etc.: None
- [x] [Documentation][docs]: None
- [x] Merged latest from "develop" [branch][] and resolved conflicts

[tests]: http://guides.dataverse.org/en/latest/developers/testing.html
[SQL updates]: http://guides.dataverse.org/en/latest/developers/sql-upgrade-scripts.html
[Solr updates]: https://github.com/IQSS/dataverse/blob/develop/conf/solr/7.3.0/schema.xml
[docs]: http://guides.dataverse.org/en/latest/developers/documentation.html
[branch]: http://guides.dataverse.org/en/latest/developers/branching-strategy.html
