### PR TITLE
match the start and end dataverse specific comment blocks in solr schema

### DIFF
--- a/conf/solr/7.7.2/schema.xml
+++ b/conf/solr/7.7.2/schema.xml
@@ -293,7 +293,7 @@
     <!-- Dataverse copyField from http://localhost:8080/api/admin/index/solr/schema -->
     <xi:include href="schema_dv_mdb_copies.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />
     
-<!-- End: Dataverse Specific -->
+<!-- End: Dataverse-specific -->
     
     <!-- This can be enabled, in case the client does not know what fields may be searched. It isn't enabled by default
          because it's very expensive to index everything twice. -->


### PR DESCRIPTION
**What this PR does / why we need it**:
Makes it easier to find the end block region to customize in the solr schema (helpful for developing metadata blocks).

**Which issue(s) this PR closes**:

Closes #6718 

**Special notes for your reviewer**:

**Suggestions on how to test this**:
test searching for the dataverse specific block in a text editor.
 
**Does this PR introduce a user interface change?**:
No.
**Is there a release notes update needed for this change?**:
No.
**Additional documentation**:
