### PR TITLE
#6525 update weld-osgi call to match that of docker-aio et al.

### DIFF
--- a/conf/docker-aio/0prep_deps.sh
+++ b/conf/docker-aio/0prep_deps.sh
@@ -8,7 +8,7 @@ if [ ! -e dv/deps/glassfish4dv.tgz ]; then
 	mkdir -p /tmp/dv-prep/gf
 	cd /tmp/dv-prep/gf
 	wget http://download.java.net/glassfish/4.1/release/glassfish-4.1.zip
-	wget http://search.maven.org/remotecontent?filepath=org/jboss/weld/weld-osgi-bundle/2.2.10.Final/weld-osgi-bundle-2.2.10.Final-glassfish4.jar -O weld-osgi-bundle-2.2.10.Final-glassfish4.jar
+	wget https://search.maven.org/remotecontent?filepath=org/jboss/weld/weld-osgi-bundle/2.2.10.Final/weld-osgi-bundle-2.2.10.Final-glassfish4.jar -O weld-osgi-bundle-2.2.10.Final-glassfish4.jar
 	unzip glassfish-4.1.zip
 	rm glassfish4/glassfish/modules/weld-osgi-bundle.jar
 	mv weld-osgi-bundle-2.2.10.Final-glassfish4.jar glassfish4/glassfish/modules

--- a/doc/sphinx-guides/source/installation/prerequisites.rst
+++ b/doc/sphinx-guides/source/installation/prerequisites.rst
@@ -76,7 +76,7 @@ Once Glassfish is installed, you'll need a newer version of the Weld library (v2
 
 	# cd /usr/local/glassfish4/glassfish/modules
 	# rm weld-osgi-bundle.jar
-	# wget http://central.maven.org/maven2/org/jboss/weld/weld-osgi-bundle/2.2.10.SP1/weld-osgi-bundle-2.2.10.SP1-glassfish4.jar
+	# curl -L -O http://search.maven.org/remotecontent?filepath=org/jboss/weld/weld-osgi-bundle/2.2.10.Final/weld-osgi-bundle-2.2.10.Final-glassfish4.jar
 
 - Change from ``-client`` to ``-server`` under ``<jvm-options>-client</jvm-options>``::
 

--- a/doc/sphinx-guides/source/installation/prerequisites.rst
+++ b/doc/sphinx-guides/source/installation/prerequisites.rst
@@ -76,7 +76,7 @@ Once Glassfish is installed, you'll need a newer version of the Weld library (v2
 
 	# cd /usr/local/glassfish4/glassfish/modules
 	# rm weld-osgi-bundle.jar
-	# curl -L -O http://search.maven.org/remotecontent?filepath=org/jboss/weld/weld-osgi-bundle/2.2.10.Final/weld-osgi-bundle-2.2.10.Final-glassfish4.jar
+	# curl -L -O https://search.maven.org/remotecontent?filepath=org/jboss/weld/weld-osgi-bundle/2.2.10.Final/weld-osgi-bundle-2.2.10.Final-glassfish4.jar
 
 - Change from ``-client`` to ``-server`` under ``<jvm-options>-client</jvm-options>``::
 

--- a/downloads/download.sh
+++ b/downloads/download.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 curl -L -O http://download.java.net/glassfish/4.1/release/glassfish-4.1.zip
 curl -L -O https://archive.apache.org/dist/lucene/solr/7.3.1/solr-7.3.1.tgz
-curl -L -O http://search.maven.org/remotecontent?filepath=org/jboss/weld/weld-osgi-bundle/2.2.10.Final/weld-osgi-bundle-2.2.10.Final-glassfish4.jar
+curl -L -O https://search.maven.org/remotecontent?filepath=org/jboss/weld/weld-osgi-bundle/2.2.10.Final/weld-osgi-bundle-2.2.10.Final-glassfish4.jar
 curl -s -L http://sourceforge.net/projects/schemaspy/files/schemaspy/SchemaSpy%205.0.0/schemaSpy_5.0.0.jar/download > schemaSpy_5.0.0.jar


### PR DESCRIPTION
**What this PR does / why we need it**: current weld-osgi link in installation documentation is broken

**Which issue(s) this PR closes**:

Closes #6525 

**Special notes for your reviewer**: bumping from SP1 to Final, but all other such calls in docs use Final

**Suggestions on how to test this**: spin up branch and test normally

**Does this PR introduce a user interface change?**: no

**Is there a release notes update needed for this change?**: no

**Additional documentation**:
