### PR TITLE
ingest RDX3 RData files #6803

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/ingest/IngestableDataChecker.java
+++ b/src/main/java/edu/harvard/iq/dataverse/ingest/IngestableDataChecker.java
@@ -68,7 +68,7 @@ public class IngestableDataChecker implements java.io.Serializable {
     private static String regex = "^test(\\w+)format$";
 
     // static initialization block
-    private static String rdargx = "^(52)(44)(41|42|58)(31|32)(0A)$";
+    private static String rdargx = "^(52)(44)(41|42|58)(31|32|33)(0A)$";
     private static int RDA_HEADER_SIZE = 5;
     private static Pattern ptn;
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The more modern "RDX3" RData format is not being ingested.

**Which issue(s) this PR closes**:

Closes #6803

**Special notes for your reviewer**:

We are changing...

`RD[ABX][12]\n`

... to ...

`RD[ABX][123]\n`

From `man ascii`

```
     The hexadecimal set:

     00 nul   01 soh   02 stx   03 etx   04 eot   05 enq   06 ack   07 bel
     08 bs    09 ht    0a nl    0b vt    0c np    0d cr    0e so    0f si
     10 dle   11 dc1   12 dc2   13 dc3   14 dc4   15 nak   16 syn   17 etb
     18 can   19 em    1a sub   1b esc   1c fs    1d gs    1e rs    1f us
     20 sp    21  !    22  "    23  #    24  $    25  %    26  &    27  '
     28  (    29  )    2a  *    2b  +    2c  ,    2d  -    2e  .    2f  /
     30  0    31  1    32  2    33  3    34  4    35  5    36  6    37  7
     38  8    39  9    3a  :    3b  ;    3c  <    3d  =    3e  >    3f  ?
     40  @    41  A    42  B    43  C    44  D    45  E    46  F    47  G
     48  H    49  I    4a  J    4b  K    4c  L    4d  M    4e  N    4f  O
     50  P    51  Q    52  R    53  S    54  T    55  U    56  V    57  W
     58  X    59  Y    5a  Z    5b  [    5c  \    5d  ]    5e  ^    5f  _
     60  `    61  a    62  b    63  c    64  d    65  e    66  f    67  g
     68  h    69  i    6a  j    6b  k    6c  l    6d  m    6e  n    6f  o
     70  p    71  q    72  r    73  s    74  t    75  u    76  v    77  w
     78  x    79  y    7a  z    7b  {    7c  |    7d  }    7e  ~    7f del
```

**Suggestions on how to test this**:

Try an RData file from https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/OFQUAN

**Does this PR introduce a user interface change?**:

No.

**Is there a release notes update needed for this change?**:

No.

**Additional documentation**:

None.