### PR TITLE
add button for API test status, differentiate from unit tests #4812

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ Dataverse is a trademark of President and Fellows of Harvard College and is regi
 
 [![Dataverse Project logo](src/main/webapp/resources/images/dataverseproject_logo.jpg?raw=true "Dataverse Project")](http://dataverse.org)
 
-[![Build Status](https://travis-ci.org/IQSS/dataverse.svg?branch=develop)](https://travis-ci.org/IQSS/dataverse) [![Coverage Status](https://coveralls.io/repos/IQSS/dataverse/badge.svg?branch=develop&service=github)](https://coveralls.io/github/IQSS/dataverse?branch=develop)
+[![API Test Status](https://jenkins.dataverse.org/buildStatus/icon?job=IQSS-dataverse-develop&subject=API%20Test%20Status)](https://jenkins.dataverse.org/job/IQSS-dataverse-develop/)
+[![Unit Test Status](https://img.shields.io/travis/IQSS/dataverse?label=Unit%20Test%20Status)](https://travis-ci.org/IQSS/dataverse)
+[![Unit Test Coverage](https://img.shields.io/coveralls/github/IQSS/dataverse?label=Unit%20Test%20Coverage)](https://coveralls.io/github/IQSS/dataverse?branch=develop)
 
 [dataverse.org]: https://dataverse.org
 [demo.dataverse.org]: https://demo.dataverse.org


### PR DESCRIPTION
Closes #4812

This pull request adds a new button to reflect the status of API tests passing or failing according to https://jenkins.dataverse.org/job/IQSS-dataverse-develop/

Basically, if the tests are not passing, we probably shouldn't cut a release!

Because we now have two buttons showing unit vs. API tests I differentiated the labels on them. Here's what we have now, in this pull request:

- API Tests on jenkins.dataverse.org
- Unit Tests on Travis
- Unit Test coverage on Coveralls

Coming sometime soon, we hope, as part of #6124, is a button for API Test coverage.

I'm realizing that I called these buttons in my commit but I guess they're also called badges or shields.

## Old

![Screen Shot 2019-10-11 at 3 53 36 PM](https://user-images.githubusercontent.com/21006/66680796-4ff40e00-ec3f-11e9-8e66-54a6bc49fa90.png)

## New 

![Screen Shot 2019-10-11 at 3 53 23 PM](https://user-images.githubusercontent.com/21006/66680795-4ff40e00-ec3f-11e9-8911-225a7428aee0.png)

