### PR TITLE
#6682 add API Test Coverage button to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Dataverse is a trademark of President and Fellows of Harvard College and is regi
 [![Dataverse Project logo](src/main/webapp/resources/images/dataverseproject_logo.jpg?raw=true "Dataverse Project")](http://dataverse.org)
 
 [![API Test Status](https://jenkins.dataverse.org/buildStatus/icon?job=IQSS-dataverse-develop&subject=API%20Test%20Status)](https://jenkins.dataverse.org/job/IQSS-dataverse-develop/)
+[![API Test Coverage](https://img.shields.io/jenkins/coverage/jacoco?jobUrl=https%3A%2F%2Fjenkins.dataverse.org%2Fjob%2FIQSS-dataverse-develop&label=API%20Test%20Coverage)](https://jenkins.dataverse.org/job/IQSS-dataverse-develop/)
 [![Unit Test Status](https://img.shields.io/travis/IQSS/dataverse?label=Unit%20Test%20Status)](https://travis-ci.org/IQSS/dataverse)
 [![Unit Test Coverage](https://img.shields.io/coveralls/github/IQSS/dataverse?label=Unit%20Test%20Coverage)](https://coveralls.io/github/IQSS/dataverse?branch=develop)
 


### PR DESCRIPTION
**What this PR does / why we need it**: adds an API Test Suite coverage shield to the bottom of README.md:

![Screen Shot 2020-02-27 at 09 50 53](https://user-images.githubusercontent.com/12831666/75455925-e3588200-5947-11ea-8908-376447f8bed9.png)

**Which issue(s) this PR closes**: #6682

Closes #6682

**Special notes for your reviewer**: This PR adds an additional shield, which pulls coverage  from a jenkins.dataverse.org API. It will significantly increase page load time and, depending on the state of Jenkins or shields.io at any time, may produce image placeholders at the bottom of the README. Phil and Gustavo are willing to assume this risk in exchange for a dynamically-populated proof of coverage which links back to the Jenkins job.

**Suggestions on how to test this**: load https://github.com/OdumInstitute/dataverse/tree/6682_coverage_button

**Does this PR introduce a user interface change?**: no

**Is there a release notes update needed for this change?**: no

**Additional documentation**: none