### PR TITLE
Issue #6514: Implement affiliation reading from Shibboleth attribute.

### DIFF
--- a/doc/release-notes/6514-shib-updates
+++ b/doc/release-notes/6514-shib-updates
@@ -1,1 +1,1 @@
-New JVM option :ShibAffiliationAttribute
+New DB option :ShibAffiliationAttribute

--- a/doc/release-notes/6514-shib-updates
+++ b/doc/release-notes/6514-shib-updates
@@ -1,0 +1,1 @@
+New JVM option :ShibAffiliationAttribute

--- a/doc/sphinx-guides/source/installation/config.rst
+++ b/doc/sphinx-guides/source/installation/config.rst
@@ -1780,9 +1780,9 @@ You can set the value of "#THIS PAGE#" to the URL of your Dataverse homepage, or
 :ShibAffiliationAttribute
 +++++++++++++++++++++++++
 
-The Shibboleth affiliation attribute holds information about the affiliation of the user (e.g. "ou"). The Shibboleth affiliation string is read from the DiscoFeed at each login. ``:ShibAffiliationAttribute`` is a name of a Shibboleth attribute, which takes place in Shibboleth header, and Dataverse will read the affiliation string from that. If this value is not set or empty, Dataverse uses the DiscoFeed.
+The Shibboleth affiliation attribute holds information about the affiliation of the user (e.g. "OU") and is read from the DiscoFeed at each login. ``:ShibAffiliationAttribute`` is a name of a Shibboleth attribute in the Shibboleth header which Dataverse will read from instead of DiscoFeed. If this value is not set or empty, Dataverse uses the DiscoFeed.
 
-If the attribute is not yet set for the Shibboleth, please consult the Shibboleth administrators how to set it. Typically it requires changing of the `/etc/shibboleth/attribute-map.xml` file by adding an attribute request, e.g.
+If the attribute is not yet set for the Shibboleth, please consult the Shibboleth Administrators at your institution. Typically it requires changing of the `/etc/shibboleth/attribute-map.xml` file by adding an attribute request, e.g.
 
 ```
     <Attribute name="urn:oid:2.5.4.11" id="ou">

--- a/doc/sphinx-guides/source/installation/config.rst
+++ b/doc/sphinx-guides/source/installation/config.rst
@@ -1777,6 +1777,23 @@ You can set the value of "#THIS PAGE#" to the URL of your Dataverse homepage, or
 
 ``curl -X PUT -d true http://localhost:8080/api/admin/settings/:ShibPassiveLoginEnabled``
 
+:ShibAffiliationAttribute
++++++++++++++++++++++++++
+
+Shibboleth affiliation attribute which holds information about the affiliation of the user (e.g. "ou"). In case of Shibboleth affiliation string is read from the DiscoFeed at each login. ``:ShibAffiliationAttribute`` is a name of a Shibboleth attribute, which takes place in Shibboleth header, and Dataverse will read the affiliation string from that. If this value is not set or empty, Dataverse uses the DiscoFeed.
+
+To set ``:ShibAffiliationAttribute``:
+
+``curl -X PUT -d "ou" http://localhost:8080/api/admin/settings/:ShibAffiliationAttribute``
+
+To delete ``:ShibAffiliationAttribute``:
+
+``curl -X DELETE http://localhost:8080/api/admin/settings/:ShibAffiliationAttribute``
+
+To check the current value of ``:ShibAffiliationAttribute``:
+
+``curl -X GET http://localhost:8080/api/admin/settings/:ShibAffiliationAttribute``
+
 .. _:ComputeBaseUrl:
 
 :ComputeBaseUrl

--- a/doc/sphinx-guides/source/installation/config.rst
+++ b/doc/sphinx-guides/source/installation/config.rst
@@ -1782,6 +1782,36 @@ You can set the value of "#THIS PAGE#" to the URL of your Dataverse homepage, or
 
 Shibboleth affiliation attribute which holds information about the affiliation of the user (e.g. "ou"). In case of Shibboleth affiliation string is read from the DiscoFeed at each login. ``:ShibAffiliationAttribute`` is a name of a Shibboleth attribute, which takes place in Shibboleth header, and Dataverse will read the affiliation string from that. If this value is not set or empty, Dataverse uses the DiscoFeed.
 
+If the attribute is not yet set for the Shibboleth, please consult the Shibboleth administrators how o set it. Typically it requires changing of `/etc/shibboleth/attribute-map.xml` file by adding an attribute request, e.g.
+
+```
+    <Attribute name="urn:oid:2.5.4.11" id="ou">
+        <AttributeDecoder xsi:type="StringAttributeDecoder" caseSensitive="false"/>
+    </Attribute>
+```
+
+In order to take place the change, you should restart Shibboleth and Apache2 services:
+
+```
+sudo service shibd restart
+sudo service apache2 restart
+```
+
+To check if the attribute is sent, you should log in again to Dataverse and check Shibboleth's transaction log. You should see something like this:
+
+```
+INFO Shibboleth-TRANSACTION [25]: Cached the following attributes with session (ID: _9d1f34c0733b61c0feb0ca7596ef43b2) for (applicationId: default) {
+INFO Shibboleth-TRANSACTION [25]: 	givenName (1 values)
+INFO Shibboleth-TRANSACTION [25]: 	ou (1 values)
+INFO Shibboleth-TRANSACTION [25]: 	sn (1 values)
+INFO Shibboleth-TRANSACTION [25]: 	eppn (1 values)
+INFO Shibboleth-TRANSACTION [25]: 	mail (1 values)
+INFO Shibboleth-TRANSACTION [25]: 	displayName (1 values)
+INFO Shibboleth-TRANSACTION [25]: }
+```
+
+If you see the attribue you requested in this list, you can set the attribute in Dataverse.
+
 To set ``:ShibAffiliationAttribute``:
 
 ``curl -X PUT -d "ou" http://localhost:8080/api/admin/settings/:ShibAffiliationAttribute``

--- a/doc/sphinx-guides/source/installation/config.rst
+++ b/doc/sphinx-guides/source/installation/config.rst
@@ -1780,9 +1780,9 @@ You can set the value of "#THIS PAGE#" to the URL of your Dataverse homepage, or
 :ShibAffiliationAttribute
 +++++++++++++++++++++++++
 
-Shibboleth affiliation attribute which holds information about the affiliation of the user (e.g. "ou"). In case of Shibboleth affiliation string is read from the DiscoFeed at each login. ``:ShibAffiliationAttribute`` is a name of a Shibboleth attribute, which takes place in Shibboleth header, and Dataverse will read the affiliation string from that. If this value is not set or empty, Dataverse uses the DiscoFeed.
+The Shibboleth affiliation attribute holds information about the affiliation of the user (e.g. "ou"). The Shibboleth affiliation string is read from the DiscoFeed at each login. ``:ShibAffiliationAttribute`` is a name of a Shibboleth attribute, which takes place in Shibboleth header, and Dataverse will read the affiliation string from that. If this value is not set or empty, Dataverse uses the DiscoFeed.
 
-If the attribute is not yet set for the Shibboleth, please consult the Shibboleth administrators how o set it. Typically it requires changing of `/etc/shibboleth/attribute-map.xml` file by adding an attribute request, e.g.
+If the attribute is not yet set for the Shibboleth, please consult the Shibboleth administrators how to set it. Typically it requires changing of the `/etc/shibboleth/attribute-map.xml` file by adding an attribute request, e.g.
 
 ```
     <Attribute name="urn:oid:2.5.4.11" id="ou">
@@ -1790,7 +1790,7 @@ If the attribute is not yet set for the Shibboleth, please consult the Shibbolet
     </Attribute>
 ```
 
-In order to take place the change, you should restart Shibboleth and Apache2 services:
+In order to implement the change, you should restart Shibboleth and Apache2 services:
 
 ```
 sudo service shibd restart

--- a/src/main/java/edu/harvard/iq/dataverse/Shib.java
+++ b/src/main/java/edu/harvard/iq/dataverse/Shib.java
@@ -11,9 +11,12 @@ import edu.harvard.iq.dataverse.authorization.providers.shib.ShibServiceBean;
 import edu.harvard.iq.dataverse.authorization.providers.shib.ShibUserNameFields;
 import edu.harvard.iq.dataverse.authorization.providers.shib.ShibUtil;
 import edu.harvard.iq.dataverse.authorization.users.AuthenticatedUser;
+import edu.harvard.iq.dataverse.settings.SettingsServiceBean;
 import edu.harvard.iq.dataverse.util.BundleUtil;
 import edu.harvard.iq.dataverse.util.JsfHelper;
 import edu.harvard.iq.dataverse.util.SystemConfig;
+import org.apache.commons.lang.StringUtils;
+
 import java.io.IOException;
 import java.sql.Timestamp;
 import java.util.ArrayList;
@@ -50,6 +53,8 @@ public class Shib implements java.io.Serializable {
     GroupServiceBean groupService;
     @EJB
     UserNotificationServiceBean userNotificationService;
+    @EJB
+    SettingsServiceBean settingsService;
 
     HttpServletRequest request;
 
@@ -205,7 +210,11 @@ public class Shib implements java.io.Serializable {
         internalUserIdentifer = ShibUtil.generateFriendlyLookingUserIdentifer(usernameAssertion, emailAddress);
         logger.fine("friendly looking identifer (backend will enforce uniqueness):" + internalUserIdentifer);
 
-        String affiliation = shibService.getAffiliation(shibIdp, shibService.getDevShibAccountType());
+        String shibAffiliationAttribute = settingsService.getValueForKey(SettingsServiceBean.Key.ShibAffiliationAttribute);
+        String affiliation = (StringUtils.isNotBlank(shibAffiliationAttribute))
+            ? getValueFromAssertion(shibAffiliationAttribute)
+            : shibService.getAffiliation(shibIdp, shibService.getDevShibAccountType());
+
         if (affiliation != null) {
             affiliationToDisplayAtConfirmation = affiliation;
             friendlyNameForInstitution = affiliation;

--- a/src/main/java/edu/harvard/iq/dataverse/settings/SettingsServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/settings/SettingsServiceBean.java
@@ -411,7 +411,13 @@ public class SettingsServiceBean {
          * Lifespan, in minutes, of a login user session 
          * (both DataverseSession and the underlying HttpSession)
          */
-        LoginSessionTimeout;
+        LoginSessionTimeout,
+
+        /**
+         * Shibboleth affiliation attribute which holds information about the affiliation of the user (e.g. ou)
+         */
+        ShibAffiliationAttribute
+        ;
 
         @Override
         public String toString() {


### PR DESCRIPTION
**What this PR does / why we need it**: It adds a new setting :ShibAffiliationAttribute, which contains the name of a Shibboleth attribute (as a string), which attribute holds the affiliation of the user. If it is set, Dataverse reads the content of the attribute from the Shibboleth response, otherwise it reads from the DiscoFeed (which is currently the one and only source of affiliation). DiscoFeed is a wrong source in our use case. A closely related problem is that Dataverse overwrites the affiliation from Shibboleth for every login, so as a site admin it is not an option to fix the wrong data comes from the DiscoFeed by changing the database, because the next login eliminate my changes.

**Which issue(s) this PR closes**: #6514 

Closes #6514

**Special notes for your reviewer**: The configuration this PR implements adds a new database setting. I am aware that @poikilotherm is working on a related issue #6694 which will provide a common configuration for all authentication related settings. Once that ticket will be ready, we can modify this mechanism to use the JSON configuration. On the meantime I also provided documentation for the database setting.

**Suggestions on how to test this**: 
1. First the site admin should contact the Shibboleth administration to ask how to modify attribute-mapping.xml in order to retrieve the affiliation value. 
2. Then it should be tested and check the transaction log if the attribute is arrived. Let's suppose the Shibboleth response contain "ou" attribute as the affiliation.
3. Set the database setting:
```
curl -X PUT -d "ou" http://localhost:8080/api/admin/settings/:ShibAffiliationAttribute
```
4. log in, and check on the account data if the affiliation string has been changed (the value should come now from the Shibboleth attribute).
5. Log out, and delete the database setting:
```
curl -X DELETE http://localhost:8080/api/admin/settings/:ShibAffiliationAttribute
```
6. log in, and check on the account data if the affiliation string has been changed again back to the previous value (comes from DiscoFeed).

**Does this PR introduce a user interface change?**: no

**Is there a release notes update needed for this change?**: Yes, refer to the documentation this PR provides

**Additional documentation**: Yes, in the commit.
