### PR TITLE
more docs on code coverage for integration tests #6124

### DIFF
--- a/doc/sphinx-guides/source/_static/util/instrument_war_jacoco.bash
+++ b/doc/sphinx-guides/source/_static/util/instrument_war_jacoco.bash
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-JACOCO_HOME=${HOME}/local/jacoco-0.8.2/lib/
+JACOCO_HOME=${HOME}/local/jacoco-0.8.1/lib/
 PID=$$
 WAR_IN=$1
 WAR_OUT=$2

--- a/doc/sphinx-guides/source/developers/testing.rst
+++ b/doc/sphinx-guides/source/developers/testing.rst
@@ -197,15 +197,86 @@ To see the full list of tests used by the Docker option mentioned above, see :do
 
 Measuring Coverage of Integration Tests
 ---------------------------------------
-Measuring the code coverage of integration tests with jacoco requires several steps:
 
-- Instrument the WAR file. Using an approach similar to :download:`this script <../_static/util/instrument_war_jacoco.bash>` is probably preferable to instrumenting the WAR directly (at least until the ``nu.xom.UnicodeUtil.decompose`` method too large exceptions get sorted).
-- Deploy the WAR file to a glassfish server with ``jacocoagent.jar`` in ``glassfish4/glassfish/lib/``
-- Run integration tests as usual
-- Use ``glassfish4/glassfish/domains/domain1/config/jacoco.exec`` to generate a report: ``java -jar ${JACOCO_HOME}/jacococli.jar report --classfiles ${DV_REPO}/target/classes --sourcefiles ${DV_REPO}/src/main/java --html ${DV_REPO}/target/coverage-it/ jacoco.exec``
+Measuring the code coverage of integration tests with Jacoco requires several steps. In order to make these steps clear we'll use "/usr/local/glassfish4" as the Glassfish directory and "glassfish" as the Glassfish Unix user.
 
-The same approach could be used to measure code paths exercised in normal use (by substituting the "run integration tests" step).
-There is obvious potential to improve automation of this process.
+Add jacocoagent.jar to Glassfish
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In order to get code coverage reports out of Glassfish we'll be adding jacocoagent.jar to the Glassfish "lib" directory.
+
+First, we need to download Jacoco. Look in pom.xml to determine which version of Jacoco we are using. As of this writing we are using 0.8.1 so so in the example below we download the Jacoco zip from https://github.com/jacoco/jacoco/releases/tag/v0.8.1
+
+Note that we are running the following commands as the user "glassfish". In short, we stop Glassfish, add the Jacoco jar file, and start up Glassfish again.
+
+.. code-block:: bash
+
+  su - glassfish
+  cd /home/glassfish
+  mkdir -p local/jacoco-0.8.1
+  cd local/jacoco-0.8.1
+  wget https://github.com/jacoco/jacoco/releases/download/v0.8.1/jacoco-0.8.1.zip
+  unzip jacoco-0.8.1.zip
+  /usr/local/glassfish4/bin/asadmin stop-domain
+  cp /home/glassfish/local/jacoco-0.8.1/lib/jacocoagent.jar /usr/local/glassfish4/glassfish/lib
+  /usr/local/glassfish4/bin/asadmin start-domain
+
+Add jacococli.jar to the WAR File
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+As the "glassfish" user download :download:`instrument_war_jacoco.bash <../_static/util/instrument_war_jacoco.bash>` (or skip ahead to the "git clone" step to get the script that way) and give it two arguments:
+
+- path to your pristine WAR file
+- path to the new WAR file the script will create with jacococli.jar in it
+
+.. code-block:: bash
+
+  ./instrument_war_jacoco.bash dataverse.war dataverse-jacoco.war
+
+Deploy the Instrumented WAR File
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Please note that you'll want to undeploy the old WAR file first, if necessary.
+
+Run this as the "glassfish" user.
+
+.. code-block:: bash
+
+  /usr/local/glassfish4/bin/asadmin deploy dataverse-jacoco.war
+
+Note that after deployment the file "/usr/local/glassfish4/glassfish/domains/domain1/config/jacoco.exec" exists and is empty.
+
+Run Integration Tests
+~~~~~~~~~~~~~~~~~~~~~
+
+Note that even though you see "docker-aio" in the command below, we assume you are not necessarily running the test suite within Docker. (Some day we'll probably move this script to another directory.) For this reason, we pass the URL with the normal port (8080) that Glassfish runs on to the ``run-test-suite.sh`` script.
+
+Note that "/usr/local/glassfish4/glassfish/domains/domain1/config/jacoco.exec" will become non-empty after you stop and start Glassfish. You must stop and start Glassfish before every run of the integration test suite.
+
+.. code-block:: bash
+
+  /usr/local/glassfish4/bin/asadmin stop-domain
+  /usr/local/glassfish4/bin/asadmin start-domain
+  git clone https://github.com/IQSS/dataverse.git
+  cd dataverse
+  conf/docker-aio/run-test-suite.sh http://localhost:8080
+
+(As an aside, you are not limited to API tests for the purposes of learning which code paths are being executed. You could click around the GUI, for example. Jacoco doesn't know or care how you exercise the application.)
+
+Create Code Coverage Report
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Run these commands as the "glassfish" user. The ``cd dataverse`` means that you should change to the directory where you cloned the "dataverse" git repo.
+
+.. code-block:: bash
+
+  cd dataverse
+  java -jar /home/glassfish/local/jacoco-0.8.1/lib/jacococli.jar report --classfiles target/classes --sourcefiles src/main/java --html target/coverage-it/ /usr/local/glassfish4/glassfish/domains/domain1/config/jacoco.exec
+
+Read Code Coverage Report
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+target/coverage-it/index.html is the place to start reading the code coverage report you just created.
 
 Load/Performance Testing
 ------------------------

--- a/doc/sphinx-guides/source/developers/testing.rst
+++ b/doc/sphinx-guides/source/developers/testing.rst
@@ -205,7 +205,7 @@ Add jacocoagent.jar to Glassfish
 
 In order to get code coverage reports out of Glassfish we'll be adding jacocoagent.jar to the Glassfish "lib" directory.
 
-First, we need to download Jacoco. Look in pom.xml to determine which version of Jacoco we are using. As of this writing we are using 0.8.1 so so in the example below we download the Jacoco zip from https://github.com/jacoco/jacoco/releases/tag/v0.8.1
+First, we need to download Jacoco. Look in pom.xml to determine which version of Jacoco we are using. As of this writing we are using 0.8.1 so in the example below we download the Jacoco zip from https://github.com/jacoco/jacoco/releases/tag/v0.8.1
 
 Note that we are running the following commands as the user "glassfish". In short, we stop Glassfish, add the Jacoco jar file, and start up Glassfish again.
 


### PR DESCRIPTION
Relates to #6124

As I was saying at standup today, the first step is to improve the documentation for how to measure code coverage for integration tests. That's what this pull request is about.

I have lots of hopes and dreams for where to go from here. I'm still using the very helpful script @pameyer provided. We should probably put the logic in Maven as well (but it doesn't hurt to keep the script and docs because users might want to instrument an existing war file).

I'm hoping these docs will be useful to @donsizemore and he and I work on automating some of this using Ansible in https://github.com/IQSS/dataverse-ansible/issues/67

But the first step, again, is better docs.