### PR TITLE
remove extra tab character for publicationIDNumber #5766

### DIFF
--- a/doc/release-notes/5766-citation-tsv
+++ b/doc/release-notes/5766-citation-tsv
@@ -1,4 +1,4 @@
 Update citation metadata block
 curl http://localhost:8080/api/admin/datasetfield/load -X POST --data-binary @citation.tsv -H "C
 
-Run ReExportall to update the citation metadata block to remove an errant tab: http://guides.dataverse.org/en/4.10/admin/metadataexport.html?highlight=export#batch-exports-through-the-api
+Run ReExportall to update the citation metadata block to remove an errant tab: http://guides.dataverse.org/en/4.16/admin/metadataexport.html?highlight=export#batch-exports-through-the-api

--- a/doc/release-notes/5766-citation-tsv
+++ b/doc/release-notes/5766-citation-tsv
@@ -1,0 +1,4 @@
+Update citation metadata block
+curl http://localhost:8080/api/admin/datasetfield/load -X POST --data-binary @citation.tsv -H "C
+
+Run ReExportall to update the citation metadata block to remove an errant tab: http://guides.dataverse.org/en/4.10/admin/metadataexport.html?highlight=export#batch-exports-through-the-api

--- a/doc/release-notes/5766-citation-tsv
+++ b/doc/release-notes/5766-citation-tsv
@@ -1,4 +1,4 @@
 Update citation metadata block
-curl http://localhost:8080/api/admin/datasetfield/load -X POST --data-binary @citation.tsv -H "C
+curl http://localhost:8080/api/admin/datasetfield/load -X POST --data-binary @citation.tsv -H "Content-type: text/tab-separated-values"
 
 Run ReExportall to update the citation metadata block to remove an errant tab: http://guides.dataverse.org/en/4.16/admin/metadataexport.html?highlight=export#batch-exports-through-the-api

--- a/scripts/api/data/metadatablocks/citation.tsv
+++ b/scripts/api/data/metadatablocks/citation.tsv
@@ -32,7 +32,7 @@
 	publication	Related Publication	Publications that use the data from this Dataset.		none	28		FALSE	FALSE	TRUE	FALSE	TRUE	FALSE		citation	http://purl.org/dc/terms/isReferencedBy
 	publicationCitation	Citation	The full bibliographic citation for this related publication.		textbox	29	#VALUE	TRUE	FALSE	FALSE	FALSE	TRUE	FALSE	publication	citation	http://purl.org/dc/terms/bibliographicCitation
 	publicationIDType	ID Type	The type of digital identifier used for this publication (e.g., Digital Object Identifier (DOI)).		text	30	#VALUE: 	TRUE	TRUE	FALSE	FALSE	TRUE	FALSE	publication	citation	http://purl.org/spar/datacite/ResourceIdentifierScheme
-	publicationIDNumber	ID Number	The identifier for the selected ID type.		text	31	#VALUE	TRUE	FALSE	FALSE	FALSE	TRUE	FALSE	publication	citation		http://purl.org/spar/datacite/ResourceIdentifier
+	publicationIDNumber	ID Number	The identifier for the selected ID type.		text	31	#VALUE	TRUE	FALSE	FALSE	FALSE	TRUE	FALSE	publication	citation	http://purl.org/spar/datacite/ResourceIdentifier
 	publicationURL	URL	Link to the publication web page (e.g., journal article page, archive record page, or other).	Enter full URL, starting with http://	url	32	<a href="#VALUE" target="_blank">#VALUE</a>	FALSE	FALSE	FALSE	FALSE	FALSE	FALSE	publication	citation	https://schema.org/distribution
 	notesText	Notes	Additional important information about the Dataset.		textbox	33		FALSE	FALSE	FALSE	FALSE	TRUE	FALSE		citation
 	language	Language	Language of the Dataset		text	34		TRUE	TRUE	TRUE	TRUE	FALSE	FALSE		citation	http://purl.org/dc/terms/language

--- a/scripts/api/data/metadatablocks/citation.tsv
+++ b/scripts/api/data/metadatablocks/citation.tsv
@@ -95,7 +95,7 @@
 	subject	Social Sciences	D11	12											
 	subject	Other	D12	13											
 	publicationIDType	ark		0											
-	publicationIDType	arXiv		1	arxiv										
+	publicationIDType	arXiv		1											
 	publicationIDType	bibcode		2											
 	publicationIDType	doi		3											
 	publicationIDType	ean13		4											


### PR DESCRIPTION
Closes #5766

Head up that I did not remove the extra "arxiv" mentioned in #5766. (Update: it was later removed in 4cbfef1.)

Also, I didn't test this at all. I just removed the tab character.