### PR TITLE
6660 restore originals

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DataFileServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DataFileServiceBean.java
@@ -29,6 +29,8 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.ejb.EJB;
 import javax.ejb.Stateless;
+import javax.ejb.TransactionAttribute;
+import javax.ejb.TransactionAttributeType;
 import javax.inject.Named;
 import javax.persistence.EntityManager;
 import javax.persistence.NoResultException;
@@ -933,6 +935,17 @@ public class DataFileServiceBean implements java.io.Serializable {
     }
     
     public DataFile save(DataFile dataFile) {
+
+        if (dataFile.isMergeable()) {   
+            DataFile savedDataFile = em.merge(dataFile);
+            return savedDataFile;
+        } else {
+            throw new IllegalArgumentException("This DataFile object has been set to NOT MERGEABLE; please ensure a MERGEABLE object is passed to the save method.");
+        } 
+    }
+    
+    @TransactionAttribute(TransactionAttributeType.REQUIRES_NEW)
+    public DataFile saveInTransaction(DataFile dataFile) {
 
         if (dataFile.isMergeable()) {   
             DataFile savedDataFile = em.merge(dataFile);

--- a/src/main/java/edu/harvard/iq/dataverse/ingest/IngestServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/ingest/IngestServiceBean.java
@@ -958,7 +958,7 @@ public class IngestServiceBean {
                     dataFile = fileService.saveInTransaction(dataFile);
                     databaseSaveSuccessful = true;
 
-                    logger.fine("Ingest (" + dataFile.getFileMetadata().getLabel() + ".");
+                    logger.info("Ingest (" + dataFile.getFileMetadata().getLabel() + ".");
 
                     if (additionalData != null) {
                         // remove the extra tempfile, if there was one:
@@ -996,7 +996,7 @@ public class IngestServiceBean {
                     // and we want to save the original of the ingested file: 
                     try {
                         dataAccess.backupAsAux(FileUtil.SAVED_ORIGINAL_FILENAME_EXTENSION);
-                        logger.fine("Saved the ingested original as a backup aux file "+FileUtil.SAVED_ORIGINAL_FILENAME_EXTENSION);
+                        logger.info("Saved the ingested original as a backup aux file "+FileUtil.SAVED_ORIGINAL_FILENAME_EXTENSION);
                     } catch (IOException iox) {
                         logger.warning("Failed to save the ingested original! " + iox.getMessage());
                     }
@@ -1005,6 +1005,9 @@ public class IngestServiceBean {
                     dataAccess.savePath(Paths.get(tabFile.getAbsolutePath()));
                     // Reset the file size: 
                     dataFile.setFilesize(dataAccess.getSize());
+                    
+                    dataFile = fileService.save(dataFile);
+                    logger.info("saved data file after updating the size");
 
                     // delete the temp tab-file:
                     tabFile.delete();

--- a/src/main/java/edu/harvard/iq/dataverse/ingest/IngestServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/ingest/IngestServiceBean.java
@@ -958,7 +958,7 @@ public class IngestServiceBean {
                     dataFile = fileService.saveInTransaction(dataFile);
                     databaseSaveSuccessful = true;
 
-                    logger.info("Ingest (" + dataFile.getFileMetadata().getLabel() + ".");
+                    logger.fine("Ingest (" + dataFile.getFileMetadata().getLabel() + ".");
 
                     if (additionalData != null) {
                         // remove the extra tempfile, if there was one:
@@ -982,7 +982,7 @@ public class IngestServiceBean {
                 }
 
                 if (!databaseSaveSuccessful) {
-                    logger.warning("Ingest failure (!databaseSaveSuccessful).");
+                    logger.warning("Ingest failure (failed to save the tabular data in the database; file left intact as uploaded).");
                     return false;
                 }
 
@@ -996,7 +996,7 @@ public class IngestServiceBean {
                     // and we want to save the original of the ingested file: 
                     try {
                         dataAccess.backupAsAux(FileUtil.SAVED_ORIGINAL_FILENAME_EXTENSION);
-                        logger.info("Saved the ingested original as a backup aux file "+FileUtil.SAVED_ORIGINAL_FILENAME_EXTENSION);
+                        logger.fine("Saved the ingested original as a backup aux file "+FileUtil.SAVED_ORIGINAL_FILENAME_EXTENSION);
                     } catch (IOException iox) {
                         logger.warning("Failed to save the ingested original! " + iox.getMessage());
                     }
@@ -1007,7 +1007,7 @@ public class IngestServiceBean {
                     dataFile.setFilesize(dataAccess.getSize());
                     
                     dataFile = fileService.save(dataFile);
-                    logger.info("saved data file after updating the size");
+                    logger.fine("saved data file after updating the size");
 
                     // delete the temp tab-file:
                     tabFile.delete();

--- a/src/main/java/edu/harvard/iq/dataverse/ingest/IngestServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/ingest/IngestServiceBean.java
@@ -955,7 +955,7 @@ public class IngestServiceBean {
                             throw new EJBException("Deliberate database save failure");
                         }
                      */
-                    dataFile = fileService.save(dataFile);
+                    dataFile = fileService.saveInTransaction(dataFile);
                     databaseSaveSuccessful = true;
 
                     logger.fine("Ingest (" + dataFile.getFileMetadata().getLabel() + ".");


### PR DESCRIPTION
**What this PR does / why we need it**:
Ensures that certain ingest failures DO NOT result in a half-baked, semi-ingested state - where the file appears as uningested, but the physical file has been replaced by the generated tab-delimited version.
**Which issue(s) this PR closes**:

Closes #6660

**Special notes for your reviewer**:
Very straightforward, simple solution; we don't even need to replace the tab version with the saved original. Instead we are ensuring that the original is never overwritten, if the final database save of the ingested data has not succeeded. 

**Suggestions on how to test this**:
- Download this file: https://dataverse.harvard.edu/file.xhtml?persistentId=doi:10.7910/DVN/BIIFAJ/TGPKX7&version=1.0 (converted_data_occupancy);
- Save it with the `.csv` extension; 
- (when ingested as csv, the file is guaranteed to fail ingest with an EJB exception in the final database save; for one, the lines are not csv, but semicolon-separated values)
- Upload the file into a dataset. 
Expected behavior:
*Before this PR:* The file will fail ingest; will appear as a .csv, with the ingest error message in a red triangle. Downloading the file and checking the md5 will produce a **different** md5 from what's shown on the page. 
*After this PR:* Same as above, except downloading the file will get you the same original you uploaded, with the correct md5. 


**Does this PR introduce a user interface change?**:
No
**Is there a release notes update needed for this change?**:
No
**Additional documentation**:
None