### PR TITLE
ingest now completes, fix assertions #6322

### DIFF
--- a/src/test/java/edu/harvard/iq/dataverse/api/InReviewWorkflowIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/InReviewWorkflowIT.java
@@ -338,10 +338,11 @@ public class InReviewWorkflowIT {
                 // TODO: Test this issue from the UI as well: https://github.com/IQSS/dataverse/issues/2526
                 .body("data.notifications[0].type", equalTo("SUBMITTEDDS"))
                 //.body("data.notifications[0].reasonsForReturn[0].message", equalTo("You forgot to upload any files."))
-                .body("data.notifications[1].type", equalTo("SUBMITTEDDS"))
+                .body("data.notifications[1].type", equalTo("INGESTCOMPLETED"))
+                .body("data.notifications[2].type", equalTo("SUBMITTEDDS"))
                 // Yes, it's a little weird that the first "SUBMITTEDDS" notification now shows the return reason when it showed nothing before. For now we are simply always showing all the reasons for return. They start to stack up. That way you can see the history.
                 //.body("data.notifications[1].reasonsForReturn[0].message", equalTo("You forgot to upload any files."))
-                .body("data.notifications[2].type", equalTo("CREATEACC"))
+                .body("data.notifications[3].type", equalTo("CREATEACC"))
                 //.body("data.notifications[2].reasonsForReturn", equalTo(null))
                 .statusCode(OK.getStatusCode());
 
@@ -393,11 +394,12 @@ public class InReviewWorkflowIT {
                 .body("data.notifications[1].type", equalTo("SUBMITTEDDS"))
                 //  .body("data.notifications[1].reasonsForReturn[0].message", equalTo("You forgot to upload any files."))
                 //   .body("data.notifications[1].reasonsForReturn[1].message", equalTo("A README is required."))
-                .body("data.notifications[2].type", equalTo("SUBMITTEDDS"))
+                .body("data.notifications[2].type", equalTo("INGESTCOMPLETED"))
+                .body("data.notifications[3].type", equalTo("SUBMITTEDDS"))
                 // Yes, it's a little weird that the first "SUBMITTEDDS" notification now shows the return reason when it showed nothing before. We're showing the history.
                 //   .body("data.notifications[2].reasonsForReturn[0].message", equalTo("You forgot to upload any files."))
                 //   .body("data.notifications[2].reasonsForReturn[1].message", equalTo("A README is required."))
-                .body("data.notifications[3].type", equalTo("CREATEACC"))
+                .body("data.notifications[4].type", equalTo("CREATEACC"))
                 //   .body("data.notifications[3].reasonsForReturn", equalTo(null))
                 .statusCode(OK.getStatusCode());
 


### PR DESCRIPTION
partial solution for #6322

Here's how the output looks now, and I changed the assertions to match:

## assert from line 337 

```
{
    "status": "OK",
    "data": {
        "notifications": [
            {
                "id": 818,
                "type": "SUBMITTEDDS"
            },
            {
                "id": 816,
                "type": "INGESTCOMPLETED"
            },
            {
                "id": 815,
                "type": "SUBMITTEDDS"
            },
            {
                "id": 812,
                "type": "CREATEACC"
            }
        ]
    }
}
```

## assert from line 389

```
{
    "status": "OK",
    "data": {
        "notifications": [
            {
                "id": 827,
                "type": "SUBMITTEDDS"
            },
            {
                "id": 825,
                "type": "SUBMITTEDDS"
            },
            {
                "id": 823,
                "type": "INGESTCOMPLETED"
            },
            {
                "id": 822,
                "type": "SUBMITTEDDS"
            },
            {
                "id": 819,
                "type": "CREATEACC"
            }
        ]
    }

```

I suppose this means that ingest is now succeeding while previously it was not. I'm not sure why. Here's the transition on phoenix where it flipped from passing to failing:

- passing: https://build.hmdc.harvard.edu:8443/job/phoenix.dataverse.org-apitest-develop/437/testReport/
- failing: https://build.hmdc.harvard.edu:8443/job/phoenix.dataverse.org-apitest-develop/438/testReport/