### PR TITLE
assume .md files are Markdown

### DIFF
--- a/src/main/java/propertyFiles/MimeTypeDetectionByFileExtension.properties
+++ b/src/main/java/propertyFiles/MimeTypeDetectionByFileExtension.properties
@@ -11,6 +11,7 @@ ipynb=application/x-ipynb+json
 json=application/json
 m=text/x-matlab
 mat=application/matlab-mat
+md=text/markdown
 mp3=audio/mp3
 nii=image/nii
 nc=application/netcdf


### PR DESCRIPTION
My README.md file shows "Unknown":

![Screen Shot 2019-06-11 at 1 35 59 PM](https://user-images.githubusercontent.com/21006/59293764-e8589280-8c4d-11e9-969d-f0d41072127b.png)

In this pull request I'm suggesting that we treat .md files as Markdown.

This is related to #2739 and #5372 in the sense that I think we can expect a lot more README.md files making their way into Dataverse once we make easier to deposit from GitHub. I think we want them to look like this:

![Screen Shot 2019-06-11 at 1 48 54 PM](https://user-images.githubusercontent.com/21006/59294539-b34d3f80-8c4f-11e9-881c-1b2499fd7a7f.png)
