### PR TITLE
avoid "paginationStart must be 0 or greater"

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/search/SearchIncludeFragment.java
+++ b/src/main/java/edu/harvard/iq/dataverse/search/SearchIncludeFragment.java
@@ -307,7 +307,7 @@ public class SearchIncludeFragment implements java.io.Serializable {
         String allTypesFilterQuery = SearchFields.TYPE + ":(dataverses OR datasets OR files)";
         filterQueriesFinalAllTypes.add(allTypesFilterQuery);
 
-        if (page == 0) {
+        if (page <= 1) {
             // http://balusc.omnifaces.org/2015/10/the-empty-string-madness.html
             page = 1;
         }

--- a/src/main/java/edu/harvard/iq/dataverse/search/SearchIncludeFragment.java
+++ b/src/main/java/edu/harvard/iq/dataverse/search/SearchIncludeFragment.java
@@ -307,6 +307,10 @@ public class SearchIncludeFragment implements java.io.Serializable {
         String allTypesFilterQuery = SearchFields.TYPE + ":(dataverses OR datasets OR files)";
         filterQueriesFinalAllTypes.add(allTypesFilterQuery);
 
+        if (page == 0) {
+            // http://balusc.omnifaces.org/2015/10/the-empty-string-madness.html
+            page = 1;
+        }
         int paginationStart = (page - 1) * paginationGuiRows;
         /**
          * @todo


### PR DESCRIPTION
This has something to do with upgrading from Glassfish 4.1.

This is the error we're trying to avoid:

java.lang.IllegalArgumentException: paginationStart must be 0 or greater at edu.harvard.iq.dataverse.search.SearchServiceBean.search(SearchServiceBean.java:148)