### PR TITLE
Fixing the link to the 4.19 milestone page

### DIFF
--- a/doc/release-notes/4.19-release-notes.md
+++ b/doc/release-notes/4.19-release-notes.md
@@ -83,7 +83,7 @@ Additional fields are now available via the Search API, mostly related to inform
 
 ## Complete List of Changes
 
-For the complete list of code changes in this release, see the <a href="https://github.com/IQSS/dataverse/milestone/86?closed=1">4.19 milestone</a> in Github.
+For the complete list of code changes in this release, see the <a href="https://github.com/IQSS/dataverse/milestone/87?closed=1">4.19 milestone</a> in Github.
 
 For help with upgrading, installing, or general questions please post to the <a href="https://groups.google.com/forum/#!forum/dataverse-community">Dataverse Google Group</a> or email support@dataverse.org.
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the link to the 4.19 milestone in the release notes.

**Which issue(s) this PR closes**:

Closes #6687