### PR TITLE
6284 Added ui:param to guestbook-responses pg to fix header

### DIFF
--- a/src/main/webapp/guestbook-responses.xhtml
+++ b/src/main/webapp/guestbook-responses.xhtml
@@ -20,7 +20,8 @@
         </f:metadata>
         <ui:composition template="/dataverse_template.xhtml">
             <ui:param name="pageTitle" value="#{bundle['dataset.guestbookResponses.pageTitle']}"/>
-
+            <ui:param name="dataverse" value="#{guestbookResponsesPage.dataverse}"/>
+            <ui:param name="showMessagePanel" value="#{true}"/>
             <ui:define name="body">
                 <h:form id="manageGuestbooksForm">
                     <p:fragment id="tooManyEntries" rendered="#{guestbookResponsesPage.guestbook.responseCount gt systemConfig.guestbookResponsesPageDisplayLimit}">


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix dataverse header on the Guestbook Responses pg so that it displays the correct subdataverse name/theme in the header, and the root by default.

**Which issue(s) this PR closes**:

Closes #6284 Guestbook Responses pg - Dataverse theme/header broken, shows Root theme/header 

**Special notes for your reviewer**:

![Screen Shot 2020-02-27 at 2 26 06 PM](https://user-images.githubusercontent.com/687227/75479598-cdf64e80-596d-11ea-9bb1-8a19d4a5baef.png)


**Suggestions on how to test this**:

View the responses for a guestbook on a subdataverse (not root), make sure the dataverse header shows the correct name/theme, and not root.

**Does this PR introduce a user interface change?**:

Change, no. Bug fix, yes.

**Is there a release notes update needed for this change?**:

No.

**Additional documentation**:

N/A
