### PR TITLE
6684 thumbnails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,8 @@ scripts/installer/default.config
 tests/node_modules
 tests/package-lock.json
 venv
+
+# from thumbnail tests in SearchIT
+scripts/search/data/binary/trees.png.thumb140
+src/main/webapp/resources/images/cc0.png.thumb140
+src/main/webapp/resources/images/dataverseproject.png.thumb140

--- a/doc/sphinx-guides/source/api/dataaccess.rst
+++ b/doc/sphinx-guides/source/api/dataaccess.rst
@@ -58,8 +58,8 @@ the following parameter values are supported (for image and pdf files only):
 ==============  ===========
 Value           Description
 ==============  ===========
-true            Generates a thumbnail image, by rescaling to the default thumbnail size (64 pixels)
-``N``           Rescales the image to ``N`` pixels.
+true            Generates a thumbnail image by rescaling to the default thumbnail size (140 pixels wide).
+``N``           Rescales the image to ``N`` pixels wide. ``imageThumb=true`` and ``imageThumb=140`` are equivalent.
 ==============  ===========
 
 Multiple File ("bundle") download

--- a/doc/sphinx-guides/source/api/dataaccess.rst
+++ b/doc/sphinx-guides/source/api/dataaccess.rst
@@ -58,8 +58,8 @@ the following parameter values are supported (for image and pdf files only):
 ==============  ===========
 Value           Description
 ==============  ===========
-true            Generates a thumbnail image by rescaling to the default thumbnail size (140 pixels wide).
-``N``           Rescales the image to ``N`` pixels wide. ``imageThumb=true`` and ``imageThumb=140`` are equivalent.
+true            Generates a thumbnail image by rescaling to the default thumbnail size (64 pixels wide).
+``N``           Rescales the image to ``N`` pixels wide. ``imageThumb=true`` and ``imageThumb=64`` are equivalent.
 ==============  ===========
 
 Multiple File ("bundle") download

--- a/src/main/java/edu/harvard/iq/dataverse/DatasetWidgetsPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetWidgetsPage.java
@@ -117,7 +117,7 @@ public class DatasetWidgetsPage implements java.io.Serializable {
     public void setDataFileAsThumbnail() {
         logger.fine("setDataFileAsThumbnail clicked");
         updateDatasetThumbnailCommand = new UpdateDatasetThumbnailCommand(dvRequestService.getDataverseRequest(), dataset, UpdateDatasetThumbnailCommand.UserIntent.setDatasetFileAsThumbnail, datasetFileThumbnailToSwitchTo.getId(), null);
-        String base64image = ImageThumbConverter.getImageThumbnailAsBase64(datasetFileThumbnailToSwitchTo, ImageThumbConverter.DEFAULT_CARDIMAGE_SIZE);
+        String base64image = ImageThumbConverter.getImageThumbnailAsBase64(datasetFileThumbnailToSwitchTo, ImageThumbConverter.DEFAULT_DATASET_THUMBNAIL_SIZE);
         datasetThumbnail = new DatasetThumbnail(base64image, datasetFileThumbnailToSwitchTo);
     }
 
@@ -146,7 +146,7 @@ public class DatasetWidgetsPage implements java.io.Serializable {
             Logger.getLogger(DatasetWidgetsPage.class.getName()).log(Level.SEVERE, null, ex);
             return;
         }
-        String base64image = ImageThumbConverter.generateImageThumbnailFromFileAsBase64(file, ImageThumbConverter.DEFAULT_CARDIMAGE_SIZE);
+        String base64image = ImageThumbConverter.generateImageThumbnailFromFileAsBase64(file, ImageThumbConverter.DEFAULT_DATASET_THUMBNAIL_SIZE);
         if (base64image != null) {
             datasetThumbnail = new DatasetThumbnail(base64image, datasetFileThumbnailToSwitchTo);
         } else {

--- a/src/main/java/edu/harvard/iq/dataverse/ThumbnailServiceWrapper.java
+++ b/src/main/java/edu/harvard/iq/dataverse/ThumbnailServiceWrapper.java
@@ -70,9 +70,8 @@ public class ThumbnailServiceWrapper implements java.io.Serializable  {
                 return null;
             }
 
-            String imageSourceBase64 = ImageThumbConverter.getImageThumbnailAsBase64(
-                    assignedThumbnailFile,
-                    ImageThumbConverter.DEFAULT_CARDIMAGE_SIZE);
+            String imageSourceBase64 = ImageThumbConverter.getImageThumbnailAsBase64(assignedThumbnailFile,
+                    ImageThumbConverter.DEFAULT_DATASET_THUMBNAIL_SIZE);
 
             if (imageSourceBase64 != null) {
                 this.dvobjectThumbnailsMap.put(assignedThumbnailFileId, imageSourceBase64);

--- a/src/main/java/edu/harvard/iq/dataverse/dataaccess/ImageThumbConverter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/dataaccess/ImageThumbConverter.java
@@ -62,7 +62,7 @@ public class ImageThumbConverter {
     public static String THUMBNAIL_MIME_TYPE = "image/png";
 
     public static int DEFAULT_CARDIMAGE_SIZE = 48;
-    public static int DEFAULT_THUMBNAIL_SIZE = 64;
+    public static int DEFAULT_THUMBNAIL_SIZE = 140;
     public static int DEFAULT_PREVIEW_SIZE = 400;
 
     private static final Logger logger = Logger.getLogger(ImageThumbConverter.class.getCanonicalName());

--- a/src/main/java/edu/harvard/iq/dataverse/dataaccess/ImageThumbConverter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/dataaccess/ImageThumbConverter.java
@@ -62,7 +62,8 @@ public class ImageThumbConverter {
     public static String THUMBNAIL_MIME_TYPE = "image/png";
 
     public static int DEFAULT_CARDIMAGE_SIZE = 48;
-    public static int DEFAULT_THUMBNAIL_SIZE = 140;
+    public static int DEFAULT_THUMBNAIL_SIZE = 64;
+    public static int DEFAULT_DATASET_THUMBNAIL_SIZE = 140;
     public static int DEFAULT_PREVIEW_SIZE = 400;
 
     private static final Logger logger = Logger.getLogger(ImageThumbConverter.class.getCanonicalName());

--- a/src/main/java/edu/harvard/iq/dataverse/dataset/DatasetUtil.java
+++ b/src/main/java/edu/harvard/iq/dataverse/dataset/DatasetUtil.java
@@ -88,7 +88,7 @@ public class DatasetUtil {
                     && ImageThumbConverter.isThumbnailAvailable(dataFile)
                     && !dataFile.isRestricted()) {
                 String imageSourceBase64 = null;
-                imageSourceBase64 = ImageThumbConverter.getImageThumbnailAsBase64(dataFile, ImageThumbConverter.DEFAULT_CARDIMAGE_SIZE);
+                imageSourceBase64 = ImageThumbConverter.getImageThumbnailAsBase64(dataFile, ImageThumbConverter.DEFAULT_DATASET_THUMBNAIL_SIZE);
 
                 if (imageSourceBase64 != null) {
                     DatasetThumbnail datasetThumbnail = new DatasetThumbnail(imageSourceBase64, dataFile);
@@ -160,7 +160,7 @@ public class DatasetUtil {
                         logger.fine("Dataset (id :" + dataset.getId() + ") does not have a thumbnail available that could be selected automatically.");
                         return null;
                     } else {
-                        String imageSourceBase64 = ImageThumbConverter.getImageThumbnailAsBase64(thumbnailFile, ImageThumbConverter.DEFAULT_CARDIMAGE_SIZE);
+                        String imageSourceBase64 = ImageThumbConverter.getImageThumbnailAsBase64(thumbnailFile, ImageThumbConverter.DEFAULT_DATASET_THUMBNAIL_SIZE);
                         DatasetThumbnail defaultDatasetThumbnail = new DatasetThumbnail(imageSourceBase64, thumbnailFile);
                         logger.fine("thumbnailFile (id :" + thumbnailFile.getId() + ") will get thumbnail through automatic selection from DataFile id " + thumbnailFile.getId());
                         return defaultDatasetThumbnail;
@@ -170,7 +170,7 @@ public class DatasetUtil {
                 logger.fine("Dataset (id :" + dataset.getId() + ") has a thumbnail the user selected but the file must have later been restricted. Returning null.");
                 return null;
             } else {
-                String imageSourceBase64 = ImageThumbConverter.getImageThumbnailAsBase64(thumbnailFile, ImageThumbConverter.DEFAULT_CARDIMAGE_SIZE);
+                String imageSourceBase64 = ImageThumbConverter.getImageThumbnailAsBase64(thumbnailFile, ImageThumbConverter.DEFAULT_DATASET_THUMBNAIL_SIZE);
                 DatasetThumbnail userSpecifiedDatasetThumbnail = new DatasetThumbnail(imageSourceBase64, thumbnailFile);
                 logger.fine("Dataset (id :" + dataset.getId() + ")  will get thumbnail the user specified from DataFile id " + thumbnailFile.getId());
                 return userSpecifiedDatasetThumbnail;
@@ -252,7 +252,7 @@ public class DatasetUtil {
         for (FileMetadata fmd : datasetVersion.getFileMetadatas()) {
             DataFile testFile = fmd.getDataFile();
             // We don't want to use a restricted image file as the dedicated thumbnail:
-            if (!testFile.isRestricted() && FileUtil.isThumbnailSupported(testFile) && ImageThumbConverter.isThumbnailAvailable(testFile, ImageThumbConverter.DEFAULT_CARDIMAGE_SIZE)) {
+            if (!testFile.isRestricted() && FileUtil.isThumbnailSupported(testFile) && ImageThumbConverter.isThumbnailAvailable(testFile, ImageThumbConverter.DEFAULT_DATASET_THUMBNAIL_SIZE)) {
                 return testFile;
             }
         }
@@ -329,7 +329,7 @@ public class DatasetUtil {
             logger.severe(ex.getMessage());
             return null;
         }
-        String thumbFileLocation = ImageThumbConverter.rescaleImage(fullSizeImage, width, height, ImageThumbConverter.DEFAULT_CARDIMAGE_SIZE, tmpFileForResize.toPath().toString());
+        String thumbFileLocation = ImageThumbConverter.rescaleImage(fullSizeImage, width, height, ImageThumbConverter.DEFAULT_DATASET_THUMBNAIL_SIZE, tmpFileForResize.toPath().toString());
         logger.fine("thumbFileLocation = " + thumbFileLocation);
         logger.fine("tmpFileLocation=" + tmpFileForResize.toPath().toString());
         //now we must save the updated thumbnail 

--- a/src/main/webapp/resources/css/structure.css
+++ b/src/main/webapp/resources/css/structure.css
@@ -747,7 +747,6 @@ div[id$="filesTable"] .col-file-thumb {padding:4px 10px; width:84px;}
 div[id$="filesTable"] .col-file-thumb div.thumbnail-block {position:relative;width:64px;height:64px;margin:0 auto;}
 div[id$="filesTable"] .col-file-thumb div.thumbnail-block span.file-thumbnail-icon {font-size:62px;line-height:1.05;}
 div[id$="filesTable"] .col-file-thumb div.thumbnail-block span.file-thumbnail-preview-img {display:block;}
-div[id$="filesTable"] .col-file-thumb div.thumbnail-block span.file-thumbnail-preview-img img {max-width:64px; max-height:64px;}
 div[id$="filesTable"] .col-file-thumb div.thumbnail-block div.file-icon-restricted-block {display:block;position:absolute;bottom:-4px;right:-1px;}
 div[id$="filesTable"] .file-metadata-block {-webkit-flex: 1 100%;
 	-moz-flex: 1 100%;

--- a/src/main/webapp/resources/css/structure.css
+++ b/src/main/webapp/resources/css/structure.css
@@ -747,6 +747,7 @@ div[id$="filesTable"] .col-file-thumb {padding:4px 10px; width:84px;}
 div[id$="filesTable"] .col-file-thumb div.thumbnail-block {position:relative;width:64px;height:64px;margin:0 auto;}
 div[id$="filesTable"] .col-file-thumb div.thumbnail-block span.file-thumbnail-icon {font-size:62px;line-height:1.05;}
 div[id$="filesTable"] .col-file-thumb div.thumbnail-block span.file-thumbnail-preview-img {display:block;}
+div[id$="filesTable"] .col-file-thumb div.thumbnail-block span.file-thumbnail-preview-img img {max-width:64px; max-height:64px;}
 div[id$="filesTable"] .col-file-thumb div.thumbnail-block div.file-icon-restricted-block {display:block;position:absolute;bottom:-4px;right:-1px;}
 div[id$="filesTable"] .file-metadata-block {-webkit-flex: 1 100%;
 	-moz-flex: 1 100%;

--- a/src/test/java/edu/harvard/iq/dataverse/api/SearchIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/SearchIT.java
@@ -334,7 +334,7 @@ public class SearchIT {
         
         File trees = new File("scripts/search/data/binary/trees.png");
         String treesAsBase64 = null;
-        treesAsBase64 = ImageThumbConverter.generateImageThumbnailFromFileAsBase64(trees, ImageThumbConverter.DEFAULT_CARDIMAGE_SIZE);
+        treesAsBase64 = ImageThumbConverter.generateImageThumbnailFromFileAsBase64(trees, ImageThumbConverter.DEFAULT_DATASET_THUMBNAIL_SIZE);
 
         if (treesAsBase64 == null) {
             Logger.getLogger(SearchIT.class.getName()).log(Level.SEVERE, "Failed to generate a base64 thumbnail from the file trees.png");
@@ -444,7 +444,7 @@ public class SearchIT {
             int height = bufferedImage.getHeight();
             System.out.println("width: " + width);
             System.out.println("height: " + height);
-            int expectedWidth = 140;
+            int expectedWidth = 64;
             assertEquals(expectedWidth, width);
         } catch (IOException ex) {
             Logger.getLogger(SearchIT.class.getName()).log(Level.SEVERE, null, ex);
@@ -495,7 +495,7 @@ public class SearchIT {
 
         File dataverseProjectLogo = new File(pathToFile);
         String dataverseProjectLogoAsBase64 = null;
-        dataverseProjectLogoAsBase64 = ImageThumbConverter.generateImageThumbnailFromFileAsBase64(dataverseProjectLogo, ImageThumbConverter.DEFAULT_CARDIMAGE_SIZE);
+        dataverseProjectLogoAsBase64 = ImageThumbConverter.generateImageThumbnailFromFileAsBase64(dataverseProjectLogo, ImageThumbConverter.DEFAULT_DATASET_THUMBNAIL_SIZE);
 
         if (dataverseProjectLogoAsBase64 == null) {
             Logger.getLogger(SearchIT.class.getName()).log(Level.SEVERE, "Failed to generate a base64 thumbnail from the file dataverseproject.png");
@@ -556,7 +556,7 @@ public class SearchIT {
 
         String datasetLogo = "src/main/webapp/resources/images/cc0.png";
         File datasetLogoFile = new File(datasetLogo);
-        String datasetLogoAsBase64 = datasetLogoAsBase64 = ImageThumbConverter.generateImageThumbnailFromFileAsBase64(datasetLogoFile, ImageThumbConverter.DEFAULT_CARDIMAGE_SIZE);
+        String datasetLogoAsBase64 = datasetLogoAsBase64 = ImageThumbConverter.generateImageThumbnailFromFileAsBase64(datasetLogoFile, ImageThumbConverter.DEFAULT_DATASET_THUMBNAIL_SIZE);
 
         if (datasetLogoAsBase64 == null) {
             Logger.getLogger(SearchIT.class.getName()).log(Level.SEVERE, "Failed to generate a base64 thumbnail from the file dataverseproject.png");

--- a/src/test/java/edu/harvard/iq/dataverse/api/SearchIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/SearchIT.java
@@ -23,8 +23,11 @@ import org.hamcrest.CoreMatchers;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import edu.harvard.iq.dataverse.dataaccess.ImageThumbConverter;
+import java.awt.image.BufferedImage;
+import java.io.IOException;
 import static junit.framework.Assert.assertEquals;
 import static java.lang.Thread.sleep;
+import javax.imageio.ImageIO;
 import static javax.ws.rs.core.Response.Status.CREATED;
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static javax.ws.rs.core.Response.Status.OK;
@@ -428,6 +431,24 @@ public class SearchIT {
         getThumbnailImageA.then().assertThat()
                 .contentType("image/png")
                 .statusCode(OK.getStatusCode());
+
+        String trueOrWidthInPixels = "true";
+        Response getFileThumbnailImageA = UtilIT.getFileThumbnail(dataFileId1.toString(), trueOrWidthInPixels, apiToken);
+        getFileThumbnailImageA.then().assertThat()
+                .contentType("image/png")
+                .statusCode(OK.getStatusCode());
+
+        try {
+            BufferedImage bufferedImage = ImageIO.read(getFileThumbnailImageA.body().asInputStream());
+            int width = bufferedImage.getWidth();
+            int height = bufferedImage.getHeight();
+            System.out.println("width: " + width);
+            System.out.println("height: " + height);
+            int expectedWidth = 140;
+            assertEquals(expectedWidth, width);
+        } catch (IOException ex) {
+            Logger.getLogger(SearchIT.class.getName()).log(Level.SEVERE, null, ex);
+        }
 
         InputStream inputStream2creator = UtilIT.getInputStreamFromUnirest(thumbnailUrl, apiToken);
         assertEquals(treesAsBase64, UtilIT.inputStreamToDataUrlSchemeBase64Png(inputStream2creator));

--- a/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
@@ -1360,6 +1360,15 @@ public class UtilIT {
                 .get("/api/admin/datasets/thumbnailMetadata/" + datasetId);
     }
 
+    /**
+     * @param trueOrWidthInPixels Passing "true" will result in the default width in pixels (64).
+     */
+    static Response getFileThumbnail(String fileDatabaseId, String trueOrWidthInPixels, String apiToken) {
+        return given()
+                .header(API_TOKEN_HTTP_HEADER, apiToken)
+                .get("/api/access/datafile/" + fileDatabaseId + "?imageThumb=" + trueOrWidthInPixels);
+    }
+
     static Response useThumbnailFromDataFile(String datasetPersistentId, long dataFileId1, String apiToken) {
         return given()
                 .header(API_TOKEN_HTTP_HEADER, apiToken)


### PR DESCRIPTION
**What this PR does / why we need it**:

On the dataset page the image next to the dataset title is wider (going from 64 pixels wide to 140)

**Which issue(s) this PR closes**:

Closes #6769

**Special notes for your reviewer**:

Please note that CSS changes are still required. Right now the image overlaps the title. Also search cards need to be constrained to a smaller width. Screenshots below.

## dataset page

<img width="582" alt="Screen Shot 2020-04-16 at 1 58 50 PM" src="https://user-images.githubusercontent.com/21006/79492291-c5c1a380-7fed-11ea-9bc5-82e26331fff4.png">

## search cards

<img width="602" alt="Screen Shot 2020-04-16 at 1 58 16 PM" src="https://user-images.githubusercontent.com/21006/79492284-c35f4980-7fed-11ea-8b63-e17a2e7928ef.png">

**Suggestions on how to test this**:

Test thumbnails. Observed a larger size next to dataset title.

**Does this PR introduce a user interface change?**:

Yes.

**Is there a release notes update needed for this change?**:

No.

**Additional documentation**:

None.