### PR TITLE
#6499 change log level to warning for log message issued in exception…

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DataverseServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DataverseServiceBean.java
@@ -199,12 +199,12 @@ public class DataverseServiceBean implements java.io.Serializable {
     public Dataverse findByAlias(String anAlias) {
         try {
             return (anAlias.toLowerCase().equals(":root"))
-				? findRootDataverse()
-				: em.createNamedQuery("Dataverse.findByAlias", Dataverse.class)
-					.setParameter("alias", anAlias.toLowerCase())
-					.getSingleResult();
+              ? findRootDataverse()
+              : em.createNamedQuery("Dataverse.findByAlias", Dataverse.class)
+                  .setParameter("alias", anAlias.toLowerCase())
+                  .getSingleResult();
         } catch ( NoResultException|NonUniqueResultException ex ) {
-            logger.fine("Unable to find a single dataverse using alias \"" + anAlias + "\": " + ex);
+            logger.warning("Unable to find a single dataverse using alias \"" + anAlias + "\": " + ex);
             return null;
         }
     }


### PR DESCRIPTION
… handling at DataverseServiceBean.findByAlias()

**What this PR does / why we need it**: This pull request makes error message generated by DataverseServiceBean.findByAlias() separated in the log from FINE messages.

**Which issue(s) this PR closes**: #6499 Change logging level from fine to warn for exceptions

**Is there a release notes update needed for this change?**: Improve logging