### PR TITLE
5952 - tell admins to reexport following email privacy change

### DIFF
--- a/doc/sphinx-guides/source/installation/config.rst
+++ b/doc/sphinx-guides/source/installation/config.rst
@@ -1351,6 +1351,12 @@ Set ``:ExcludeEmailFromExport`` to prevent email addresses for contacts from bei
 
 ``curl -X PUT -d true http://localhost:8080/api/admin/settings/:ExcludeEmailFromExport``
 
+Note: After making a change to this setting, a reExportAll needs to be run before the changes will be reflected in the exports:
+
+``curl http://localhost:8080/api/admin/metadata/reExportAll``
+
+This will *force* a re-export of every published, local dataset, regardless of whether it has already been exported or not. 
+
 :NavbarAboutUrl
 +++++++++++++++
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Changing the setting to expose/not expose emails addresses in exports doesn't make the change, a reexport is required. There was a suggestion to call this out in the docs and it seemed like a helpful addition.

**Which issue(s) this PR closes**:

Closes #5952 

**Special notes for your reviewer**:

I looked and I didn't see other DB settings or JVM options where we'd want admins to run a reexport, but if there are others, let me know and I'll add this there as well. 

**Suggestions on how to test this**:

Just make sure I didn't make any formatting errors!

**Does this PR introduce a user interface change?**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
