### PR TITLE
OpenAIRE metadata export: fix how location information is expressed (production place and geospatial metadata)

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/export/openaire/OpenAireExportUtil.java
+++ b/src/main/java/edu/harvard/iq/dataverse/export/openaire/OpenAireExportUtil.java
@@ -1332,6 +1332,10 @@ public class OpenAireExportUtil {
         String geoLocationPlace = dto2Primitive(datasetVersionDTO, DatasetFieldConstant.productionPlace);
         boolean geoLocations_check = false;
 
+        // write geoLocations
+        geoLocations_check = writeOpenTag(xmlw, "geoLocations", geoLocations_check);
+        writeGeolocationPlace(xmlw, geoLocationPlace, language);
+                
         // get DatasetFieldConstant.geographicBoundingBox
         for (Map.Entry<String, MetadataBlockDTO> entry : datasetVersionDTO.getMetadataBlocks().entrySet()) {
             MetadataBlockDTO value = entry.getValue();
@@ -1340,10 +1344,10 @@ public class OpenAireExportUtil {
                     geoLocations_check = writeOpenTag(xmlw, "geoLocations", geoLocations_check);
                     if (fieldDTO.getMultiple()) {
                         for (HashSet<FieldDTO> foo : fieldDTO.getMultipleCompound()) {
-                            writeGeoLocationsElement(xmlw, foo, geoLocationPlace, language);
+                            writeGeoLocationsElement(xmlw, foo, language);
                         }
                     } else {
-                        writeGeoLocationsElement(xmlw, fieldDTO.getSingleCompound(), geoLocationPlace, language);
+                        writeGeoLocationsElement(xmlw, fieldDTO.getSingleCompound(), language);
                     }
                 }
             }
@@ -1355,22 +1359,36 @@ public class OpenAireExportUtil {
     /**
      * 18 GeoLocation (R)
      *
+     * Write geoLocationPlace inside geoLocation element
+     * 
      * @param xmlw The Steam writer
-     * @param foo
-     * @param geoLocationPlace
+     * @param geoLocationPlace Geo location place
      * @param language current language
      * @throws XMLStreamException
      */
-    public static void writeGeoLocationsElement(XMLStreamWriter xmlw, Set<FieldDTO> foo, String geoLocationPlace, String language) throws XMLStreamException {
+    public static void writeGeolocationPlace(XMLStreamWriter xmlw, String geoLocationPlace, String language) throws XMLStreamException {
+        boolean geoLocation_check = false;
+        
+        if (StringUtils.isNotBlank(geoLocationPlace)) {
+            geoLocation_check = writeOpenTag(xmlw, "geoLocation", geoLocation_check);
+            writeFullElement(xmlw, null, "geoLocationPlace", null, geoLocationPlace, language);
+        }
+        writeEndTag(xmlw, geoLocation_check);
+    }
+    
+    /**
+     * 18 GeoLocation (R)
+     *
+     * @param xmlw The Steam writer
+     * @param foo
+     * @param language current language
+     * @throws XMLStreamException
+     */
+    public static void writeGeoLocationsElement(XMLStreamWriter xmlw, Set<FieldDTO> foo, String language) throws XMLStreamException {
         //boolean geoLocations_check = false;
         boolean geoLocation_check = false;
         boolean geoLocationbox_check = false;
 
-        if (StringUtils.isNotBlank(geoLocationPlace)) {
-
-            geoLocation_check = writeOpenTag(xmlw, "geoLocation", geoLocation_check);
-            writeFullElement(xmlw, null, "geoLocationPlace", null, geoLocationPlace, language);
-        }
         geoLocation_check = writeOpenTag(xmlw, "geoLocation", geoLocation_check);
         geoLocationbox_check = writeOpenTag(xmlw, "geoLocationBox", geoLocationbox_check);
 

--- a/src/test/java/edu/harvard/iq/dataverse/export/OpenAireExportUtilTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/export/OpenAireExportUtilTest.java
@@ -22,7 +22,6 @@ import javax.xml.stream.XMLStreamWriter;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
-import static org.junit.Assert.assertTrue;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -1047,7 +1046,8 @@ public class OpenAireExportUtilTest {
         xmlw.close();
         Assert.assertEquals("<geoLocations>"
                 + "<geoLocation>"
-                + "<geoLocationPlace>ProductionPlace</geoLocationPlace>"
+                + "<geoLocationPlace>ProductionPlace</geoLocationPlace></geoLocation>"
+                + "<geoLocation>"
                 + "<geoLocationBox>"
                 + "<westBoundLongitude>10</westBoundLongitude>"
                 + "<eastBoundLongitude>20</eastBoundLongitude>"
@@ -1056,7 +1056,6 @@ public class OpenAireExportUtilTest {
                 + "</geoLocationBox>"
                 + "</geoLocation>"
                 + "<geoLocation>"
-                + "<geoLocationPlace>ProductionPlace</geoLocationPlace>"
                 + "<geoLocationBox>"
                 + "<southBoundLatitude>80</southBoundLatitude>"
                 + "<northBoundLatitude>70</northBoundLatitude>"


### PR DESCRIPTION
This Pull request is related to issue #6049. It fixes the location information generated by OpenAIRE export. For example, setting geolocation place to "Production Place" and geospatial metadata to [4, 3, 1, 2] and [d, c, a, b], we obtain as Openaire export:

```
<geoLocations>
	<geoLocation>
		<geoLocationPlace>Production Place</geoLocationPlace>
	</geoLocation>
	<geoLocation>
		<geoLocationBox>
			<northBoundLatitude>3</northBoundLatitude>
			<eastBoundLongitude>2</eastBoundLongitude>
			<westBoundLongitude>1</westBoundLongitude>
			<southBoundLatitude>4</southBoundLatitude>
		</geoLocationBox>
	</geoLocation>
	<geoLocation>
		<geoLocationBox>
			<northBoundLatitude>c</northBoundLatitude>
			<eastBoundLongitude>b</eastBoundLongitude>
			<westBoundLongitude>a</westBoundLongitude>
			<southBoundLatitude>d</southBoundLatitude>
		</geoLocationBox>
	</geoLocation>
</geoLocations>
```

## Related Issues

- #6049: In OpenAIRE metadata export, fix how location information is expressed (production place and geospatial metadata) 