### PR TITLE
allow installation to hide thumbnail on dataset landing page #6108

### DIFF
--- a/doc/sphinx-guides/source/installation/config.rst
+++ b/doc/sphinx-guides/source/installation/config.rst
@@ -1859,3 +1859,14 @@ Allows Cross-Origin Resource sharing(CORS). By default this setting is absent an
 If you don’t want to allow CORS for your installation, set:
 
 ``curl -X PUT -d 'false' http://localhost:8080/api/admin/settings/:AllowCors``
+
+.. _:HideDatasetThumbnails:
+
+:HideDatasetThumbnails
+++++++++++++++++++++++
+
+Dataset thumbnails are described at :ref:`thumbnails-widgets` in the User Guide.
+
+To disable a custom thumbnail (user uploaded or selected from a data file) from appearing, set ``:HideDatasetThumbnails`` to true like this:
+
+``curl -X PUT -d 'true' http://localhost:8080/api/admin/settings/:HideDatasetThumbnails``

--- a/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
@@ -398,6 +398,11 @@ public class DatasetPage implements java.io.Serializable {
             
             
         }
+        if (settingsWrapper.isTrueForKey(SettingsServiceBean.Key.HideDatasetThumbnails, false)) {
+            // This installation doesn't want to show a custom thumbnail on the dataset landing page.
+            thumbnailString = "";
+            return null;
+        }
         return thumbnailString;
     }
 

--- a/src/main/java/edu/harvard/iq/dataverse/settings/SettingsServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/settings/SettingsServiceBean.java
@@ -206,6 +206,7 @@ public class SettingsServiceBean {
         /* the number of files the GUI user is allowed to upload in one batch, 
             via drag-and-drop, or through the file select dialog */
         MultipleUploadFilesLimit,
+        HideDatasetThumbnails,
         /* Size limits for generating thumbnails on the fly */
         /* (i.e., we'll attempt to generate a thumbnail on the fly if the 
          * size of the file is less than this)


### PR DESCRIPTION
Closes #6108 

## Before (out of the box)

![Screen Shot 2019-11-26 at 10 42 05 AM](https://user-images.githubusercontent.com/21006/69648645-b7242100-1039-11ea-93c5-50ecdf9e817c.png)

## After (new setting `:HideDatasetThumbnails` set to true)

![Screen Shot 2019-11-26 at 10 42 17 AM](https://user-images.githubusercontent.com/21006/69648646-b7242100-1039-11ea-95bc-051b811b3236.png)
