### PR TITLE
avoid null pointer when getting email for OAI-PMH #3619

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/harvest/server/web/servlet/OAIServlet.java
+++ b/src/main/java/edu/harvard/iq/dataverse/harvest/server/web/servlet/OAIServlet.java
@@ -54,6 +54,7 @@ import java.util.logging.Logger;
 import java.util.zip.DeflaterOutputStream;
 import java.util.zip.GZIPOutputStream;
 import javax.ejb.EJB;
+import javax.mail.internet.InternetAddress;
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
@@ -178,14 +179,14 @@ public class OAIServlet extends HttpServlet {
         
         String dataverseName = dataverseService.findRootDataverse().getName();
         String repositoryName = StringUtils.isEmpty(dataverseName) || "Root".equals(dataverseName) ? "Test Dataverse OAI Archive" : dataverseName + " Dataverse OAI Archive";
-        
+        InternetAddress internetAddress = MailUtil.parseSystemAddress(settingsService.getValueForKey(SettingsServiceBean.Key.SystemEmail));
 
         RepositoryConfiguration repositoryConfiguration = new RepositoryConfiguration()
                 .withRepositoryName(repositoryName)
                 .withBaseUrl(systemConfig.getDataverseSiteUrl()+"/oai")
                 .withCompression("gzip")        // ?
                 .withCompression("deflate")     // ?
-                .withAdminEmail(MailUtil.parseSystemAddress(settingsService.getValueForKey(SettingsServiceBean.Key.SystemEmail)).getAddress())
+                .withAdminEmail(internetAddress != null ? internetAddress.getAddress() : null)
                 .withDeleteMethod(DeletedRecord.TRANSIENT)
                 .withGranularity(Granularity.Second)
                 .withMaxListIdentifiers(100)


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request is a follow up to pull request #6513 where I accidentally introduced the chance of 500 errors being thrown at URLs such as http://phoenix.dataverse.org/oai?verb=Indentify when the system email address has not been configured:

![Screen Shot 2020-01-17 at 9 45 40 AM](https://user-images.githubusercontent.com/21006/72620909-38978180-390e-11ea-939a-ffdd799a51b2.png)

**Which issue(s) this PR closes**:

Closes #3619 (re-closes)

**Special notes for your reviewer**:

None.

**Suggestions on how to test this**:

Configure Dataverse with and without a system email, stopping and starting Glassfish in between each configuration change. For both cases, go to a URL such as http://phoenix.dataverse.org/oai?verb=Indentify and make sure a 500 error is not thrown.

When the system email is not configured, you should see something like `<adminEmail/>` (I checked that this is how it works in 4.18.1 so it's the same.).

When the system email is configured, only the email address should be shown like this: `<adminEmail>noreply@dataverse.yourinstitution.edu</adminEmail>`. As with the the original change in #6513 in order to help OAI-PMH validate, we should never see the "personal" part like `<adminEmail>Dataverse Support <noreply@dataverse.yourinstitution.edu></adminEmail>.

**Does this PR introduce a user interface change?**:

No.

**Is there a release notes update needed for this change?**:

No.

**Additional documentation**:

None.