### PR TITLE
6307 email dataverse support

### DIFF
--- a/src/main/webapp/dataverse_header.xhtml
+++ b/src/main/webapp/dataverse_header.xhtml
@@ -80,7 +80,7 @@
                         </li>
                         <ui:fragment rendered="#{empty settingsWrapper.get(':NavbarSupportUrl')}">
                             <o:form useRequestURI="true" class="navbar-form navbar-left navbar-form-link">
-                                <p:commandLink oncomplete="PF('contactForm').show()" update=":contactDialog" actionListener="#{sendFeedbackDialog.initUserInput}">
+                                <p:commandLink oncomplete="PF('contactForm').show()" update=":contactDialog" actionListener="#{sendFeedbackDialog.initUserInput}" id="headerSupportLink">
                                     <f:setPropertyActionListener target="#{sendFeedbackDialog.messageSubject}" value=""/>
                                     <f:setPropertyActionListener target="#{sendFeedbackDialog.recipient}" value="#{null}"/>
                                     <f:setPropertyActionListener target="#{sendFeedbackDialog.userMessage}" value=""/>

--- a/src/main/webapp/dataverse_template.xhtml
+++ b/src/main/webapp/dataverse_template.xhtml
@@ -106,7 +106,10 @@
 
                 // Rebind bootstrap UI components
                 bind_bsui_components();
-            });
+            });            
+            function clickSupportLink() {
+                $("[id$='headerSupportLink']").click();
+            }            
             //]]>
         </script>
     </h:body>

--- a/src/main/webapp/loginpage.xhtml
+++ b/src/main/webapp/loginpage.xhtml
@@ -79,7 +79,6 @@
                                     <div class="form-group" jsf:rendered="#{LoginPage.requireExtraValidation}">
                                         <div class="col-sm-offset-4 col-sm-8">
                                             <p>
-                                                Login Page validation Extra Validation
                                                 <h:outputText styleClass="highlightBold" value="#{bundle['contact.question']}"/> <span class="glyphicon glyphicon-asterisk text-danger" title="#{bundle.requiredField}"/>
                                             </p>
                                             <h:outputFormat value="#{LoginPage.op1} + #{LoginPage.op2} = "/>

--- a/src/main/webapp/loginpage.xhtml
+++ b/src/main/webapp/loginpage.xhtml
@@ -79,6 +79,7 @@
                                     <div class="form-group" jsf:rendered="#{LoginPage.requireExtraValidation}">
                                         <div class="col-sm-offset-4 col-sm-8">
                                             <p>
+                                                Login Page validation Extra Validation
                                                 <h:outputText styleClass="highlightBold" value="#{bundle['contact.question']}"/> <span class="glyphicon glyphicon-asterisk text-danger" title="#{bundle.requiredField}"/>
                                             </p>
                                             <h:outputFormat value="#{LoginPage.op1} + #{LoginPage.op2} = "/>
@@ -113,13 +114,9 @@
                                             <f:param value="#{systemConfig.guidesVersion}"/>
                                         </h:outputFormat>
                                         <h:outputFormat value="#{bundle['login.institution.support.blurbwithLink']}" escape="false">
-                                            <o:param>
-                                                <p:commandLink value="#{settingsWrapper.supportTeamName}" oncomplete="PF('contactForm').show()" update=":contactDialog" actionListener="#{sendFeedbackDialog.initUserInput}">
-                                                    <f:setPropertyActionListener target="#{sendFeedbackDialog.messageSubject}" value=""/>
-                                                    <f:setPropertyActionListener target="#{sendFeedbackDialog.recipient}" value="#{null}"/>
-                                                    <f:setPropertyActionListener target="#{sendFeedbackDialog.userMessage}" value=""/>
-                                                    <f:setPropertyActionListener target="#{sendFeedbackDialog.userEmail}" value=""/>
-                                                </p:commandLink>                               
+                                            <o:param>      
+                                                <p:commandLink value="Hello, #{settingsWrapper.supportTeamName}" onclick ="clickSupportLink();" >
+                                                </p:commandLink>
                                             </o:param>
                                         </h:outputFormat>
                                     </p>

--- a/src/main/webapp/loginpage.xhtml
+++ b/src/main/webapp/loginpage.xhtml
@@ -114,7 +114,7 @@
                                         </h:outputFormat>
                                         <h:outputFormat value="#{bundle['login.institution.support.blurbwithLink']}" escape="false">
                                             <o:param>      
-                                                <p:commandLink value="Hello, #{settingsWrapper.supportTeamName}" onclick ="clickSupportLink();" >
+                                                <p:commandLink value="#{bundle['notification.email.greeting']} #{settingsWrapper.supportTeamName}" onclick ="clickSupportLink();" >
                                                 </p:commandLink>
                                             </o:param>
                                         </h:outputFormat>

--- a/src/main/webapp/loginpage.xhtml
+++ b/src/main/webapp/loginpage.xhtml
@@ -114,7 +114,7 @@
                                         </h:outputFormat>
                                         <h:outputFormat value="#{bundle['login.institution.support.blurbwithLink']}" escape="false">
                                             <o:param>      
-                                                <p:commandLink value="#{bundle['notification.email.greeting']} #{settingsWrapper.supportTeamName}" onclick ="clickSupportLink();" >
+                                                <p:commandLink value="#{settingsWrapper.supportTeamName}" onclick ="clickSupportLink();" >
                                                 </p:commandLink>
                                             </o:param>
                                         </h:outputFormat>

--- a/src/main/webapp/resources/iqbs/messages.xhtml
+++ b/src/main/webapp/resources/iqbs/messages.xhtml
@@ -25,16 +25,12 @@
                     <h:outputText value="#{flash['errorMsg']} " escape="false"/>
                     <h:outputFormat value="#{bundle['error.support.message']}" escape="false">
                         <o:param>
-                            <p:commandLink value="#{settingsWrapper.supportTeamName}" oncomplete="PF('contactForm').show()" update=":contactDialog" actionListener="#{sendFeedbackDialog.initUserInput}">
-                                <f:setPropertyActionListener target="#{sendFeedbackDialog.messageSubject}" value=""/>
-                                <f:setPropertyActionListener target="#{sendFeedbackDialog.recipient}" value="#{null}"/>
-                                <f:setPropertyActionListener target="#{sendFeedbackDialog.userMessage}" value=""/>
-                                <f:setPropertyActionListener target="#{sendFeedbackDialog.userEmail}" value=""/>
+                            <p:commandLink value="#{settingsWrapper.supportTeamName}" onclick ="clickSupportLink();" >
                             </p:commandLink>                                
                         </o:param>
                     </h:outputFormat>
                 </o:form>
-            </div>
+            </div>           
         </ui:fragment>
         <ui:fragment rendered="#{not empty flash['infoMsg']}">
             <div class="alert alert-info">


### PR DESCRIPTION
**What this PR does / why we need it**:
When the app throws a command exception or there's a login exception an error message is displayed that includes a link to contact support via email. Clicking the link brings up a contact form, but if the user fills it in and clicks "SEND" no email is sent,

**Which issue(s) this PR closes**:

Closes #6307 

**Special notes for your reviewer**: This also fixes the situation where there is an error message for a Command Exception (such as when Publish Dataset fails)

**Suggestions on how to test this**: Login with incorrect credentials and see that the form is created properly (it has an actual math problem) and it successfully sends an email to support.

**Does this PR introduce a user interface change?**: There is no change to the UI

**Is there a release notes update needed for this change?**: No, unless we want to highlight this as a bug fix.

**Additional documentation**: None