### PR TITLE
only show email portion system email via Harvesting #3619

### DIFF
--- a/doc/sphinx-guides/source/admin/harvestserver.rst
+++ b/doc/sphinx-guides/source/admin/harvestserver.rst
@@ -22,6 +22,8 @@ You might consider adding your OAI-enabled production instance of Dataverse to
 `this shared list <https://docs.google.com/spreadsheets/d/12cxymvXCqP_kCsLKXQD32go79HBWZ1vU_tdG4kvP5S8/>`_
 of such instances.
 
+The email portion of :ref:`systemEmail` will be visible via OAI-PMH (from the "Identify" verb).
+
 How does it work? 
 -----------------
 

--- a/src/main/java/edu/harvard/iq/dataverse/harvest/server/web/servlet/OAIServlet.java
+++ b/src/main/java/edu/harvard/iq/dataverse/harvest/server/web/servlet/OAIServlet.java
@@ -38,6 +38,7 @@ import edu.harvard.iq.dataverse.harvest.server.xoai.XitemRepository;
 import edu.harvard.iq.dataverse.harvest.server.xoai.XsetRepository;
 import edu.harvard.iq.dataverse.harvest.server.xoai.XlistRecords;
 import edu.harvard.iq.dataverse.settings.SettingsServiceBean;
+import edu.harvard.iq.dataverse.util.MailUtil;
 import edu.harvard.iq.dataverse.util.SystemConfig;
 import org.apache.commons.lang.StringUtils;
 
@@ -184,7 +185,7 @@ public class OAIServlet extends HttpServlet {
                 .withBaseUrl(systemConfig.getDataverseSiteUrl()+"/oai")
                 .withCompression("gzip")        // ?
                 .withCompression("deflate")     // ?
-                .withAdminEmail(settingsService.getValueForKey(SettingsServiceBean.Key.SystemEmail))
+                .withAdminEmail(MailUtil.parseSystemAddress(settingsService.getValueForKey(SettingsServiceBean.Key.SystemEmail)).getAddress())
                 .withDeleteMethod(DeletedRecord.TRANSIENT)
                 .withGranularity(Granularity.Second)
                 .withMaxListIdentifiers(100)


### PR DESCRIPTION
**What this PR does / why we need it**:

Avoids OAI-PMH validation errors like this:

![65978606-fff89880-e441-11e9-9f58-5f19382163da](https://user-images.githubusercontent.com/21006/72292707-ead5fd00-361f-11ea-8279-3405fc1365a0.png)

In my local testing, before making this pull request, I was seeing output like this...

`<adminEmail>Support2 &lt;support2@example.edu&gt;</adminEmail>`

... from http://localhost:8080/oai?verb=Identify

**Which issue(s) this PR closes**:

Closes #3619

**Special notes for your reviewer**:

**Suggestions on how to test this**:

If you do something like this...

curl -X PUT -d "Support2 <support2@example.edu>" http://localhost:8080/api/admin/settings/:SystemEmail

... and then stop and start Glassfish (required to see the change, apparently) and then look for "adminEmail in the output of http://localhost:8080/oai?verb=Identify (or equivalent for your server) you should only see the email portion (support2@example.edu) of :SystemEmail, without the "personal name" (Support2).

To test if Dataverse validates in terms of OAI-PMH, I'd suggest using http://oval.base-search.net where the screenshot above comes from.

**Does this PR introduce a user interface change?**:

No.

**Is there a release notes update needed for this change?**:

Probably not worth it.

**Additional documentation**:

I put a line in the guides, the section on setting up a harvesting server.