### PR TITLE
clarify the page on docs in the dev guide is for **writing** docs

### DIFF
--- a/doc/sphinx-guides/source/api/faq.rst
+++ b/doc/sphinx-guides/source/api/faq.rst
@@ -35,7 +35,7 @@ SWORD only supports a dozen or so operations. The Native API supports many more.
 To Operate on a Dataset Should I Use Its DOI (or Handle) or Its Database ID?
 ----------------------------------------------------------------------------
 
-It's fine to target a datasets using either its Persistent ID (PID such as DOI or Handle) or its database id.
+It is fine to target a datasets using either its Persistent ID (PID such as DOI or Handle) or its database id.
 
 Here's an example from :ref:`publish-dataset-api` of targeting a dataset using its DOI:
 
@@ -56,7 +56,7 @@ Where is the Comprehensive List of All API Functionality?
 
 There are so many Dataverse APIs that a single page in this guide would probably be overwhelming. See :ref:`list-of-dataverse-apis` for links to various pages.
 
-It's possible to get a complete list of API functionality in Swagger/OpenAPI format if you deploy Dataverse to Payara 5+. For details, see https://github.com/IQSS/dataverse/issues/5794
+It is possible to get a complete list of API functionality in Swagger/OpenAPI format if you deploy Dataverse to Payara 5+. For details, see https://github.com/IQSS/dataverse/issues/5794
 
 Is There a Changelog of API Functionality That Has Been Added Over Time?
 ------------------------------------------------------------------------
@@ -66,7 +66,7 @@ No, but there probably should be. If you have suggestions for how it should look
 .. _no-api:
 
 What Functionality is GUI Only and Not Available Via API
--------------------------------------------------------
+--------------------------------------------------------
 
 The following tasks cannot currently be automated via API because no API exists for them. The web interface should be used instead for these GUI-only features:
 
@@ -84,12 +84,12 @@ If you would like APIs for any of the features above, please open a GitHub issue
 
 You are also welcome to open an issue to add to the list above. Or you are welcome to make a pull request. Please see the :doc:`/developers/documentation` section of the Developer Guide for instructions.
 
-Why Aren't the Return Values (HTTP Status Codes) Documented?
-------------------------------------------------------------
+Why Are the Return Values (HTTP Status Codes) Not Documented?
+-------------------------------------------------------------
 
 They should be. Please consider making a pull request to help. The :doc:`/developers/documentation` section of the Developer Guide should help you get started. :ref:`create-dataverse-api` has an example you can follow or you can come up with a better way.
 
-What If My Question Isn't Answered Here?
-----------------------------------------
+What If My Question Is Not Answered Here?
+-----------------------------------------
 
 Please ask! For information on where to ask, please see :ref:`getting-help-with-apis`.

--- a/doc/sphinx-guides/source/api/getting-started.rst
+++ b/doc/sphinx-guides/source/api/getting-started.rst
@@ -23,7 +23,7 @@ Once you have identified a server to test with, create an account, click on your
 .. _curl-examples-and-environment-variables:
 
 curl Examples and Environment Variables
---------------------------------------
+---------------------------------------
 
 The examples in this guide use `curl`_ for the following reasons:
 

--- a/doc/sphinx-guides/source/developers/documentation.rst
+++ b/doc/sphinx-guides/source/developers/documentation.rst
@@ -1,6 +1,6 @@
-=============
-Documentation
-=============
+=====================
+Writing Documentation
+=====================
 
 .. contents:: |toctitle|
 	:local:

--- a/doc/sphinx-guides/source/developers/version-control.rst
+++ b/doc/sphinx-guides/source/developers/version-control.rst
@@ -53,7 +53,7 @@ Pull requests take all shapes and sizes, from a one-character typo fix to hundre
 
 If you are writing code (rather than documentation), please see :doc:`testing` for guidance on writing tests.
 
-The example of creating a pull request below has to do with fixing an important issue with the :doc:`documentation` but applies to fixing code as well.
+The example of creating a pull request below has to do with fixing an important issue with the documentation but applies to fixing code as well.
 
 Find or Create a GitHub Issue
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/sphinx-guides/source/index.rst
+++ b/doc/sphinx-guides/source/index.rst
@@ -3,10 +3,10 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Dataverse |version| Guides
-==========================
+Dataverse Documentation v. |version|
+====================================
 
-These guides are for the |version| version of Dataverse. To find guides belonging to previous versions, :ref:`guides_versions` has a list of all available versions.
+These documentation guides are for the |version| version of Dataverse. To find guides belonging to previous versions, :ref:`guides_versions` has a list of all available versions.
 
 .. toctree::
   :glob:
@@ -21,11 +21,11 @@ These guides are for the |version| version of Dataverse. To find guides belongin
   style/index
 
 How the Guides Are Organized
-=============================
+============================
 
-The Guides are reference documents that explain how to use Dataverse,
+The guides are documentation that explain how to use Dataverse,
 which are divided into the following sections: User Guide,
-Installation Guide, Developer Guide, and API Guide. The User Guide is further divided into primary activities: finding & using
+Installation Guide, Developer Guide, API Guide and Style Guide. The User Guide is further divided into primary activities: finding & using
 data, adding Datasets, administering dataverses or Datasets, and Dataset exploration/visualizations. Details
 on all of the above tasks can be found in the Users Guide. The
 Installation Guide is for people or organizations who want to host their
@@ -35,7 +35,7 @@ project or who want to modify the code to suit their own needs. Finally, the API
 Developers that work on other applications and are interested in connecting with Dataverse through our APIs.
 
 Other Resources
-=========================
+===============
 
 **Dataverse Project Site**
 
@@ -56,9 +56,9 @@ For up to date news, information and developments, follow our twitter account: `
 
 **Support**
 
-We maintain an email based support service that's free of charge. We
+We maintain an email based support service that is free of charge. We
 attempt to respond within one business day to all questions and if it
-cannot be resolved immediately, we'll let you know what to expect.
+cannot be resolved immediately, we will let you know what to expect.
 
 The support email address is `support@dataverse.org <mailto:support@dataverse.org>`__.
 
@@ -70,7 +70,7 @@ if you have some code, scripts or documentation that you'd like to share.
 If you have a **security issue** to report, please email `security@dataverse.org <mailto:security@dataverse.org>`__.
 
 
-Indices and tables
+Indices and Tables
 ==================
 
 * :ref:`genindex`

--- a/doc/sphinx-guides/source/versions.rst
+++ b/doc/sphinx-guides/source/versions.rst
@@ -1,10 +1,10 @@
 :orphan:
 .. _guides_versions:
 
-Dataverse Guides Versions
-=========================
+Dataverse Documentation Versions
+================================
 
-This list provides a way to refer to previous versions of the Dataverse guides, which we still host. In order to learn more about the updates delivered from one version to another, visit the `Releases <https://github.com/IQSS/dataverse/releases>`__ page in our GitHub repo.
+This list provides a way to refer to the documentation for previous versions of Dataverse. In order to learn more about the updates delivered from one version to another, visit the `Releases <https://github.com/IQSS/dataverse/releases>`__ page in our GitHub repo.
 
 - 4.16
 


### PR DESCRIPTION
People sometimes google for "dataverse documentation" and land on the page about **writing documentation** in the dev guide. See the screenshot below for an example screenshot.

Recently @TaniaSchlatter @scolapasta and I agreed that for external tool makers the title "Building External Tools" is better that "External Tools" because it describes the activity. By the same logic, for documentation writers, "Writing Documentation" is better than just "Documentation". So that's what this pull request is about.

![Screen Shot 2019-09-13 at 8 43 08 AM](https://user-images.githubusercontent.com/21006/64863288-89b30400-d602-11e9-8fb9-525b4d68f11e.png)
