### PR TITLE
6443 ingest oncomplete refresh

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
@@ -2695,7 +2695,11 @@ public class DatasetPage implements java.io.Serializable {
             //as well as the ingest success message
             //SEK 12/20/2019 - since we are ingesting a file we know that there is a current draft version
             lockedDueToIngestVar = null;
-            return "/dataset.xhtml?persistentId=" + dataset.getGlobalIdString() + "&showIngestSuccess=true&version=DRAFT&faces-redirect=true";
+            if (canViewUnpublishedDataset()) {
+                return "/dataset.xhtml?persistentId=" + dataset.getGlobalIdString() + "&showIngestSuccess=true&version=DRAFT&faces-redirect=true";
+            } else {
+                return "/dataset.xhtml?persistentId=" + dataset.getGlobalIdString() + "&showIngestSuccess=true&faces-redirect=true";
+            }
         }
 
         return "";

--- a/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
@@ -2693,8 +2693,9 @@ public class DatasetPage implements java.io.Serializable {
         if (lockedDueToIngestVar != null && lockedDueToIngestVar) {
             //we need to add a redirect here to disply the explore buttons as needed
             //as well as the ingest success message
+            //SEK 12/20/2019 - since we are ingesting a file we know that there is a current draft version
             lockedDueToIngestVar = null;
-            return "/dataset.xhtml?persistentId=" + dataset.getGlobalIdString() + "&showIngestSuccess=true&faces-redirect=true";
+            return "/dataset.xhtml?persistentId=" + dataset.getGlobalIdString() + "&showIngestSuccess=true&version=DRAFT&faces-redirect=true";
         }
 
         return "";


### PR DESCRIPTION
**What this PR does / why we need it**:
We need this so that on the completion of a file ingest the dataset owner is not redirected to the last published version of a dataset instead of the current draft which is where the freshly ingested file resides.

**Which issue(s) this PR closes**:

Closes #6443 

**Special notes for your reviewer**:
none
**Suggestions on how to test this**:
if the user does not have view draft permission on the dataset she will be redirected to the last published version
**Does this PR introduce a user interface change?**:
no
**Is there a release notes update needed for this change?**:
no
**Additional documentation**:
none