### PR TITLE
prevent JSF validation error on Payara 5 #4172

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -293,7 +293,8 @@
         <dependency>
             <groupId>org.omnifaces</groupId>
             <artifactId>omnifaces</artifactId>
-            <version>1.7</version> <!-- Or 1.8-SNAPSHOT -->
+            <!-- "For users who are still on JSF 2.2, use 2.7.1 instead." http://omnifaces.org -->
+            <version>2.7.1</version>
         </dependency>
         <dependency>
             <groupId>org.hibernate</groupId>

--- a/src/main/webapp/dataverse.xhtml
+++ b/src/main/webapp/dataverse.xhtml
@@ -17,7 +17,7 @@
             <ui:define name="body">
                 <f:metadata>
                     <f:viewParam name="id" value="#{DataversePage.dataverse.id}"/>
-                    <f:viewParam name="alias" value="#{DataversePage.dataverse.alias}"/>
+                    <o:viewParam name="alias" value="#{DataversePage.dataverse.alias}" default="root"/>
                     <f:viewParam name="ownerId" value="#{DataversePage.ownerId}"/>
                     <f:viewParam name="editMode" value="#{DataversePage.editMode}"/>
                     <f:viewAction action="#{dataverseSession.updateLocaleInViewRoot}"/>


### PR DESCRIPTION
The issue for supporting Payara 5 at #4172 and the issue for not being locked to Glassfish 4.1 at #2628 are both related but this is a "small chunk" fix that I don't believe causes any problems on Glassfish 4.1. Thank you to @smillidge for the suggestion at https://github.com/IQSS/dataverse/issues/4172#issuecomment-498446352 

Here is the error that I am trying to prevent on Payara 5.192 when visiting the home page of Dataverse:

![58837007-51c21b00-8628-11e9-9040-c25cb33dc276](https://user-images.githubusercontent.com/21006/59291855-c1985d00-8c49-11e9-8295-83d12c0b8e61.png)

I see #4172 as representing full support for Payara 5 in the sense of an updated Dataverse Installation Guide, etc. so this pull request is not intended as a fix for that issue. Rather, the idea is to do no harm to existing Dataverse installations on Glassfish 4.1 but help move the needle on Payara 5 support.