### PR TITLE
5846 Initial Framework for UI Testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,10 @@ scripts/installer/default.config
 .idea
 **/*.iml
 /bin/
+
+# do not track Visual Studio Code files
+.vscode
+
+# ignore UI testing related files
+tests/node_modules
+tests/package-lock.json

--- a/.travis.yml.future
+++ b/.travis.yml.future
@@ -1,0 +1,42 @@
+services:
+  - docker
+
+jobs:
+  include:
+    # Execute java unit- and integration tests
+    - stage: test
+      language: java
+      jdk:
+        - oraclejdk8
+      script: mvn -DcompilerArgument=-Xlint:unchecked test -P all-unit-tests
+      after_success: mvn jacoco:report coveralls:report
+
+    # Execute Cypress for UI testing
+    # see https://docs.cypress.io/guides/guides/continuous-integration.html
+    - stage: test
+      language: node_js
+      node_js:
+        - "10"
+      addons:
+        apt:
+          packages:
+            # Ubuntu 16+ does not install this dependency by default, so we need to install it ourselves
+            - libgconf-2-4
+      cache:
+        # Caches $HOME/.npm when npm ci is default script command
+        # Caches node_modules in all other cases
+        npm: true
+        directories:
+          # we also need to cache folder with Cypress binary
+          - ~/.cache
+          # we want to cache the Glassfish and Solr dependencies as well
+          - conf/docker-aio/dv/deps
+      before_install:
+        - cd tests
+      install:
+        - npm ci
+      before_script:
+        - ./run_docker_dataverse.sh
+      script:
+        # --key needs to be injected using CYPRESS_RECORD_KEY to keep it secret
+        - $(npm bin)/cypress run --record

--- a/tests/cypress.json
+++ b/tests/cypress.json
@@ -1,0 +1,4 @@
+{
+  "baseUrl": "http://localhost:8084",
+  "projectId": "ufkudc"
+}

--- a/tests/cypress/fixtures/example.json
+++ b/tests/cypress/fixtures/example.json
@@ -1,0 +1,5 @@
+{
+  "name": "Using fixtures to represent data",
+  "email": "hello@cypress.io",
+  "body": "Fixtures are a great way to mock data for responses to routes"
+}

--- a/tests/cypress/integration/test_dv.spec.js
+++ b/tests/cypress/integration/test_dv.spec.js
@@ -1,0 +1,75 @@
+import { login } from '../util'
+
+describe('Dataverse', function() {
+  beforeEach(function() {
+    login(cy)
+  })
+
+  it('can be created with minimal customization', function() {
+    cy.visit('/dataverse.xhtml?ownerId=1')
+
+    // setup aliases for used fields
+    cy.get('input[id="dataverseForm:name"]').as('name')
+    cy.get('input[id="dataverseForm:identifier"]').as('identifier')
+    cy.get('select[id="dataverseForm:dataverseCategory"]').as(
+      'categorySelection'
+    )
+    cy.get('input[id="dataverseForm:affiliation"]').as('affiliation')
+    cy.get('textarea[id="dataverseForm:description"]').as('description')
+    cy.get('input[id="dataverseForm:metadataRoot"]').as('metadataRoot')
+    cy.get('input[id="dataverseForm:facetsRoot"]').as('facetsRoot')
+
+    // assert that there are no alerts in the initial state
+    cy.get('.alert:not(.alert-success)').should('not.exist')
+    cy.get('.ui-message-error-detail').should('not.exist')
+
+    // assert that the initial values have been set correctly
+    cy.get('@name').should('have.value', 'Dataverse Admin Dataverse')
+    cy.get('@identifier').should('be.empty')
+    cy.get('@categorySelection').should('have.value', '')
+    cy.get('@affiliation').should('have.value', 'Dataverse.org')
+    cy.get('@description').should('be.empty')
+    cy.get('@metadataRoot').should('be.checked')
+    cy.get('@facetsRoot').should('be.checked')
+
+    // try to create a dataverse
+    cy.contains('Create Dataverse').click()
+
+    // expect validation to fail for some key fields
+    cy.get('.alert').should('exist')
+    cy.get('.ui-message-error-detail').should('have.length', 2)
+
+    // fill in the remaining forms
+    cy.get('@identifier').type('testDv')
+    cy.get('@categorySelection').select('DEPARTMENT')
+
+    // create a dataverse
+    cy.contains('Create Dataverse').click()
+
+    // ensure that we have been redirected to the correct dataverse page
+    cy.url().should('contain', '/dataverse/testDv')
+    cy.get('.dataverseHeaderCell').should('contain', 'Unpublished')
+  })
+
+  it('allows datasets to be created', function() {
+    cy.visit('/dataverse/testDv')
+
+    // click through to the new dataset page
+    // TODO: this should all be tested in a different spec
+    cy.contains('Add Data').click()
+    cy.contains('New Dataset').click()
+
+    // fill in the necessary fields for the simplest new dataset
+    cy.get('.panel-body').within(() => {
+      cy.get('> :nth-child(1) input[type="text"]').type('Some dataset')
+      cy.get('> :nth-child(4) textarea').type('It is about some data')
+      cy.get('> :nth-child(5) tr:nth-child(5) div.ui-chkbox-box').click()
+    })
+
+    // save the new dataset
+    cy.contains('Save Dataset').click()
+
+    // ensure that we have been redirected to the correct dataverse page
+    cy.url().should('contain', '/dataset.xhtml')
+  })
+})

--- a/tests/cypress/integration/test_dv_user.spec.js
+++ b/tests/cypress/integration/test_dv_user.spec.js
@@ -1,0 +1,76 @@
+import { login } from '../util'
+
+describe('Dataverse User', function() {
+  beforeEach(function() {
+    login(cy)
+  })
+
+  it('allows the user to read and remove notifications', function() {
+    cy.visit('/dataverseuser.xhtml?selectTab=notifications')
+
+    // expect there to be one notification
+    cy.get('.notification-item').should('have.length.of', 1)
+
+    // remove the notification
+    cy.get('.notification-item')
+      .eq(0)
+      .find('.notification-item-cell')
+      .eq(1)
+      .click()
+
+    // expect there to be no more notifications
+    cy.get('.notification-item').should('have.length.of', 0)
+  })
+
+  it('allows looking up account information', function() {
+    cy.visit('/dataverseuser.xhtml?selectTab=accountInfo')
+
+    cy.get('.form-control-static')
+      .eq(0)
+      .should('contain', 'dataverseAdmin')
+
+    cy.get('.form-control-static')
+      .eq(1)
+      .should('contain', 'Dataverse')
+
+    cy.get('.form-control-static')
+      .eq(2)
+      .should('contain', 'Admin')
+
+    cy.get('.form-control-static')
+      .eq(3)
+      .should('contain', 'dataverse@mailinator.com')
+
+    cy.get('.form-control-static')
+      .eq(4)
+      .should('contain', 'Not Verified')
+
+    cy.get('.form-control-static')
+      .eq(5)
+      .should('contain', 'Dataverse.org')
+
+    cy.get('.form-control-static')
+      .eq(6)
+      .should('contain', 'Admin')
+  })
+
+  it('enables recreation of the API token', function() {
+    const tokenTabId =
+      'div[id="dataverseUserForm:dataRelatedToMeView:apiTokenTab"]'
+    cy.visit('/dataverseuser.xhtml?selectTab=apiTokenTab')
+
+    cy.get(`${tokenTabId} pre code`)
+      .should('not.be.empty')
+      .then(oldToken => {
+        // click the token recreation button
+        cy.get(`${tokenTabId} button[type=submit]`).click()
+
+        cy.get(`${tokenTabId} pre code`)
+          .should('not.be.empty')
+          .then(newToken => {
+            // assert that the new token is different from the old one
+            expect(newToken[0].textContent).to.not.eq(oldToken[0].textContent)
+          })
+      })
+  })
+})

--- a/tests/cypress/integration/test_login.spec.js
+++ b/tests/cypress/integration/test_login.spec.js
@@ -1,0 +1,61 @@
+describe('Log In', function() {
+  beforeEach(function() {
+    // visit the log in page
+    cy.visit('/loginpage.xhtml')
+
+    // should create a session cookie
+    cy.getCookie('JSESSIONID').should('exist')
+
+    // fill out the login form inputs
+    cy.get('input[name="loginForm:credentialsContainer:0:credValue"]').type(
+      'dataverseAdmin'
+    )
+    cy.get('input[name="loginForm:credentialsContainer:1:sCredValue"]').type(
+      'admin1'
+    )
+  })
+
+  it('enables logging in with the enter key', function() {
+    // press enter
+    cy.get('input[name="loginForm:credentialsContainer:1:sCredValue"]').type(
+      '{enter}'
+    )
+
+    // should redirect to the dataverse root page
+    cy.url().should('include', '/dataverse/root')
+
+    // should show the user name in the navbar
+    cy.get('span[id=userDisplayInfoTitle]').should('contain', 'Dataverse Admin')
+  })
+
+  it('enables logging in by clicking the submit button', function() {
+    // click the login button
+    cy.get('button[name="loginForm:login').click()
+
+    // should redirect to the dataverse root page
+    cy.url().should('include', '/dataverse/root')
+
+    // should show the user name in the navbar
+    cy.get('span[id=userDisplayInfoTitle]').should('contain', 'Dataverse Admin')
+  })
+
+  it('prevents an invalid login', function() {
+    // add some additional characters to the valid credentials
+    cy.get('input[name="loginForm:credentialsContainer:0:credValue"]').type(
+      'Invalid'
+    )
+    cy.get('input[name="loginForm:credentialsContainer:1:sCredValue"]').type(
+      'Invalid'
+    )
+    // click the login button
+    cy.get('button[name="loginForm:login').click()
+
+    cy.url().should('contain', '/loginpage.xhtml')
+    cy.get('.alert').should('contain', 'Error')
+  })
+
+  it('allows jumping to the password reset page', function() {
+    cy.get('a[href="passwordreset.xhtml"]').click()
+    cy.url().should('contain', '/passwordreset.xhtml')
+  })
+})

--- a/tests/cypress/integration/test_password_reset.spec.js
+++ b/tests/cypress/integration/test_password_reset.spec.js
@@ -1,0 +1,21 @@
+describe('Password Reset', function() {
+  it('allows a valid user to request its password', function() {
+    cy.visit('/passwordreset.xhtml')
+
+    cy.get('input[name="passwordReset:email"]').type(
+      'dataverse@mailinator.com{enter}'
+    )
+
+    cy.get('.alert').should('contain', 'Password Reset Initiated')
+  })
+
+  it('does not treat invalid users differently', function() {
+    cy.visit('/passwordreset.xhtml')
+
+    cy.get('input[name="passwordReset:email"]').type(
+      'invalid_user@gmail.com{enter}'
+    )
+
+    cy.get('.alert').should('contain', 'Password Reset Initiated')
+  })
+})

--- a/tests/cypress/plugins/index.js
+++ b/tests/cypress/plugins/index.js
@@ -1,0 +1,18 @@
+
+// ***********************************************************
+// This example plugins/index.js can be used to load plugins
+//
+// You can change the location of this file or turn off loading
+// the plugins file with the 'pluginsFile' configuration option.
+//
+// You can read more here:
+// https://on.cypress.io/plugins-guide
+// ***********************************************************
+
+// This function is called when a project is opened or re-opened (e.g. due to
+// the project's config changing)
+
+module.exports = (on, config) => {
+  // `on` is used to hook into various events Cypress emits
+  // `config` is the resolved Cypress config
+}

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -1,0 +1,25 @@
+// ***********************************************
+// This example commands.js shows you how to
+// create various custom commands and overwrite
+// existing commands.
+//
+// For more comprehensive examples of custom
+// commands please read more here:
+// https://on.cypress.io/custom-commands
+// ***********************************************
+//
+//
+// -- This is a parent command --
+// Cypress.Commands.add("login", (email, password) => { ... })
+//
+//
+// -- This is a child command --
+// Cypress.Commands.add("drag", { prevSubject: 'element'}, (subject, options) => { ... })
+//
+//
+// -- This is a dual command --
+// Cypress.Commands.add("dismiss", { prevSubject: 'optional'}, (subject, options) => { ... })
+//
+//
+// -- This is will overwrite an existing command --
+// Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })

--- a/tests/cypress/support/index.js
+++ b/tests/cypress/support/index.js
@@ -1,0 +1,20 @@
+// ***********************************************************
+// This example support/index.js is processed and
+// loaded automatically before your test files.
+//
+// This is a great place to put global configuration and
+// behavior that modifies Cypress.
+//
+// You can change the location of this file or turn off
+// automatically serving support files with the
+// 'supportFile' configuration option.
+//
+// You can read more here:
+// https://on.cypress.io/configuration
+// ***********************************************************
+
+// Import commands.js using ES2015 syntax:
+import './commands'
+
+// Alternatively you can use CommonJS syntax:
+// require('./commands')

--- a/tests/cypress/util.js
+++ b/tests/cypress/util.js
@@ -1,0 +1,31 @@
+/**
+ * Function that performs a programmatic login
+ * @param {Cypress} cy
+ */
+export function login(cy, cb) {
+  // need to visit the login page to get the CSRF token
+  cy.visit('/loginpage.xhtml')
+
+  // a session needs to have been setup
+  cy.getCookie('JSESSIONID').should('exist')
+
+  // extract the CSRF token from the view state
+  cy.get('#loginForm input[name="javax.faces.ViewState"]').then(viewState => {
+    cy.request({
+      method: 'POST',
+      url: 'http://localhost:8084/loginpage.xhtml',
+      form: true,
+      body: {
+        'javax.faces.partial.ajax': true,
+        'javax.faces.source': 'loginForm:login',
+        'javax.faces.partial.execute': '@all',
+        'javax.faces.partial.render': '@all',
+        'loginForm:login': 'loginForm:login',
+        loginForm: 'loginForm',
+        'loginForm:credentialsContainer:0:credValue': 'dataverseAdmin',
+        'loginForm:credentialsContainer:1:sCredValue': 'admin1',
+        'javax.faces.ViewState': viewState[0].value,
+      },
+    }).then(cb ? cb : () => null)
+  })
+}

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "dataverse-tests",
+  "version": "0.0.1",
+  "scripts": {
+    "cypress:dev": "cypress open",
+    "cypress:ci": "cypress run"
+  },
+  "devDependencies": {
+    "cypress": "3.3.1"
+  }
+}

--- a/tests/run_docker_dataverse.sh
+++ b/tests/run_docker_dataverse.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+cd ..
+. ./conf/docker-aio/prep_it.bash


### PR DESCRIPTION
This pull requests includes the results of my initial investigation into UI testing the dataverse project using Cypress (see https://github.com/IQSS/dataverse/issues/5846 for the overall discussion and https://www.cypress.io/ for a general overview of the tool).

![ezgif com-optimize](https://user-images.githubusercontent.com/395846/58661220-9ba8b980-8327-11e9-8a39-b1f8554f2dea.gif)

Some important points to consider regarding the code added in this PR:

- Cypress is based on JavaScript/NodeJS and thus requires an installation of `node`. It runs its tests in a browser-instance based on chromium/chrome/electron, depending on the browsers that are installed. Cypress can be installed by running `npm install` within `tests/`, and run locally using `npm run cypress:dev` or in CI using `npm run cypress:ci`.
  - Cypress is not (yet) usable for cross-browser testing but I think they are working on it.
- Cypress is configured with the `cypress.json` file located in `tests/cypress.json`. This "default" configuration can be overridden with environment variables (e.g., in CI):
  - Define `CYPRESS_baseUrl=https://staging.app.com` to override the default setting. Could be useful to point Cypress to another instance of dataverse when running in CI.
  - See also https://docs.cypress.io/guides/guides/environment-variables.html#Setting
- To setup the integration with the Cypress dashboard (see https://www.cypress.io/dashboard/), update `projectId` in `cypress.json` or set it dynamically using environment variable as described above.
  - The dashboard (free for OSS) displays screen recordings and other meta information that have been created by Cypress when run in CI. The dashboard does not actually execute the tests! 
  - To receive recordings, the CI runner also depends on the `CYPRESS_RECORD_KEY` environment variable, the value of which is shown when creating the Cypress project.
  - For an example of what the dashboard could do, see https://dashboard.cypress.io/#/projects/ufkudc/runs, which displays some of the runs executed when I was developing.
- The dataverse application stack needs to be in pristine state prior to testing, as the UI frameworks expects that the environment is always initialized the same way. Naive example: there always needs to be "one notification to be read", which is then marked as read by the UI tests.
  - When running a Dataverse instance in CI (`docker-aio` or `dataverse-kubernetes`), this will implicitly be the case, as the instance is spun up separately in each job.
  - When executing against a `phoenix` instance, this needs to be ensured manually, or cleanup API calls need to be added to `beforeEach` in the respective UI tests.
  - See https://docs.cypress.io/guides/references/best-practices.html for best practices in general and regarding this point (the Cypress docs are quite good).
- When running UI tests as developed for this PR, one can run into some incompatibilities with the frame busting techniques applied in Dataverse. The following line in `dataverse_template.xhtml` would need to be disabled/removed when testing, or refactored in general: 
  - `if (window !== top) top.location = window.location;`

## Related Issues

- #5846 UZH - UI Testing / Additional Test Improvements

## Pull Request Checklist

- [x] Unit [tests][] completed
- [x] Integration [tests][]: None
- [x] Deployment requirements, [SQL updates][], [Solr updates][], etc.: None
- [x] [Documentation][docs] completed
- [x] Merged latest from "develop" [branch][] and resolved conflicts

[tests]: http://guides.dataverse.org/en/latest/developers/testing.html
[SQL updates]: http://guides.dataverse.org/en/latest/developers/sql-upgrade-scripts.html
[Solr updates]: https://github.com/IQSS/dataverse/blob/develop/conf/solr/7.3.0/schema.xml
[docs]: http://guides.dataverse.org/en/latest/developers/documentation.html
[branch]: http://guides.dataverse.org/en/latest/developers/branching-strategy.html
