### PR TITLE
#6083 update examples in File part of Native API: 'Datafile Integrity' section.

### DIFF
--- a/doc/sphinx-guides/source/api/native-api.rst
+++ b/doc/sphinx-guides/source/api/native-api.rst
@@ -2228,11 +2228,38 @@ The fully expanded example above (without environment variables) looks like this
 Datafile Integrity
 ~~~~~~~~~~~~~~~~~~
 
-Starting the release 4.10 the size of the saved original file (for an ingested tabular datafile) is stored in the database. The following API will retrieve and permanently store the sizes for any already existing saved originals::
+Starting the release 4.10 the size of the saved original file (for an ingested tabular datafile) is stored in the database. The following API will retrieve and permanently store the sizes for any already existing saved originals:
 
-	    GET http://$SERVER/api/admin/datafiles/integrity/fixmissingoriginalsizes{?limit=N}
+.. code-block:: bash
+
+  export SERVER_URL=https://localhost
+
+  curl $SERVER_URL/api/admin/datafiles/integrity/fixmissingoriginalsizes
+
+with limit parameter:
+
+.. code-block:: bash
+
+  export SERVER_URL=https://localhost
+  export LIMIT=10
+
+  curl "$SERVER_URL/api/admin/datafiles/integrity/fixmissingoriginalsizes?limit=$LIMIT"
+
+The fully expanded example above (without environment variables) looks like this:
+
+.. code-block:: bash
+
+  curl https://localhost/api/admin/datafiles/integrity/fixmissingoriginalsizes"
+
+with limit parameter:
+
+.. code-block:: bash
+
+  curl https://localhost/api/admin/datafiles/integrity/fixmissingoriginalsizes?limit=10"
 
 Note the optional "limit" parameter. Without it, the API will attempt to populate the sizes for all the saved originals that don't have them in the database yet. Otherwise it will do so for the first N such datafiles. 
+
+By default the admin API calls are restricted to be called from the localhost. See more details in :ref:`:BlockedApiEndpoints <:BlockedApiEndpoints>` and :ref:`:BlockedApiPolicy <:BlockedApiPolicy>` settings in :doc:`/installation/config`.
 
 Users Token Management
 ----------------------

--- a/doc/sphinx-guides/source/api/native-api.rst
+++ b/doc/sphinx-guides/source/api/native-api.rst
@@ -2259,7 +2259,7 @@ with limit parameter:
 
 Note the optional "limit" parameter. Without it, the API will attempt to populate the sizes for all the saved originals that don't have them in the database yet. Otherwise it will do so for the first N such datafiles. 
 
-By default the admin API calls are restricted to be called from the localhost. See more details in :ref:`:BlockedApiEndpoints <:BlockedApiEndpoints>` and :ref:`:BlockedApiPolicy <:BlockedApiPolicy>` settings in :doc:`/installation/config`.
+By default, the admin API calls are blocked and can only be called from localhost. See more details in :ref:`:BlockedApiEndpoints <:BlockedApiEndpoints>` and :ref:`:BlockedApiPolicy <:BlockedApiPolicy>` settings in :doc:`/installation/config`.
 
 Users Token Management
 ----------------------


### PR DESCRIPTION
**What this PR does / why we need it**: It improves the Native API documentation by providing full curl examples for a File regarding call in 'Datafile Integrity' section

**Which issue(s) this PR closes**: #6083 (finally)

**Special notes for your reviewer**: This PR continue previous pull requests which handles examples regarding dataverses/datasets/files (e.g. #6600). This one is about reformatting a file API call. It was not clear for me if this call wirks both with file ID and persistent ID, so I just improved the example for the file id, and did not add example for the persistent ID.

**Suggestions on how to test this**:

```
cd doc/sphinx-guides
make clean && make html
firefox build/html/api/native-api.html
```
Check 'Datafile Integrity' section

**Does this PR introduce a user interface change?**: no

**Is there a release notes update needed for this change?**: no

**Additional documentation**: no
