### PR TITLE
5828 additional unit tests

### DIFF
--- a/src/test/java/edu/harvard/iq/dataverse/util/StringUtilTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/util/StringUtilTest.java
@@ -290,5 +290,23 @@ public class StringUtilTest {
             
             assertFalse( StringUtil.isTrue(null) );
         }
+
+        @Test
+        public void testNonEmpty_normalString() {
+            String expected = "someString";
+            assertTrue(StringUtil.nonEmpty(expected));
+        }
+
+        @Test
+        public void testNonEmpty_null() {
+            String expected = null;
+            assertFalse(StringUtil.nonEmpty(expected));
+        }
+
+        @Test
+        public void testNonEmpty_emptyString() {
+            String expected = "";
+            assertFalse(StringUtil.nonEmpty(expected));
+        }
     }
 }

--- a/src/test/java/edu/harvard/iq/dataverse/util/StringUtilTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/util/StringUtilTest.java
@@ -227,6 +227,52 @@ public class StringUtilTest {
         }
     }
 
+    @RunWith(Parameterized.class)
+    public static class TestSanitizeFileDirectory {
+
+        public String inputString;
+        public String expected;
+        public boolean aggressively;
+
+        public TestSanitizeFileDirectory(String inputString, String expected, boolean aggressively) {
+            this.inputString = inputString;
+            this.expected = expected;
+            this.aggressively = aggressively;
+        }
+
+        @Parameters
+        public static Collection<Object[]> parameters() {
+            return Arrays.asList(
+                    new Object[][] { 
+                        {"some\\path\\to\\a\\directory", "some/path/to/a/directory", false},
+                        {"some\\//path\\//to\\//a\\//directory", "some/path/to/a/directory", false},
+                        // starts with / or - or . or whitepsace
+                        {"/some/path/to/a/directory", "some/path/to/a/directory", false},
+                        {"-some/path/to/a/directory", "some/path/to/a/directory", false},
+                        {".some/path/to/a/directory", "some/path/to/a/directory", false},
+                        {" some/path/to/a/directory", "some/path/to/a/directory", false},
+                        // ends with / or - or . or whitepsace
+                        {"some/path/to/a/directory/", "some/path/to/a/directory", false},
+                        {"some/path/to/a/directory-", "some/path/to/a/directory", false},
+                        {"some/path/to/a/directory.", "some/path/to/a/directory", false},
+                        {"some/path/to/a/directory ", "some/path/to/a/directory", false},
+
+                        {"", null, false},
+                        {"/", null, false},
+
+                        // aggressively
+                        {"some/path/to/a/dire{`~}ctory", "some/path/to/a/dire.ctory", true},
+                        {"some/path/to/a/directory\\.\\.", "some/path/to/a/directory", true},
+                    }
+            );
+        }
+
+        @Test
+        public void testSanitizeFileDirectory() {
+            assertEquals(expected, StringUtil.sanitizeFileDirectory(inputString, aggressively));
+        }
+    }
+
     public static class StringUtilNoParamTest{
 
         @Test

--- a/src/test/java/edu/harvard/iq/dataverse/util/StringUtilTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/util/StringUtilTest.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.assertTrue;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import org.junit.After;
@@ -17,7 +18,6 @@ import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 
 
@@ -193,6 +193,37 @@ public class StringUtilTest {
         @Test
         public void testSubstringIncludingLast() {
             assertEquals( expectedString, StringUtil.substringIncludingLast(str, separator) );
+        }
+    }
+
+    @RunWith(Parameterized.class)
+    public static class TestToOption {
+
+        public String inputString;
+        public Optional<String> expected;
+
+        public TestToOption(String inputString, Optional<String> expected) {
+            this.inputString = inputString;
+            this.expected = expected;
+        }
+
+        @Parameters
+        public static Collection<Object[]> parameters() {
+            return Arrays.asList(
+                    new Object[][] { 
+                        {null, Optional.empty()},
+                        {"", Optional.empty()},
+                        {"    leadingWhitespace", Optional.of("leadingWhitespace")},
+                        {"trailingWhiteSpace    ", Optional.of("trailingWhiteSpace")},
+                        {"someString", Optional.of("someString")},
+                        {"some string with spaces", Optional.of("some string with spaces")}
+                    }
+            );
+        }
+
+        @Test
+        public void testToOption() {
+            assertEquals(expected, StringUtil.toOption(inputString));
         }
     }
 

--- a/src/test/java/edu/harvard/iq/dataverse/util/xml/XmlValidatorTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/util/xml/XmlValidatorTest.java
@@ -1,20 +1,23 @@
 package edu.harvard.iq.dataverse.util.xml;
 
 import edu.harvard.iq.dataverse.NonEssentialTests;
+
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URL;
-import java.util.logging.Logger;
+
 import javax.xml.parsers.ParserConfigurationException;
-import org.junit.Assert;
+
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.xml.sax.SAXException;
 
 public class XmlValidatorTest {
-
-    private static final Logger logger = Logger.getLogger(XmlValidatorTest.class.getCanonicalName());
 
     //Ignored as this relies on an external resource that has been down occasionally. 
     //May be a good test for our full vs. everytime test classifications (#4896) -MAD 4.9.1
@@ -24,42 +27,53 @@ public class XmlValidatorTest {
     public void testValidateXml() throws IOException, SAXException, ParserConfigurationException {
         assertTrue(XmlValidator.validateXmlSchema("src/test/java/edu/harvard/iq/dataverse/util/xml/sendToDataCite.xml", new URL("https://schema.datacite.org/meta/kernel-3/metadata.xsd")));
         // FIXME: Make sure the DDI we export is valid: https://github.com/IQSS/dataverse/issues/3648
-//        assertTrue(XmlValidator.validateXml("src/test/java/edu/harvard/iq/dataverse/export/ddi/dataset-finch1.xml", new URL("http://www.ddialliance.org/Specification/DDI-Codebook/2.5/XMLSchema/codebook.xsd")));
+        // assertTrue(XmlValidator.validateXml("src/test/java/edu/harvard/iq/dataverse/export/ddi/dataset-finch1.xml", new URL("http://www.ddialliance.org/Specification/DDI-Codebook/2.5/XMLSchema/codebook.xsd")));
     }
 
-    @Category(NonEssentialTests.class)
     @Test
-    public void testWellFormedXml() {
-
-        // well-formed XML
-        Exception ex1 = null;
+    public void validateXmlWellFormed_validXML() {
+        String xmlFile = "src/test/java/edu/harvard/iq/dataverse/util/xml/sendToDataCite.xml";
         try {
-            assertTrue(XmlValidator.validateXmlWellFormed("src/test/java/edu/harvard/iq/dataverse/util/xml/sendToDataCite.xml"));
-        } catch (Exception ex) {
-            ex1 = ex;
+            assertTrue(XmlValidator.validateXmlWellFormed(xmlFile));
+        } catch(Exception e) {
+            fail();
         }
-        Assert.assertNull(ex1);
-
-        // not well-formed XML
-        Exception ex2 = null;
-        try {
-            XmlValidator.validateXmlWellFormed("src/test/java/edu/harvard/iq/dataverse/util/xml/not-well-formed.xml");
-        } catch (Exception ex) {
-            ex2 = ex;
-        }
-        Assert.assertNotNull(ex2);
-        Assert.assertEquals("XML is not well formed: The element type \"br\" must be terminated by the matching end-tag \"</br>\".", ex2.getMessage());
-
-        // other exception
-        Exception ex3 = null;
-        try {
-            XmlValidator.validateXmlWellFormed("path/to/nowhere.xml");
-        } catch (Exception ex) {
-            ex3 = ex;
-        }
-        Assert.assertNotNull(ex3);
-        Assert.assertEquals("class java.io.FileNotFoundException", ex3.getClass().toString());
-
     }
 
+    @Test
+    public void validateXmlWellFormed_invalidXML() {
+        String xmlFile = "src/test/java/edu/harvard/iq/dataverse/util/xml/not-well-formed.xml";
+        try {
+            assertTrue(XmlValidator.validateXmlWellFormed(xmlFile));
+            fail("validateXmlWellFormed() should throw exception on malformed XML");
+        } catch(Exception e) {
+            return;
+        }
+    }
+
+    @Test
+    public void validateXmlWellFormed_exceptionMessage() {
+        String xmlFile = "src/test/java/edu/harvard/iq/dataverse/util/xml/not-well-formed.xml";
+        String expectedExceptionMessage = "XML is not well formed: The element type \"br\" must be terminated by the matching end-tag \"</br>\".";
+        String actualExceptionMessage = "";
+
+        try {
+            XmlValidator.validateXmlWellFormed(xmlFile);
+            fail("validateXmlWellFormed() should throw exception on malformed XML");
+        } catch (Exception ex) {
+            actualExceptionMessage = ex.getMessage();
+        }
+        assertEquals(expectedExceptionMessage, actualExceptionMessage);
+    }
+
+    @Test
+    public void validateXmlWellFormed_nonexistentFile() {
+        String xmlFile = "path/to/nowhere.xml";
+        try {
+            XmlValidator.validateXmlWellFormed(xmlFile);
+            fail("validateXmlWellFormed() should throw exception on malformed XML");
+        } catch(Exception e) {
+            assertEquals(FileNotFoundException.class, e.getClass());
+        }
+    }
 }


### PR DESCRIPTION
### Additional Unit Tests

As mentioned in #5828, I tried to improve the coverage.

This pull requests contains the following:
- c26e92b: additional test cases and refactorings to reach full branch coverage for `validateXMLWellFormed` in `XmlValidator.java`
- 60b4970: parameterized test for `toOption` in `StringUtil.java`
- e2fafb2: unit tests for `nonEmpty` in `StringUtil.java`
- 73dae8e: parameterized test for `sanitizeFileDirectory` in `StringUtil.java`

## Related Issues

- connects to #5828 

## Pull Request Checklist

- [x] Unit [tests][] completed
- [x] Integration [tests][]: None
- [x] Deployment requirements, [SQL updates][], [Solr updates][], etc.: None
- [x] [Documentation][docs] completed
- [x] Merged latest from "develop" [branch][] and resolved conflicts

[tests]: http://guides.dataverse.org/en/latest/developers/testing.html
[SQL updates]: http://guides.dataverse.org/en/latest/developers/sql-upgrade-scripts.html
[Solr updates]: https://github.com/IQSS/dataverse/blob/develop/conf/solr/7.3.0/schema.xml
[docs]: http://guides.dataverse.org/en/latest/developers/documentation.html
[branch]: http://guides.dataverse.org/en/latest/developers/branching-strategy.html
