### PR TITLE
Enhancing the Solr schema update script. See #6529

### DIFF
--- a/conf/solr/7.3.1/updateSchemaMDB.sh
+++ b/conf/solr/7.3.1/updateSchemaMDB.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -euo pipefail
 
 # This script updates the <field> and <copyField> schema configuration necessary to properly
@@ -60,6 +60,12 @@ fi
 echo "Retrieve schema data from ${DATAVERSE_URL}/api/admin/index/solr/schema"
 TMPFILE=`mktemp`
 curl -f -sS "${DATAVERSE_URL}/api/admin/index/solr/schema${UNBLOCK_KEY}" > $TMPFILE
+
+### Fail gracefull if Dataverse is not ready yet.
+if [[ "`wc -l ${TMPFILE}`" < "3" ]]; then
+  echo "Dataverse responded with empty file. Did you bootstrap yet?"
+  exit 123
+fi
 
 ### Processing
 echo "Writing ${TARGET}/schema_dv_mdb_fields.xml"

--- a/conf/solr/7.3.1/updateSchemaMDB.sh
+++ b/conf/solr/7.3.1/updateSchemaMDB.sh
@@ -63,7 +63,7 @@ curl -f -sS "${DATAVERSE_URL}/api/admin/index/solr/schema${UNBLOCK_KEY}" > $TMPF
 
 ### Fail gracefull if Dataverse is not ready yet.
 if [[ "`wc -l ${TMPFILE}`" < "3" ]]; then
-  echo "Dataverse responded with empty file. Did you bootstrap yet?"
+  echo "Dataverse responded with empty file. When running on K8s: did you bootstrap yet?"
   exit 123
 fi
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Enhances the ``updateSchemaMDB.sh`` to safeguard the processing when downloading from a non-bootstrapped Dataverse installation.

**Which issue(s) this PR closes**:

Closes #6529 

**Special notes for your reviewer**:
n/a

**Suggestions on how to test this**:
n/a (see [Cloud & Container Guide](https://dataverse-k8s.readthedocs.io/en/latest/day2/job-index.html#update-solr-schema-with-custom-metadata-fields) for live action)

**Does this PR introduce a user interface change?**:
No.

**Is there a release notes update needed for this change?**:
IMHO it's to small. If @djbrooke votes to have one, sure.

**Additional documentation**:
n/a