### PR TITLE
5806 dataverse languagepack api

### DIFF
--- a/doc/sphinx-guides/source/installation/config.rst
+++ b/doc/sphinx-guides/source/installation/config.rst
@@ -540,6 +540,81 @@ Once you have the location of your custom CSS file, run this curl command to add
 
 ``curl -X PUT -d '/var/www/dataverse/branding/custom-stylesheet.css' http://localhost:8080/api/admin/settings/:StyleCustomizationFile``
 
+.. _i18n:
+
+Internationalization
+--------------------
+
+Dataverse is being translated into multiple languages by the Dataverse community! Please see below for how to help with this effort!
+
+Adding Multiple Languages to the Dropdown in the Header
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+The presence of the :ref:`:Languages` database setting adds a dropdown in the header for multiple languages. For example to add English and French to the dropdown:
+
+``curl http://localhost:8080/api/admin/settings/:Languages -X PUT -d '[{"locale":"en","title":"English"},{"locale":"fr","title":"Français"}]'``
+
+Configuring the "lang" Directory
+++++++++++++++++++++++++++++++++
+
+Translations for Dataverse are stored in "properties" files in a directory on disk (e.g. ``/home/glassfish/langBundles``) that you specify with the :ref:`dataverse.lang.directory` ``dataverse.lang.directory`` JVM option, like this:
+
+``./asadmin create-jvm-options '-Ddataverse.lang.directory=/home/glassfish/langBundles'``
+
+Go ahead and create the directory you specified.
+
+``mkdir /home/glassfish/langBundles``
+
+Creating a languages.zip File
++++++++++++++++++++++++++++++
+
+Dataverse provides and API endpoint for adding languages using a zip file.
+
+First, clone the "dataverse-language-packs" git repo.
+
+``git clone https://github.com/GlobalDataverseCommunityConsortium/dataverse-language-packs.git``
+
+Take a look at https://github.com/GlobalDataverseCommunityConsortium/dataverse-language-packs/branches to see if the version of Dataverse you're running has translations.
+
+Change to the directory for the git repo you just cloned.
+
+``cd dataverse-language-packs``
+
+Switch (``git checkout``) to the branch based on Dataverse version you are running. The branch "dataverse-v4.13" is used in the example below.
+
+``export BRANCH_NAME=dataverse-v4.13``
+
+``git checkout $BRANCH_NAME``
+
+Create a "languages" directory in "/tmp".
+
+``mkdir /tmp/languages``
+
+Copy the properties files into the "languages" directory
+
+``cp -R en_US/*.properties /tmp/languages``
+
+``cp -R fr_CA/*.properties /tmp/languages``
+
+Create the zip file
+
+``cd /tmp/languages``
+
+``zip languages.zip *.properties``
+
+Load the languages.zip file into Dataverse.
+
+``curl http://localhost:8080/api/admin/datasetfield/loadpropertyfiles -X POST --upload-file /tmp/languages/languages.zip -H "Content-Type: application/zip"``
+
+Click on the languages using the drop down in the header to try them out.
+
+How to Help Translate Dataverse Into Your Language
+++++++++++++++++++++++++++++++++++++++++++++++++++
+
+Please join the `dataverse-internationalization-wg`_ mailing list and contribute to https://github.com/GlobalDataverseCommunityConsortium/dataverse-language-packs to help translate Dataverse into various languages!
+
+.. _dataverse-internationalization-wg: https://groups.google.com/forum/#!forum/dataverse-internationalization-wg
+
 .. _Web-Analytics-Code:
 
 Web Analytics Code
@@ -897,13 +972,13 @@ This JVM option is only relevant if you plan to run multiple Glassfish servers f
 dataverse.lang.directory
 ++++++++++++++++++++++++
 
-This JVM option is used to configure the path where all the language specific property files are to be stored.  If this option is set then the english property file must be present in the path along with any other language property file. You can download language property files from https://github.com/GlobalDataverseCommunityConsortium/dataverse-language-packs
+This JVM option is used to configure the path where all the language specific property files are to be stored.  If this option is set then the English property file must be present in the path along with any other language property file. You can download language property files from https://github.com/GlobalDataverseCommunityConsortium/dataverse-language-packs
 
 ``./asadmin create-jvm-options '-Ddataverse.lang.directory=PATH_LOCATION_HERE'``
 
 If this value is not set, by default, a Dataverse installation will read the English language property files from the Java Application.
 
-See also the ``:Languages`` setting below.
+See also :ref:`i18n`.
 
 dataverse.files.hide-schema-dot-org-download-urls
 +++++++++++++++++++++++++++++++++++++++++++++++++
@@ -1633,15 +1708,15 @@ Sets the path where the raw Make Data Count logs are stored before being process
 
 ``curl -X PUT -d '/usr/local/glassfish4/glassfish/domains/domain1/logs' http://localhost:8080/api/admin/settings/:MDCLogPath``
 
+.. _:Languages:
+
 :Languages
 ++++++++++
 
 Sets which languages should be available. If there is more than one, a dropdown is displayed
-in the header. This should be formated as a JSON array as shown below.
+in the header.
 
-``curl http://localhost:8080/api/admin/settings/:Languages -X PUT -d '[{  "locale":"en", "title":"English"},  {  "locale":"fr", "title":"Français"}]'``
-
-See also the ``dataverse.lang.directory`` JVM option above.
+See :ref:`i18n` for a curl example and related settings.
 
 :InheritParentRoleAssignments
 +++++++++++++++++++++++++++++

--- a/src/main/java/edu/harvard/iq/dataverse/api/DatasetFieldServiceApi.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/DatasetFieldServiceApi.java
@@ -17,6 +17,9 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.List;
 import javax.ejb.EJB;
@@ -31,6 +34,8 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.core.Response;
+
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import static edu.harvard.iq.dataverse.util.json.JsonPrinter.asJsonArray;
 import edu.harvard.iq.dataverse.util.json.NullSafeJsonBuilder;
@@ -39,6 +44,17 @@ import java.util.logging.Logger;
 import javax.persistence.NoResultException;
 import javax.persistence.TypedQuery;
 import javax.ws.rs.core.Response.Status;
+
+import java.io.BufferedInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.util.Enumeration;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
 
 @Path("admin/datasetfield")
 public class DatasetFieldServiceApi extends AbstractApiBean {
@@ -403,4 +419,79 @@ public class DatasetFieldServiceApi extends AbstractApiBean {
         datasetFieldService.save(cvv);
         return cvv.getStrValue();
     }
+
+
+    @POST
+    @Consumes("application/zip")
+    @Path("loadpropertyfiles")
+    public Response loadLanguagePropertyFile(File inputFile) {
+        try
+        {
+            ZipFile file = new ZipFile(inputFile);
+            FileSystem fileSystem = FileSystems.getDefault();
+            //Get file entries
+            Enumeration<? extends ZipEntry> entries = file.entries();
+
+            //We will unzip files in this folder
+            String dataverseLangDirectory = getDataverseLangDirectory();
+
+            System.out.println(" ==== dataverseLangDirectory ===== " + dataverseLangDirectory);
+
+            //Iterate over entries
+            while (entries.hasMoreElements())
+            {
+                ZipEntry entry = entries.nextElement();
+                System.out.println(" ==== entry.getName() ===== " + entry.getName());
+                if (entry.isDirectory())
+                {
+                    System.out.println("Creating Directory:" + dataverseLangDirectory + entry.getName());
+                    Files.createDirectories(fileSystem.getPath(dataverseLangDirectory + "/" + entry.getName()));
+                }
+                //Else create the file
+                else {
+                    String dataverseLangFileName = dataverseLangDirectory + "/" + entry.getName();
+                    java.nio.file.Path uncompressedFilePath = fileSystem.getPath(dataverseLangFileName);
+
+                    System.out.println("======Creating file:" + uncompressedFilePath );
+
+
+                    Files.createFile(uncompressedFilePath);
+                    FileOutputStream fileOutput = new FileOutputStream(dataverseLangFileName);
+
+                    InputStream is = file.getInputStream(entry);
+                    BufferedInputStream bis = new BufferedInputStream(is);
+
+                    while (bis.available() > 0) {
+                        fileOutput.write(bis.read());
+                    }
+                    fileOutput.close();
+                }
+            }
+        }
+        catch(IOException e)
+        {
+            e.printStackTrace();
+        }
+
+        return Response.status(200).entity("Uploaded the file successfully ").build();
+    }
+
+    public static String getDataverseLangDirectory() {
+        String dataverseLangDirectory = System.getProperty("dataverse.lang.directory");
+        if (dataverseLangDirectory == null || dataverseLangDirectory.equals("")) {
+            dataverseLangDirectory = "/tmp/files";
+        }
+
+        if (!Files.exists(Paths.get(dataverseLangDirectory))) {
+            try {
+                Files.createDirectories(Paths.get(dataverseLangDirectory));
+            } catch (IOException ex) {
+                logger.severe("Failed to create dataverseLangDirectory: " + dataverseLangDirectory );
+                return null;
+            }
+        }
+
+        return dataverseLangDirectory;
+    }
+
 }


### PR DESCRIPTION

- connects to #5806 


curl http://localhost:8080/api/admin/datasetfield/loadpropertyfiles -X POST --data-binary @fr_CA.zip -H "Content-Type: application/zip"

Using the above API call, zip file containing property files will be copied to the file location specified at http://guides.dataverse.org/en/4.14/installation/config.html#dataverse-lang-directory

Dataverse language bundle files can be downloaded from https://github.com/GlobalDataverseCommunityConsortium/dataverse-language-packs

