### PR TITLE
get FITS metadata extract working again #5919

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/ingest/IngestServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/ingest/IngestServiceBean.java
@@ -277,20 +277,6 @@ public class IngestServiceBean {
                     }
                 }
 
-                // ... and let's delete the main temp file:
-                // Commenting out this "delete" for code review because otherwise "extractMetadata"
-                // below (for FITS files) fails with "Could not open temp file".
-                // See https://github.com/IQSS/dataverse/issues/5919
-/*
-                try {
-                    logger.fine("Will attempt to delete the temp file " + tempLocationPath.toString());
-                    Files.delete(tempLocationPath);
-                } catch (IOException ex) {
-                    // (non-fatal - it's just a temp file.)
-                    logger.warning("Failed to delete temp file " + tempLocationPath.toString());
-                }
-*/
-
                 if (unattached) {
                     dataFile.setOwner(null);
                 }
@@ -368,8 +354,17 @@ public class IngestServiceBean {
                     
                     ret.add(dataFile);
                 }
-            }
 
+                // ... and let's delete the main temp file:
+                try {
+                    logger.fine("Will attempt to delete the temp file " + tempLocationPath.toString());
+                    Files.delete(tempLocationPath);
+                } catch (IOException ex) {
+                    // (non-fatal - it's just a temp file.)
+                    logger.warning("Failed to delete temp file " + tempLocationPath.toString());
+                }
+
+            }
             logger.fine("Done! Finished saving new files in permanent storage and adding them to the dataset.");
         }
         

--- a/src/main/java/edu/harvard/iq/dataverse/ingest/IngestServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/ingest/IngestServiceBean.java
@@ -278,6 +278,10 @@ public class IngestServiceBean {
                 }
 
                 // ... and let's delete the main temp file:
+                // Commenting out this "delete" for code review because otherwise "extractMetadata"
+                // below (for FITS files) fails with "Could not open temp file".
+                // See https://github.com/IQSS/dataverse/issues/5919
+/*
                 try {
                     logger.fine("Will attempt to delete the temp file " + tempLocationPath.toString());
                     Files.delete(tempLocationPath);
@@ -285,6 +289,7 @@ public class IngestServiceBean {
                     // (non-fatal - it's just a temp file.)
                     logger.warning("Failed to delete temp file " + tempLocationPath.toString());
                 }
+*/
 
                 if (unattached) {
                     dataFile.setOwner(null);


### PR DESCRIPTION
**What this PR does / why we need it**:

FITS file metadata extraction is an advertised feature of Dataverse...

- https://dataverse.org/software-features
- http://guides.dataverse.org/en/4.19/user/dataset-management.html#astronomy-fits

... but my guess it has been broken since 4.9 and dc6ff86

**Which issue(s) this PR closes**:

Closes #5919

**Special notes for your reviewer**:

This is a draft pull request (Update: now it's real) because while removing the call to "delete" on the temp file fixes the problem allowing FITS metadata to be extracted...

![Screen Shot 2020-02-04 at 2 52 14 PM](https://user-images.githubusercontent.com/21006/73782364-f9678e00-475f-11ea-95b5-67487858064d.png)

... I'm sure we need to keep the "delete" in there. 2bc4690 is just the first commit to make it easy for me to have a conversation with @landreev to see what he recommends.

Update: I moved the delete method down. @landreev I had to keep it in the for loop to keep the variables in scope. I couldn't move it all the way down to the return like we talked about.

**Suggestions on how to test this**:

The screenshot above is from testing with perseus60.fits from https://dataverse.harvard.edu/file.xhtml?persistentId=doi:10.7910/DVN/NTT77F/LASN2S

**Does this PR introduce a user interface change?**:

No.

**Is there a release notes update needed for this change?**:

It might be nice to explain this feature has been restored.

**Additional documentation**:
