### PR TITLE
Iqss/6776 - Replace File API fix

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/datasetutility/AddReplaceFileHelper.java
+++ b/src/main/java/edu/harvard/iq/dataverse/datasetutility/AddReplaceFileHelper.java
@@ -367,7 +367,6 @@ public class AddReplaceFileHelper{
         if (!this.step_005_loadFileToReplaceById(oldFileId)){
             return false;
         }
-        logger.info("owner id " + fileToReplace.getOwner().getId());
         return this.runAddReplaceFile(fileToReplace.getOwner(), newFileName, newFileContentType, newFileInputStream, optionalFileParams);
     }
     

--- a/src/main/java/edu/harvard/iq/dataverse/datasetutility/AddReplaceFileHelper.java
+++ b/src/main/java/edu/harvard/iq/dataverse/datasetutility/AddReplaceFileHelper.java
@@ -367,7 +367,7 @@ public class AddReplaceFileHelper{
         if (!this.step_005_loadFileToReplaceById(oldFileId)){
             return false;
         }
-
+        logger.info("owner id " + fileToReplace.getOwner().getId());
         return this.runAddReplaceFile(fileToReplace.getOwner(), newFileName, newFileContentType, newFileInputStream, optionalFileParams);
     }
     
@@ -394,10 +394,10 @@ public class AddReplaceFileHelper{
      */
     private boolean runAddReplaceFile(Dataset owner, String newFileName, String newFileContentType,
 			InputStream newFileInputStream, OptionalFileParams optionalFileParams) {
-		return runAddReplaceFile(dataset,newFileName, newFileContentType, null, newFileInputStream, optionalFileParams);
+		return runAddReplaceFile(owner,newFileName, newFileContentType, null, newFileInputStream, optionalFileParams);
 	}
     
-    private boolean runAddReplaceFile(Dataset dataset,  
+    private boolean runAddReplaceFile(Dataset owner,  
             String newFileName, String newFileContentType, 
             String newStorageIdentifier, InputStream newFileInputStream,
             OptionalFileParams optionalFileParams){
@@ -405,14 +405,13 @@ public class AddReplaceFileHelper{
         // Run "Phase 1" - Initial ingest of file + error check
         // But don't save the dataset version yet
         //
-        boolean phase1Success = runAddReplacePhase1(dataset,  
+        boolean phase1Success = runAddReplacePhase1(owner,  
                                         newFileName,  
                                         newFileContentType,  
                                         newStorageIdentifier,
                                         newFileInputStream,
                                         optionalFileParams
                                         );
-        
         if (!phase1Success){
             return false;
         }
@@ -476,7 +475,7 @@ public class AddReplaceFileHelper{
      * 
      * @return 
      */
-    private boolean runAddReplacePhase1(Dataset dataset,  
+    private boolean runAddReplacePhase1(Dataset owner,  
             String newFileName, 
             String newFileContentType,
             String newStorageIdentifier, InputStream newFileInputStream,
@@ -487,7 +486,7 @@ public class AddReplaceFileHelper{
         }
 
         msgt("step_001_loadDataset");
-        if (!this.step_001_loadDataset(dataset)){
+        if (!this.step_001_loadDataset(owner)){
             return false;
         }
         
@@ -988,7 +987,7 @@ public class AddReplaceFileHelper{
         // Does the file exist?
         //
         DataFile existingFile = fileService.find(dataFileId);
-
+        
         if (existingFile == null){           
             this.addError(BundleUtil.getStringFromBundle("file.addreplace.error.existing_file_to_replace_not_found_by_id", Collections.singletonList(dataFileId.toString())));
             return false;


### PR DESCRIPTION
**What this PR does / why we need it**: Fixes a bug in the replace File API call 
(this is expected to make the integration tests pass on jenkins.dataverse.org; we want to merge this before the release is cut)

**Which issue(s) this PR closes**:

Closes #6776

**Special notes for your reviewer**: 

**Suggestions on how to test this**: should fix the FileIT tests but can also be tested by calling the replace file api directly

**Does this PR introduce a user interface change?**: no

**Is there a release notes update needed for this change?**: no

**Additional documentation**:
a cut/paste error made possible by having params with the same name as a class variable 
