### PR TITLE
keep integration (4 widgets) working with Drupal 8 version (under development) of OpenScholar #6381

### DIFF
--- a/doc/sphinx-guides/source/admin/integrations.rst
+++ b/doc/sphinx-guides/source/admin/integrations.rst
@@ -41,6 +41,17 @@ As of this writing only OJS 2.x is supported and instructions for getting starte
 
 If you are interested in OJS 3.x supporting deposit from Dataverse, please leave a comment on https://github.com/pkp/pkp-lib/issues/1822
 
+Embedding Data on Websites
+--------------------------
+
+OpenScholar
++++++++++++
+
+`OpenScholar <https://theopenscholar.com>`_ is oriented toward hosting websites for academic institutions and offers `Dataverse Widgets <https://help.theopenscholar.com/dataverse>`_ that can be added to web pages. See also:
+
+- :ref:`openscholar-dataverse-level` (dataverse level)
+- :ref:`openscholar-dataset-level` (dataset level)
+
 Analysis and Computation
 ------------------------
 

--- a/doc/sphinx-guides/source/api/apps.rst
+++ b/doc/sphinx-guides/source/api/apps.rst
@@ -129,3 +129,10 @@ OJS
 The Open Journal Systems (OJS) Dataverse Plugin adds data sharing and preservation to the OJS publication process.
 
 https://github.com/pkp/ojs/tree/ojs-stable-2_4_8/plugins/generic/dataverse
+
+OpenScholar
+~~~~~~~~~~~
+
+The Dataverse module from OpenScholar allows Dataverse widgets to be easily embedded in its web pages:
+
+https://github.com/openscholar/openscholar/tree/SCHOLAR-3.x/openscholar/modules/os_features/os_dataverse

--- a/doc/sphinx-guides/source/user/dataset-management.rst
+++ b/doc/sphinx-guides/source/user/dataset-management.rst
@@ -421,6 +421,8 @@ Dataset Citation Widget
 
 The Dataset Citation Widget will provide a citation for your dataset on your personal or project website. Users can download the citation in various formats by using the Cite Data button. The persistent URL in the citation will direct users to the dataset in your dataverse.
 
+.. _openscholar-dataset-level:
+
 Adding Widgets to an OpenScholar Website
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/sphinx-guides/source/user/dataverse-management.rst
+++ b/doc/sphinx-guides/source/user/dataverse-management.rst
@@ -89,6 +89,8 @@ Dataverse Listing Widget
 
 The Dataverse Listing Widget provides a listing of all your dataverses and datasets for users to browse, sort, filter and search. When someone clicks on a dataverse or dataset in the widget, it displays the content in the widget on your website. They can download data files directly from the datasets within the widget. If a file is restricted, they will be directed to your dataverse to log in, instead of logging in through the widget on your website.
 
+.. _openscholar-dataverse-level:
+
 Adding Widgets to an OpenScholar Website
 ******************************************
 #. Log in to your OpenScholar website

--- a/src/main/webapp/resources/js/widgets.js
+++ b/src/main/webapp/resources/js/widgets.js
@@ -25,6 +25,8 @@ function parseQueryString(queryString) {
         for (var i=0; i < keyValues.length; i++) {
             var pair = keyValues[i].split('=');
             params[pair[0]] = pair[1].replace(pl, " ");
+            // OpenScholar is encoding ":" as "%3A". See https://github.com/IQSS/dataverse/issues/6381
+            params[pair[0]] = pair[1].replace("%3A", ":");
         }
     }
     return params;


### PR DESCRIPTION
**What this PR does / why we need it**:

OpenScholar is upgrading to Drupal 8 and some of the Dataverse widgets aren't working. Maybe all.

**Which issue(s) this PR closes**:

Closes #6381

**Special notes for your reviewer**:

This is the tiniest fix I could make to fix a simple non-OpenScholar test I tried with these two variations:

## original

`<script src="http://localhost:8080/resources/js/widgets.js?persistentId=doi:10.5072/FK2/6YRLFR&amp;dvUrl=http://localhost:8080&amp;widget=iframe&amp;heightPx=500"</script>`

## encoded colons

`<script src="http://localhost:8080/resources/js/widgets.js?persistentId=doi%3A10.5072/FK2/6YRLFR&amp;dvUrl=http%3A//localhost:8080&amp;widget=iframe&amp;heightPx=500"</script>`

**Suggestions on how to test this**:

- Deploy this branch to a server
- Contact OpenScholar and ask them to point a test server at your Dataverse deployment

**Does this PR introduce a user interface change?**:

No. In fact, I didn't touch the Dataverse UI where people can copy with widgets from. The old URL with a colon (:) still seemed to work  from my simply test.

**Is there a release notes update needed for this change?**:

Maybe something like "If you are running OpenScholar future version whatever, Dataverse widgets do not work. You must be running this version of Dataverse or newer."

**Additional documentation**:

With no changes to Dataverse, I was getting this error with the "encoded colons" version above:

![Screen Shot 2020-01-06 at 3 59 45 PM](https://user-images.githubusercontent.com/21006/71848546-bc937300-309d-11ea-9a03-623c9a494dda.png)

With this pull request, it seems to work, at least for this widget:

![Screen Shot 2020-01-06 at 4 00 00 PM](https://user-images.githubusercontent.com/21006/71848547-bc937300-309d-11ea-8ee1-f1f1022f073f.png)
