### PR TITLE
6516 edit dataverse revert mdbs

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DataversePage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DataversePage.java
@@ -731,13 +731,8 @@ public class DataversePage implements java.io.Serializable {
     public String resetToInherit() {
 
         setInheritMetadataBlockFromParent(true);
-        if (editMode.equals(DataversePage.EditMode.CREATE)) {;
-            refreshAllMetadataBlocks();
-            return null;
-        } else {
-            String retVal = save();
-            return retVal;
-        }
+        refreshAllMetadataBlocks();
+        return null;
     }
 
     public void cancelMetadataBlocks() {

--- a/src/main/webapp/dataverse.xhtml
+++ b/src/main/webapp/dataverse.xhtml
@@ -250,7 +250,8 @@
                                         </p:commandButton>
                                         <p:commandButton value="Direct" id="resetToInherit"
                                                          style="display:none"
-                                                         update="@all"
+                                                         update="@widgetVar(optionBlock)" 
+                                                         process="@this @widgetVar(optionBlock)"
                                                          action="#{DataversePage.resetToInherit()}">
                                         </p:commandButton>
                                         <ui:repeat value="#{DataversePage.allMetadataBlocks}" var="mdb">


### PR DESCRIPTION
**What this PR does / why we need it**: Fixes a couple of annoying UI anomalies on the create/edit dataverse workflow with respect to inheriting parent metadata blocks

**Which issue(s) this PR closes**:

Closes #6516 Closes #6518 

**Special notes for your reviewer**:
None

**Suggestions on how to test this**:
On Dataverse create and edit click the "Use metadata fields from [parent DV name]" back and forth and verify that the UI reacts as expected

**Does this PR introduce a user interface change?**: No.

**Is there a release notes update needed for this change?**: No

**Additional documentation**: None