### PR TITLE
5838 Unit Tests for SystemConfig/FileDownloadHelper

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/util/SystemConfig.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/SystemConfig.java
@@ -424,13 +424,11 @@ public class SystemConfig {
      */
     public long getZipDownloadLimit() {
         String zipLimitOption = settingsService.getValueForKey(SettingsServiceBean.Key.ZipDownloadLimit);
-
         return getLongLimitFromStringOrDefault(zipLimitOption, 0L);
     }
     
     public int getZipUploadFilesLimit() {
         String limitOption = settingsService.getValueForKey(SettingsServiceBean.Key.ZipUploadFilesLimit);
-
         return getIntLimitFromStringOrDefault(limitOption, defaultZipUploadFilesLimit);
     }
     
@@ -440,13 +438,11 @@ public class SystemConfig {
     */
     public int getMultipleUploadFilesLimit() {
         String limitOption = settingsService.getValueForKey(SettingsServiceBean.Key.MultipleUploadFilesLimit);
-
         return getIntLimitFromStringOrDefault(limitOption, defaultMultipleUploadFilesLimit);
     }
     
     public long getGuestbookResponsesPageDisplayLimit() {
         String limitSetting = settingsService.getValueForKey(SettingsServiceBean.Key.GuestbookResponsesPageDisplayLimit);
-
         return getLongLimitFromStringOrDefault(limitSetting, DEFAULT_GUESTBOOK_RESPONSES_DISPLAY_LIMIT);
     }
     

--- a/src/main/java/edu/harvard/iq/dataverse/util/SystemConfig.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/SystemConfig.java
@@ -388,7 +388,7 @@ public class SystemConfig {
         return metricsUrl;
     }
 
-    protected long getLongLimitFromStringOrDefault(String limitSetting, Long defaultValue) {
+    static long getLongLimitFromStringOrDefault(String limitSetting, Long defaultValue) {
         Long limit = null;
 
         if (limitSetting != null && !limitSetting.equals("")) {
@@ -402,7 +402,7 @@ public class SystemConfig {
         return limit != null ? limit : defaultValue;
     }
 
-    protected int getIntLimitFromStringOrDefault(String limitSetting, Integer defaultValue) {
+    static int getIntLimitFromStringOrDefault(String limitSetting, Integer defaultValue) {
         Integer limit = null;
 
         if (limitSetting != null && !limitSetting.equals("")) {

--- a/src/main/java/edu/harvard/iq/dataverse/util/SystemConfig.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/SystemConfig.java
@@ -388,49 +388,50 @@ public class SystemConfig {
         return metricsUrl;
     }
 
+    protected long getLongLimitFromStringOrDefault(String limitSetting, Long defaultValue) {
+        Long limit = null;
+
+        if (limitSetting != null && !limitSetting.equals("")) {
+            try {
+                limit = new Long(limitSetting);
+            } catch (NumberFormatException nfe) {
+                limit = null;
+            }
+        }
+
+        return limit != null ? limit : defaultValue;
+    }
+
+    protected int getIntLimitFromStringOrDefault(String limitSetting, Integer defaultValue) {
+        Integer limit = null;
+
+        if (limitSetting != null && !limitSetting.equals("")) {
+            try {
+                limit = new Integer(limitSetting);
+            } catch (NumberFormatException nfe) {
+                limit = null;
+            }
+        }
+
+        return limit != null ? limit : defaultValue;
+    }
+
     /**
      * Download-as-zip size limit.
      * returns 0 if not specified; 
      * (the file zipper will then use the default value)
      * set to -1 to disable zip downloads. 
      */
-    
     public long getZipDownloadLimit() {
-        String zipLimitOption = settingsService.getValueForKey(SettingsServiceBean.Key.ZipDownloadLimit);   
-        
-        Long zipLimit = null; 
-        if (zipLimitOption != null && !zipLimitOption.equals("")) {
-            try {
-                zipLimit = new Long(zipLimitOption);
-            } catch (NumberFormatException nfe) {
-                zipLimit = null; 
-            }
-        }
-        
-        if (zipLimit != null) {
-            return zipLimit.longValue();
-        }
-        
-        return 0L; 
+        String zipLimitOption = settingsService.getValueForKey(SettingsServiceBean.Key.ZipDownloadLimit);
+
+        return getLongLimitFromStringOrDefault(zipLimitOption, 0L);
     }
     
     public int getZipUploadFilesLimit() {
         String limitOption = settingsService.getValueForKey(SettingsServiceBean.Key.ZipUploadFilesLimit);
-        Integer limit = null; 
-        
-        if (limitOption != null && !limitOption.equals("")) {
-            try {
-                limit = new Integer(limitOption);
-            } catch (NumberFormatException nfe) {
-                limit = null; 
-            }
-        }
-        
-        if (limit != null) {
-            return limit;
-        }
-        
-        return defaultZipUploadFilesLimit; 
+
+        return getIntLimitFromStringOrDefault(limitOption, defaultZipUploadFilesLimit);
     }
     
     /*
@@ -439,40 +440,14 @@ public class SystemConfig {
     */
     public int getMultipleUploadFilesLimit() {
         String limitOption = settingsService.getValueForKey(SettingsServiceBean.Key.MultipleUploadFilesLimit);
-        Integer limit = null; 
-        
-        if (limitOption != null && !limitOption.equals("")) {
-            try {
-                limit = new Integer(limitOption);
-            } catch (NumberFormatException nfe) {
-                limit = null; 
-            }
-        }
-        
-        if (limit != null) {
-            return limit;
-        }
-        
-        return defaultMultipleUploadFilesLimit; 
+
+        return getIntLimitFromStringOrDefault(limitOption, defaultMultipleUploadFilesLimit);
     }
     
     public long getGuestbookResponsesPageDisplayLimit() {
-        String limitSetting = settingsService.getValueForKey(SettingsServiceBean.Key.GuestbookResponsesPageDisplayLimit);   
-        
-        Long limit = null; 
-        if (limitSetting != null && !limitSetting.equals("")) {
-            try {
-                limit = new Long(limitSetting);
-            } catch (NumberFormatException nfe) {
-                limit = null; 
-            }
-        }
-        
-        if (limit != null) {
-            return limit.longValue();
-        }
-        
-        return DEFAULT_GUESTBOOK_RESPONSES_DISPLAY_LIMIT; 
+        String limitSetting = settingsService.getValueForKey(SettingsServiceBean.Key.GuestbookResponsesPageDisplayLimit);
+
+        return getLongLimitFromStringOrDefault(limitSetting, DEFAULT_GUESTBOOK_RESPONSES_DISPLAY_LIMIT);
     }
     
     public long getUploadLogoSizeLimit(){
@@ -501,21 +476,8 @@ public class SystemConfig {
         } else if ("PDF".equals(type)) {
             option = System.getProperty("dataverse.dataAccess.thumbnail.pdf.limit");
         }
-        Long limit = null; 
-        
-        if (option != null && !option.equals("")) {
-            try {
-                limit = new Long(option);
-            } catch (NumberFormatException nfe) {
-                limit = null; 
-            }
-        }
-        
-        if (limit != null) {
-            return limit.longValue();
-        }
-        
-        return 0l;
+
+        return getLongLimitFromStringOrDefault(option, 0L);
     }
     
     public boolean isThumbnailGenerationDisabledForType(String type) {

--- a/src/test/java/edu/harvard/iq/dataverse/FileDownloadHelperTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/FileDownloadHelperTest.java
@@ -1,19 +1,16 @@
 package edu.harvard.iq.dataverse;
 
 import edu.harvard.iq.dataverse.authorization.Permission;
-import edu.harvard.iq.dataverse.authorization.RoleAssignee;
-import edu.harvard.iq.dataverse.authorization.users.User;
-import jena.query;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -27,22 +24,16 @@ class FileDownloadHelperTest {
     private DataverseSession dataverseSession;
 
     @Mock
-    private PermissionServiceBean.StaticPermissionQuery staticPermissionQuery;
+    private DataverseRequestServiceBean dataverseRequestServiceBean;
 
     private FileDownloadHelper fileDownloadHelper;
-    private FileMetadata fileMetadata;
 
     @BeforeEach
     void setup() {
         fileDownloadHelper = new FileDownloadHelper();
         fileDownloadHelper.permissionService = permissionServiceBean;
         fileDownloadHelper.session = dataverseSession;
-
-        fileMetadata = new FileMetadata();
-        DatasetVersion datasetVersion = new DatasetVersion();
-        datasetVersion.setDataset(new Dataset());
-        fileMetadata.setDatasetVersion(datasetVersion);
-        fileMetadata.setDataFile(new DataFile());
+        fileDownloadHelper.dvRequestService = dataverseRequestServiceBean;
     }
 
     @Test
@@ -52,48 +43,177 @@ class FileDownloadHelperTest {
 
     @Test
     void testDoesSessionUserHavePermission_forEditDatasetPermission() {
-        // if the permission service is called with a Dataset, return a static permission query
-        when(permissionServiceBean.userOn(ArgumentMatchers.any(), ArgumentMatchers.any(Dataset.class))).thenReturn(staticPermissionQuery);
+        DatasetVersion datasetVersion = new DatasetVersion();
+        datasetVersion.setDataset(new Dataset());
+        DataFile dataFile = new DataFile();
 
-        when(staticPermissionQuery.has(Permission.EditDataset)).thenReturn(false);
-        assertFalse(fileDownloadHelper.doesSessionUserHavePermission(Permission.EditDataset, this.fileMetadata));
+        FileMetadata fileMetadata = new FileMetadata();
+        fileMetadata.setDatasetVersion(datasetVersion);
+        fileMetadata.setDataFile(dataFile);
 
-        when(staticPermissionQuery.has(Permission.EditDataset)).thenReturn(true);
-        assertTrue(fileDownloadHelper.doesSessionUserHavePermission(Permission.EditDataset, this.fileMetadata));
+        mockPermissionResponseUserOn(Permission.EditDataset, false);
+        assertFalse(fileDownloadHelper.doesSessionUserHavePermission(Permission.EditDataset, fileMetadata));
+
+        mockPermissionResponseUserOn(Permission.EditDataset, true);
+        assertTrue(fileDownloadHelper.doesSessionUserHavePermission(Permission.EditDataset, fileMetadata));
     }
 
     @Test
     void testDoesSessionUserHavePermission_forDownloadFilePermission() {
-        // if the permission service is called with a DataFile, return a static permission query
-        when(permissionServiceBean.userOn(ArgumentMatchers.any(), ArgumentMatchers.any(DataFile.class))).thenReturn(staticPermissionQuery);
+        DatasetVersion datasetVersion = new DatasetVersion();
+        datasetVersion.setDataset(new Dataset());
+        DataFile dataFile = new DataFile();
 
-        when(staticPermissionQuery.has(Permission.DownloadFile)).thenReturn(false);
-        assertFalse(fileDownloadHelper.doesSessionUserHavePermission(Permission.DownloadFile, this.fileMetadata));
+        FileMetadata fileMetadata = new FileMetadata();
+        fileMetadata.setDatasetVersion(datasetVersion);
+        fileMetadata.setDataFile(dataFile);
 
-        when(staticPermissionQuery.has(Permission.DownloadFile)).thenReturn(true);
-        assertTrue(fileDownloadHelper.doesSessionUserHavePermission(Permission.DownloadFile, this.fileMetadata));
+        mockPermissionResponseUserOn(Permission.DownloadFile, false);
+        assertFalse(fileDownloadHelper.doesSessionUserHavePermission(Permission.DownloadFile, fileMetadata));
+
+        mockPermissionResponseUserOn(Permission.DownloadFile, true);
+        assertTrue(fileDownloadHelper.doesSessionUserHavePermission(Permission.DownloadFile, fileMetadata));
     }
 
     @Test
     void testDoesSessionUserHavePermission_forAnyOtherPermission() {
-        assertFalse(fileDownloadHelper.doesSessionUserHavePermission(Permission.ManageDataversePermissions, this.fileMetadata));
+        DatasetVersion datasetVersion = new DatasetVersion();
+        datasetVersion.setDataset(new Dataset());
+        DataFile dataFile = new DataFile();
+
+        FileMetadata fileMetadata = new FileMetadata();
+        fileMetadata.setDatasetVersion(datasetVersion);
+        fileMetadata.setDataFile(dataFile);
+
+        assertFalse(fileDownloadHelper.doesSessionUserHavePermission(Permission.ManageDataversePermissions, fileMetadata));
     }
 
     @Test
     void testDoesSessionUserHavePermission_withNullDataset() {
         FileMetadata fileMetadata = new FileMetadata();
         fileMetadata.setDatasetVersion(new DatasetVersion());
+
         assertFalse(fileDownloadHelper.doesSessionUserHavePermission(Permission.EditDataset, fileMetadata));
     }
 
     @Test
     void testDoesSessionUserHavePermission_withNullDataFile() {
         FileMetadata fileMetadata = new FileMetadata();
+
         assertFalse(fileDownloadHelper.doesSessionUserHavePermission(Permission.DownloadFile, fileMetadata));
     }
 
     @Test
-    void testCanDownloadFile() {
+    void testCanDownloadFile_withoutFileMetadata() {
+        assertFalse(fileDownloadHelper.canDownloadFile(null));
+    }
 
+    @Test
+    void testCanDownloadFile_withNullMetadataId() {
+        FileMetadata fileMetadata = new FileMetadata();
+        fileMetadata.setId(null);
+
+        assertFalse(fileDownloadHelper.canDownloadFile(fileMetadata));
+    }
+
+    @Test
+    void testCanDownloadFile_withNullDataFileId() {
+        FileMetadata fileMetadata = new FileMetadata();
+        fileMetadata.setId(1L);
+        DataFile dataFile = new DataFile();
+        dataFile.setId(null);
+        fileMetadata.setDataFile(dataFile);
+
+        assertFalse(fileDownloadHelper.canDownloadFile(fileMetadata));
+    }
+
+    @ParameterizedTest
+    @CsvSource({ "false", "true" })
+    void testCanDownloadFile_forDeaccessionedFile(boolean hasPermission) {
+        DataFile dataFile = new DataFile();
+        dataFile.setId(2L);
+
+        DatasetVersion datasetVersion = new DatasetVersion();
+        datasetVersion.setDataset(new Dataset());
+        datasetVersion.setVersionState(DatasetVersion.VersionState.DEACCESSIONED);
+
+        FileMetadata fileMetadata = new FileMetadata();
+        fileMetadata.setId(1L);
+        fileMetadata.setDataFile(dataFile);
+        fileMetadata.setDatasetVersion(datasetVersion);
+
+        mockPermissionResponseUserOn(Permission.EditDataset, hasPermission);
+
+        assertEquals(hasPermission, fileDownloadHelper.canDownloadFile(fileMetadata), "Initial response does not match expectation!");
+
+        // call again to exercise the cache and ensure it returns the same result
+        assertEquals(hasPermission, fileDownloadHelper.canDownloadFile(fileMetadata), "Cached response does not match initial response!");
+    }
+
+    @Test
+    void testCanDownloadFile_forUnrestrictedReleasedFile() {
+        DataFile dataFile = new DataFile();
+        dataFile.setId(2L);
+
+        DatasetVersion datasetVersion = new DatasetVersion();
+        datasetVersion.setVersionState(DatasetVersion.VersionState.RELEASED);
+
+        FileMetadata fileMetadata = new FileMetadata();
+        fileMetadata.setId(1L);
+        fileMetadata.setRestricted(false);
+        fileMetadata.setDataFile(dataFile);
+        fileMetadata.setDatasetVersion(datasetVersion);
+
+        assertTrue(fileDownloadHelper.canDownloadFile(fileMetadata));
+
+        // call again to exercise the cache and ensure it returns the same result
+        assertTrue(fileDownloadHelper.canDownloadFile(fileMetadata));
+    }
+
+    @ParameterizedTest
+    @CsvSource({"false", "true"})
+    void testCanDownloadFile_forRestrictedReleasedFile(boolean hasPermission) {
+        DataFile dataFile = new DataFile();
+        dataFile.setId(2L);
+
+        DatasetVersion datasetVersion = new DatasetVersion();
+        datasetVersion.setVersionState(DatasetVersion.VersionState.RELEASED);
+
+        FileMetadata fileMetadata = new FileMetadata();
+        fileMetadata.setId(1L);
+        fileMetadata.setRestricted(true);
+        fileMetadata.setDataFile(dataFile);
+        fileMetadata.setDatasetVersion(datasetVersion);
+
+        mockPermissionResponseRequestOn(Permission.DownloadFile, hasPermission);
+
+        assertEquals(hasPermission, fileDownloadHelper.canDownloadFile(fileMetadata), "Initial response does not match expectation!");
+
+        // call again to exercise the cache and ensure it returns the same result
+        assertEquals(hasPermission, fileDownloadHelper.canDownloadFile(fileMetadata), "Cached response does not match initial response!");
+    }
+
+    private void mockPermissionResponseUserOn(Permission permission, boolean response) {
+        PermissionServiceBean.StaticPermissionQuery staticPermissionQuery = mock(PermissionServiceBean.StaticPermissionQuery.class);
+
+        if (permission.equals(Permission.EditDataset)) {
+            when(permissionServiceBean.userOn(ArgumentMatchers.any(), ArgumentMatchers.any(Dataset.class))).thenReturn(staticPermissionQuery);
+        } else {
+            when(permissionServiceBean.userOn(ArgumentMatchers.any(), ArgumentMatchers.any(DataFile.class))).thenReturn(staticPermissionQuery);
+        }
+
+        when(staticPermissionQuery.has(permission)).thenReturn(response);
+    }
+
+    private void mockPermissionResponseRequestOn(Permission permission, boolean response) {
+        PermissionServiceBean.RequestPermissionQuery requestPermissionQuery = mock(PermissionServiceBean.RequestPermissionQuery.class);
+
+        if (permission.equals(Permission.EditDataset)) {
+            when(permissionServiceBean.requestOn(ArgumentMatchers.any(), ArgumentMatchers.any(Dataset.class))).thenReturn(requestPermissionQuery);
+        } else {
+            when(permissionServiceBean.requestOn(ArgumentMatchers.any(), ArgumentMatchers.any(DataFile.class))).thenReturn(requestPermissionQuery);
+        }
+
+        when(requestPermissionQuery.has(permission)).thenReturn(response);
     }
 }

--- a/src/test/java/edu/harvard/iq/dataverse/FileDownloadHelperTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/FileDownloadHelperTest.java
@@ -1,0 +1,5 @@
+package edu.harvard.iq.dataverse;
+
+public class FileDownloadHelperTest {
+
+}

--- a/src/test/java/edu/harvard/iq/dataverse/FileDownloadHelperTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/FileDownloadHelperTest.java
@@ -1,5 +1,99 @@
 package edu.harvard.iq.dataverse;
 
-public class FileDownloadHelperTest {
+import edu.harvard.iq.dataverse.authorization.Permission;
+import edu.harvard.iq.dataverse.authorization.RoleAssignee;
+import edu.harvard.iq.dataverse.authorization.users.User;
+import jena.query;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class FileDownloadHelperTest {
+
+    @Mock
+    private PermissionServiceBean permissionServiceBean;
+
+    @Mock
+    private DataverseSession dataverseSession;
+
+    @Mock
+    private PermissionServiceBean.StaticPermissionQuery staticPermissionQuery;
+
+    private FileDownloadHelper fileDownloadHelper;
+    private FileMetadata fileMetadata;
+
+    @BeforeEach
+    void setup() {
+        fileDownloadHelper = new FileDownloadHelper();
+        fileDownloadHelper.permissionService = permissionServiceBean;
+        fileDownloadHelper.session = dataverseSession;
+
+        fileMetadata = new FileMetadata();
+        DatasetVersion datasetVersion = new DatasetVersion();
+        datasetVersion.setDataset(new Dataset());
+        fileMetadata.setDatasetVersion(datasetVersion);
+        fileMetadata.setDataFile(new DataFile());
+    }
+
+    @Test
+    void testDoesSessionUserHavePermission_withoutPermissionToCheck() {
+        assertFalse(fileDownloadHelper.doesSessionUserHavePermission(null, new FileMetadata()));
+    }
+
+    @Test
+    void testDoesSessionUserHavePermission_forEditDatasetPermission() {
+        // if the permission service is called with a Dataset, return a static permission query
+        when(permissionServiceBean.userOn(ArgumentMatchers.any(), ArgumentMatchers.any(Dataset.class))).thenReturn(staticPermissionQuery);
+
+        when(staticPermissionQuery.has(Permission.EditDataset)).thenReturn(false);
+        assertFalse(fileDownloadHelper.doesSessionUserHavePermission(Permission.EditDataset, this.fileMetadata));
+
+        when(staticPermissionQuery.has(Permission.EditDataset)).thenReturn(true);
+        assertTrue(fileDownloadHelper.doesSessionUserHavePermission(Permission.EditDataset, this.fileMetadata));
+    }
+
+    @Test
+    void testDoesSessionUserHavePermission_forDownloadFilePermission() {
+        // if the permission service is called with a DataFile, return a static permission query
+        when(permissionServiceBean.userOn(ArgumentMatchers.any(), ArgumentMatchers.any(DataFile.class))).thenReturn(staticPermissionQuery);
+
+        when(staticPermissionQuery.has(Permission.DownloadFile)).thenReturn(false);
+        assertFalse(fileDownloadHelper.doesSessionUserHavePermission(Permission.DownloadFile, this.fileMetadata));
+
+        when(staticPermissionQuery.has(Permission.DownloadFile)).thenReturn(true);
+        assertTrue(fileDownloadHelper.doesSessionUserHavePermission(Permission.DownloadFile, this.fileMetadata));
+    }
+
+    @Test
+    void testDoesSessionUserHavePermission_forAnyOtherPermission() {
+        assertFalse(fileDownloadHelper.doesSessionUserHavePermission(Permission.ManageDataversePermissions, this.fileMetadata));
+    }
+
+    @Test
+    void testDoesSessionUserHavePermission_withNullDataset() {
+        FileMetadata fileMetadata = new FileMetadata();
+        fileMetadata.setDatasetVersion(new DatasetVersion());
+        assertFalse(fileDownloadHelper.doesSessionUserHavePermission(Permission.EditDataset, fileMetadata));
+    }
+
+    @Test
+    void testDoesSessionUserHavePermission_withNullDataFile() {
+        FileMetadata fileMetadata = new FileMetadata();
+        assertFalse(fileDownloadHelper.doesSessionUserHavePermission(Permission.DownloadFile, fileMetadata));
+    }
+
+    @Test
+    void testCanDownloadFile() {
+
+    }
 }

--- a/src/test/java/edu/harvard/iq/dataverse/util/SystemConfigTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/util/SystemConfigTest.java
@@ -3,6 +3,7 @@ package edu.harvard.iq.dataverse.util;
 import edu.harvard.iq.dataverse.DataverseServiceBean;
 import edu.harvard.iq.dataverse.authorization.AuthenticationServiceBean;
 import edu.harvard.iq.dataverse.settings.SettingsServiceBean;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;

--- a/src/test/java/edu/harvard/iq/dataverse/util/SystemConfigTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/util/SystemConfigTest.java
@@ -1,36 +1,11 @@
 package edu.harvard.iq.dataverse.util;
 
-import edu.harvard.iq.dataverse.DataverseServiceBean;
-import edu.harvard.iq.dataverse.authorization.AuthenticationServiceBean;
-import edu.harvard.iq.dataverse.settings.SettingsServiceBean;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
-import org.mockito.Mock;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class SystemConfigTest {
-
-    @Mock
-    private AuthenticationServiceBean authenticationServiceBean;
-
-    @Mock
-    private DataverseServiceBean dataverseServiceBean;
-
-    @Mock
-    private SettingsServiceBean settingsServiceBean;
-
-    private SystemConfig systemConfig;
-
-    @BeforeEach
-    void setup() {
-        systemConfig = new SystemConfig();
-        systemConfig.authenticationService = authenticationServiceBean;
-        systemConfig.dataverseService = dataverseServiceBean;
-        systemConfig.settingsService = settingsServiceBean;
-    }
+class SystemConfigTest {
 
     @ParameterizedTest
     @CsvSource({
@@ -41,7 +16,7 @@ public class SystemConfigTest {
             "10, 10"
     })
     void testGetLongLimitFromStringOrDefault(String inputString, long expectedResult) {
-        long actualResult = systemConfig.getLongLimitFromStringOrDefault(inputString, 5L);
+        long actualResult = SystemConfig.getLongLimitFromStringOrDefault(inputString, 5L);
         assertEquals(expectedResult, actualResult);
     }
 
@@ -54,7 +29,7 @@ public class SystemConfigTest {
             "10, 10"
     })
     void testGetIntLimitFromStringOrDefault(String inputString, int expectedResult) {
-        int actualResult = systemConfig.getIntLimitFromStringOrDefault(inputString, 5);
+        int actualResult = SystemConfig.getIntLimitFromStringOrDefault(inputString, 5);
         assertEquals(expectedResult, actualResult);
     }
 }

--- a/src/test/java/edu/harvard/iq/dataverse/util/SystemConfigTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/util/SystemConfigTest.java
@@ -1,11 +1,26 @@
 package edu.harvard.iq.dataverse.util;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class SystemConfigTest {
+
+    @Test
+    void testGetLongLimitFromStringOrDefault_withNullInput() {
+        long defaultValue = 5L;
+        long actualResult = SystemConfig.getLongLimitFromStringOrDefault(null, defaultValue);
+        assertEquals(defaultValue, actualResult);
+    }
+
+    @Test
+    void testGetIntLimitFromStringOrDefault_withNullInput() {
+        int defaultValue = 5;
+        int actualResult = SystemConfig.getIntLimitFromStringOrDefault(null, defaultValue);
+        assertEquals(defaultValue, actualResult);
+    }
 
     @ParameterizedTest
     @CsvSource({
@@ -15,7 +30,7 @@ class SystemConfigTest {
             "0, 0",
             "10, 10"
     })
-    void testGetLongLimitFromStringOrDefault(String inputString, long expectedResult) {
+    void testGetLongLimitFromStringOrDefault_withStringInputs(String inputString, long expectedResult) {
         long actualResult = SystemConfig.getLongLimitFromStringOrDefault(inputString, 5L);
         assertEquals(expectedResult, actualResult);
     }
@@ -28,7 +43,7 @@ class SystemConfigTest {
             "0, 0",
             "10, 10"
     })
-    void testGetIntLimitFromStringOrDefault(String inputString, int expectedResult) {
+    void testGetIntLimitFromStringOrDefault_withStringInputs(String inputString, int expectedResult) {
         int actualResult = SystemConfig.getIntLimitFromStringOrDefault(inputString, 5);
         assertEquals(expectedResult, actualResult);
     }

--- a/src/test/java/edu/harvard/iq/dataverse/util/SystemConfigTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/util/SystemConfigTest.java
@@ -1,0 +1,59 @@
+package edu.harvard.iq.dataverse.util;
+
+import edu.harvard.iq.dataverse.DataverseServiceBean;
+import edu.harvard.iq.dataverse.authorization.AuthenticationServiceBean;
+import edu.harvard.iq.dataverse.settings.SettingsServiceBean;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.Mock;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class SystemConfigTest {
+
+    @Mock
+    private AuthenticationServiceBean authenticationServiceBean;
+
+    @Mock
+    private DataverseServiceBean dataverseServiceBean;
+
+    @Mock
+    private SettingsServiceBean settingsServiceBean;
+
+    private SystemConfig systemConfig;
+
+    @BeforeEach
+    void setup() {
+        systemConfig = new SystemConfig();
+        systemConfig.authenticationService = authenticationServiceBean;
+        systemConfig.dataverseService = dataverseServiceBean;
+        systemConfig.settingsService = settingsServiceBean;
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            ", 5",
+            "test, 5",
+            "-10, -10",
+            "0, 0",
+            "10, 10"
+    })
+    void testGetLongLimitFromStringOrDefault(String inputString, long expectedResult) {
+        long actualResult = systemConfig.getLongLimitFromStringOrDefault(inputString, 5L);
+        assertEquals(expectedResult, actualResult);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            ", 5",
+            "test, 5",
+            "-10, -10",
+            "0, 0",
+            "10, 10"
+    })
+    void testGetIntLimitFromStringOrDefault(String inputString, int expectedResult) {
+        int actualResult = systemConfig.getIntLimitFromStringOrDefault(inputString, 5);
+        assertEquals(expectedResult, actualResult);
+    }
+}


### PR DESCRIPTION
This PR adds two new test classes that test parts of the respective production behavior, namely `SystemConfig.java` and `FileDownloadHelper.java`.

- `SystemConfig.java` currently contains lots of duplicated code that converts strings as extracted from settings to Long or Integer. I have tried to improve the situation as follows:
  - I have extracted this duplicated behavior into two static helper methods (in production)
    - `getIntLimitFromStringOrDefault`
    - `getLongLimitFromStringOrDefault`
  - For my new methods, I have added tests that validate all possible cases with parametrized testing
  - I have finally replaced the duplication by calls to these two helper methods. No signatures, interfaces, or similar have changed, so it should not have any external impact
- `FileDownloadHelper.java`: I have focused on testing `doesSessionUserHavePermission` and `canDownloadFile`, as from the naming, these seem somewhat critical to have working correctly
  - I have added tests that bring these two methods to 100% branch coverage
  - To simulate responses when other beans are called, I have mocked these as far as needed

## Related Issues

- connects to #5838

## Pull Request Checklist

- [x] Unit [tests][] completed
- [x] Integration [tests][]: None
- [x] Deployment requirements, [SQL updates][], [Solr updates][], etc.: None
- [x] [Documentation][docs] completed
- [x] Merged latest from "develop" [branch][] and resolved conflicts
