### PR TITLE
add release note text for coverage badge

### DIFF
--- a/doc/release-notes/6711-coverage-badge
+++ b/doc/release-notes/6711-coverage-badge
@@ -1,0 +1,3 @@
+Integration Test Coverage Reporting
+
+API-based integration tests are run every time a branch is merged to develop and the percentage of code covered by these integration tests is now shown on a badge at the bottom of the README.md file that serves as the homepage of Dataverse Github Repository.


### PR DESCRIPTION
**What this PR does / why we need it**:

This notifies release note readers that the integration test coverage is now available on the readme.

**Which issue(s) this PR closes**:

Closes #6711 

**Special notes for your reviewer**:

I may adjust the text as part of the release notes process but I just wanted to get this placeholder in. Suggestions welcome. 

**Suggestions on how to test this**:

**Does this PR introduce a user interface change?**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
