### PR TITLE
6268 link search popup blank

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DataversePage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DataversePage.java
@@ -856,9 +856,9 @@ public class DataversePage implements java.io.Serializable {
             return returnRedirect();
         }
 
-        SavedSearch savedSearch = new SavedSearch(searchIncludeFragment.getQuery(), linkingDataverse, savedSearchCreator);
+        SavedSearch savedSearch = new SavedSearch(query, linkingDataverse, savedSearchCreator);
         savedSearch.setSavedSearchFilterQueries(new ArrayList<>());
-        for (String filterQuery : searchIncludeFragment.getFilterQueriesDebug()) {
+        for (String filterQuery : filterQueries) {
             /**
              * @todo Why are there null's here anyway? Turn on debug and figure
              * this out.

--- a/src/main/java/edu/harvard/iq/dataverse/DataversePage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DataversePage.java
@@ -187,6 +187,21 @@ public class DataversePage implements java.io.Serializable {
         this.linkMode = linkMode;
     }
     
+    public boolean showLinkingPopup() {
+        String testquery = "";
+        if (session.getUser() == null) {
+            return false;
+        }
+        if (dataverse == null) {
+            return false;
+        }
+        if (query != null) {
+            testquery = query;
+        }
+
+        return (session.getUser().isSuperuser() && (dataverse.getOwner() != null || !testquery.isEmpty()));
+    }
+    
     public void setupLinkingPopup (String popupSetting){
         if (popupSetting.equals("link")){
             setLinkMode(LinkMode.LINKDATAVERSE);           

--- a/src/main/java/edu/harvard/iq/dataverse/search/SearchIncludeFragment.java
+++ b/src/main/java/edu/harvard/iq/dataverse/search/SearchIncludeFragment.java
@@ -452,7 +452,7 @@ public class SearchIncludeFragment implements java.io.Serializable {
             
             dataversePage.setQuery(query);
             dataversePage.setFacetCategoryList(facetCategoryList);
-            dataversePage.setFilterQueries(filterQueries);
+            dataversePage.setFilterQueries(filterQueriesFinal);
             dataversePage.setSearchResultsCount(searchResultsCount);
             dataversePage.setSelectedTypesString(selectedTypesString);
             dataversePage.setSortField(sortField);

--- a/src/main/java/edu/harvard/iq/dataverse/search/savedsearch/SavedSearchServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/search/savedsearch/SavedSearchServiceBean.java
@@ -189,7 +189,10 @@ public class SavedSearchServiceBean {
                     hitInfo.add(resultString, "Skipping because dataset " + datasetToLinkTo.getId() + " is already part of the subtree for " + savedSearch.getDefinitionPoint().getAlias());
                 } else if (datasetAncestorAlreadyLinked(savedSearch.getDefinitionPoint(), datasetToLinkTo)) {
                     hitInfo.add(resultString, "FIXME: implement this?");
-                } else {
+                } else if (!datasetToLinkTo.isReleased()) {
+                    hitInfo.add(resultString, "Skipping because dataset " + datasetToLinkTo.getId() + " is not released " );
+                }
+                else {
                     DatasetLinkingDataverse link = commandEngine.submitInNewTransaction(new LinkDatasetCommand(dvReq, savedSearch.getDefinitionPoint(), datasetToLinkTo));
                     hitInfo.add(resultString, "Persisted DatasetLinkingDataverse id " + link.getId() + " link of " + link.getDataset() + " to " + link.getLinkingDataverse());
                 }

--- a/src/main/webapp/dataverse.xhtml
+++ b/src/main/webapp/dataverse.xhtml
@@ -449,15 +449,15 @@
                                                         </p:commandLink>
                                                     </li>
                                                     <li class="#{SearchIncludeFragment.mode == 'search' ? '' : 'disabled'}">
-                                                        <p:commandLink action="#{DataversePage.setupLinkingPopup('savedSearch')}"
+                                                        <p:commandLink onclick="linkSavedSearchCommand();"
                                                                        oncomplete="PF('linkDataverseForm').show()"
-                                                                       update=":linkDataverseForm"
-                                                                       disabled="#{SearchIncludeFragment.mode != 'search'}">
+                                                                       update=":linkDataverseForm">
                                                             #{bundle['dataverse.savedsearch.link']}
                                                         </p:commandLink>
                                                     </li>
                                                 </ul>
                                             </div>
+                                            <p:remoteCommand name="linkSavedSearchCommand" action="#{DataversePage.setupLinkingPopup('savedSearch')}"/> 
                                             <!-- Edit Button -->
                                             <div class="btn-group" jsf:rendered="#{permissionsWrapper.canIssueUpdateDataverseCommand(DataversePage.dataverse)}">
                                                 <button type="button" class="btn btn-default btn-access dropdown-toggle" data-toggle="dropdown">
@@ -802,7 +802,6 @@
                         $('#featuredDataversesList .item').matchHeight();
                     }
                     function callOnError(){
-                        alert("in js");
                         window.scrollTo(0, 0);
                     }
                     function updateInclude() {
@@ -811,6 +810,7 @@
                     function scrollAfterUpdate() {
                         document.getElementById('metadataFieldOptionsPanel-Body').scrollTop = scrollPos;
                     }
+                    
                     function updateMetadata(checkbox) {
                         var checked = checkbox.checked;
                         if (checked === false){

--- a/src/main/webapp/dataverse.xhtml
+++ b/src/main/webapp/dataverse.xhtml
@@ -449,7 +449,7 @@
                                                         </p:commandLink>
                                                     </li>
                                                     <li class="#{SearchIncludeFragment.mode == 'search' ? '' : 'disabled'}">
-                                                        <p:commandLink onclick="linkSavedSearchCommand();"
+                                                        <p:commandLink action="#{DataversePage.setupLinkingPopup('savedSearch')}"
                                                                        oncomplete="PF('linkDataverseForm').show()"
                                                                        update=":linkDataverseForm">
                                                             #{bundle['dataverse.savedsearch.link']}
@@ -457,7 +457,6 @@
                                                     </li>
                                                 </ul>
                                             </div>
-                                            <p:remoteCommand name="linkSavedSearchCommand" action="#{DataversePage.setupLinkingPopup('savedSearch')}"/> 
                                             <!-- Edit Button -->
                                             <div class="btn-group" jsf:rendered="#{permissionsWrapper.canIssueUpdateDataverseCommand(DataversePage.dataverse)}">
                                                 <button type="button" class="btn btn-default btn-access dropdown-toggle" data-toggle="dropdown">
@@ -659,76 +658,15 @@
                 </p:dialog>
                 <!-- Link Dataverse Popup -->
                 <p:dialog id="linkDataverseForm" header="#{DataversePage.linkMode == 'SAVEDSEARCH' ? bundle['dataverse.savedsearch.link'] : bundle['dataverse.link']}" widgetVar="linkDataverseForm" modal="true">
-                    <h:form styleClass="form-horizontal" rendered="#{DataversePage.dataversesForLinking.size() > 1}">
-                        <p:focus for="dvNameSelect"/>
-                        <ui:fragment rendered="#{DataversePage.linkMode == 'LINKDATAVERSE'}">
-                            <p class="help-block">#{bundle['dataverse.link.dataverse.choose']}</p>
-                        </ui:fragment>
-                        <ui:fragment rendered="#{DataversePage.linkMode == 'SAVEDSEARCH'}">
-                            <p class="help-block">#{bundle['dataverse.savedsearch.dataverse.choose']}</p>
-                        </ui:fragment>
-                        <div class="form-group">
-                            <label class="col-sm-4 control-label">
-                                <h:outputFormat value="#{bundle['dataverse.link.yourDataverses']}">
-                                    <f:param value="#{DataversePage.dataversesForLinking.size()}"/>
-                                </h:outputFormat>
-                            </label>
-                            <div class="col-sm-7">
-                                <h:selectOneMenu id="dvNameSelect" styleClass="form-control" value="#{DataversePage.linkingDataverseId}">
-                                    <f:selectItems value="#{DataversePage.linkingDVSelectItems}" />
-                                </h:selectOneMenu>
-                                <ui:remove>
-                                <p:autoComplete id="dvName"
-                                                value="#{DataversePage.dataversesForLinking}"
-                                                queryDelay="1000"
-                                                var="u"
-                                                itemLabel="#{u.id}"
-                                                itemValue="#{u.id}">
-                                    <f:facet name="itemtip">
-                                        <div>
-                                            <strong>#{u.id}</strong><br/>
-                                            <em>#{u.affiliation}</em>
-                                        </div>
-                                    </f:facet>
-                                </p:autoComplete>
-                                </ui:remove>
-                            </div>
-                        </div>
-                        <ui:fragment rendered="#{DataversePage.linkMode == 'SAVEDSEARCH'}">
-                            <div class="form-group" jsf:rendered="#{!empty SearchIncludeFragment.query}">
-                                <label class="col-sm-4 control-label">
-                                     #{bundle['dataverse.savedsearch.searchquery']}
-                                </label>
-                                <div class="col-sm-7">
-                                    <p class="form-control-static">
-                                        #{SearchIncludeFragment.query}
-                                    </p>
-                                </div>
-                            </div>
-                            <div class="form-group" jsf:rendered="#{!empty SearchIncludeFragment.filterQueriesDebug}">
-                                <label class="col-sm-4 control-label">
-                                     #{bundle['dataverse.savedsearch.filterQueries']}
-                                </label>
-                                <div class="col-sm-7">
-                                    <ui:repeat value="#{SearchIncludeFragment.filterQueriesDebug}" var="fq">
-                                        <p class="form-control-static"><h:outputText value="#{fq}"/></p>
-                                    </ui:repeat>
-                                </div>
-                            </div>
-                        </ui:fragment>
-                        <div class="button-block">
-                            <p:commandButton styleClass="btn btn-default" value="#{bundle['dataverse.link.save']}" action="#{DataversePage.saveLinkedDataverse}"
-                                              rendered="#{DataversePage.linkMode == 'LINKDATAVERSE'}"/>
-                            <p:commandButton styleClass="btn btn-default" value="#{bundle['dataverse.savedsearch.save']}" action="#{DataversePage.saveSavedSearch}"
-                                             rendered="#{DataversePage.linkMode == 'SAVEDSEARCH'}"/>
-                            <button class="btn btn-link" onclick="PF('linkDataverseForm').hide();" type="button">                              
-                                #{bundle.cancel}
-                            </button>
-                        </div>
-                    </h:form>
-                    <ui:fragment rendered="#{DataversePage.dataversesForLinking.size() == 1}">
-                        <p class="help-block">#{bundle['dataverse.link.no.choice']}</p>
-                        <div class="form-horizontal">
+                    <h:form styleClass="form-horizontal"> 
+                        <ui:fragment rendered="#{DataversePage.dataversesForLinking.size() > 1}">
+                            <p:focus for="dvNameSelect"/>
+                            <ui:fragment rendered="#{DataversePage.linkMode == 'LINKDATAVERSE'}">
+                                <p class="help-block">#{bundle['dataverse.link.dataverse.choose']}</p>
+                            </ui:fragment>
+                            <ui:fragment rendered="#{DataversePage.linkMode == 'SAVEDSEARCH'}">
+                                <p class="help-block">#{bundle['dataverse.savedsearch.dataverse.choose']}</p>
+                            </ui:fragment>
                             <div class="form-group">
                                 <label class="col-sm-4 control-label">
                                     <h:outputFormat value="#{bundle['dataverse.link.yourDataverses']}">
@@ -736,27 +674,91 @@
                                     </h:outputFormat>
                                 </label>
                                 <div class="col-sm-7">
-                                    <p class="form-control-static">#{DataversePage.linkingDataverse.displayName}</p>
+                                    <h:selectOneMenu id="dvNameSelect" styleClass="form-control" value="#{DataversePage.linkingDataverseId}">
+                                        <f:selectItems value="#{DataversePage.linkingDVSelectItems}" />
+                                    </h:selectOneMenu>
+                                    <ui:remove>
+                                        <p:autoComplete id="dvName"
+                                                        value="#{DataversePage.dataversesForLinking}"
+                                                        queryDelay="1000"
+                                                        var="u"
+                                                        itemLabel="#{u.id}"
+                                                        itemValue="#{u.id}">
+                                            <f:facet name="itemtip">
+                                                <div>
+                                                    <strong>#{u.id}</strong><br/>
+                                                    <em>#{u.affiliation}</em>
+                                                </div>
+                                            </f:facet>
+                                        </p:autoComplete>
+                                    </ui:remove>
                                 </div>
                             </div>
-                        </div>
-                        <div class="button-block">
-                            <p:commandButton styleClass="btn btn-default" value="#{bundle['dataverse.link.save']}" onclick="PF('linkDataverseForm').hide()" actionListener="#{DataversePage.saveLinkedDataverse()}"/>
-                            <button class="btn btn-link" onclick="PF('linkDataverseForm').hide();" type="button">                              
+                            <ui:fragment rendered="#{DataversePage.linkMode == 'SAVEDSEARCH'}">
+                                <div class="form-group" jsf:rendered="#{!empty SearchIncludeFragment.query}">
+                                    <label class="col-sm-4 control-label">
+                                     #{bundle['dataverse.savedsearch.searchquery']}
+                                    </label>
+                                    <div class="col-sm-7">
+                                        <p class="form-control-static">
+                                        #{SearchIncludeFragment.query.toString()}
+                                        </p>
+                                    </div>
+                                </div>
+                                <div class="form-group" jsf:rendered="#{!empty SearchIncludeFragment.filterQueriesDebug}">
+                                    <label class="col-sm-4 control-label">
+                                     #{bundle['dataverse.savedsearch.filterQueries']}
+                                    </label>
+                                    <div class="col-sm-7">
+                                        <ui:repeat value="#{SearchIncludeFragment.filterQueriesDebug}" var="fq">
+                                            <p class="form-control-static"><h:outputText value="#{fq}"/></p>
+                                        </ui:repeat>
+                                    </div>
+                                </div>
+                            </ui:fragment>
+                            <div class="button-block">
+                                <p:commandButton styleClass="btn btn-default" value="#{bundle['dataverse.link.save']}" action="#{DataversePage.saveLinkedDataverse}"
+                                                 rendered="#{DataversePage.linkMode == 'LINKDATAVERSE'}"/>
+                            <p:commandButton styleClass="btn btn-default" value="#{bundle['dataverse.savedsearch.save']}" action="#{DataversePage.saveSavedSearch}"
+                                                 rendered="#{DataversePage.linkMode == 'SAVEDSEARCH'}"/>
+                                <button class="btn btn-link" onclick="PF('linkDataverseForm').hide();" type="button">                              
                                 #{bundle.cancel}
-                            </button>
-                        </div>
-                    </ui:fragment>
-                    <ui:fragment rendered="#{DataversePage.dataversesForLinking.size() == 0}">
-                        <p class="text-danger">
-                            <span class="glyphicon glyphicon-exclamation-sign"/> #{bundle['dataverse.link.no.linkable']}
-                        </p>
-                        <div class="button-block">
-                            <button class="btn btn-default" onclick="PF('linkDataverseForm').hide();" type="button">                              
+                                </button>
+                            </div>
+                        </ui:fragment>
+
+                        <ui:fragment rendered="#{DataversePage.dataversesForLinking.size() == 1}">
+                            <p class="help-block">#{bundle['dataverse.link.no.choice']}</p>
+                            <div class="form-horizontal">
+                                <div class="form-group">
+                                    <label class="col-sm-4 control-label">
+                                        <h:outputFormat value="#{bundle['dataverse.link.yourDataverses']}">
+                                            <f:param value="#{DataversePage.dataversesForLinking.size()}"/>
+                                        </h:outputFormat>
+                                    </label>
+                                    <div class="col-sm-7">
+                                        <p class="form-control-static">#{DataversePage.linkingDataverse.displayName}</p>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="button-block">
+                                <p:commandButton styleClass="btn btn-default" value="#{bundle['dataverse.link.save']}" onclick="PF('linkDataverseForm').hide()" actionListener="#{DataversePage.saveLinkedDataverse()}"/>
+                                <button class="btn btn-link" onclick="PF('linkDataverseForm').hide();" type="button">                              
+                                #{bundle.cancel}
+                                </button>
+                            </div>
+                        </ui:fragment>
+                        <ui:fragment rendered="#{DataversePage.dataversesForLinking.size() == 0}">
+                            <p class="text-danger">
+                                <span class="glyphicon glyphicon-exclamation-sign"/> #{bundle['dataverse.link.no.linkable']}
+                            </p>
+                            <div class="button-block">
+                                <button class="btn btn-default" onclick="PF('linkDataverseForm').hide();" type="button">                              
                                 #{bundle.close}
-                            </button>
-                        </div>
-                    </ui:fragment>
+                                </button>
+                            </div>
+                        </ui:fragment>
+                    </h:form>
                 </p:dialog>
                 <!-- Metadata Resest Modifications Popup -->
                 <p:dialog id="resetModifications" header="#{bundle['dataverse.resetModifications']}" widgetVar="resetModifications" modal="true" closable="false">

--- a/src/main/webapp/dataverse.xhtml
+++ b/src/main/webapp/dataverse.xhtml
@@ -435,7 +435,8 @@
                                                 </button>
                                             </ui:fragment>
                                             <!-- END: Publish Button -->
-                                            <div class="btn-group" jsf:rendered="#{dataverseSession.user.superuser and (SearchIncludeFragment.mode == 'search' or DataversePage.dataverse.owner != null)}">
+                                            <ui:fragment rendered="#{DataversePage.showLinkingPopup()}">
+                                            <div class="btn-group" >
                                                 <button type="button" class="btn btn-default btn-access dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
                                                     <span class="glyphicon glyphicon-link"/> #{bundle['link']} <span class="caret"></span>
                                                 </button>
@@ -444,19 +445,21 @@
                                                         <p:commandLink action="#{DataversePage.setupLinkingPopup('link')}"
                                                                        oncomplete="PF('linkDataverseForm').show()"
                                                                        update=":linkDataverseForm"
-                                                                       disabled="#{DataversePage.dataverse.owner == null}">
+                                                                       >
                                                             #{bundle['dataverse.link']}
                                                         </p:commandLink>
                                                     </li>
                                                     <li class="#{SearchIncludeFragment.mode == 'search' ? '' : 'disabled'}">
                                                         <p:commandLink action="#{DataversePage.setupLinkingPopup('savedSearch')}"
                                                                        oncomplete="PF('linkDataverseForm').show()"
-                                                                       update=":linkDataverseForm">
+                                                                       update=":linkDataverseForm"
+                                                                       >
                                                             #{bundle['dataverse.savedsearch.link']}
                                                         </p:commandLink>
                                                     </li>
                                                 </ul>
                                             </div>
+                                            </ui:fragment>
                                             <!-- Edit Button -->
                                             <div class="btn-group" jsf:rendered="#{permissionsWrapper.canIssueUpdateDataverseCommand(DataversePage.dataverse)}">
                                                 <button type="button" class="btn btn-default btn-access dropdown-toggle" data-toggle="dropdown">
@@ -648,6 +651,7 @@
                 <!-- END Search/Browse Facets Panel -->
                 <!-- POPUPS -->
                 <p:dialog id="shareDialog" header="#{bundle['dataverse.share.dataverseShare']}" widgetVar="shareDialog" modal="true">
+                    <h:form styleClass="form-horizontal"> 
                     <p class="help-block">#{bundle['dataverse.share.dataverseShare.tip']}</p>
                     <div id="sharrre-widget" data-url="#{systemConfig.dataverseSiteUrl}/dataverse/#{DataversePage.dataverse.alias}" data-text="#{bundle['dataverse.share.dataverseShare.shareText']}"></div>
                     <div class="button-block">
@@ -655,6 +659,7 @@
                             #{bundle.close}
                         </button>
                     </div>
+                    </h:form>
                 </p:dialog>
                 <!-- Link Dataverse Popup -->
                 <p:dialog id="linkDataverseForm" header="#{DataversePage.linkMode == 'SAVEDSEARCH' ? bundle['dataverse.savedsearch.link'] : bundle['dataverse.link']}" widgetVar="linkDataverseForm" modal="true">
@@ -762,6 +767,7 @@
                 </p:dialog>
                 <!-- Metadata Resest Modifications Popup -->
                 <p:dialog id="resetModifications" header="#{bundle['dataverse.resetModifications']}" widgetVar="resetModifications" modal="true" closable="false">
+                    <h:form styleClass="form-horizontal">
                     <p class="text-warning">
                         <span class="glyphicon glyphicon-warning-sign"/> #{bundle['dataverse.resetModifications.text']}
                     </p>
@@ -771,6 +777,7 @@
                             #{bundle.cancel}
                         </button>
                     </div>
+                    </h:form>
                 </p:dialog>
                 <script>
                     //<![CDATA[


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a bug in the Link Search workflow that will allow super users to link searches to dataverses.

**Which issue(s) this PR closes**:

Closes #6268 

**Special notes for your reviewer**:
In fixing the main issue (the display of a list of dataverses in the Link Search popup) I discovered that the saveSearch was broken as well. The fix for that involved getting the search parameters copied from the SearchIncludeFragment to the DataversePage. I left in a seeming inconsistency in which unpublished datasets are not linked but unpublished dataverses are. This might be worth further discussion and/or additional changes.
**Suggestions on how to test this**:
This is a superuser only feature.
**Does this PR introduce a user interface change?**:
no
**Is there a release notes update needed for this change?**:
no. unless we want to highlight it as one of the bug fixes

**Additional documentation**:
none