### PR TITLE
get FileTypeDetectionIT working from docker-aio #5827

### DIFF
--- a/src/test/java/edu/harvard/iq/dataverse/api/FileTypeDetectionIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/FileTypeDetectionIT.java
@@ -1,5 +1,6 @@
 package edu.harvard.iq.dataverse.api;
 
+import com.jayway.restassured.RestAssured;
 import com.jayway.restassured.path.json.JsonPath;
 import com.jayway.restassured.response.Response;
 import javax.json.Json;
@@ -9,9 +10,15 @@ import static javax.ws.rs.core.Response.Status.OK;
 import static javax.ws.rs.core.Response.Status.UNAUTHORIZED;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.nullValue;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class FileTypeDetectionIT {
+
+    @BeforeClass
+    public static void setUp() {
+        RestAssured.baseURI = UtilIT.getRestAssuredBaseUri();
+    }
 
     @Test
     public void testOverrideMimeType() {


### PR DESCRIPTION
Relates to #5931 

I forgot to set `RestAssured.baseURI` in `FileTypeDetectionIT`, leading to the error below when I try to run the API test suite in docker-aio.

```
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running FileTypeDetectionIT
Jun 11, 2019 7:46:34 PM edu.harvard.iq.dataverse.api.UtilIT createRandomUser
INFO: Creating random test user user3c1bda1f
<html>
  <head>
    <meta http-equiv="Content-Type" content="text/html;charset=utf-8"/>
    <title>Error 403 No valid crumb was included in the request</title>
  </head>
  <body>
    <h2>HTTP ERROR 403</h2>
    <p>Problem accessing /api/builtin-users. Reason:
</p>
    <pre>    No valid crumb was included in the request</pre>
    <hr/>
    <a shape="rect" href="http://eclipse.org/jetty">Powered by Jetty:// 9.4.z-SNAPSHOT</a>
    <hr/>
  </body>
</html>
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 3.283 s <<< FAILURE! - in FileTypeDetectionIT
[ERROR] testRedetectMimeType  Time elapsed: 3.26 s  <<< FAILURE!
java.lang.AssertionError: 
Expected status code <200> doesn't match actual status code <403>.

	at edu.harvard.iq.dataverse.api.FileTypeDetectionIT.testRedetectMimeType(FileTypeDetectionIT.java:116)

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   FileTypeDetectionIT.testRedetectMimeType:116 Expected status code <200> doesn't match actual status code <403>.

[INFO] 
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 26.369s
[INFO] Finished at: Tue Jun 11 15:46:38 EDT 2019
[INFO] Final Memory: 66M/872M
[INFO] ------------------------------------------------------------------------
```