### PR TITLE
contenttype can be null because dataset tools do not require it #6459

### DIFF
--- a/src/main/resources/db/migration/V4.18.1.1__6459-contenttype-nullable.sql
+++ b/src/main/resources/db/migration/V4.18.1.1__6459-contenttype-nullable.sql
@@ -1,0 +1,2 @@
+-- contenttype can be non-null because dataset tools do not require it
+ALTER TABLE externaltool ALTER contenttype DROP NOT NULL;

--- a/src/main/resources/db/migration/V4.18.1.1__6459-contenttype-nullable.sql
+++ b/src/main/resources/db/migration/V4.18.1.1__6459-contenttype-nullable.sql
@@ -1,2 +1,2 @@
--- contenttype can be non-null because dataset tools do not require it
+-- contenttype can be null because dataset tools do not require it
 ALTER TABLE externaltool ALTER contenttype DROP NOT NULL;


### PR DESCRIPTION
**What this PR does / why we need it**:

This issue is currently blocked:

- Add Whole Tale to Dataverse demo site #6446 

The reason is that I forgot to add a SQL migration in pull request #6059 to drop the non null constraint.

**Which issue(s) this PR closes**:

Closes #6459

**Special notes for your reviewer**:

None.

**Suggestions on how to test this**:

- Run the SQL statement on demo.
- Try to add the Whole Tale tool mentioned in #6459 

**Does this PR introduce a user interface change?**:

No.

**Is there a release notes update needed for this change?**:

At standup today we decided we'd wait until this pull request to decide where to put the note. I'm thinking we put the note in both the release notes for 4.17 (when pull request #6059 was merged) and the next release (when the flyway script will run). Happy to discuss.

**Additional documentation**:

None.