### PR TITLE
#6504 fix lock refresh

### DIFF
--- a/src/main/webapp/dataset.xhtml
+++ b/src/main/webapp/dataset.xhtml
@@ -628,6 +628,50 @@
                             <p:remoteCommand name="refreshAllCommand" process="@this" update=":datasetForm:topDatasetBlockFragment,:datasetForm:tabView:filesTable,:messagePanel" action="#{DatasetPage.refresh()}"/>
                             <!-- see the comment in the javascript below that explains what this button is for -->
                             <p:commandButton id="refreshButton" process="@this" widgetVar="refreshButton" update=":datasetForm:topDatasetBlockFragment,:datasetForm:tabView:filesTable" style="display:none"/>
+                            <script>
+                                
+                                // javascript for refreshing page when locks
+                                $(this).ready(function () {
+                                    refreshIfStillLocked();
+                                });
+                                function refreshIfStillLocked() {
+                                    if ($('input[id$="datasetLockedForAnyReasonVariable"]').val() === 'true') {
+                                        // if dataset is locked, instruct the page to
+                                        // wait and check again:
+                                        waitAndCheckLockAgain();
+                                    } else {
+                                        // if not locked, has it just been unlocked?
+                                        if ($('input[id$="datasetStateChangedVariable"]').val() === 'true') {
+                                            // For whatever unknown PrimeFaces reason
+                                            // the page needs to be refreshed twice, for all
+                                            // the pull down menus to update properly:
+                                            refreshAllCommand();
+                                            // You can't just run 2 refreshAllCommand()s in a row
+                                            // either; because the command has an "update=@all" on it,
+                                            // so I guess if you try to execute the 2nd one right after
+                                            // the first one, this fragment is still going to be loading -
+                                            // so there would not yet be a command to run! (it needs to
+                                            // be rendered, before you can execute it, that is)
+                                            setTimeout(function () {
+                                                // this button doesn't do anything, but it has an update="@all"
+                                                // attribute:
+                                                $('button[id$="refreshButton"]').trigger('click');
+                                                //refreshAllCommand();
+                                            }, 1500);
+                                        }
+                                    }
+                                }
+                                function waitAndCheckLockAgain() {
+                                    setTimeout(function () {
+                                        // refresh the lock in the
+                                        // backing bean; i.e., check, if the ingest has
+                                        // already completed in the background:
+                                        //$('button[id$="refreshButton"]').trigger('click');
+                                        //refreshLockCommand();
+                                        refreshAllLocksCommand();
+                                    }, 10000);
+                                }
+                            </script>
                         </p:fragment>
                         <ui:fragment id="uploadFilesOnCreateTab" rendered="#{!DatasetPage.workingVersion.deaccessioned and (DatasetPage.editMode == 'CREATE')}">
                             <ui:include src="editFilesFragment.xhtml">
@@ -1672,47 +1716,6 @@
                         $('button[id$="updateOwnerDataverse"]').trigger('click');
                     }
 
-                    // javascript for refreshing page when locks
-                    $(this).ready(function () {
-                        refreshIfStillLocked();
-                    });
-                    function refreshIfStillLocked() {
-                        if ($('input[id$="datasetLockedForAnyReasonVariable"]').val() === 'true') {
-                            // if dataset is locked, instruct the page to
-                            // wait and check again:
-                            waitAndCheckLockAgain();
-                        } else {
-                            // if not locked, has it just been unlocked?
-                            if ($('input[id$="datasetStateChangedVariable"]').val() === 'true') {
-                                // For whatever unknown PrimeFaces reason
-                                // the page needs to be refreshed twice, for all
-                                // the pull down menus to update properly:
-                                refreshAllCommand();
-                                // You can't just run 2 refreshAllCommand()s in a row
-                                // either; because the command has an "update=@all" on it,
-                                // so I guess if you try to execute the 2nd one right after
-                                // the first one, this fragment is still going to be loading -
-                                // so there would not yet be a command to run! (it needs to
-                                // be rendered, before you can execute it, that is)
-                                setTimeout(function () {
-                                    // this button doesn't do anything, but it has an update="@all"
-                                    // attribute:
-                                    $('button[id$="refreshButton"]').trigger('click');
-                                    //refreshAllCommand();
-                                }, 1500);
-                            }
-                        }
-                    }
-                    function waitAndCheckLockAgain() {
-                        setTimeout(function () {
-                            // refresh the lock in the
-                            // backing bean; i.e., check, if the ingest has
-                            // already completed in the background:
-                            //$('button[id$="refreshButton"]').trigger('click');
-                            //refreshLockCommand();
-                            refreshAllLocksCommand();
-                        }, 10000);
-                    }
                     //]]>
                 </script>
 

--- a/src/main/webapp/dataset.xhtml
+++ b/src/main/webapp/dataset.xhtml
@@ -629,7 +629,7 @@
                             <!-- see the comment in the javascript below that explains what this button is for -->
                             <p:commandButton id="refreshButton" process="@this" widgetVar="refreshButton" update=":datasetForm:topDatasetBlockFragment,:datasetForm:tabView:filesTable" style="display:none"/>
                             <script>
-                                
+                            //<![CDATA[    
                                 // javascript for refreshing page when locks
                                 $(this).ready(function () {
                                     refreshIfStillLocked();
@@ -671,6 +671,7 @@
                                         refreshAllLocksCommand();
                                     }, 10000);
                                 }
+                            //]]>
                             </script>
                         </p:fragment>
                         <ui:fragment id="uploadFilesOnCreateTab" rendered="#{!DatasetPage.workingVersion.deaccessioned and (DatasetPage.editMode == 'CREATE')}">


### PR DESCRIPTION
**What this PR does / why we need it**:
fixes lock refresh on dataset page

**Which issue(s) this PR closes**:

Closes #6504 

**Special notes for your reviewer**:
none

**Suggestions on how to test this**:
Verify that locks are removed automatically (without manually refreshing the dataset page)  when an ingest is successful or a ds in review changes status, etc.

**Does this PR introduce a user interface change?**:
no

**Is there a release notes update needed for this change?**:
no
**Additional documentation**:
none