### PR TITLE
expose dataset ID and DOI/Handle in version response #6397

### DIFF
--- a/doc/sphinx-guides/source/api/native-api.rst
+++ b/doc/sphinx-guides/source/api/native-api.rst
@@ -429,7 +429,7 @@ List Versions of a Dataset
 Get Version of a Dataset
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-|CORS| Show a version of the dataset. The Dataset also include any metadata blocks the data might have::
+|CORS| Show a version of the dataset. The output includes any metadata blocks the dataset might have::
 
   GET http://$SERVER/api/datasets/$id/versions/$versionNumber?key=$apiKey
 

--- a/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
@@ -310,6 +310,8 @@ public class JsonPrinter {
     public static JsonObjectBuilder json(DatasetVersion dsv) {
         JsonObjectBuilder bld = jsonObjectBuilder()
                 .add("id", dsv.getId())
+                .add("datasetId", dsv.getDataset().getId())
+                .add("datasetPid", dsv.getDataset().getGlobalId().asString())
                 .add("storageIdentifier", dsv.getDataset().getStorageIdentifier())
                 .add("versionNumber", dsv.getVersionNumber())
                 .add("versionMinorNumber", dsv.getMinorVersionNumber())

--- a/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
@@ -311,7 +311,7 @@ public class JsonPrinter {
         JsonObjectBuilder bld = jsonObjectBuilder()
                 .add("id", dsv.getId())
                 .add("datasetId", dsv.getDataset().getId())
-                .add("datasetPid", dsv.getDataset().getGlobalId().asString())
+                .add("datasetPersistentId", dsv.getDataset().getGlobalId().asString())
                 .add("storageIdentifier", dsv.getDataset().getStorageIdentifier())
                 .add("versionNumber", dsv.getVersionNumber())
                 .add("versionMinorNumber", dsv.getMinorVersionNumber())

--- a/src/test/java/edu/harvard/iq/dataverse/api/DatasetsIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/DatasetsIT.java
@@ -410,7 +410,7 @@ public class DatasetsIT {
         getDatasetVersion.prettyPrint();
         getDatasetVersion.then().assertThat()
                 .body("data.datasetId", equalTo(datasetId))
-                .body("data.datasetPid", equalTo(datasetPersistentId))
+                .body("data.datasetPersistentId", equalTo(datasetPersistentId))
                 .statusCode(OK.getStatusCode());
 
         Response citationBlock = UtilIT.getMetadataBlockFromDatasetVersion(datasetPersistentId, null, null, apiToken);

--- a/src/test/java/edu/harvard/iq/dataverse/api/DatasetsIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/DatasetsIT.java
@@ -406,6 +406,13 @@ public class DatasetsIT {
         assertTrue(datasetContactFromExport.toString().contains("finch@mailinator.com"));
         assertTrue(firstValue.toString().contains("finch@mailinator.com"));
 
+        Response getDatasetVersion = UtilIT.getDatasetVersion(datasetPersistentId, ":latest-published", apiToken);
+        getDatasetVersion.prettyPrint();
+        getDatasetVersion.then().assertThat()
+                .body("data.datasetId", equalTo(datasetId))
+                .body("data.datasetPid", equalTo(datasetPersistentId))
+                .statusCode(OK.getStatusCode());
+
         Response citationBlock = UtilIT.getMetadataBlockFromDatasetVersion(datasetPersistentId, null, null, apiToken);
         citationBlock.prettyPrint();
         citationBlock.then().assertThat()

--- a/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
@@ -1037,6 +1037,12 @@ public class UtilIT {
         return response;
     }
 
+    static Response getDatasetVersion(String persistentId, String versionNumber, String apiToken) {
+        return given()
+                .header(API_TOKEN_HTTP_HEADER, apiToken)
+                .get("/api/datasets/:persistentId/versions/" + versionNumber + "?persistentId=" + persistentId);
+    }
+
     static Response getMetadataBlockFromDatasetVersion(String persistentId, String versionNumber, String metadataBlock, String apiToken) {
         return given()
                 .header(API_TOKEN_HTTP_HEADER, apiToken)


### PR DESCRIPTION
**What this PR does / why we need it**:

Requested by an API user.

**Which issue(s) this PR closes**:

Closes #6397

**Special notes for your reviewer**:

None

**Suggestions on how to test this**:

Follow the curl example in the part of the Native API page I touched ("Get Version of a Dataset") and look for the following fields:

- datasetId
- datasetPid

**Does this PR introduce a user interface change?**:

No

**Is there a release notes update needed for this change?**:

It's a judgement call. This is a pretty minor change.

**Additional documentation**:

None.