### PR TITLE
Openaire export: use TechnicalInfo as DescriptionType to export Software information

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/export/openaire/OpenAireExportUtil.java
+++ b/src/main/java/edu/harvard/iq/dataverse/export/openaire/OpenAireExportUtil.java
@@ -1230,7 +1230,7 @@ public class OpenAireExportUtil {
 
                             if (StringUtils.isNotBlank(softwareName) && StringUtils.isNotBlank(softwareVersion)) {
                                 description_check = writeOpenTag(xmlw, "descriptions", description_check);
-                                writeDescriptionElement(xmlw, "Methods", softwareName + ", " + softwareVersion, language);
+                                writeDescriptionElement(xmlw, "TechnicalInfo", softwareName + ", " + softwareVersion, language);
                             }
                         }
                     }

--- a/src/test/java/edu/harvard/iq/dataverse/export/OpenAireExportUtilTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/export/OpenAireExportUtilTest.java
@@ -22,7 +22,6 @@ import javax.xml.stream.XMLStreamWriter;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
-import static org.junit.Assert.assertTrue;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -1005,9 +1004,9 @@ public class OpenAireExportUtilTest {
                 + "</description>"
                 + "<description descriptionType=\"Abstract\">DescriptionText2"
                 + "</description>"
-                + "<description descriptionType=\"Methods\">SoftwareName1, SoftwareVersion1"
+                + "<description descriptionType=\"TechnicalInfo\">SoftwareName1, SoftwareVersion1"
                 + "</description>"
-                + "<description descriptionType=\"Methods\">SoftwareName2, SoftwareVersion2"
+                + "<description descriptionType=\"TechnicalInfo\">SoftwareName2, SoftwareVersion2"
                 + "</description>"
                 + "<description descriptionType=\"Methods\">OriginOfSources"
                 + "</description>"


### PR DESCRIPTION
This Pull request is related to issue #6062. It fixes the description of Software Info using TechnicalInfo as description type.

For instance, if the software name is "SPSS" and the software version is 11 the following fragment is generated:

```
<descriptions>
   <description descriptionType="TechnicalInfo">SPSS, 11</description>
</descriptions>
```

## Related Issues

- #6062: In OpenAIRE metadata export, fix how Software Name and Version metadata is expressed (use descriptionType="TechnicalInfo")
