### PR TITLE
allow project properties to open in Netbeans #6811

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="https://maven.apache.org/POM/4.0.0" xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <!--
     If you are doing more than bumping the version number, please read


### PR DESCRIPTION
**What this PR does / why we need it**:

Developers using Netbeans (the IDE we use at IQSS and promote in the dev guide) need to be able to open up and edit project properties. This is currently impossible.

**Which issue(s) this PR closes**:

Closes #6811 

**Special notes for your reviewer**:

I reported this issue upstream at https://issues.apache.org/jira/browse/NETBEANS-4148

The bug was introduced in pull request #6519.

**Suggestions on how to test this**:

Try following http://guides.dataverse.org/en/4.20/developers/tips.html#ensure-that-dataverse-will-be-deployed-to-glassfish-4-1

**Does this PR introduce a user interface change?**:

No.

**Is there a release notes update needed for this change?**:

No.

**Additional documentation**:

None.