### PR TITLE
change setting of default mode to edit from property to in init method

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/EditDatafilesPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/EditDatafilesPage.java
@@ -104,7 +104,6 @@ import org.primefaces.PrimeFaces;
 public class EditDatafilesPage implements java.io.Serializable {
 
     private static final Logger logger = Logger.getLogger(EditDatafilesPage.class.getCanonicalName());
-    private FileView fileView;
     private boolean uploadWarningMessageIsNotAnError;
 
     public enum FileEditMode {
@@ -147,7 +146,6 @@ public class EditDatafilesPage implements java.io.Serializable {
     @Inject ProvPopupFragmentBean provPopupFragmentBean;
     @Inject
     SettingsWrapper settingsWrapper;
-    private final DateFormat displayDateFormat = DateFormat.getDateInstance(DateFormat.MEDIUM);
 
     private Dataset dataset = new Dataset();
     
@@ -155,7 +153,7 @@ public class EditDatafilesPage implements java.io.Serializable {
 
 
     private String selectedFileIdsString = null; 
-    private FileEditMode mode = FileEditMode.EDIT; 
+    private FileEditMode mode; 
     private List<Long> selectedFileIdsList = new ArrayList<>(); 
     private List<FileMetadata> fileMetadatas = new ArrayList<>();;
 
@@ -474,6 +472,10 @@ public class EditDatafilesPage implements java.io.Serializable {
     
 
     public String init() {
+        // default mode should be EDIT
+        if (mode == null) {
+            mode = FileEditMode.EDIT;
+        }
         
         newFiles = new ArrayList<>();
         uploadedFiles = new ArrayList<>(); 
@@ -582,7 +584,7 @@ public class EditDatafilesPage implements java.io.Serializable {
                 if (fileMetadatas.get(0).getDatasetVersion().getId() != null){
                     versionString = "DRAFT";
                 }
-            }           
+            }    
                        
         }
         


### PR DESCRIPTION
**What this PR does / why we need it**:
fixes an outstanding viewparam issue for the glassfish to payara upgrade

**Which issue(s) this PR closes**:

Fix related to #6230 

**Special notes for your reviewer**:
none

**Suggestions on how to test this**:
from dataset, select one or more files, go to edit, make sure files appear in list

**Does this PR introduce a user interface change?**:
no

**Is there a release notes update needed for this change?**:
no

**Additional documentation**:
