### PR TITLE
get tabs working on user page on Payara #6463

### DIFF
--- a/src/main/webapp/dataverseuser.xhtml
+++ b/src/main/webapp/dataverseuser.xhtml
@@ -17,15 +17,6 @@
             <ui:param name="showDataverseHeader" value="false"/>
             <ui:param name="loginRedirectPage" value="dataverseuser.xhtml"/>
             <ui:define name="body">
-                <script>
-                    //<![CDATA[
-                    window.onpageshow = function(event) {
-                        if (event.persisted) {
-                            window.location.reload();
-                        }
-                    };
-                    //]]>
-                </script>
                 <f:loadBundle basename="propertyFiles.Bundle" var="bundle"/>
                 <f:metadata>
                     <f:event type="preRenderView" listener="#{facesContext.externalContext.response.setHeader('Cache-Control', 'no-cache, no-store')}"/>
@@ -45,7 +36,7 @@
                     </p:panel>
 
                     <p:tabView id="dataRelatedToMeView" activeIndex="#{DataverseUserPage.activeIndex}" dynamic="true" rendered="#{empty DataverseUserPage.editMode}">
-                        <p:ajax event="tabChange" listener="#{DataverseUserPage.onTabChange}" update="@all" oncomplete="javascript:bind_bsui_components();" />
+                        <p:ajax event="tabChange" listener="#{DataverseUserPage.onTabChange}" update="@all"/>
                         <p:tab id="myData" title="#{bundle['user.dataRelatedToMe']}">
                             <ui:include src="mydata_fragment.xhtml"></ui:include>
                         </p:tab>
@@ -341,13 +332,13 @@
                                         <ui:fragment rendered="#{DataverseUserPage.passwordEditable or DataverseUserPage.accountDetailsEditable}">
                                             <li>
                                                 <p:commandLink id="editAccount" rendered="#{DataverseUserPage.accountDetailsEditable}"
-                                                               actionListener="#{DataverseUserPage.edit}" update="@form" oncomplete="javascript:bind_bsui_components();">
+                                                               actionListener="#{DataverseUserPage.edit}" update="@form">
                                                     <h:outputText value="#{bundle['account.info']}" />
                                                 </p:commandLink>
                                             </li>
                                             <li>
                                                 <p:commandLink id="changePassword" rendered="#{DataverseUserPage.passwordEditable}" 
-                                                               actionListener="#{DataverseUserPage.changePassword}" update="@form" oncomplete="javascript:bind_bsui_components();">
+                                                               actionListener="#{DataverseUserPage.changePassword}" update="@form">
                                                     <h:outputText value="#{bundle.passwd}" />
                                                 </p:commandLink>
                                             </li>
@@ -509,18 +500,6 @@
                                     <code class="language-html" data-lang="html">${ApiTokenPage.apiToken}</code>
                                 </pre>
                             </div>
-                            <!--Script removes "hidden" class from div containing API token to stop javascript browser exploits-->
-                            <script>
-                                //<![CDATA[
-                                $(document).ready(function() {
-                                    $("div#apiToken").removeClass("hidden");
-                                });
-                                //Produces "Are you sure you want to leave this page?" alert to allow API token to hide again
-                                $(window).on("beforeunload", function() {
-                                    $("div#apiToken").addClass("hidden");
-                                });
-                                //]]>
-                            </script>
                             <div class="btn-toolbar" role="toolbar">
                                 <button class="btn btn-default" jsf:action="#{ApiTokenPage.generate()}">
                                     #{ApiTokenPage.checkForApiToken() ? bundle['apitoken.regenerateBtn'] : bundle['apitoken.generateBtn']}


### PR DESCRIPTION
**What this PR does / why we need it**:

On Payara, users can't use the "API Token" tab. It's blank.

**Which issue(s) this PR closes**:

Closes #6463

**Special notes for your reviewer**:

I thought I'd try simply deleting all the extra Javascript in the xhtml page and it seems to have worked. I can get to the tabs now in both Firefox and Chrome. I'm not sure if I deleted too much, though. Maybe we need some that Javascript? If so, I could try a smaller change.

Also I was kind of hoping "edit user - says update successful, but changes not saved to db (somewhat similar to dataverse)" would be magically fixed but it isn't. 😢 

**Suggestions on how to test this**:

Try to replicate this:  user page - if you don't start on API token tab, clicking on that tab is blank; same behavior with My Data tab #6463 

**Does this PR introduce a user interface change?**:

No

**Is there a release notes update needed for this change?**:

No

**Additional documentation**:

No