### PR TITLE
wrong tooltips

### DIFF
--- a/src/main/webapp/file.xhtml
+++ b/src/main/webapp/file.xhtml
@@ -309,11 +309,11 @@
                                                     #{bundle['metrics.file.title']}
                                                     <ui:fragment rendered="#{!settingsWrapper.makeDataCountDisplayEnabled}">
                                                         <span class="glyphicon glyphicon-question-sign tooltip-icon" data-toggle="tooltip" data-placement="auto top" 
-                                                            data-trigger="hover" data-original-title="#{bundle['metrics.dataset.tip.default']}"></span>
+                                                            data-trigger="hover" data-original-title="#{bundle['metrics.file.tip.default']}"></span>
                                                     </ui:fragment>
                                                     <ui:fragment rendered="#{settingsWrapper.makeDataCountDisplayEnabled}">
                                                         <a tabindex="0" role="button" class="glyphicon glyphicon-question-sign tooltip-icon" data-toggle="popover" data-placement="auto top" 
-                                                            data-trigger="focus" data-html="true" data-content="#{bundle['metrics.dataset.tip.makedatacount']}"></a>
+                                                            data-trigger="focus" data-html="true" data-content="#{bundle['metrics.file.tip.makedatacount']}"></a>
                                                     </ui:fragment>
                                                 </div>
                                                 <div id="metrics-body">


### PR DESCRIPTION
**What this PR does / why we need it**: Makes the file page use the correct strings from Bundle.properties in the metrics display

**Which issue(s) this PR closes**:

Closes #6615

**Special notes for your reviewer**: Nothing but a change to which strings appear.

**Suggestions on how to test this**: Just verify that the right strings show in the file page.

**Does this PR introduce a user interface change?**: only correcting which strings are displayed.

**Is there a release notes update needed for this change?**: no

**Additional documentation**:
