### PR TITLE
remove parentheses from dataset contact affiliation #6570

### DIFF
--- a/doc/release-notes/6570-search-api-contact-affiliation.md
+++ b/doc/release-notes/6570-search-api-contact-affiliation.md
@@ -1,0 +1,1 @@
+As reported in https://github.com/IQSS/dataverse/issues/6570 the affiliation for dataset contacts has been wrapped in parentheses in the JSON output from the Search API. These parentheses have now been removed. This is a backward incompatible change but it is hoped that it won't cause any problems for integrations and API users.

--- a/src/main/java/edu/harvard/iq/dataverse/DatasetVersion.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetVersion.java
@@ -754,7 +754,16 @@ public class DatasetVersion implements Serializable {
         return MarkupChecker.escapeHtml(getDescription());
     }
 
-    public List<String[]> getDatasetContacts(){
+    public List<String[]> getDatasetContacts() {
+        boolean getDisplayValues = true;
+        return getDatasetContacts(getDisplayValues);
+    }
+
+    /**
+     * @param getDisplayValues Instead of the retrieving pristine value in the
+     * database, run the value through special formatting.
+     */
+    public List<String[]> getDatasetContacts(boolean getDisplayValues) {
         List <String[]> retList = new ArrayList<>();
         for (DatasetField dsf : this.getDatasetFields()) {
             Boolean addContributor = true;
@@ -767,10 +776,11 @@ public class DatasetVersion implements Serializable {
                             if (subField.isEmptyForDisplay()) {
                                 addContributor = false;
                             }
+                            // There is no use case yet for getting the non-display value for contributorName.
                             contributorName = subField.getDisplayValue();
                         }
                         if (subField.getDatasetFieldType().getName().equals(DatasetFieldConstant.datasetContactAffiliation)) {
-                            contributorAffiliation = subField.getDisplayValue();
+                            contributorAffiliation = getDisplayValues ? subField.getDisplayValue() : subField.getValue();
                         }
 
                     }
@@ -782,41 +792,6 @@ public class DatasetVersion implements Serializable {
             }
         }       
         return retList;        
-    }
-
-    /**
-     * This method is the same as getDatasetContacts above but the actual value
-     * is returned for affiliation instead of the "display" value, which as of
-     * this writing wraps the value in parentheses.
-     */
-    public List<String[]> getDatasetContactsNonDisplay() {
-        List<String[]> retList = new ArrayList<>();
-        for (DatasetField dsf : this.getDatasetFields()) {
-            Boolean addContributor = true;
-            String contributorName = "";
-            String contributorAffiliation = "";
-            if (dsf.getDatasetFieldType().getName().equals(DatasetFieldConstant.datasetContact)) {
-                for (DatasetFieldCompoundValue authorValue : dsf.getDatasetFieldCompoundValues()) {
-                    for (DatasetField subField : authorValue.getChildDatasetFields()) {
-                        if (subField.getDatasetFieldType().getName().equals(DatasetFieldConstant.datasetContactName)) {
-                            if (subField.isEmptyForDisplay()) {
-                                addContributor = false;
-                            }
-                            contributorName = subField.getDisplayValue();
-                        }
-                        if (subField.getDatasetFieldType().getName().equals(DatasetFieldConstant.datasetContactAffiliation)) {
-                            contributorAffiliation = subField.getValue();
-                        }
-
-                    }
-                    if (addContributor) {
-                        String[] datasetContributor = new String[]{contributorName, contributorAffiliation};
-                        retList.add(datasetContributor);
-                    }
-                }
-            }
-        }
-        return retList;
     }
 
     public List<String[]> getDatasetProducers(){

--- a/src/main/java/edu/harvard/iq/dataverse/DatasetVersion.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetVersion.java
@@ -783,7 +783,42 @@ public class DatasetVersion implements Serializable {
         }       
         return retList;        
     }
-    
+
+    /**
+     * This method is the same as getDatasetContacts above but the actual value
+     * is returned for affiliation instead of the "display" value, which as of
+     * this writing wraps the value in parentheses.
+     */
+    public List<String[]> getDatasetContactsNonDisplay() {
+        List<String[]> retList = new ArrayList<>();
+        for (DatasetField dsf : this.getDatasetFields()) {
+            Boolean addContributor = true;
+            String contributorName = "";
+            String contributorAffiliation = "";
+            if (dsf.getDatasetFieldType().getName().equals(DatasetFieldConstant.datasetContact)) {
+                for (DatasetFieldCompoundValue authorValue : dsf.getDatasetFieldCompoundValues()) {
+                    for (DatasetField subField : authorValue.getChildDatasetFields()) {
+                        if (subField.getDatasetFieldType().getName().equals(DatasetFieldConstant.datasetContactName)) {
+                            if (subField.isEmptyForDisplay()) {
+                                addContributor = false;
+                            }
+                            contributorName = subField.getDisplayValue();
+                        }
+                        if (subField.getDatasetFieldType().getName().equals(DatasetFieldConstant.datasetContactAffiliation)) {
+                            contributorAffiliation = subField.getValue();
+                        }
+
+                    }
+                    if (addContributor) {
+                        String[] datasetContributor = new String[]{contributorName, contributorAffiliation};
+                        retList.add(datasetContributor);
+                    }
+                }
+            }
+        }
+        return retList;
+    }
+
     public List<String[]> getDatasetProducers(){
         List <String[]> retList = new ArrayList<>();
         for (DatasetField dsf : this.getDatasetFields()) {

--- a/src/main/java/edu/harvard/iq/dataverse/search/SolrSearchResult.java
+++ b/src/main/java/edu/harvard/iq/dataverse/search/SolrSearchResult.java
@@ -596,7 +596,7 @@ public class SolrSearchResult {
                 if (!dv.getDatasetContacts().isEmpty()) {
                     JsonArrayBuilder contacts = Json.createArrayBuilder();
                     NullSafeJsonBuilder nullSafeJsonBuilderInner = jsonObjectBuilder();
-                    for (String contact[] : dv.getDatasetContacts()) {                       
+                    for (String contact[] : dv.getDatasetContactsNonDisplay()) {
                         nullSafeJsonBuilderInner.add("name", contact[0]);
                         nullSafeJsonBuilderInner.add("affiliation", contact[1]);
                         contacts.add(nullSafeJsonBuilderInner);

--- a/src/main/java/edu/harvard/iq/dataverse/search/SolrSearchResult.java
+++ b/src/main/java/edu/harvard/iq/dataverse/search/SolrSearchResult.java
@@ -596,7 +596,7 @@ public class SolrSearchResult {
                 if (!dv.getDatasetContacts().isEmpty()) {
                     JsonArrayBuilder contacts = Json.createArrayBuilder();
                     NullSafeJsonBuilder nullSafeJsonBuilderInner = jsonObjectBuilder();
-                    for (String contact[] : dv.getDatasetContactsNonDisplay()) {
+                    for (String contact[] : dv.getDatasetContacts(false)) {
                         nullSafeJsonBuilderInner.add("name", contact[0]);
                         nullSafeJsonBuilderInner.add("affiliation", contact[1]);
                         contacts.add(nullSafeJsonBuilderInner);


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR closes**:

Closes #6570

**Special notes for your reviewer**:

I copied and pasted a similar method above. Here's where the similar method is now used (one fewer place in this pull request since the Search API uses the new method):

![Screen Shot 2020-02-06 at 10 54 23 AM](https://user-images.githubusercontent.com/21006/73953954-21c1ca80-48cf-11ea-9b88-15a377af1ad1.png)

**Suggestions on how to test this**:

Add an affiliation to the contact of a dataset and inspect the JSON output from the Search API when finding that dataset. The value should not be wrapped in parentheses, like it is in 4.19.

**Does this PR introduce a user interface change?**:

No.

**Is there a release notes update needed for this change?**:

Yes, added. Technically this is a backward incompatible change but it's a small one and I don't think it's worth adding a configuration option for it. Sorry, API users. You no longer need to strip parentheses from affiliation if you were before. 

**Additional documentation**:

None.