### PR TITLE
Bootstrap-related no.mime.type.found warning [ref #6836]

### DIFF
--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -152,7 +152,7 @@
         <!-- Uncomment the line below to disble `;jsessionid=` in URLs -->
 	<!-- tracking-mode>COOKIE</tracking-mode -->
     </session-config>
-    <!-- web fonts -->
+    <!-- web fonts, bootstrap css map, favicon -->
     <mime-mapping>
         <extension>eot</extension>
         <mime-type>application/vnd.ms-fontobject</mime-type>
@@ -173,6 +173,11 @@
         <extension>woff2</extension>
         <mime-type>application/font-woff2</mime-type>
     </mime-mapping>
+    <mime-mapping>
+        <extension>map</extension>
+        <mime-type>application/json</mime-type>
+    </mime-mapping>
+    <mime-mapping>
     <mime-mapping>
         <extension>svg</extension>
         <mime-type>image/svg+xml</mime-type>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -178,7 +178,6 @@
         <mime-type>application/json</mime-type>
     </mime-mapping>
     <mime-mapping>
-    <mime-mapping>
         <extension>svg</extension>
         <mime-type>image/svg+xml</mime-type>
     </mime-mapping>


### PR DESCRIPTION
**What this PR does / why we need it**:

Resolve JSF warning that has been a nuisance in the server logs for far too long.

```
[glassfish 4.1] [WARNING] [jsf.externalcontext.no.mime.type.found] [javax.enterprise.resource.webcontainer.jsf.context] [tid: _ThreadID=150 _ThreadName=jk-connector(3)] [timeMillis: 1587064515184] [levelValue: 900] [[
  JSF1091: No mime type could be found for file bs/css/bootstrap.min.css.map.  To resolve this, add a mime-type mapping to the applications web.xml.]]
```

**Which issue(s) this PR closes**:

Closes **#6836 jsf.externalcontext.no.mime.type.found WARNING in logs (Pf8, 4.20, 4.19)**

**Special notes for your reviewer**:

Thank you for reviewing.

**Suggestions on how to test this**:

Check your server log while clicking around and loading various pages.

**Does this PR introduce a user interface change?**:

No.

**Is there a release notes update needed for this change?**:

No.

**Additional documentation**:
