### PR TITLE
add note: info exposed in restricted tabular files #6474

### DIFF
--- a/doc/sphinx-guides/source/user/dataset-management.rst
+++ b/doc/sphinx-guides/source/user/dataset-management.rst
@@ -236,7 +236,7 @@ Restricted Tabular Files
 
 Restricted tabular files are treated differently than other file types in that the following information is exposed when the files are published:
 
-- The name of columns (variables)
+- The name of columns (variables).
 - The "label" (description) of columns.
 - Summary statistics (max, min, mean, etc.) of columns.
 

--- a/doc/sphinx-guides/source/user/dataset-management.rst
+++ b/doc/sphinx-guides/source/user/dataset-management.rst
@@ -166,6 +166,7 @@ Additional download options available for tabular data (found in the same drop-d
 - Data File Citation (currently in either RIS, EndNote XML, or BibTeX format); 
 - All of the above, as a zipped bundle. 
 
+See also :ref:`restricted-tabular-files`.
 
 Geospatial
 ----------
@@ -218,6 +219,28 @@ There are several advanced options available for certain file types.
 
 - Image files: .jpg, .png, and .tif files are able to be selected as the default thumbnail for a dataset. The selected thumbnail will appear on the search result card for that dataset.
 - SPSS files: SPSS files can be tagged with the language they were originally coded in. This is found by clicking on Advanced Options and selecting the language from the list provided.
+
+.. _restricted-files:
+
+Restricted Files
+================
+
+When you restrict a file in Dataverse it cannot be downloaded unless permission has been granted.
+
+See also :ref:`terms-of-access` and :ref:`permissions`.
+
+.. _restricted-tabular-files:
+
+Restricted Tabular Files
+------------------------
+
+Restricted tabular files are treated differently than other file types in that the following information is exposed when the files are published:
+
+- The name of columns (variables)
+- The "label" (description) of columns.
+- Summary statistics (max, min, mean, etc.) of columns.
+
+This information can been seen from the file landing page if you click "Export Metada" and then "DDI". Depending on your installation, the information above may also be available from :doc:`/admin/external-tools`.
 
 Edit Files
 ==========
@@ -298,12 +321,16 @@ If you are unable to use the CC0 Public Domain Dedication for your datasets, you
 
 Here is an `example of a Data Usage Agreement <https://dataverse.org/best-practices/sample-dua>`_ for datasets that have de-identified human subject data.
 
+.. _terms-of-access:
+
 Restricted Files + Terms of Access 
 ----------------------------------
 
 If you restrict any files in your dataset, you will be prompted by a pop-up to enter Terms of Access for the data. This can also be edited in the Terms tab or selecting Terms in the "Edit" dropdown button in the dataset. You may also allow users to request access for your restricted files by enabling "Request Access". To add more information about the Terms of Access, we have provided fields like Data Access Place, Availability Status, Contact for Access, etc. If you restrict a file, it will not have a preview shown on the file page.
 
 **Note:** Some Dataverse installations do not allow for file restriction.
+
+See also :ref:`restricted-files`.
 
 Guestbook
 ---------


### PR DESCRIPTION
**What this PR does / why we need it**:

Dataverse users are probably unaware the the following information is exposed for restricted tabular files:

- The name of columns (variables)
- The "label" (description) of columns.
- Summary statistics (max, min, mean, etc.) of columns.

**Which issue(s) this PR closes**:

Closes #6474

**Special notes for your reviewer**:

I added a new "Restricted Files" section because it was difficult to work the content into other places. This whole page needs a rewrite. Actually, the whole User Guide could use a rewrite. Stuff is starting to feel a bit bolted on.

**Suggestions on how to test this**:

In #6474 I put some screenshots of how the information above is exposed. There may be other ways that I'm not aware of.

**Does this PR introduce a user interface change?**:

No.

**Is there a release notes update needed for this change?**:

I didn't add one but we certainly could. This behavior was surprising to me and I've been hacking on Dataverse for over seven years. 😄 

**Additional documentation**:

None.