### PR TITLE
Binder now supports Dataverse DOIs #4714

### DIFF
--- a/doc/release-notes/4714-binder.md
+++ b/doc/release-notes/4714-binder.md
@@ -1,0 +1,1 @@
+https://mybinder.org now supports spinning up Jupyter Notebooks from Dataverse DOIs.

--- a/doc/sphinx-guides/source/admin/integrations.rst
+++ b/doc/sphinx-guides/source/admin/integrations.rst
@@ -80,7 +80,7 @@ Whole Tale
 Binder
 ++++++
 
-Researchers can launch Jupyter Notebooks, RStudio, and other computational environments by inputting the DOI of a Dataverse dataset on https://mybinder.org
+Researchers can launch Jupyter Notebooks, RStudio, and other computational environments by entering the DOI of a Dataverse dataset on https://mybinder.org
 
 Institutions can self host BinderHub. Dataverse is one of the supported `repository providers <https://binderhub.readthedocs.io/en/latest/developer/repoproviders.html#supported-repoproviders>`_.
 

--- a/doc/sphinx-guides/source/admin/integrations.rst
+++ b/doc/sphinx-guides/source/admin/integrations.rst
@@ -77,6 +77,13 @@ Whole Tale
 `import data from Dataverse
 <https://wholetale.readthedocs.io/en/stable/users_guide/manage.html>`_ via identifier (e.g., DOI, URI, etc) or through the External Tools integration.  For installation instructions, see the :doc:`external-tools` section or the `Integration <https://wholetale.readthedocs.io/en/stable/users_guide/integration.html#dataverse-external-tools>`_ section of the Whole Tale User Guide.
 
+Binder
+++++++
+
+Researchers can launch Jupyter Notebooks based on the DOI of a Dataverse dataset from https://mybinder.org
+
+Institutions can self host BinderHub. Dataverse is one of the supported `repository providers <https://binderhub.readthedocs.io/en/latest/developer/repoproviders.html#supported-repoproviders>`_.
+
 Discoverability
 ---------------
 

--- a/doc/sphinx-guides/source/admin/integrations.rst
+++ b/doc/sphinx-guides/source/admin/integrations.rst
@@ -80,7 +80,7 @@ Whole Tale
 Binder
 ++++++
 
-Researchers can launch Jupyter Notebooks based on the DOI of a Dataverse dataset from https://mybinder.org
+Researchers can launch Jupyter Notebooks, RStudio, and other computational environments by inputting the DOI of a Dataverse dataset on https://mybinder.org
 
 Institutions can self host BinderHub. Dataverse is one of the supported `repository providers <https://binderhub.readthedocs.io/en/latest/developer/repoproviders.html#supported-repoproviders>`_.
 

--- a/doc/sphinx-guides/source/api/apps.rst
+++ b/doc/sphinx-guides/source/api/apps.rst
@@ -96,7 +96,8 @@ https://github.com/artefactual/archivematica/tree/v1.9.2/src/MCPClient/lib/clien
 repo2docker
 ~~~~~~~~~~~
 
-repo2docker is a command line tool that allows you to spin up a Docker container from a Dataverse DOI.
+repo2docker is a command line tool that allows you to create and start a
+Docker image from a code repository that follows the [reproducible executable environment specification](https://repo2docker.readthedocs.io/en/latest/specification.html). repo2docker supports Dataverse DOIs to find and retrieve repositories.
 
 https://github.com/jupyter/repo2docker/blob/master/repo2docker/contentproviders/dataverse.py
 

--- a/doc/sphinx-guides/source/api/apps.rst
+++ b/doc/sphinx-guides/source/api/apps.rst
@@ -97,7 +97,7 @@ repo2docker
 ~~~~~~~~~~~
 
 repo2docker is a command line tool that allows you to create and start a
-Docker image from a code repository that follows the [reproducible executable environment specification](https://repo2docker.readthedocs.io/en/latest/specification.html). repo2docker supports Dataverse DOIs to find and retrieve repositories.
+Docker image from a code repository that follows the [reproducible executable environment specification](https://repo2docker.readthedocs.io/en/latest/specification.html). repo2docker supports Dataverse DOIs to find and retrieve datasets.
 
 https://github.com/jupyter/repo2docker/blob/master/repo2docker/contentproviders/dataverse.py
 

--- a/doc/sphinx-guides/source/api/apps.rst
+++ b/doc/sphinx-guides/source/api/apps.rst
@@ -93,6 +93,13 @@ Archivematica is an integrated suite of open-source tools for processing digital
 
 https://github.com/artefactual/archivematica/tree/v1.9.2/src/MCPClient/lib/clientScripts
 
+repo2docker
+~~~~~~~~~~~
+
+repo2docker is a command line tool that allows you to spin up a Docker container from a Dataverse DOI.
+
+https://github.com/jupyter/repo2docker/blob/master/repo2docker/contentproviders/dataverse.py
+
 Java
 ----
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull requests helps ensure that installations of Dataverse are aware that they can now use https://mybinder.org to spin up Jupyter Notebooks based on DOIs of datasets in Dataverse as described in my write up linked from https://twitter.com/philipdurbin/status/1204472858413371392

**Which issue(s) this PR relates to**:

Relates to #4714

**Special notes for your reviewer**:

At this time we cannot create an external tool for Binder in Dataverse because we can only pass DOIs as query parameters and Binder requires DOIs to be in paths.

**Suggestions on how to test this**:

From https://groups.google.com/d/msg/dataverse-community/K7vKWSPLaQY/8go3fvV3AwAJ

To try it out, go to https://mybinder.org and click the dropdown to select "Dataverse DOI". Then type in the DOI of a dataset hosted in an installation of Dataverse and click "Launch" (screenshot 1, attached).

![step1-enter-doi](https://user-images.githubusercontent.com/21006/70665943-a8458d00-1c3b-11ea-88c0-23eb05acbbd8.png)

After a while, an instance of Jupyter Lab will appear with the files from the Dataverse dataset (screenshot 2).

![step2-jupyter-lab](https://user-images.githubusercontent.com/21006/70665949-ac71aa80-1c3b-11ea-9531-33273da8b0ab.png)

From Jupyter Lab you can either open an existing Jupyter Notebook that is one of the files in the Dataverse dataset or you can create a new Jupyter Notebook. (No screenshot. Hmm! Time to upload a Jupyter notebook to the dataset!)

To return to the dataset landing page in Dataverse from Jupyter Lab, click "visit repo" (screenshot 3).

![step3-return-to-dataverse](https://user-images.githubusercontent.com/21006/70665958-b1cef500-1c3b-11ea-8dca-ef13c2f4a8ca.png)

**Does this PR introduce a user interface change?**:

No.

**Is there a release notes update needed for this change?**:

Yes, suggestion added.

**Additional documentation**:

Dataverse is now listed at https://binderhub.readthedocs.io/en/latest/developer/repoproviders.html#supported-repoproviders