### PR TITLE
new API fomat for 'Show Dataverse Version and Build Number' section

### DIFF
--- a/doc/sphinx-guides/source/api/native-api.rst
+++ b/doc/sphinx-guides/source/api/native-api.rst
@@ -1156,6 +1156,8 @@ Show Dataverse Version and Build Number
 
 |CORS| Get the Dataverse version. The response contains the version and build numbers:
 
+.. note:: See :ref:`curl-examples-and-environment-variables` if you are unfamiliar with the use of export below.
+
 .. code-block:: bash
 
   export SERVER_URL=https://demo.dataverse.org

--- a/doc/sphinx-guides/source/api/native-api.rst
+++ b/doc/sphinx-guides/source/api/native-api.rst
@@ -1154,9 +1154,19 @@ Info
 Show Dataverse Version and Build Number
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-|CORS| Get the Dataverse version. The response contains the version and build numbers::
+|CORS| Get the Dataverse version. The response contains the version and build numbers:
 
-  GET http://$SERVER/api/info/version
+.. code-block:: bash
+
+  export SERVER=https://demo.dataverse.org
+
+  curl http://$SERVER/api/info/version
+
+The fully expanded example above (without environment variables) looks like this:
+
+.. code-block:: bash
+
+  curl https://demo.dataverse.org/api/info/version
 
 Show Dataverse Server Name
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/sphinx-guides/source/api/native-api.rst
+++ b/doc/sphinx-guides/source/api/native-api.rst
@@ -1158,7 +1158,7 @@ Show Dataverse Version and Build Number
 
 .. code-block:: bash
 
-  export SERVER=https://demo.dataverse.org
+  export SERVER_URL=https://demo.dataverse.org
 
   curl http://$SERVER/api/info/version
 

--- a/doc/sphinx-guides/source/api/native-api.rst
+++ b/doc/sphinx-guides/source/api/native-api.rst
@@ -1160,7 +1160,7 @@ Show Dataverse Version and Build Number
 
   export SERVER_URL=https://demo.dataverse.org
 
-  curl http://$SERVER/api/info/version
+  curl $SERVER_URL/api/info/version
 
 The fully expanded example above (without environment variables) looks like this:
 


### PR DESCRIPTION
Changing one API call to the new format

## Related Issues

- closes #6190: Switch "info/version" API doc to new format
