### PR TITLE
5786 mocking

### DIFF
--- a/src/test/java/edu/harvard/iq/dataverse/PermissionsWrapperTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/PermissionsWrapperTest.java
@@ -1,0 +1,75 @@
+package edu.harvard.iq.dataverse;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import edu.harvard.iq.dataverse.authorization.users.GuestUser;
+import edu.harvard.iq.dataverse.authorization.users.User;
+import edu.harvard.iq.dataverse.engine.command.DataverseRequest;
+import edu.harvard.iq.dataverse.PermissionServiceBean.RequestPermissionQuery;
+import edu.harvard.iq.dataverse.authorization.Permission;
+
+public class PermissionsWrapperTest {
+
+    private PermissionsWrapper permissionWrapper;
+
+    @Before
+    public void setUp() {
+        this.permissionWrapper = new PermissionsWrapper();
+        this.permissionWrapper.permissionService = mock(PermissionServiceBean.class);
+        this.permissionWrapper.dvRequestService = mock(DataverseRequestServiceBean.class);
+    }
+
+    @After
+    public void tearDown() {
+        this.permissionWrapper = null;
+    }
+
+    @Test
+    public void testCanManageDatasetPermissionsWithUndefinedDataverse() {
+        Dataverse dataverse = null;
+        User user = GuestUser.get();
+
+        assertFalse(this.permissionWrapper.canManageDataversePermissions(user, dataverse));
+    }
+
+    @Test
+    public void testCanManageDatasetPermissionsWithUndefinedDataverseId() {
+        Dataverse dataverse = new Dataverse();
+        User user = GuestUser.get();
+
+        assertFalse(this.permissionWrapper.canManageDataversePermissions(user, dataverse));
+    }
+
+    @Test
+    public void testCanManageDatasetPermissionsWithUndefinedUser() {
+        Dataverse dataverse = new Dataverse();
+        dataverse.setId(1L);
+        User user = null;
+
+        assertFalse(this.permissionWrapper.canManageDataversePermissions(user, dataverse));
+    }
+
+    @Test
+    public void testCanManageDatasetPermissions() {
+        Dataverse dataverse = new Dataverse();
+        dataverse.setId(1L);
+        User user = GuestUser.get();
+
+        DataverseRequest dataverseRequest = this.permissionWrapper.dvRequestService.getDataverseRequest();
+        RequestPermissionQuery requestPermissionQuery = mock(RequestPermissionQuery.class);
+
+        // mock permission service request
+        Mockito.when(this.permissionWrapper.permissionService.requestOn(dataverseRequest, dataverse)).thenReturn(requestPermissionQuery);
+        Mockito.when(requestPermissionQuery.has(Permission.ManageDataversePermissions)).thenReturn(true);
+
+        assertTrue(this.permissionWrapper.canManageDataversePermissions(user, dataverse));
+    }
+
+}

--- a/src/test/java/edu/harvard/iq/dataverse/datasetutility/DuplicateFileCheckerTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/datasetutility/DuplicateFileCheckerTest.java
@@ -1,12 +1,32 @@
 package edu.harvard.iq.dataverse.datasetutility;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
+import edu.harvard.iq.dataverse.DatasetVersion;
 import edu.harvard.iq.dataverse.DatasetVersionServiceBean;
 
 public class DuplicateFileCheckerTest {
+
+    private DuplicateFileChecker duplicateFileChecker;
+    private DatasetVersionServiceBean datasetVersionServiceBean;
+
+    @Before
+    public void setUp() {
+        this.datasetVersionServiceBean = mock(DatasetVersionServiceBean.class);
+        this.duplicateFileChecker = new DuplicateFileChecker(datasetVersionServiceBean);
+    }
+
+    @After
+    public void tearDown() {
+        duplicateFileChecker = null;
+    }
 
     @Test(expected = NullPointerException.class)
     public void testConstructorWithUndefinedDatasetVersionService() {
@@ -17,6 +37,34 @@ public class DuplicateFileCheckerTest {
     public void testConstructorWithDefinedDatasetVersionService() {
         DuplicateFileChecker duplicateFileChecker = new DuplicateFileChecker(new DatasetVersionServiceBean());
         assertNotNull(duplicateFileChecker);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testIsFileInSavedDatasetVersionWithCheckSumParamWithUndefinedDatasetVersion() {
+        DatasetVersion datasetVersion = null;
+        String checkSum = "checkSum";
+
+        this.duplicateFileChecker.isFileInSavedDatasetVersion(datasetVersion, checkSum);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testIsFileInSavedDatasetVersionWithChecksumParamWithUndefinedChecksum() {
+        DatasetVersion datasetVersion = new DatasetVersion();
+        String checkSum = null;
+
+        this.duplicateFileChecker.isFileInSavedDatasetVersion(datasetVersion, checkSum);
+    }
+
+    @Test
+    public void testIsFileInSavedDatasetVersionWithChecksumParamWithUnsavedFile() {
+        DatasetVersion datasetVersion = new DatasetVersion();
+        String checkSum = "checkSum";
+
+        // mock sql query
+        Mockito.when(this.datasetVersionServiceBean.doesChecksumExistInDatasetVersion(datasetVersion, checkSum))
+                .thenReturn(false);
+
+        assertFalse(this.duplicateFileChecker.isFileInSavedDatasetVersion(datasetVersion, checkSum));
     }
 
 }

--- a/src/test/java/edu/harvard/iq/dataverse/datasetutility/DuplicateFileCheckerTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/datasetutility/DuplicateFileCheckerTest.java
@@ -9,8 +9,10 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import edu.harvard.iq.dataverse.DataFile;
 import edu.harvard.iq.dataverse.DatasetVersion;
 import edu.harvard.iq.dataverse.DatasetVersionServiceBean;
+import edu.harvard.iq.dataverse.FileMetadata;
 
 public class DuplicateFileCheckerTest {
 
@@ -28,6 +30,10 @@ public class DuplicateFileCheckerTest {
         duplicateFileChecker = null;
     }
 
+    // ----------------------------------------------------------------------------------------------------------
+    // test constructor
+    // ----------------------------------------------------------------------------------------------------------
+
     @Test(expected = NullPointerException.class)
     public void testConstructorWithUndefinedDatasetVersionService() {
         DuplicateFileChecker duplicateFileChecker = new DuplicateFileChecker(null);
@@ -38,6 +44,10 @@ public class DuplicateFileCheckerTest {
         DuplicateFileChecker duplicateFileChecker = new DuplicateFileChecker(new DatasetVersionServiceBean());
         assertNotNull(duplicateFileChecker);
     }
+
+    // ----------------------------------------------------------------------------------------------------------
+    // test public boolean isFileInSavedDatasetVersion(DatasetVersion datasetVersion, String checkSum)
+    // ----------------------------------------------------------------------------------------------------------
 
     @Test(expected = NullPointerException.class)
     public void testIsFileInSavedDatasetVersionWithCheckSumParamWithUndefinedDatasetVersion() {
@@ -65,6 +75,40 @@ public class DuplicateFileCheckerTest {
                 .thenReturn(false);
 
         assertFalse(this.duplicateFileChecker.isFileInSavedDatasetVersion(datasetVersion, checkSum));
+    }
+
+    // ----------------------------------------------------------------------------------------------------------
+    // test public boolean isFileInSavedDatasetVersion(DatasetVersion datasetVersion, FileMetadata fileMetadata)
+    // ----------------------------------------------------------------------------------------------------------
+
+    @Test(expected = NullPointerException.class)
+    public void testIsFileInSavedDatasetVersionWithFileMetadataParamWithUndefinedDatasetVersion() {
+        DatasetVersion datasetVersion = null;
+        FileMetadata fileMetadata = new FileMetadata();
+
+        this.duplicateFileChecker.isFileInSavedDatasetVersion(datasetVersion, fileMetadata);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testIsFileInSavedDatasetVersionWithFileMetadataParamWithUndefinedFileMetadata() {
+        DatasetVersion datasetVersion = new DatasetVersion();
+        FileMetadata fileMetadata = null;
+
+        this.duplicateFileChecker.isFileInSavedDatasetVersion(datasetVersion, fileMetadata);
+    }
+
+    @Test
+    public void testIsFileInSavedDatasetVersionWithFileMetadataParamWithUnsavedFile() {
+        DatasetVersion datasetVersion = new DatasetVersion();
+        FileMetadata fileMetadata = new FileMetadata();
+        String checkSum = "checkSum";
+        fileMetadata.setDataFile(new DataFile());
+        fileMetadata.getDataFile().setChecksumValue(checkSum);
+
+        // mock sql query
+        Mockito.when(this.datasetVersionServiceBean.doesChecksumExistInDatasetVersion(datasetVersion, checkSum)).thenReturn(false);
+
+        assertFalse(this.duplicateFileChecker.isFileInSavedDatasetVersion(datasetVersion, fileMetadata));
     }
 
 }

--- a/src/test/java/edu/harvard/iq/dataverse/datasetutility/DuplicateFileCheckerTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/datasetutility/DuplicateFileCheckerTest.java
@@ -1,0 +1,22 @@
+package edu.harvard.iq.dataverse.datasetutility;
+
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.Test;
+
+import edu.harvard.iq.dataverse.DatasetVersionServiceBean;
+
+public class DuplicateFileCheckerTest {
+
+    @Test(expected = NullPointerException.class)
+    public void testConstructorWithUndefinedDatasetVersionService() {
+        DuplicateFileChecker duplicateFileChecker = new DuplicateFileChecker(null);
+    }
+
+    @Test
+    public void testConstructorWithDefinedDatasetVersionService() {
+        DuplicateFileChecker duplicateFileChecker = new DuplicateFileChecker(new DatasetVersionServiceBean());
+        assertNotNull(duplicateFileChecker);
+    }
+
+}

--- a/src/test/java/edu/harvard/iq/dataverse/worldmapauth/WorldMapTokenServiceBeanTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/worldmapauth/WorldMapTokenServiceBeanTest.java
@@ -1,0 +1,76 @@
+package edu.harvard.iq.dataverse.worldmapauth;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import edu.harvard.iq.dataverse.DataFile;
+import edu.harvard.iq.dataverse.PermissionServiceBean;
+import edu.harvard.iq.dataverse.PermissionServiceBean.StaticPermissionQuery;
+import edu.harvard.iq.dataverse.authorization.Permission;
+import edu.harvard.iq.dataverse.authorization.users.AuthenticatedUser;
+
+public class WorldMapTokenServiceBeanTest {
+
+    private WorldMapTokenServiceBean worldMapTokenServiceBean;
+
+    @Before
+    public void setUp() {
+        this.worldMapTokenServiceBean = new WorldMapTokenServiceBean();
+        this.worldMapTokenServiceBean.permissionService = mock(PermissionServiceBean.class);
+    }
+
+    @After
+    public void tearDown() {
+        this.worldMapTokenServiceBean = null;
+    }
+
+    private WorldMapToken createWorldMapToken(AuthenticatedUser user, DataFile file) {
+        WorldMapToken worldMapToken = new WorldMapToken();
+        worldMapToken.setDataverseUser(user);
+        worldMapToken.setDatafile(file);
+
+        return worldMapToken;
+    }
+
+    private void mockPermissionServiceCallForEditDataset(AuthenticatedUser user, DataFile file,
+            boolean isUserPermitted) {
+        StaticPermissionQuery query = mock(StaticPermissionQuery.class);
+        Mockito.when(this.worldMapTokenServiceBean.permissionService.userOn(user, file)).thenReturn(query);
+        Mockito.when(query.has(Permission.EditDataset)).thenReturn(isUserPermitted);
+    }
+
+    @Test
+    public void testCanTokenUserEditFileWithUndefinedWorldMapToken() {
+        WorldMapToken worldMapToken = null;
+
+        assertFalse(this.worldMapTokenServiceBean.canTokenUserEditFile(worldMapToken));
+    }
+
+    @Test
+    public void testCanTokenUserEditFileWithPermission() {
+        AuthenticatedUser user = new AuthenticatedUser();
+        DataFile file = new DataFile();
+        WorldMapToken worldMapToken = this.createWorldMapToken(user, file);
+
+        this.mockPermissionServiceCallForEditDataset(user, file, true);
+
+        assertTrue(this.worldMapTokenServiceBean.canTokenUserEditFile(worldMapToken));
+    }
+
+    @Test
+    public void testCanTokenUserEditFileWithoutPermission() {
+        AuthenticatedUser user = new AuthenticatedUser();
+        DataFile file = new DataFile();
+        WorldMapToken worldMapToken = this.createWorldMapToken(user, file);
+
+        this.mockPermissionServiceCallForEditDataset(user, file, false);
+
+        assertFalse(this.worldMapTokenServiceBean.canTokenUserEditFile(worldMapToken));
+    }
+}


### PR DESCRIPTION
This PR creates new unit tests using [mockito](https://site.mockito.org/) to mock services. The following changes were made:
- 7762eba: test constructor of DuplicateFileChecker #5732
- 5681a00: test isFileInSavedDatasetVesion with checksum param with mockito #5732
Mock `datasetVersionServiceBean` and its method `doesChecksumExistInDatasetVersion`
- d44adb9: test isFileInSavedDatasetVesion with fileMetadata param with mockito #5732
- 9c9f58f: test canManageDatasetPermissions of PermissionsWrapper with mockito #5732
Mock `permissionService` and `dvRequestService` to test `PermissionWrapper.canManageDataversePermissions`
- 17c5b56: test canTokenUserEditFile of WorldMapTokenServiceBean with mockito #5732
Mock `PermissionServiceBean` to test `WorldMapTokenServiceBean.canTokenUserEditFile`

## Related Issues

- connects to #5786: Unit Testing (Mocking)

## Pull Request Checklist

- [x] Unit [tests][] completed
- [x] Integration [tests][]: None
- [x] Deployment requirements, [SQL updates][], [Solr updates][], etc.: None
- [x] [Documentation][docs]: None
- [x] Merged latest from "develop" [branch][] and resolved conflicts

[tests]: http://guides.dataverse.org/en/latest/developers/testing.html
[SQL updates]: http://guides.dataverse.org/en/latest/developers/sql-upgrade-scripts.html
[Solr updates]: https://github.com/IQSS/dataverse/blob/develop/conf/solr/7.3.0/schema.xml
[docs]: http://guides.dataverse.org/en/latest/developers/documentation.html
[branch]: http://guides.dataverse.org/en/latest/developers/branching-strategy.html
