### PR TITLE
add scope=file for TwoRavens external tool manifest #6203

### DIFF
--- a/doc/sphinx-guides/source/_static/installation/files/root/external-tools/twoRavens.json
+++ b/doc/sphinx-guides/source/_static/installation/files/root/external-tools/twoRavens.json
@@ -1,6 +1,7 @@
 {
   "displayName": "TwoRavens",
   "description": "A system of interlocking statistical tools for data exploration, analysis, and meta-analysis.",
+  "scope": "file",
   "type": "explore",
   "toolUrl": "https://tworavens.dataverse.example.edu/dataexplore/gui.html",
   "toolParameters": {


### PR DESCRIPTION
Fixes #6203 but an alternative would be to enforce what we document in the new "Building External Tools" section of the API Guide (blue emphasis below):

![Screen Shot 2019-09-20 at 4 26 42 PM](https://user-images.githubusercontent.com/21006/65357269-91efde00-dbc4-11e9-9573-9f9e2fde7743.png)
![Screen Shot 2019-09-20 at 4 27 19 PM](https://user-images.githubusercontent.com/21006/65357270-91efde00-dbc4-11e9-8566-ac1c9b68e741.png)

@TwoRavens if you're listening, you are very welcome to start hosting your own manifest file (like we ask all other external toolmakers to do). 😄 I'm happy to help explain this process and point to examples. For now I consider you grandfathered in until we pick up #4429 😄 

For QA, here is the part of the doc to look at. I didn't change the text so here's the 4.16 version: http://guides.dataverse.org/en/4.16/installation/r-rapache-tworavens.html#e-enable-tworavens-button-in-dataverse