### PR TITLE
6777 Bug with Manage Permissions - Edit Access

### DIFF
--- a/src/main/webapp/permissions-configure.xhtml
+++ b/src/main/webapp/permissions-configure.xhtml
@@ -26,7 +26,7 @@
         </label>
         <div class="col-sm-offset-1">
             <p:selectOneRadio id="defaultContributorRoleRadio" value="#{managePermissionsPage.defaultContributorRoleAlias}" layout="custom" >
-                <f:selectItem itemLabel="#{bundle.editor}" itemValue="editor" /> 
+                <f:selectItem itemLabel="#{bundle.editor}" itemValue="contributor" /> 
                 <f:selectItem itemLabel="#{bundle.curator}" itemValue="curator" /> 
                 <f:selectItem itemLabel="#{managePermissionsPage.customDefaultContributorRoleName}" itemValue="#{managePermissionsPage.customDefaultContributorRoleAlias}" /> #{managePermissionsPage.customDefaultContributorRoleAlias}               
             </p:selectOneRadio>


### PR DESCRIPTION
**What this PR does / why we need it**:
modifies the radio button value on the UI for edit access settings on a dataverse

**Which issue(s) this PR closes**:

Closes #6777

**Special notes for your reviewer**:
none

**Suggestions on how to test this**:
make sure you can edit the access setting of a dataverse (see the issue for the two specific case I had seen)

**Does this PR introduce a user interface change?**:
No

**Is there a release notes update needed for this change?**:
No

**Additional documentation**:
