### PR TITLE
use "root" as default alias, handle page=0 #5907

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -292,7 +292,8 @@
         <dependency>
             <groupId>org.omnifaces</groupId>
             <artifactId>omnifaces</artifactId>
-            <version>1.7</version> <!-- Or 1.8-SNAPSHOT -->
+            <!-- "For users who are still on JSF 2.2, use 2.7.1 instead." http://omnifaces.org -->
+            <version>2.7.1</version>
         </dependency>
         <dependency>
             <groupId>org.hibernate</groupId>

--- a/src/main/java/edu/harvard/iq/dataverse/search/SearchIncludeFragment.java
+++ b/src/main/java/edu/harvard/iq/dataverse/search/SearchIncludeFragment.java
@@ -307,6 +307,10 @@ public class SearchIncludeFragment implements java.io.Serializable {
         String allTypesFilterQuery = SearchFields.TYPE + ":(dataverses OR datasets OR files)";
         filterQueriesFinalAllTypes.add(allTypesFilterQuery);
 
+        if (page == 0) {
+            logger.info("Variable 'page' was zero. Changing it one. What does this have to do with upgrading from Glassfish 4.1 to Payara 5?");
+            page = 1;
+        }
         int paginationStart = (page - 1) * paginationGuiRows;
         /**
          * @todo

--- a/src/main/webapp/dataverse.xhtml
+++ b/src/main/webapp/dataverse.xhtml
@@ -17,7 +17,7 @@
             <ui:define name="body">
                 <f:metadata>
                     <f:viewParam name="id" value="#{DataversePage.dataverse.id}"/>
-                    <f:viewParam name="alias" value="#{DataversePage.dataverse.alias}"/>
+                    <o:viewParam name="alias" value="#{DataversePage.dataverse.alias}" default="root"/>
                     <f:viewParam name="ownerId" value="#{DataversePage.ownerId}"/>
                     <f:viewParam name="editMode" value="#{DataversePage.editMode}"/>
                     <f:viewAction action="#{dataverseSession.updateLocaleInViewRoot}"/>


### PR DESCRIPTION
Related to #5907, an alternative to pull request #5908.

This pull request feels like progress in getting Dataverse to work properly on Payara 5 in the sense that there is no validation error when you visit the homepage and after logging in as dataverseAdmin, one does not see an Internal Server Error. However, the "Create Dataverse" button doesn't work. The page flashes and you land on http://ec2-34-207-192-222.compute-1.amazonaws.com:8080/dataverse.xhtml?ownerId=1 (for example) but you are not redirected to the "create dataverse" page.