### PR TITLE
6083 documentation update native api examples

### DIFF
--- a/doc/sphinx-guides/source/api/native-api.rst
+++ b/doc/sphinx-guides/source/api/native-api.rst
@@ -138,9 +138,9 @@ Show Contents of a Dataverse
 
   export API_TOKEN=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
   export SERVER_URL=https://demo.dataverse.org
-  export ALIAS=root
+  export ID=root
 
-  curl -H X-Dataverse-key:$API_TOKEN $SERVER_URL/api/dataverses/$ALIAS/contents
+  curl -H X-Dataverse-key:$API_TOKEN $SERVER_URL/api/dataverses/$ID/contents
 
 The fully expanded example above (without environment variables) looks like this:
 
@@ -365,9 +365,9 @@ Please note that an API token is only required if the dataverse has not been pub
 
   export API_TOKEN=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
   export SERVER_URL=https://demo.dataverse.org
-  export ALIAS=root
+  export ID=root
 
-  curl -H X-Dataverse-key:$API_TOKEN $SERVER_URL/api/dataverses/$ALIAS/metadatablocks
+  curl -H X-Dataverse-key:$API_TOKEN $SERVER_URL/api/dataverses/$ID/metadatablocks
 
 The fully expanded example above (without environment variables) looks like this:
 
@@ -390,9 +390,9 @@ The metadata blocks that are available with a default installation of Dataverse 
 
   export API_TOKEN=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
   export SERVER_URL=https://demo.dataverse.org
-  export ALIAS=root
+  export ID=root
 
-  curl -H X-Dataverse-key:$API_TOKEN -X POST -H \"Content-type:application/json\" --upload-file define-metadatablocks.json $SERVER_URL/api/dataverses/$ALIAS/metadatablocks
+  curl -H X-Dataverse-key:$API_TOKEN -X POST $SERVER_URL/api/dataverses/$ID/metadatablocks -H \"Content-type:application/json\" --upload-file define-metadatablocks.json
 
 The fully expanded example above (without environment variables) looks like this:
 

--- a/doc/sphinx-guides/source/api/native-api.rst
+++ b/doc/sphinx-guides/source/api/native-api.rst
@@ -82,11 +82,27 @@ To view a published dataverse:
 
   curl $SERVER_URL/api/dataverses/$id
 
-To view an unpublished dataverse:
+The fully expanded example above (without environment variables) looks like this:
 
 .. code-block:: bash
 
   curl https://demo.dataverse.org/api/dataverses/root
+
+To view an unpublished dataverse:
+
+.. code-block:: bash
+
+  export API_TOKEN=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+  export SERVER_URL=https://demo.dataverse.org
+  export id=root
+
+  curl -H X-Dataverse-key:$API_TOKEN $SERVER_URL/api/dataverses/$id
+
+The fully expanded example above (without environment variables) looks like this:
+
+.. code-block:: bash
+
+  curl -H X-Dataverse-key:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx https://demo.dataverse.org/api/dataverses/root
 
 Delete a Dataverse
 ~~~~~~~~~~~~~~~~~~

--- a/doc/sphinx-guides/source/api/native-api.rst
+++ b/doc/sphinx-guides/source/api/native-api.rst
@@ -220,9 +220,19 @@ Creates a new role under dataverse ``id``. Needs a json file with the role descr
 
 .. code-block:: bash
 
-  curl -H X-Dataverse-key:$API_TOKEN -X POST $SERVER/api/dataverses/$id/roles
-  
-POSTed JSON example::
+  export API_TOKEN=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+  export SERVER_URL=https://demo.dataverse.org
+  export id=root
+
+  curl -H X-Dataverse-key:$API_TOKEN -X POST $SERVER/api/dataverses/$id/roles --upload-file roles.json
+
+The fully expanded example above (without environment variables) looks like this:
+
+.. code-block:: bash
+
+  curl -H X-Dataverse-key:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx https://demo.dataverse.org/api/dataverses/root/roles --upload-file roles.json
+
+Where ``roles.json`` looks like this::
 
   {
     "alias": "sys1",

--- a/doc/sphinx-guides/source/api/native-api.rst
+++ b/doc/sphinx-guides/source/api/native-api.rst
@@ -348,10 +348,10 @@ Please note that an API token is only required if the dataverse has not been pub
 .. code-block:: bash
 
   export API_TOKEN=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-  export ALIAS=root
   export SERVER_URL=https://demo.dataverse.org
+  export alias=root
 
-  curl -H X-Dataverse-key:$API_TOKEN $SERVER_URL/api/dataverses/$ALIAS/metadatablocks
+  curl -H X-Dataverse-key:$API_TOKEN $SERVER_URL/api/dataverses/$alias/metadatablocks
 
 The fully expanded example above (without environment variables) looks like this:
 

--- a/doc/sphinx-guides/source/api/native-api.rst
+++ b/doc/sphinx-guides/source/api/native-api.rst
@@ -53,9 +53,9 @@ Next you need to figure out the alias or database id of the "parent" dataverse i
 .. code-block:: bash
 
   export API_TOKEN=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-  export PARENT=root
   export SERVER_URL=https://demo.dataverse.org
-  
+  export PARENT=root
+
   curl -H X-Dataverse-key:$API_TOKEN -X POST $SERVER_URL/api/dataverses/$PARENT --upload-file dataverse-complete.json
 
 The fully expanded example above (without environment variables) looks like this:
@@ -78,9 +78,9 @@ To view a published dataverse:
 .. code-block:: bash
 
   export SERVER_URL=https://demo.dataverse.org
-  export ID=root
+  export id=root
 
-  curl $SERVER_URL/api/dataverses/$ID
+  curl $SERVER_URL/api/dataverses/$id
 
 To view an unpublished dataverse:
 
@@ -99,9 +99,9 @@ Deletes the dataverse whose database ID or alias is given:
 
   export API_TOKEN=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
   export SERVER_URL=https://demo.dataverse.org
-  export ID=root
+  export id=root
 
-  curl -H X-Dataverse-key:$API_TOKEN -X DELETE $SERVER_URL/api/dataverses/$ID
+  curl -H X-Dataverse-key:$API_TOKEN -X DELETE $SERVER_URL/api/dataverses/$id
 
 The fully expanded example above (without environment variables) looks like this:
 
@@ -121,10 +121,10 @@ Show Contents of a Dataverse
 .. code-block:: bash
 
   export API_TOKEN=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-  export ALIAS=root
   export SERVER_URL=https://demo.dataverse.org
-  
-  curl -H X-Dataverse-key:$API_TOKEN $SERVER_URL/api/dataverses/$ALIAS/contents
+  export alias=root
+
+  curl -H X-Dataverse-key:$API_TOKEN $SERVER_URL/api/dataverses/$alias/contents
 
 The fully expanded example above (without environment variables) looks like this:
 
@@ -165,7 +165,7 @@ All the roles defined directly in the dataverse identified by ``id``::
   export SERVER_URL=https://demo.dataverse.org
   export id=root
 
-  curl -H X-Dataverse-key:$API_TOKEN $SERVER/api/dataverses/$id/roles
+  curl -H X-Dataverse-key:$API_TOKEN $SERVER_URL/api/dataverses/$id/roles
 
 The fully expanded example above (without environment variables) looks like this:
 
@@ -184,7 +184,7 @@ List Facets Configured for a Dataverse
   export SERVER_URL=https://demo.dataverse.org
   export id=root
 
-  curl -H X-Dataverse-key:$API_TOKEN $SERVER/api/dataverses/$id/facets
+  curl -H X-Dataverse-key:$API_TOKEN $SERVER_URL/api/dataverses/$id/facets
 
 The fully expanded example above (without environment variables) looks like this:
 
@@ -203,7 +203,7 @@ Assign search facets for a given dataverse identified by ``id``::
   export SERVER_URL=https://demo.dataverse.org
   export id=root
 
-  curl -H X-Dataverse-key:$API_TOKEN" -X POST $SERVER/api/dataverses/$id/facets --upload-file facets.json
+  curl -H X-Dataverse-key:$API_TOKEN" -X POST $SERVER_URL/api/dataverses/$id/facets --upload-file facets.json
 
 The fully expanded example above (without environment variables) looks like this:
 
@@ -224,7 +224,7 @@ Creates a new role under dataverse ``id``. Needs a json file with the role descr
   export SERVER_URL=https://demo.dataverse.org
   export id=root
 
-  curl -H X-Dataverse-key:$API_TOKEN -X POST $SERVER/api/dataverses/$id/roles --upload-file roles.json
+  curl -H X-Dataverse-key:$API_TOKEN -X POST $SERVER_URL/api/dataverses/$id/roles --upload-file roles.json
 
 The fully expanded example above (without environment variables) looks like this:
 
@@ -256,7 +256,7 @@ List all the role assignments at the given dataverse::
   export SERVER_URL=https://demo.dataverse.org
   export id=root
 
-  curl -H X-Dataverse-key:$API_TOKEN $SERVER/api/dataverses/$id/assignments
+  curl -H X-Dataverse-key:$API_TOKEN $SERVER_URL/api/dataverses/$id/assignments
 
 The fully expanded example above (without environment variables) looks like this:
 

--- a/doc/sphinx-guides/source/api/native-api.rst
+++ b/doc/sphinx-guides/source/api/native-api.rst
@@ -199,7 +199,17 @@ Assign search facets for a given dataverse identified by ``id``::
 
 .. code-block:: bash
 
+  export API_TOKEN=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+  export SERVER_URL=https://demo.dataverse.org
+  export id=root
+
   curl -H X-Dataverse-key:$API_TOKEN" -X POST $SERVER/api/dataverses/$id/facets --upload-file facets.json
+
+The fully expanded example above (without environment variables) looks like this:
+
+.. code-block:: bash
+
+  curl -H X-Dataverse-key:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx https://demo.dataverse.org/api/dataverses/root/facets --upload-file facets.json
 
 Where ``facets.json`` contains a JSON encoded list of metadata keys (e.g. ``["authorName","authorAffiliation"]``).
 

--- a/doc/sphinx-guides/source/api/native-api.rst
+++ b/doc/sphinx-guides/source/api/native-api.rst
@@ -373,9 +373,9 @@ The metadata blocks that are available with a default installation of Dataverse 
 .. code-block:: bash
 
   export API_TOKEN=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-  export ALIAS=root
   export SERVER_URL=https://demo.dataverse.org
-  
+  export ALIAS=root
+
   curl -H X-Dataverse-key:$API_TOKEN -X POST -H \"Content-type:application/json\" --upload-file define-metadatablocks.json $SERVER_URL/api/dataverses/$ALIAS/metadatablocks
 
 The fully expanded example above (without environment variables) looks like this:
@@ -391,7 +391,17 @@ Get whether the dataverse is a metadata block root, or does it uses its parent b
 
 .. code-block:: bash
 
-  curl -H X-Dataverse-key:$API_TOKEN $SERVER/api/dataverses/$id/metadatablocks/isRoot
+  export API_TOKEN=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+  export SERVER_URL=https://demo.dataverse.org
+  export id=root
+
+  curl -H X-Dataverse-key:$API_TOKEN $SERVER_URL/api/dataverses/$id/metadatablocks/isRoot
+
+The fully expanded example above (without environment variables) looks like this:
+
+.. code-block:: bash
+
+  curl -H X-Dataverse-key:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx https://demo.dataverse.org/api/dataverses/root/metadatablocks/isRoot
 
 Configure a Dataverse to Inherit Its Metadata Blocks from Its Parent
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/sphinx-guides/source/api/native-api.rst
+++ b/doc/sphinx-guides/source/api/native-api.rst
@@ -252,8 +252,18 @@ List all the role assignments at the given dataverse::
 
 .. code-block:: bash
 
+  export API_TOKEN=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+  export SERVER_URL=https://demo.dataverse.org
+  export id=root
+
   curl -H X-Dataverse-key:$API_TOKEN $SERVER/api/dataverses/$id/assignments
-  
+
+The fully expanded example above (without environment variables) looks like this:
+
+.. code-block:: bash
+
+  curl -H X-Dataverse-key:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx https://demo.dataverse.org/api/dataverses/root/assignments
+
 Assign Default Role to User Creating a Dataset in a Dataverse
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/sphinx-guides/source/api/native-api.rst
+++ b/doc/sphinx-guides/source/api/native-api.rst
@@ -209,7 +209,7 @@ The fully expanded example above (without environment variables) looks like this
 
 .. code-block:: bash
 
-  curl -H X-Dataverse-key:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx https://demo.dataverse.org/api/dataverses/root/facets --upload-file facets.json
+  curl -H X-Dataverse-key:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx -X POST https://demo.dataverse.org/api/dataverses/root/facets --upload-file facets.json
 
 Where ``facets.json`` contains a JSON encoded list of metadata keys (e.g. ``["authorName","authorAffiliation"]``).
 
@@ -230,7 +230,7 @@ The fully expanded example above (without environment variables) looks like this
 
 .. code-block:: bash
 
-  curl -H X-Dataverse-key:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx https://demo.dataverse.org/api/dataverses/root/roles --upload-file roles.json
+  curl -H X-Dataverse-key:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx -X POST https://demo.dataverse.org/api/dataverses/root/roles --upload-file roles.json
 
 Where ``roles.json`` looks like this::
 
@@ -282,7 +282,7 @@ The fully expanded example above (without environment variables) looks like this
 
 .. code-block:: bash
 
-  curl -H X-Dataverse-key:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx https://demo.dataverse.org/api/dataverses/root/defaultContributorRole/curator
+  curl -H X-Dataverse-key:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx -X PUT https://demo.dataverse.org/api/dataverses/root/defaultContributorRole/curator
 
 Note: You may use "none" as the ``roleAlias``. This will prevent a user who creates a dataset from having any role on that dataset. It is not recommended for dataverses with human contributors.
 
@@ -305,7 +305,7 @@ The fully expanded example above (without environment variables) looks like this
 
 .. code-block:: bash
 
-  curl -H X-Dataverse-key:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx https://demo.dataverse.org/api/dataverses/root/assignments --upload-file role.json
+  curl -H X-Dataverse-key:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx -X POST https://demo.dataverse.org/api/dataverses/root/assignments --upload-file role.json
 
 POSTed JSON example (the content of ``role.json`` file)::
 
@@ -323,7 +323,18 @@ Delete the assignment whose id is ``$id``::
 
 .. code-block:: bash
 
-  curl -H X-Dataverse-key:$API_TOKEN -X DELETE $SERVER/api/dataverses/$id/assignments/$id
+  export API_TOKEN=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+  export SERVER_URL=https://demo.dataverse.org
+  export id=root
+  export assignmentId=6
+
+  curl -H X-Dataverse-key:$API_TOKEN -X DELETE $SERVER_URL/api/dataverses/$id/assignments/$assignmentId
+
+The fully expanded example above (without environment variables) looks like this:
+
+.. code-block:: bash
+
+  curl -H X-Dataverse-key:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx -X DELETE https://demo.dataverse.org/api/dataverses/root/assignments/6
 
 List Metadata Blocks Defined on a Dataverse
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/sphinx-guides/source/api/native-api.rst
+++ b/doc/sphinx-guides/source/api/native-api.rst
@@ -78,9 +78,9 @@ To view a published dataverse:
 .. code-block:: bash
 
   export SERVER_URL=https://demo.dataverse.org
-  export id=root
+  export ID=root
 
-  curl $SERVER_URL/api/dataverses/$id
+  curl $SERVER_URL/api/dataverses/$ID
 
 The fully expanded example above (without environment variables) looks like this:
 
@@ -94,9 +94,9 @@ To view an unpublished dataverse:
 
   export API_TOKEN=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
   export SERVER_URL=https://demo.dataverse.org
-  export id=root
+  export ID=root
 
-  curl -H X-Dataverse-key:$API_TOKEN $SERVER_URL/api/dataverses/$id
+  curl -H X-Dataverse-key:$API_TOKEN $SERVER_URL/api/dataverses/$ID
 
 The fully expanded example above (without environment variables) looks like this:
 
@@ -115,9 +115,9 @@ Deletes the dataverse whose database ID or alias is given:
 
   export API_TOKEN=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
   export SERVER_URL=https://demo.dataverse.org
-  export id=root
+  export ID=root
 
-  curl -H X-Dataverse-key:$API_TOKEN -X DELETE $SERVER_URL/api/dataverses/$id
+  curl -H X-Dataverse-key:$API_TOKEN -X DELETE $SERVER_URL/api/dataverses/$ID
 
 The fully expanded example above (without environment variables) looks like this:
 
@@ -138,9 +138,9 @@ Show Contents of a Dataverse
 
   export API_TOKEN=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
   export SERVER_URL=https://demo.dataverse.org
-  export alias=root
+  export ALIAS=root
 
-  curl -H X-Dataverse-key:$API_TOKEN $SERVER_URL/api/dataverses/$alias/contents
+  curl -H X-Dataverse-key:$API_TOKEN $SERVER_URL/api/dataverses/$ALIAS/contents
 
 The fully expanded example above (without environment variables) looks like this:
 
@@ -157,9 +157,9 @@ Shows the combined size in bytes of all the files uploaded into the dataverse ``
 
   export API_TOKEN=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
   export SERVER_URL=https://demo.dataverse.org
-  export id=root
+  export ID=root
 
-  curl -H X-Dataverse-key:$API_TOKEN $SERVER_URL/api/dataverses/$id/storagesize
+  curl -H X-Dataverse-key:$API_TOKEN $SERVER_URL/api/dataverses/$ID/storagesize
 
 The fully expanded example above (without environment variables) looks like this:
 
@@ -179,9 +179,9 @@ All the roles defined directly in the dataverse identified by ``id``::
 
   export API_TOKEN=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
   export SERVER_URL=https://demo.dataverse.org
-  export id=root
+  export ID=root
 
-  curl -H X-Dataverse-key:$API_TOKEN $SERVER_URL/api/dataverses/$id/roles
+  curl -H X-Dataverse-key:$API_TOKEN $SERVER_URL/api/dataverses/$ID/roles
 
 The fully expanded example above (without environment variables) looks like this:
 
@@ -198,9 +198,9 @@ List Facets Configured for a Dataverse
 
   export API_TOKEN=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
   export SERVER_URL=https://demo.dataverse.org
-  export id=root
+  export ID=root
 
-  curl -H X-Dataverse-key:$API_TOKEN $SERVER_URL/api/dataverses/$id/facets
+  curl -H X-Dataverse-key:$API_TOKEN $SERVER_URL/api/dataverses/$ID/facets
 
 The fully expanded example above (without environment variables) looks like this:
 
@@ -217,9 +217,9 @@ Assign search facets for a given dataverse identified by ``id``::
 
   export API_TOKEN=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
   export SERVER_URL=https://demo.dataverse.org
-  export id=root
+  export ID=root
 
-  curl -H X-Dataverse-key:$API_TOKEN" -X POST $SERVER_URL/api/dataverses/$id/facets --upload-file facets.json
+  curl -H X-Dataverse-key:$API_TOKEN" -X POST $SERVER_URL/api/dataverses/$ID/facets --upload-file facets.json
 
 The fully expanded example above (without environment variables) looks like this:
 
@@ -238,9 +238,9 @@ Creates a new role under dataverse ``id``. Needs a json file with the role descr
 
   export API_TOKEN=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
   export SERVER_URL=https://demo.dataverse.org
-  export id=root
+  export ID=root
 
-  curl -H X-Dataverse-key:$API_TOKEN -X POST $SERVER_URL/api/dataverses/$id/roles --upload-file roles.json
+  curl -H X-Dataverse-key:$API_TOKEN -X POST $SERVER_URL/api/dataverses/$ID/roles --upload-file roles.json
 
 The fully expanded example above (without environment variables) looks like this:
 
@@ -270,9 +270,9 @@ List all the role assignments at the given dataverse::
 
   export API_TOKEN=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
   export SERVER_URL=https://demo.dataverse.org
-  export id=root
+  export ID=root
 
-  curl -H X-Dataverse-key:$API_TOKEN $SERVER_URL/api/dataverses/$id/assignments
+  curl -H X-Dataverse-key:$API_TOKEN $SERVER_URL/api/dataverses/$ID/assignments
 
 The fully expanded example above (without environment variables) looks like this:
 
@@ -289,10 +289,10 @@ Assign a default role to a user creating a dataset in a dataverse ``id`` where `
 
   export API_TOKEN=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
   export SERVER_URL=https://demo.dataverse.org
-  export id=root
-  export roleAlias=curator
+  export ID=root
+  export ROLE_ALIAS=curator
 
-  curl -H X-Dataverse-key:$API_TOKEN -X PUT $SERVER_URL/api/dataverses/$id/defaultContributorRole/$roleAlias
+  curl -H X-Dataverse-key:$API_TOKEN -X PUT $SERVER_URL/api/dataverses/$ID/defaultContributorRole/$ROLE_ALIAS
 
 The fully expanded example above (without environment variables) looks like this:
 
@@ -300,7 +300,7 @@ The fully expanded example above (without environment variables) looks like this
 
   curl -H X-Dataverse-key:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx -X PUT https://demo.dataverse.org/api/dataverses/root/defaultContributorRole/curator
 
-Note: You may use "none" as the ``roleAlias``. This will prevent a user who creates a dataset from having any role on that dataset. It is not recommended for dataverses with human contributors.
+Note: You may use "none" as the ``ROLE_ALIAS``. This will prevent a user who creates a dataset from having any role on that dataset. It is not recommended for dataverses with human contributors.
 
 .. _assign-role-on-a-dataverse-api:
 
@@ -313,9 +313,9 @@ Assigns a new role, based on the POSTed JSON. ::
 
   export API_TOKEN=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
   export SERVER_URL=https://demo.dataverse.org
-  export id=root
+  export ID=root
 
-  curl -H X-Dataverse-key:$API_TOKEN -X POST $SERVER_URL/api/dataverses/$id/assignments --upload-file role.json
+  curl -H X-Dataverse-key:$API_TOKEN -X POST $SERVER_URL/api/dataverses/$ID/assignments --upload-file role.json
 
 The fully expanded example above (without environment variables) looks like this:
 
@@ -341,10 +341,10 @@ Delete the assignment whose id is ``$id``::
 
   export API_TOKEN=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
   export SERVER_URL=https://demo.dataverse.org
-  export id=root
-  export assignmentId=6
+  export ID=root
+  export ASSIGNMENT_ID=6
 
-  curl -H X-Dataverse-key:$API_TOKEN -X DELETE $SERVER_URL/api/dataverses/$id/assignments/$assignmentId
+  curl -H X-Dataverse-key:$API_TOKEN -X DELETE $SERVER_URL/api/dataverses/$ID/assignments/$ASSIGNMENT_ID
 
 The fully expanded example above (without environment variables) looks like this:
 
@@ -365,9 +365,9 @@ Please note that an API token is only required if the dataverse has not been pub
 
   export API_TOKEN=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
   export SERVER_URL=https://demo.dataverse.org
-  export alias=root
+  export ALIAS=root
 
-  curl -H X-Dataverse-key:$API_TOKEN $SERVER_URL/api/dataverses/$alias/metadatablocks
+  curl -H X-Dataverse-key:$API_TOKEN $SERVER_URL/api/dataverses/$ALIAS/metadatablocks
 
 The fully expanded example above (without environment variables) looks like this:
 
@@ -409,9 +409,9 @@ Get whether the dataverse is a metadata block root, or does it uses its parent b
 
   export API_TOKEN=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
   export SERVER_URL=https://demo.dataverse.org
-  export id=root
+  export ID=root
 
-  curl -H X-Dataverse-key:$API_TOKEN $SERVER_URL/api/dataverses/$id/metadatablocks/isRoot
+  curl -H X-Dataverse-key:$API_TOKEN $SERVER_URL/api/dataverses/$ID/metadatablocks/isRoot
 
 The fully expanded example above (without environment variables) looks like this:
 
@@ -429,9 +429,9 @@ values are ``true`` and ``false`` (both are valid JSON expressions). ::
 
   export API_TOKEN=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
   export SERVER_URL=https://demo.dataverse.org
-  export id=root
+  export ID=root
 
-  curl -H X-Dataverse-key:$API_TOKEN -X PUT $SERVER_URL/api/dataverses/$id/metadatablocks/isRoot
+  curl -H X-Dataverse-key:$API_TOKEN -X PUT $SERVER_URL/api/dataverses/$ID/metadatablocks/isRoot
 
 The fully expanded example above (without environment variables) looks like this:
 

--- a/doc/sphinx-guides/source/api/native-api.rst
+++ b/doc/sphinx-guides/source/api/native-api.rst
@@ -139,7 +139,17 @@ Shows the combined size in bytes of all the files uploaded into the dataverse ``
 
 .. code-block:: bash
 
+  export API_TOKEN=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+  export SERVER_URL=https://demo.dataverse.org
+  export id=root
+
   curl -H X-Dataverse-key:$API_TOKEN $SERVER_URL/api/dataverses/$id/storagesize
+
+The fully expanded example above (without environment variables) looks like this:
+
+.. code-block:: bash
+
+  curl -H X-Dataverse-key:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx https://demo.dataverse.org/api/dataverses/root/storagesize
 
 The size of published and unpublished files will be summed both in the dataverse specified and beneath all its sub-dataverses, recursively. 
 By default, only the archival files are counted - i.e., the files uploaded by users (plus the tab-delimited versions generated for tabular data files on ingest). If the optional argument ``includeCached=true`` is specified, the API will also add the sizes of all the extra files generated and cached by Dataverse - the resized thumbnail versions for image files, the metadata exports for published datasets, etc. 

--- a/doc/sphinx-guides/source/api/native-api.rst
+++ b/doc/sphinx-guides/source/api/native-api.rst
@@ -180,7 +180,17 @@ List Facets Configured for a Dataverse
 
 .. code-block:: bash
 
+  export API_TOKEN=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+  export SERVER_URL=https://demo.dataverse.org
+  export id=root
+
   curl -H X-Dataverse-key:$API_TOKEN $SERVER/api/dataverses/$id/facets
+
+The fully expanded example above (without environment variables) looks like this:
+
+.. code-block:: bash
+
+  curl -H X-Dataverse-key:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx https://demo.dataverse.org/api/dataverses/root/facets
 
 Set Facets for a Dataverse
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/sphinx-guides/source/api/native-api.rst
+++ b/doc/sphinx-guides/source/api/native-api.rst
@@ -161,7 +161,17 @@ All the roles defined directly in the dataverse identified by ``id``::
 
 .. code-block:: bash
 
+  export API_TOKEN=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+  export SERVER_URL=https://demo.dataverse.org
+  export id=root
+
   curl -H X-Dataverse-key:$API_TOKEN $SERVER/api/dataverses/$id/roles
+
+The fully expanded example above (without environment variables) looks like this:
+
+.. code-block:: bash
+
+  curl -H X-Dataverse-key:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx https://demo.dataverse.org/api/dataverses/root/roles
 
 List Facets Configured for a Dataverse
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/sphinx-guides/source/api/native-api.rst
+++ b/doc/sphinx-guides/source/api/native-api.rst
@@ -77,13 +77,16 @@ To view a published dataverse:
 
 .. code-block:: bash
 
-  curl $SERVER_URL/api/dataverses/$id
+  export SERVER_URL=https://demo.dataverse.org
+  export ID=root
+
+  curl $SERVER_URL/api/dataverses/$ID
 
 To view an unpublished dataverse:
 
 .. code-block:: bash
 
-  curl -H X-Dataverse-key:$API_TOKEN $SERVER_URL/api/dataverses/$id
+  curl https://demo.dataverse.org/api/dataverses/root
 
 Delete a Dataverse
 ~~~~~~~~~~~~~~~~~~

--- a/doc/sphinx-guides/source/api/native-api.rst
+++ b/doc/sphinx-guides/source/api/native-api.rst
@@ -271,8 +271,19 @@ Assign a default role to a user creating a dataset in a dataverse ``id`` where `
 
 .. code-block:: bash
 
-  curl -H X-Dataverse-key:$API_TOKEN -X PUT $SERVER/api/dataverses/$id/defaultContributorRole/$roleAlias
-  
+  export API_TOKEN=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+  export SERVER_URL=https://demo.dataverse.org
+  export id=root
+  export roleAlias=curator
+
+  curl -H X-Dataverse-key:$API_TOKEN -X PUT $SERVER_URL/api/dataverses/$id/defaultContributorRole/$roleAlias
+
+The fully expanded example above (without environment variables) looks like this:
+
+.. code-block:: bash
+
+  curl -H X-Dataverse-key:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx https://demo.dataverse.org/api/dataverses/root/defaultContributorRole/curator
+
 Note: You may use "none" as the ``roleAlias``. This will prevent a user who creates a dataset from having any role on that dataset. It is not recommended for dataverses with human contributors.
 
 .. _assign-role-on-a-dataverse-api:

--- a/doc/sphinx-guides/source/api/native-api.rst
+++ b/doc/sphinx-guides/source/api/native-api.rst
@@ -295,9 +295,19 @@ Assigns a new role, based on the POSTed JSON. ::
 
 .. code-block:: bash
 
-  curl -H X-Dataverse-key:$API_TOKEN -X POST $SERVER/api/dataverses/$id/assignments
+  export API_TOKEN=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+  export SERVER_URL=https://demo.dataverse.org
+  export id=root
 
-POSTed JSON example::
+  curl -H X-Dataverse-key:$API_TOKEN -X POST $SERVER_URL/api/dataverses/$id/assignments --upload-file role.json
+
+The fully expanded example above (without environment variables) looks like this:
+
+.. code-block:: bash
+
+  curl -H X-Dataverse-key:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx https://demo.dataverse.org/api/dataverses/root/assignments --upload-file role.json
+
+POSTed JSON example (the content of ``role.json`` file)::
 
   {
     "assignee": "@uma",

--- a/doc/sphinx-guides/source/api/native-api.rst
+++ b/doc/sphinx-guides/source/api/native-api.rst
@@ -411,7 +411,17 @@ values are ``true`` and ``false`` (both are valid JSON expressions). ::
 
 .. code-block:: bash
 
-  curl -H X-Dataverse-key:$API_TOKEN -X PUT $SERVER/api/dataverses/$id/metadatablocks/isRoot
+  export API_TOKEN=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+  export SERVER_URL=https://demo.dataverse.org
+  export id=root
+
+  curl -H X-Dataverse-key:$API_TOKEN -X PUT $SERVER_URL/api/dataverses/$id/metadatablocks/isRoot
+
+The fully expanded example above (without environment variables) looks like this:
+
+.. code-block:: bash
+
+  curl -H X-Dataverse-key:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx -X PUT https://demo.dataverse.org/api/dataverses/root/metadatablocks/isRoot
 
 .. note:: Previous endpoints ``$SERVER/api/dataverses/$id/metadatablocks/:isRoot`` and ``POST http://$SERVER/api/dataverses/$id/metadatablocks/:isRoot?key=$apiKey`` are deprecated, but supported.
 

--- a/doc/sphinx-guides/source/api/native-api.rst
+++ b/doc/sphinx-guides/source/api/native-api.rst
@@ -97,7 +97,17 @@ Deletes the dataverse whose database ID or alias is given:
 
 .. code-block:: bash
 
-  curl -H X-Dataverse-key:$API_TOKEN -X DELETE $SERVER_URL/api/dataverses/$id
+  export API_TOKEN=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+  export SERVER_URL=https://demo.dataverse.org
+  export ID=root
+
+  curl -H X-Dataverse-key:$API_TOKEN -X DELETE $SERVER_URL/api/dataverses/$ID
+
+The fully expanded example above (without environment variables) looks like this:
+
+.. code-block:: bash
+
+  curl -H X-Dataverse-key:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx -X DELETE https://demo.dataverse.org/api/dataverses/root
 
 .. _show-contents-of-a-dataverse-api:
 


### PR DESCRIPTION
**What this PR does / why we need it**: Improve the curl examples of the Dataverse related sections of the Native API documentation

**Which issue(s) this PR closes**: It does not close any partucular issue. There is a large issue which talks about the full page of the Native API: #6083 

**Special notes for your reviewer**: This pull request is quite format related, it does not revise fully the content, so later revisions of the sections from content perspective is needed. E.g. the dataverse ID is sometimes referred as $id and other times as $alias.
