### PR TITLE
6216 - Repair broken dataverse view

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,7 @@
         See https://github.com/jacoco/jacoco/issues/772 for discussion of how the XML changed.
         -->
         <jacoco.version>0.8.1</jacoco.version>
+        <omnifaces.version>2.7.1</omnifaces.version>
     </properties>
     <!--Maven checks for dependendies from these repos in the order shown in the pom.xml
         This isn't well documented and seems to change between maven versions -MAD 4.9.4 -->
@@ -292,7 +293,7 @@
         <dependency>
             <groupId>org.omnifaces</groupId>
             <artifactId>omnifaces</artifactId>
-            <version>1.7</version> <!-- Or 1.8-SNAPSHOT -->
+            <version>${omnifaces.version}</version> <!-- Or 1.8-SNAPSHOT -->
         </dependency>
         <dependency>
             <groupId>org.hibernate</groupId>

--- a/src/main/java/edu/harvard/iq/dataverse/DataversePage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DataversePage.java
@@ -107,10 +107,16 @@ public class DataversePage implements java.io.Serializable {
     @Inject PermissionsWrapper permissionsWrapper;
 
     private Dataverse dataverse = new Dataverse();
+    
+    /**
+     * View parameters
+     */
+    private Long id = null;
+    private String alias = null;
+    private Long ownerId = null;
     private EditMode editMode;
     private LinkMode linkMode;
-
-    private Long ownerId;
+    
     private DualListModel<DatasetFieldType> facets = new DualListModel<>(new ArrayList<>(), new ArrayList<>());
     private DualListModel<Dataverse> featuredDataverses = new DualListModel<>(new ArrayList<>(), new ArrayList<>());
     private List<Dataverse> dataversesForLinking;
@@ -247,6 +253,12 @@ public class DataversePage implements java.io.Serializable {
     public void setDataverse(Dataverse dataverse) {
         this.dataverse = dataverse;
     }
+    
+    public Long getId() { return this.id; }
+    public void setId(Long id) { this.id = id; }
+    
+    public String getAlias() { return this.alias; }
+    public void setAlias(String alias) { this.alias = alias; }
 
     public EditMode getEditMode() {
         return editMode;
@@ -266,12 +278,13 @@ public class DataversePage implements java.io.Serializable {
 
     public String init() {
         //System.out.println("_YE_OLDE_QUERY_COUNTER_");  // for debug purposes
-
-        if (dataverse.getAlias() != null || dataverse.getId() != null || ownerId == null) {// view mode for a dataverse
-            if (dataverse.getAlias() != null) {
-                dataverse = dataverseService.findByAlias(dataverse.getAlias());
-            } else if (dataverse.getId() != null) {
-                dataverse = dataverseService.find(dataverse.getId());
+    
+        // TODO: all these parameters should be validated to be matching names (regex) or null
+        if (this.getAlias() != null || this.getId() != null || this.getOwnerId() == null) {// view mode for a dataverse
+            if (this.getAlias() != null) {
+                dataverse = dataverseService.findByAlias(this.getAlias());
+            } else if (this.getId() != null) {
+                dataverse = dataverseService.find(this.getId());
             } else {
                 try {
                     dataverse = dataverseService.findRootDataverse();

--- a/src/main/webapp/dataverse.xhtml
+++ b/src/main/webapp/dataverse.xhtml
@@ -19,8 +19,8 @@
             </ui:define>
             <ui:define name="body">
                 <f:metadata>
-                    <f:viewParam name="id" value="#{DataversePage.dataverse.id}"/>
-                    <f:viewParam name="alias" value="#{DataversePage.dataverse.alias}"/>
+                    <f:viewParam name="id" value="#{DataversePage.id}"/>
+                    <f:viewParam name="alias" value="#{DataversePage.alias}"/>
                     <f:viewParam name="ownerId" value="#{DataversePage.ownerId}"/>
                     <f:viewParam name="editMode" value="#{DataversePage.editMode}"/>
                     <f:viewAction action="#{dataverseSession.updateLocaleInViewRoot}"/>


### PR DESCRIPTION
## Related Issues

- Solves #6216.

## TODOs / TODISCUSS

- Validation obviously did not work back on Glassfish 4.1. See #6216 for more "behind the scenes".
- [ ] Bean validation or JSF validation should ensure that no bad values are injected via alias, id, ownerid, etc. It might be usefull to create a custom validator + annotation using the Patterns, etc, as those allow `null`. The model var for `alias` could still have `@NonBlank`.
- [ ] I upgraded to OmniFaces 2.7.1, the last release version still supporting JSF 2.2. All of this stuff should be usable right away on GF 4.1, but more tests are needed.
- [ ] We need to discuss if you feel OK with my approach to handle the situation. There are others, but felt like the cleanest way: simply handle GET params not as part of the model.

## Pull Request Checklist

- [ ] Unit [tests][] completed
- [ ] Integration [tests][]: None
- [ ] Deployment requirements, [SQL updates][], [Solr updates][], etc.: None
- [ ] [Documentation][docs] completed
- [ ] Merged latest from "develop" [branch][] and resolved conflicts

[tests]: http://guides.dataverse.org/en/latest/developers/testing.html
[SQL updates]: http://guides.dataverse.org/en/latest/developers/sql-upgrade-scripts.html
[Solr updates]: https://github.com/IQSS/dataverse/blob/develop/conf/solr/7.3.0/schema.xml
[docs]: http://guides.dataverse.org/en/latest/developers/documentation.html
[branch]: http://guides.dataverse.org/en/latest/developers/branching-strategy.html
