### PR TITLE
advise devs to limit Solr to localhost

### DIFF
--- a/doc/sphinx-guides/source/developers/dev-environment.rst
+++ b/doc/sphinx-guides/source/developers/dev-environment.rst
@@ -163,7 +163,9 @@ To install Solr, execute the following commands:
 
 ``cd /usr/local/solr/solr-7.3.1``
 
-``bin/solr start``
+(Please note that the extra jetty argument below is a security measure to limit connections to Solr to only your computer. For extra security, run a firewall.)
+
+``bin/solr start -j "-Djetty.host=127.0.0.1"``
 
 ``bin/solr create_core -c collection1 -d server/solr/collection1/conf``
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull requests encourages developers to only allow Solr to be accessed from their own computer (localhost or 127.0.0.1). Adding `-j "-Djetty.host=127.0.0.1"` matches what we mention in the propose release note most recently updated in pull request #6429.

**Which issue(s) this PR relates to**:

Relates to https://github.com/IQSS/dataverse-security/issues/10

**Special notes for your reviewer**:

I tested this on Mac with a bogus value like this:

`bin/solr start -j "-Djetty.host=127000.0.0.1"`

This (eventually, after the timeout) gave a UnresolvedAddressException and Solr didn't start. This helped convince me that the setting is working.

**Please note that I only have one computer on my subnet so I haven't tested actually trying to access Solr from another computer with the old way we recommended starting Solr. So I don't really know if it works or not. I'd be happy to sit with someone who can help me test this.**

**Suggestions on how to test this**:

From the same subnet, try to reach Solr before and after this change.

**Does this PR introduce a user interface change?**:

No.

**Is there a release notes update needed for this change?**:

Maybe. I considered piling on to the release note most recently edited in pull request #6429 but it seemed to be targeted at sysadmins and production environments. In the actual release notes, maybe it would be good to mention developers too?

**Additional documentation**:
