### PR TITLE
Iqss/6725 analytics bug

### DIFF
--- a/doc/release-notes/6725-analytics-bug.md
+++ b/doc/release-notes/6725-analytics-bug.md
@@ -1,0 +1,3 @@
+# Google Analytics Download Tracking Bug
+
+The button tracking capability discussed in the installation guide (http://guides.dataverse.org/en/4.20/installation/config.html#id88) relies on an analytics-code.html file that must be configured using the :WebAnalyticsCode setting. The example file provided in the installation guide is no longer compatible with recent Dataverse releases (>v4.16). Installations using this feature should update their analytics-code.html file by following the installation instructions using the updated example file. (Alternately, sites can modify their existing files to include the one-line change made in the example file at line 120.)

--- a/doc/sphinx-guides/source/_static/installation/files/var/www/dataverse/branding/analytics-code.html
+++ b/doc/sphinx-guides/source/_static/installation/files/var/www/dataverse/branding/analytics-code.html
@@ -117,7 +117,7 @@
       var row = target.parents('tr')[0];
       if(row != null) {
         //finds the file id/DOI in the Dataset page
-        label = $(row).find('td.col-file-metadata > a').attr('href');
+        label = $(row).find('td.col-file-metadata  a').attr('href');
       } else {
         //finds the file id/DOI in the file page
         label = $('#fileForm').attr('action');


### PR DESCRIPTION
**What this PR does / why we need it**: Fixes a bug in the analytics-code.html example file in the docs, which breaks button-level tracking for Google analytics.

**Which issue(s) this PR closes**:

Closes #6725 

**Special notes for your reviewer**:

**Suggestions on how to test this**:
The issue shows a javascript console error that should go away when the fix is applied.

**Does this PR introduce a user interface change?**:

**Is there a release notes update needed for this change?**:
Up to you - I created one. To fix the bug, installations have to reinstall the analytics-code.html file or modify their existing one. It does look to me like this has been broken since ~v.417 - hard to tell if it was a bug/typo in the code or if a UI change broke things at some point. (Pretty sure it worked to start but I can't say when the UI change might have happened.) That said, it only affects installs that have deployed a custom analytics file though.

**Additional documentation**:
