### PR TITLE
5909 bug shape file nfs

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/util/FileUtil.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/FileUtil.java
@@ -938,7 +938,14 @@ public class FileUtil implements java.io.Serializable  {
             }
             
             // Delete the temp directory used for unzipping
-            FileUtils.deleteDirectory(rezipFolder);
+            // The try-catch is due to error encounterd in using NFS for stocking file,
+            // cf. https://github.com/IQSS/dataverse/issues/5909
+            try {
+            	FileUtils.deleteDirectory(rezipFolder);
+            } catch (IOException ioex) {
+                // do nothing - it's a tempo folder.
+                logger.warning("Could not remove temp folder, error message : " + ioex.getMessage());
+            }
             
             if (datafiles.size() > 0) {
                 // remove the uploaded zip file:

--- a/src/main/java/edu/harvard/iq/dataverse/util/FileUtil.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/FileUtil.java
@@ -938,7 +938,7 @@ public class FileUtil implements java.io.Serializable  {
             }
             
             // Delete the temp directory used for unzipping
-            // The try-catch is due to error encounterd in using NFS for stocking file,
+            // The try-catch is due to error encountered in using NFS for stocking file,
             // cf. https://github.com/IQSS/dataverse/issues/5909
             try {
             	FileUtils.deleteDirectory(rezipFolder);


### PR DESCRIPTION
closes #5909 

bug fix for zipped shapefile on NFS, from dataverse version 4.10