### PR TITLE
#6083 update examples in File part of Native API: 'Accessing (downloading) files' section

### DIFF
--- a/doc/sphinx-guides/source/api/native-api.rst
+++ b/doc/sphinx-guides/source/api/native-api.rst
@@ -1615,10 +1615,27 @@ Accessing (downloading) files
 
 **Note** Data Access API calls can now be made using persistent identifiers (in addition to database ids). This is done by passing the constant ``:persistentId`` where the numeric id of the file is expected, and then passing the actual persistent id as a query parameter with the name ``persistentId``.
 
-  Example: Getting the file whose DOI is *10.5072/FK2/J8SJZB* ::
+Example: Getting the file whose DOI is *10.5072/FK2/J8SJZB*
 
-    GET http://$SERVER/api/access/datafile/:persistentId/?persistentId=doi:10.5072/FK2/J8SJZB    
+.. code-block:: bash
 
+  export API_TOKEN=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+  export SERVER_URL=https://demo.dataverse.org
+  export PERSISTENT_ID=doi:10.5072/FK2/J8SJZB
+
+  curl "$SERVER_URL/api/access/datafile/:persistentId/?persistentId=$PERSISTENT_ID"
+
+The fully expanded example above (without environment variables) looks like this:
+
+.. code-block:: bash
+
+  curl "https://demo.dataverse.org/api/access/datafile/:persistentId/?persistentId=doi:10.5072/FK2/J8SJZB"
+
+Note: you can use the combination of cURL's ``-J`` (``--remote-header-name``) and ``-O`` (``--remote-name``) options to save the file in its original file name, such as
+
+.. code-block:: bash
+
+  curl -J -O "https://demo.dataverse.org/api/access/datafile/:persistentId/?persistentId=doi:10.5072/FK2/J8SJZB"
 
 Restrict Files
 ~~~~~~~~~~~~~~


### PR DESCRIPTION
**What this PR does / why we need it**: It improves the Native API documentation by providing full curl examples for a File regarding call in 'Accessing (downloading) files' section

**Which issue(s) this PR closes**: none of them. It is an additional step for solving #6083

Closes #

**Special notes for your reviewer**: These commits continue a previous pull request which handles examples regarding dataverses (e.g. #6600). This one finishes the reformatting of file API calls.

**Suggestions on how to test this**:

```
cd doc/sphinx-guides
make clean && make html
firefox build/html/api/native-api.html
```

**Does this PR introduce a user interface change?**: no

**Is there a release notes update needed for this change?**: no

**Additional documentation**: no
