### PR TITLE
5789 test smells refactoring

### DIFF
--- a/src/test/java/edu/harvard/iq/dataverse/DatasetFieldValidatorTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/DatasetFieldValidatorTest.java
@@ -55,7 +55,7 @@ public class DatasetFieldValidatorTest {
         value.setTemplate(new Template());
         boolean expResult = true;
         boolean result = instance.isValid(value, ctx);
-        assertEquals(expResult, result);
+        assertEquals("test isValid() on template field", expResult, result);
         
         
         //if not template and required
@@ -74,18 +74,18 @@ public class DatasetFieldValidatorTest {
         value.setSingleValue("");
         dfv.setValue("");
         result = instance.isValid(value, ctx);
-        assertEquals(false, result);
+        assertEquals("test isValid() if not template field and required with empty DataSetField", false, result);
         
         //Fill in a value - should be valid now....
         value.setSingleValue("value");
         result = instance.isValid(value, ctx);
-        assertEquals(true, result);
+        assertEquals("test isValid() if not template field and required with non-empty DataSetField", true, result);
         
         //if not required - can be blank
         dft.setRequired(false);
         value.setSingleValue("");
         result = instance.isValid(value, ctx);
-        assertEquals(true, result);
+        assertEquals("test isValid() if not template field and not required", true, result);
     }
     
 }

--- a/src/test/java/edu/harvard/iq/dataverse/DatasetFieldValidatorTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/DatasetFieldValidatorTest.java
@@ -19,6 +19,8 @@ import org.mockito.Mockito;
  * @author skraffmi
  */
 public class DatasetFieldValidatorTest {
+
+    final ConstraintValidatorContext constraintValidatorContext = Mockito.mock(ConstraintValidatorContext.class);
     
     public DatasetFieldValidatorTest() {
     }
@@ -45,46 +47,42 @@ public class DatasetFieldValidatorTest {
      */
     @Test
     public void testIsValid() {
-        System.out.println("isValid");
-        DatasetField value = new DatasetField();
+        DatasetField dataSetField = new DatasetField();
+        DatasetFieldValidator datasetFieldValidator = new DatasetFieldValidator();
 
-        final ConstraintValidatorContext ctx =
-            Mockito.mock(ConstraintValidatorContext.class);
-        DatasetFieldValidator instance = new DatasetFieldValidator();
-        //If its a template field it is always valid
-        value.setTemplate(new Template());
+        // if it is a template field it is always valid
+        dataSetField.setTemplate(new Template());
         boolean expResult = true;
-        boolean result = instance.isValid(value, ctx);
+        boolean result = datasetFieldValidator.isValid(dataSetField, constraintValidatorContext);
         assertEquals("test isValid() on template field", expResult, result);
-        
-        
-        //if not template and required
-        value.setTemplate(null);
+
+        // if not a template field and required
+        dataSetField.setTemplate(null);
         DatasetVersion datasetVersion = new DatasetVersion();
         Dataset dataset = new Dataset();
         Dataverse dataverse = new Dataverse();
         dataset.setOwner(dataverse);
         datasetVersion.setDataset(dataset);
-        value.setDatasetVersion(datasetVersion);
-        
-        DatasetFieldValue dfv = new DatasetFieldValue();
-        DatasetFieldType dft = new DatasetFieldType("test", DatasetFieldType.FieldType.TEXT, false);
-        dft.setRequired(true);
-        value.setDatasetFieldType(dft);
-        value.setSingleValue("");
-        dfv.setValue("");
-        result = instance.isValid(value, ctx);
+        dataSetField.setDatasetVersion(datasetVersion);
+
+        DatasetFieldValue datasetFieldValue = new DatasetFieldValue();
+        DatasetFieldType datasetFieldType = new DatasetFieldType("test", DatasetFieldType.FieldType.TEXT, false);
+        datasetFieldType.setRequired(true);
+        dataSetField.setDatasetFieldType(datasetFieldType);
+        dataSetField.setSingleValue("");
+        datasetFieldValue.setValue("");
+        result = datasetFieldValidator.isValid(dataSetField, constraintValidatorContext);
         assertEquals("test isValid() if not template field and required with empty DataSetField", false, result);
-        
-        //Fill in a value - should be valid now....
-        value.setSingleValue("value");
-        result = instance.isValid(value, ctx);
+
+        // fill in a value - the required constraint is satisfied now
+        dataSetField.setSingleValue("value");
+        result = datasetFieldValidator.isValid(dataSetField, constraintValidatorContext);
         assertEquals("test isValid() if not template field and required with non-empty DataSetField", true, result);
-        
-        //if not required - can be blank
-        dft.setRequired(false);
-        value.setSingleValue("");
-        result = instance.isValid(value, ctx);
+
+        // if not required the field can be blank
+        datasetFieldType.setRequired(false);
+        dataSetField.setSingleValue("");
+        result = datasetFieldValidator.isValid(dataSetField, constraintValidatorContext);
         assertEquals("test isValid() if not template field and not required", true, result);
     }
     

--- a/src/test/java/edu/harvard/iq/dataverse/externaltools/ExternalToolTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/externaltools/ExternalToolTest.java
@@ -20,12 +20,12 @@ public class ExternalToolTest {
         externalTool.setId(42l);
         JsonObject jsonObject = externalTool.toJson().build();
         System.out.println("result: " + jsonObject);
-        assertEquals("myDisplayName", jsonObject.getString(ExternalTool.DISPLAY_NAME));
-        assertEquals("myDescription", jsonObject.getString(ExternalTool.DESCRIPTION));
-        assertEquals("explore", jsonObject.getString(ExternalTool.TYPE));
-        assertEquals("http://example.com", jsonObject.getString(ExternalTool.TOOL_URL));
-        assertEquals("{}", jsonObject.getString(ExternalTool.TOOL_PARAMETERS));
-        assertEquals(DataFileServiceBean.MIME_TYPE_TSV_ALT, jsonObject.getString(ExternalTool.CONTENT_TYPE));
+        assertEquals("testToJson() with ExternalTool.DISPLAY_NAME", "myDisplayName", jsonObject.getString(ExternalTool.DISPLAY_NAME));
+        assertEquals("testToJson() with ExternalTool.DESCRIPTION", "myDescription", jsonObject.getString(ExternalTool.DESCRIPTION));
+        assertEquals("testToJson() with ExternalTool.TYPE", "explore", jsonObject.getString(ExternalTool.TYPE));
+        assertEquals("testToJson() with ExternalTool.TOOL_URL", "http://example.com", jsonObject.getString(ExternalTool.TOOL_URL));
+        assertEquals("testToJson() with ExternalTool.TOOL_PARAMETERS", "{}", jsonObject.getString(ExternalTool.TOOL_PARAMETERS));
+        assertEquals("testToJson() with ExternalTool.CONTENT_TYPE", DataFileServiceBean.MIME_TYPE_TSV_ALT, jsonObject.getString(ExternalTool.CONTENT_TYPE));
     }
 
 }

--- a/src/test/java/edu/harvard/iq/dataverse/util/FileUtilTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/util/FileUtilTest.java
@@ -17,6 +17,8 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
+
 import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
@@ -263,12 +265,15 @@ public class FileUtilTest {
         @Test
         public void testDetermineFileType() {
             File file = new File("src/main/webapp/resources/images/cc0.png");
-            try {
-                assertEquals("image/png", FileUtil.determineFileType(file, "cc0.png"));
-            } catch (IOException ex) {
-                Logger.getLogger(FileUtilTest.class.getName()).log(Level.SEVERE, null, ex);
+            if (file.exists()) {
+                try {
+                    assertEquals("image/png", FileUtil.determineFileType(file, "cc0.png"));
+                } catch (IOException ex) {
+                    Logger.getLogger(FileUtilTest.class.getName()).log(Level.SEVERE, null, ex);
+                }
+            } else {
+                fail("File does not exist: " + file.toPath().toString());
             }
-
         }
 
         // isThumbnailSuppported() has been moved from DataFileService to FileUtil:


### PR DESCRIPTION
This pull requests refactors existing unit tests with the goal to remove test smells.
* 7542feb fixes a **Resource Optimism** test smell
* ff558bb fixes a **Assertion Roulette** test smell
* 4261df1 adds more precise variable names to `DatasetFieldValidatorTest.java`
* d274b86 fixes a **Assertion Roulette** test smell

**Resource Optimism**: accessing/using files in unit tests without making sure it exists
**Assertion Roulette**: number of assertions without explanation - if the test fails, it is hard to determine which assertion failed


## Related Issues

- connects to #5789: UZH: Unit Testing (Test Smells Refactoring)

## Pull Request Checklist

- [x] Unit [tests][] completed
- [x] Integration [tests][]: None
- [x] Deployment requirements, [SQL updates][], [Solr updates][], etc.: None
- [x] [Documentation][docs] completed
- [x] Merged latest from "develop" [branch][] and resolved conflicts

[tests]: http://guides.dataverse.org/en/latest/developers/testing.html
[SQL updates]: http://guides.dataverse.org/en/latest/developers/sql-upgrade-scripts.html
[Solr updates]: https://github.com/IQSS/dataverse/blob/develop/conf/solr/7.3.0/schema.xml
[docs]: http://guides.dataverse.org/en/latest/developers/documentation.html
[branch]: http://guides.dataverse.org/en/latest/developers/branching-strategy.html
