### PR TITLE
change DDI schemaLocation to https #6553

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/export/DDIExporter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/export/DDIExporter.java
@@ -13,6 +13,8 @@ import javax.xml.stream.XMLStreamWriter;
 import javax.xml.stream.XMLOutputFactory;
 
 /**
+ * This exporter is for the "full" DDI, that includes the file-level,
+ * <data> and <var> metadata.
  *
  * @author Leonid Andreev
  * (based on the original DDIExporter by
@@ -21,15 +23,10 @@ import javax.xml.stream.XMLOutputFactory;
  */
 @AutoService(Exporter.class)
 public class DDIExporter implements Exporter {
-    // TODO: 
-    // move these into the ddi export utility
-    private static String DEFAULT_XML_NAMESPACE = "ddi:codebook:2_5"; 
-    // This redirects to https://ddialliance.org/Specification/DDI-Codebook/2.5/XMLSchema/codebook.xsd
-    private static String DEFAULT_XML_SCHEMALOCATION = "http://www.ddialliance.org/Specification/DDI-Codebook/2.5/XMLSchema/codebook.xsd";
-    private static String DEFAULT_XML_VERSION = "2.5";
+    public static String DEFAULT_XML_NAMESPACE = "ddi:codebook:2_5";
+    public static String DEFAULT_XML_SCHEMALOCATION = "https://ddialliance.org/Specification/DDI-Codebook/2.5/XMLSchema/codebook.xsd";
+    public static String DEFAULT_XML_VERSION = "2.5";
     
-    // This exporter is for the "full" DDI, that includes the file-level, 
-    // <data> and <var> metadata.
     @Override
     public String getProviderName() {
         return "ddi";

--- a/src/main/java/edu/harvard/iq/dataverse/export/DDIExporter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/export/DDIExporter.java
@@ -24,6 +24,7 @@ public class DDIExporter implements Exporter {
     // TODO: 
     // move these into the ddi export utility
     private static String DEFAULT_XML_NAMESPACE = "ddi:codebook:2_5"; 
+    // This redirects to https://ddialliance.org/Specification/DDI-Codebook/2.5/XMLSchema/codebook.xsd
     private static String DEFAULT_XML_SCHEMALOCATION = "http://www.ddialliance.org/Specification/DDI-Codebook/2.5/XMLSchema/codebook.xsd";
     private static String DEFAULT_XML_VERSION = "2.5";
     

--- a/src/main/java/edu/harvard/iq/dataverse/export/OAI_DDIExporter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/export/OAI_DDIExporter.java
@@ -11,19 +11,18 @@ import javax.json.JsonObject;
 import javax.xml.stream.XMLStreamException;
 
 /**
+ * This exporter is for the OAI ("short") flavor of the DDI - that is, without
+ * the variable/data information. The ddi export utility does not need the
+ * version entity to produce that.
  *
  * @author skraffmi
  */
 @AutoService(Exporter.class)
 public class OAI_DDIExporter implements Exporter {
-    // TODO: move these to the export utility:
-    private static String DEFAULT_XML_NAMESPACE = "ddi:codebook:2_5"; 
-    // This redirects to https://ddialliance.org/Specification/DDI-Codebook/2.5/XMLSchema/codebook.xsd
-    private static String DEFAULT_XML_SCHEMALOCATION = "http://www.ddialliance.org/Specification/DDI-Codebook/2.5/XMLSchema/codebook.xsd";
-    private static String DEFAULT_XML_VERSION = "2.5";
     
     @Override
     public String getProviderName() {
+        // TODO: Consider adding this "short form" to the "Export Metadata" dropdown in the GUI.
         return "oai_ddi";
     }
 
@@ -35,9 +34,6 @@ public class OAI_DDIExporter implements Exporter {
     @Override
     public void exportDataset(DatasetVersion version, JsonObject json, OutputStream outputStream) throws ExportException {
         try {
-            // This exporter is for the OAI ("short") flavor of the DDI - 
-            // that is, without the variable/data information. The ddi export 
-            // utility does not need the version entity to produce that. 
             DdiExportUtil.datasetJson2ddi(json, outputStream);
         } catch (XMLStreamException xse) {
             throw new ExportException ("Caught XMLStreamException performing DDI export");
@@ -61,17 +57,17 @@ public class OAI_DDIExporter implements Exporter {
     
     @Override
     public String getXMLNameSpace() throws ExportException {
-        return OAI_DDIExporter.DEFAULT_XML_NAMESPACE;   
+        return DDIExporter.DEFAULT_XML_NAMESPACE;
     }
     
     @Override
     public String getXMLSchemaLocation() throws ExportException {
-        return OAI_DDIExporter.DEFAULT_XML_SCHEMALOCATION;
+        return DDIExporter.DEFAULT_XML_SCHEMALOCATION;
     }
     
     @Override
     public String getXMLSchemaVersion() throws ExportException {
-        return OAI_DDIExporter.DEFAULT_XML_VERSION;
+        return DDIExporter.DEFAULT_XML_VERSION;
     }
     
     @Override

--- a/src/main/java/edu/harvard/iq/dataverse/export/OAI_DDIExporter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/export/OAI_DDIExporter.java
@@ -18,6 +18,7 @@ import javax.xml.stream.XMLStreamException;
 public class OAI_DDIExporter implements Exporter {
     // TODO: move these to the export utility:
     private static String DEFAULT_XML_NAMESPACE = "ddi:codebook:2_5"; 
+    // This redirects to https://ddialliance.org/Specification/DDI-Codebook/2.5/XMLSchema/codebook.xsd
     private static String DEFAULT_XML_SCHEMALOCATION = "http://www.ddialliance.org/Specification/DDI-Codebook/2.5/XMLSchema/codebook.xsd";
     private static String DEFAULT_XML_VERSION = "2.5";
     

--- a/src/main/java/edu/harvard/iq/dataverse/export/ddi/DdiExportUtil.java
+++ b/src/main/java/edu/harvard/iq/dataverse/export/ddi/DdiExportUtil.java
@@ -26,6 +26,7 @@ import static edu.harvard.iq.dataverse.export.DDIExportServiceBean.NOTE_SUBJECT_
 import static edu.harvard.iq.dataverse.export.DDIExportServiceBean.NOTE_SUBJECT_UNF;
 import static edu.harvard.iq.dataverse.export.DDIExportServiceBean.NOTE_TYPE_TAG;
 import static edu.harvard.iq.dataverse.export.DDIExportServiceBean.NOTE_TYPE_UNF;
+import edu.harvard.iq.dataverse.export.DDIExporter;
 import static edu.harvard.iq.dataverse.util.SystemConfig.FQDN;
 import static edu.harvard.iq.dataverse.util.SystemConfig.SITE_URL;
 import edu.harvard.iq.dataverse.util.json.JsonUtil;
@@ -110,9 +111,8 @@ public class DdiExportUtil {
         xmlw.writeStartElement("codeBook");
         xmlw.writeDefaultNamespace("ddi:codebook:2_5");
         xmlw.writeAttribute("xmlns:xsi", "http://www.w3.org/2001/XMLSchema-instance");
-        // This redirects to https://ddialliance.org/Specification/DDI-Codebook/2.5/XMLSchema/codebook.xsd
-        xmlw.writeAttribute("xsi:schemaLocation", "ddi:codebook:2_5 https://www.ddialliance.org/Specification/DDI-Codebook/2.5/XMLSchema/codebook.xsd");
-        writeAttribute(xmlw, "version", "2.5");
+        xmlw.writeAttribute("xsi:schemaLocation", DDIExporter.DEFAULT_XML_NAMESPACE + " " + DDIExporter.DEFAULT_XML_SCHEMALOCATION);
+        writeAttribute(xmlw, "version", DDIExporter.DEFAULT_XML_VERSION);
         createStdyDscr(xmlw, datasetDto);
         createOtherMats(xmlw, datasetDto.getDatasetVersion().getFiles());
         xmlw.writeEndElement(); // codeBook
@@ -130,9 +130,8 @@ public class DdiExportUtil {
         xmlw.writeStartElement("codeBook");
         xmlw.writeDefaultNamespace("ddi:codebook:2_5");
         xmlw.writeAttribute("xmlns:xsi", "http://www.w3.org/2001/XMLSchema-instance");
-        // This redirects to https://ddialliance.org/Specification/DDI-Codebook/2.5/XMLSchema/codebook.xsd
-        xmlw.writeAttribute("xsi:schemaLocation", "ddi:codebook:2_5 https://www.ddialliance.org/Specification/DDI-Codebook/2.5/XMLSchema/codebook.xsd");
-        writeAttribute(xmlw, "version", "2.5");
+        xmlw.writeAttribute("xsi:schemaLocation", DDIExporter.DEFAULT_XML_NAMESPACE + " " + DDIExporter.DEFAULT_XML_SCHEMALOCATION);
+        writeAttribute(xmlw, "version", DDIExporter.DEFAULT_XML_VERSION);
         createStdyDscr(xmlw, datasetDto);
         createFileDscr(xmlw, version);
         createDataDscr(xmlw, version);

--- a/src/main/java/edu/harvard/iq/dataverse/export/ddi/DdiExportUtil.java
+++ b/src/main/java/edu/harvard/iq/dataverse/export/ddi/DdiExportUtil.java
@@ -110,7 +110,8 @@ public class DdiExportUtil {
         xmlw.writeStartElement("codeBook");
         xmlw.writeDefaultNamespace("ddi:codebook:2_5");
         xmlw.writeAttribute("xmlns:xsi", "http://www.w3.org/2001/XMLSchema-instance");
-        xmlw.writeAttribute("xsi:schemaLocation", "ddi:codebook:2_5 http://www.ddialliance.org/Specification/DDI-Codebook/2.5/XMLSchema/codebook.xsd");
+        // This redirects to https://ddialliance.org/Specification/DDI-Codebook/2.5/XMLSchema/codebook.xsd
+        xmlw.writeAttribute("xsi:schemaLocation", "ddi:codebook:2_5 https://www.ddialliance.org/Specification/DDI-Codebook/2.5/XMLSchema/codebook.xsd");
         writeAttribute(xmlw, "version", "2.5");
         createStdyDscr(xmlw, datasetDto);
         createOtherMats(xmlw, datasetDto.getDatasetVersion().getFiles());
@@ -129,7 +130,8 @@ public class DdiExportUtil {
         xmlw.writeStartElement("codeBook");
         xmlw.writeDefaultNamespace("ddi:codebook:2_5");
         xmlw.writeAttribute("xmlns:xsi", "http://www.w3.org/2001/XMLSchema-instance");
-        xmlw.writeAttribute("xsi:schemaLocation", "ddi:codebook:2_5 http://www.ddialliance.org/Specification/DDI-Codebook/2.5/XMLSchema/codebook.xsd");
+        // This redirects to https://ddialliance.org/Specification/DDI-Codebook/2.5/XMLSchema/codebook.xsd
+        xmlw.writeAttribute("xsi:schemaLocation", "ddi:codebook:2_5 https://www.ddialliance.org/Specification/DDI-Codebook/2.5/XMLSchema/codebook.xsd");
         writeAttribute(xmlw, "version", "2.5");
         createStdyDscr(xmlw, datasetDto);
         createFileDscr(xmlw, version);

--- a/src/test/java/edu/harvard/iq/dataverse/export/ddi/dataset-finch1.xml
+++ b/src/test/java/edu/harvard/iq/dataverse/export/ddi/dataset-finch1.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<codeBook xmlns="ddi:codebook:2_5" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="ddi:codebook:2_5 http://www.ddialliance.org/Specification/DDI-Codebook/2.5/XMLSchema/codebook.xsd" version="2.5">
+<codeBook xmlns="ddi:codebook:2_5" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="ddi:codebook:2_5 https://www.ddialliance.org/Specification/DDI-Codebook/2.5/XMLSchema/codebook.xsd" version="2.5">
   <docDscr>
     <citation>
       <titlStmt>

--- a/src/test/java/edu/harvard/iq/dataverse/export/ddi/dataset-finch1.xml
+++ b/src/test/java/edu/harvard/iq/dataverse/export/ddi/dataset-finch1.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<codeBook xmlns="ddi:codebook:2_5" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="ddi:codebook:2_5 https://www.ddialliance.org/Specification/DDI-Codebook/2.5/XMLSchema/codebook.xsd" version="2.5">
+<codeBook xmlns="ddi:codebook:2_5" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="ddi:codebook:2_5 https://ddialliance.org/Specification/DDI-Codebook/2.5/XMLSchema/codebook.xsd" version="2.5">
   <docDscr>
     <citation>
       <titlStmt>


### PR DESCRIPTION
**What this PR does / why we need it**:

We want validation tools like https://www.freeformatter.com/xml-validator-xsd.html to demonstrate to us that DDI exports are valid.

**Which issue(s) this PR closes**:

Closes #6553

**Special notes for your reviewer**:

I did the bare minimum of adding an "s" to "http" but I noticed (with `curl -i`) that redirects are in place that land on this URL with no "www": https://ddialliance.org/Specification/DDI-Codebook/2.5/XMLSchema/codebook.xsd . So maybe we should use that instead?

I also noticed a couple other places in the code (DDIExporter.java and OAI_DDIExporter.java) where the vanilla "http" URL exists. I left a comment on these so they can be easily seen in this pull request.

I was glad to see that a test broke when I changed the URL. This tells us that the code is being exercised. I updated the file used in the test code to match the new URL.

**Suggestions on how to test this**:

Create a new dataset, publish it, export as DDI and look at the the `<codeBook xsi:schemaLocation=` line.

I did not try using https://www.freeformatter.com/xml-validator-xsd.html but that would be good too.

**Does this PR introduce a user interface change?**:

No.

**Is there a release notes update needed for this change?**:

No. I doubt this will break any integration or API user's code.

**Additional documentation**:

None.