### PR TITLE
#6083 update examples in File part of Native API: 'Editing Variable Level Metadata' section.

### DIFF
--- a/doc/sphinx-guides/source/api/native-api.rst
+++ b/doc/sphinx-guides/source/api/native-api.rst
@@ -1985,11 +1985,24 @@ Also note that dataFileTags are not versioned and changes to these will update t
 Editing Variable Level Metadata
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Updates variable level metadata using ddi xml ``$file``, where ``$id`` is file id::
+Updates variable level metadata using ddi xml ``FILE``, where ``ID`` is file id.
 
-    PUT https://$SERVER/api/edit/$id --upload-file $file
+A curl example using an ``ID``
 
-Example: ``curl -H "X-Dataverse-key:$API_TOKEN" -X PUT http://localhost:8080/api/edit/95 --upload-file dct.xml``
+.. code-block:: bash
+
+  export API_TOKEN=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+  export SERVER_URL=https://demo.dataverse.org
+  export ID=24
+  export FILE=dct.xml
+
+  curl -H "X-Dataverse-key:$API_TOKEN" -X PUT $SERVER_URL/api/edit/$ID --upload-file $FILE
+
+The fully expanded example above (without environment variables) looks like this:
+
+.. code-block:: bash
+
+  curl -H "X-Dataverse-key:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" -X PUT https://demo.dataverse.org/api/edit/24 --upload-file dct.xml
 
 You can download :download:`dct.xml <../../../../src/test/resources/xml/dct.xml>` from the example above to see what the XML looks like.
 


### PR DESCRIPTION
**What this PR does / why we need it**: It improves the Native API documentation by providing full curl examples for a File regarding call in 'Editing Variable Level Metadata' section

**Which issue(s) this PR closes**: none of them. It is an additional step for solving #6083

**Special notes for your reviewer**: This PR continue previous pull requests which handles examples regarding dataverses/datasets/files (e.g. #6600). This one is about reformatting a file API call. It was not clear for me if this call wirks both with file ID and persistent ID, so I just improved the example for the file id, and did not add example for the persistent ID.

**Suggestions on how to test this**:

```
cd doc/sphinx-guides
make clean && make html
firefox build/html/api/native-api.html
```
Check 'Editing Variable Level Metadata' section

**Does this PR introduce a user interface change?**: no

**Is there a release notes update needed for this change?**: no

**Additional documentation**: no
