### PR TITLE
get "merge accounts" working again #5978

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/GuestbookResponse.java
+++ b/src/main/java/edu/harvard/iq/dataverse/GuestbookResponse.java
@@ -26,6 +26,11 @@ import javax.persistence.*;
         @Index(columnList = "dataset_id")
 })
 
+@NamedQueries(
+        @NamedQuery(name = "GuestbookResponse.findByAuthenticatedUserId",
+                query = "SELECT gbr FROM GuestbookResponse gbr WHERE gbr.authenticatedUser.id=:authenticatedUserId")
+)
+
 public class GuestbookResponse implements Serializable {
     private static final long serialVersionUID = 1L;
     @Id


### PR DESCRIPTION
Fixes #5978

The NamedQuery `GuestbookResponse.findByAuthenticatedUserId` was removed in pull request #5863 and I don't know why.

What I do know is that UsersIT.testMergeAccounts is failing, as reported in #5978 

This pull request restores the NamedQuery back to how it was in Dataverse 4.15 before pull request #5863 was merged.

I haven't tested if the "Merge User Accounts" feature of the native API works or not but here are the docs: http://guides.dataverse.org/en/4.15/api/native-api.html#merge-accounts-label

---

Update 1.

On the phoenix server running 2f477c9 , the latest in develop, I just tried merging the user "chestnut" into user "sparrow" and it failed a CommandException.

So this is a case of the phoenix server catching a real regression. You can't merge accounts anymore if you're running the "develop" branch.

![Screen Shot 2019-06-27 at 3 22 37 PM](https://user-images.githubusercontent.com/21006/60294855-5492f180-98f0-11e9-9218-d370da4e6022.png)

<img width="937" alt="Screen Shot 2019-06-27 at 3 23 22 PM" src="https://user-images.githubusercontent.com/21006/60294646-d8001300-98ef-11e9-910c-e265a855676d.png">

`curl -H "X-Dataverse-key: $API_TOKEN" -X POST http://localhost:8080/api/users/chestnut/mergeIntoUser/sparrow`

`{"status":"ERROR","message":"Error calling ChangeUserIdentifierCommand: edu.harvard.iq.dataverse.engine.command.exception.CommandException: Command edu.harvard.iq.dataverse.engine.command.impl.MergeInAccountCommand@6dfcd65c failed: null"}`

It's the same error I reported at https://github.com/IQSS/dataverse/issues/5978#issuecomment-506468278

`Caused by: java.lang.IllegalArgumentException: NamedQuery of name: GuestbookResponse.findByAuthenticatedUserId not found.`

So I hope that this pull request is a good fix. I added that NamedQuery back in. I don't know why it was removed.