### PR TITLE
prevent label (filename) from being null #6821

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/UningestFileCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/UningestFileCommand.java
@@ -58,7 +58,9 @@ public class UningestFileCommand extends AbstractVoidCommand  {
         if (!uningest.isTabularData()) {
             throw new IllegalCommandException("UningestFileCommand called on a non-tabular data file (id="+uningest.getId()+")", this);
         }
-        
+
+        String originalFileName = uningest.getOriginalFileName();
+
         StorageIO<DataFile> dataAccess = null;
         // size of the stored original:
         Long storedOriginalFileSize;
@@ -139,7 +141,6 @@ public class UningestFileCommand extends AbstractVoidCommand  {
         // could be more than one: 
         
        // String originalExtension = FileUtil.generateOriginalExtension(originalFileFormat);
-        String originalFileName = uningest.getOriginalFileName();
         for (FileMetadata fm : uningest.getFileMetadatas()) {
             
             fm.setLabel(originalFileName);


### PR DESCRIPTION
**What this PR does / why we need it**:

Tests are failing, but more importantly, uningest stopped working (500 errors) probably due to 786593e or other commits in pull request #6774.

**Which issue(s) this PR closes**:

Closes #6821

**Special notes for your reviewer**:

The getOriginalFileName method only works on tabular files so we need call it early before the file becomes non-tabular. For non-tabular files, null is returned which causes a ConstraintViolationException because label (filename) can't be null.

**Suggestions on how to test this**:

- On the "develop" branch, check if uningest works. I predict 500 errors.
- On this branch, check uningest.

**Does this PR introduce a user interface change?**:

No.

**Is there a release notes update needed for this change?**:

No.

**Additional documentation**:

None.