### PR TITLE
#6528 s/http/https/g

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <repository>
             <id>central-repo</id>
             <name>Central Repository</name>
-            <url>http://repo1.maven.org/maven2</url>
+            <url>https://repo1.maven.org/maven2</url>
             <layout>default</layout>
         </repository>
         <repository>


### PR DESCRIPTION
**What this PR does / why we need it**: http://repo1.maven.org/maven2 returns a 501

**Which issue(s) this PR closes**: 6528

Closes #6528 

**Special notes for your reviewer**: corrects maven central-repo URL

**Suggestions on how to test this**: mvn -DcompilerArgument=-Xlint:unchecked test -P all-unit-tests package

**Does this PR introduce a user interface change?**: no

**Is there a release notes update needed for this change?**: no

**Additional documentation**:
