### PR TITLE
#6083 update examples in Dataset part of Native API: storagesize and …

### DIFF
--- a/doc/sphinx-guides/source/api/native-api.rst
+++ b/doc/sphinx-guides/source/api/native-api.rst
@@ -1215,13 +1215,13 @@ In practice, you only need one the ``dataset_id`` or the ``persistentId``. The e
 Report the data (file) size of a Dataset
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Shows the combined size in bytes of all the files uploaded into the dataset ``id``. ::
+Shows the combined size in bytes of all the files uploaded into the dataset ``id``.
 
 .. code-block:: bash
 
   export API_TOKEN=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
   export SERVER_URL=https://demo.dataverse.org
-  export ID=xxxxxx
+  export ID=24
 
   curl -H X-Dataverse-key:$API_TOKEN $SERVER_URL/api/datasets/$ID/storagesize
 
@@ -1229,7 +1229,7 @@ The fully expanded example above (without environment variables) looks like this
 
 .. code-block:: bash
 
-  curl -H X-Dataverse-key:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx https://demo.dataverse.org/api/datasets/xxxxxx/storagesize
+  curl -H X-Dataverse-key:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx https://demo.dataverse.org/api/datasets/24/storagesize
 
 The size of published and unpublished files will be summed in the dataset specified. 
 By default, only the archival files are counted - i.e., the files uploaded by users (plus the tab-delimited versions generated for tabular data files on ingest). If the optional argument ``includeCached=true`` is specified, the API will also add the sizes of all the extra files generated and cached by Dataverse - the resized thumbnail versions for image files, the metadata exports for published datasets, etc. Because this deals with unpublished files the token supplied must have permission to view unpublished drafts. 
@@ -1238,14 +1238,14 @@ By default, only the archival files are counted - i.e., the files uploaded by us
 Get the size of Downloading all the files of a Dataset Version
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Shows the combined size in bytes of all the files available for download from version ``versionId`` of dataset ``id``. ::
+Shows the combined size in bytes of all the files available for download from version ``versionId`` of dataset ``id``.
 
 .. code-block:: bash
 
   export API_TOKEN=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
   export SERVER_URL=https://demo.dataverse.org
-  export ID=xxxxxx
-  export VERSIONID=x.x
+  export ID=24
+  export VERSIONID=1.0
 
   curl -H X-Dataverse-key:$API_TOKEN $SERVER_URL/api/datasets/$ID/versions/$VERSIONID/downloadsize
 
@@ -1253,7 +1253,7 @@ The fully expanded example above (without environment variables) looks like this
 
 .. code-block:: bash
 
-  curl -H X-Dataverse-key:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx https://demo.dataverse.org/api/datasets/xxxxxx/versions/x.x/downloadsize
+  curl -H X-Dataverse-key:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx https://demo.dataverse.org/api/datasets/24/versions/1.0/downloadsize
 
 The size of all files available for download will be returned. 
 If :draft is passed as versionId the token supplied must have permission to view unpublished drafts. A token is not required for published datasets. Also restricted files will be included in this total regardless of whether the user has access to download the restricted file(s).


### PR DESCRIPTION
…downloadsize calls.

**What this PR does / why we need it**: This ones fix a display issue (one should use either :: at the end of line or ".. code-block:: bash", but never both), and provides realistic example values (as asked by @pdurbin at http://irclog.iq.harvard.edu/dataverse/2020-02-10#i_118137).

**Which issue(s) this PR closes**: #6083 

Closes none

**Special notes for your reviewer**: These commits continue a previous pull request which handles examples regarding dataverses (e.g. #6600). This one finishes the reformatting of dataset API calls. The file related API call will be handled in different pull requests.

**Suggestions on how to test this**:


```
cd doc/sphinx-guides
make clean && make html
firefox build/html/api/native-api.html
```

Check "Report the data (file) size of a Dataset" and "Get the size of Downloading all the files of a Dataset Version" sections.


**Does this PR introduce a user interface change?**: no

**Is there a release notes update needed for this change?**: no

**Additional documentation**: no
