### PR TITLE
document that Stata 15 is supported #6444

### DIFF
--- a/doc/sphinx-guides/source/user/tabulardataingest/stata.rst
+++ b/doc/sphinx-guides/source/user/tabulardataingest/stata.rst
@@ -5,8 +5,3 @@ Stata
 	:local:
 
 Of all the third party statistical software providers, Stata does the best job at documenting the internal format of their files, by far. And at making that documentation freely and easily available to developers (yes, we are looking at you, SPSS). Because of that, Stata is the best supported format for tabular data ingest.  
-
-
-**New in Dataverse 4.0:** support for Stata v.13 has been added.
-
-

--- a/doc/sphinx-guides/source/user/tabulardataingest/supportedformats.rst
+++ b/doc/sphinx-guides/source/user/tabulardataingest/supportedformats.rst
@@ -11,7 +11,7 @@ Tabular Data ingest supports the following file formats:
 File format                      Versions supported 
 ================================ ==================================
 SPSS (POR and SAV formats)	 7 to 22
-STATA				 4 to 13
+STATA				 4 to 15
 R 				 up to 3
 Excel				 XLSX only (XLS is NOT supported)
 CSV (comma-separated values) 	 (limited support)


### PR DESCRIPTION
**What this PR does / why we need it**:

Support for Stata 15 was added in Dataverse 4.9.2 in pull request #4708

This is just a documentation update.

We need it because otherwise people reading our documentation are confused about which versions of Stata are supported.

**Which issue(s) this PR closes**:

Closes #6444 

**Special notes for your reviewer**:

None.

**Suggestions on how to test this**:

Build the docs.

**Does this PR introduce a user interface change?**:

No.

**Is there a release notes update needed for this change?**:

I don't think so.

**Additional documentation**:

None.