### PR TITLE
in Search API show fileCount for datasets #6601

### DIFF
--- a/doc/sphinx-guides/source/api/search.rst
+++ b/doc/sphinx-guides/source/api/search.rst
@@ -116,6 +116,7 @@ https://demo.dataverse.org/api/search?q=trees
                        "Astronomy and Astrophysics",
                        "Other"
                     ],
+                    "fileCount":3,
                     "versionId":1260,
                     "versionState":"RELEASED",
                     "majorVersion":3,
@@ -291,6 +292,7 @@ The above example ``fq=publicationStatus:Published`` retrieves only "RELEASED" v
                     "subjects": [
                         "Medicine, Health and Life Sciences"
                     ],
+                    "fileCount":6,
                     "versionId": 53001,
                     "versionState": "RELEASED",
                     "majorVersion": 1,
@@ -323,6 +325,7 @@ The above example ``fq=publicationStatus:Published`` retrieves only "RELEASED" v
                     "subjects": [
                         "Medicine, Health and Life Sciences"
                     ],
+                    "fileCount":9,
                     "versionId": 53444,
                     "versionState": "RELEASED",
                     "majorVersion": 1,

--- a/src/main/java/edu/harvard/iq/dataverse/search/SolrSearchResult.java
+++ b/src/main/java/edu/harvard/iq/dataverse/search/SolrSearchResult.java
@@ -584,6 +584,7 @@ public class SolrSearchResult {
                     subjects.add(subject);
                 }
                 nullSafeJsonBuilder.add("subjects", subjects);
+                nullSafeJsonBuilder.add("fileCount", dv.getFileMetadatas().size());
                 nullSafeJsonBuilder.add("versionId", dv.getId());
                 nullSafeJsonBuilder.add("versionState", dv.getVersionState().toString());
                 if(this.isPublishedState()){

--- a/src/test/java/edu/harvard/iq/dataverse/api/SearchIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/SearchIT.java
@@ -384,6 +384,7 @@ public class SearchIT {
         search2.prettyPrint();
         search2.then().assertThat()
                 .body("data.items[0].name", CoreMatchers.equalTo("Darwin's Finches"))
+                .body("data.items[0].fileCount", CoreMatchers.equalTo(1))
                 .statusCode(200);
 
         //Unpublished datafiles no longer populate the dataset thumbnail


### PR DESCRIPTION
**What this PR does / why we need it**:

Search API users have requested counts of files in datasets.

**Which issue(s) this PR closes**:

Closes #6601

**Special notes for your reviewer**:

Despite the noise I made in the issue about reindexing, I went for a database hit, nestled in several lines of other database hits. We already have the datasetVersion in our hands. It seemed pretty quick with my local testing, admittedly only a few files.

**Suggestions on how to test this**:

Look for "fileCount" in the response for datasets. It might be nice to test a dataset with many files to see if it's slow. A zero is returned, as expected, with no files.

**Does this PR introduce a user interface change?**:

No.

**Is there a release notes update needed for this change?**:

I didn't bother since it seems like a small feature. I'm reminded that some day we might want to keep an API change log. See also http://guides.dataverse.org/en/4.19/api/faq.html#is-there-a-changelog-of-api-functionality-that-has-been-added-over-time

**Additional documentation**:

None. I did update the JSON examples in the Search API docs to show "fileCount".