### PR TITLE
#4285 implement sorting in Manage Users table.

### DIFF
--- a/src/main/webapp/dashboard-users.xhtml
+++ b/src/main/webapp/dashboard-users.xhtml
@@ -47,26 +47,26 @@
                     </ui:include>
 
                     <p:dataTable id="userTable" value="#{DashboardUsersPage.userList}" var="user" widgetVar="userTable">
-                        <p:column style="width:60px" class="text-center" headerText="#{bundle['dashboard.list_users.tbl_header.userId']}">
+                        <p:column style="width:60px" class="text-center" headerText="#{bundle['dashboard.list_users.tbl_header.userId']}" sortBy="#{user.id}">
                             <h:outputText value="#{user.id}" />
                         </p:column>
-                        <p:column headerText="#{bundle['dashboard.list_users.tbl_header.userIdentifier']}">
+                        <p:column headerText="#{bundle['dashboard.list_users.tbl_header.userIdentifier']}" sortBy="#{user.userIdentifier}">
                             <span class="glyphicon glyphicon-user text-danger" jsf:rendered="#{user.superuser}" style="margin-right:6px;"></span>
                             <h:outputText value="#{user.userIdentifier}" class="#{user.superuser ? 'text-danger' : ''}" />
                         </p:column>
-                        <p:column headerText="#{bundle['dashboard.list_users.tbl_header.name']}">
+                        <p:column headerText="#{bundle['dashboard.list_users.tbl_header.name']}" sortBy="#{user.lastName}">
                             <h:outputText value="#{user.firstName} #{user.lastName}" />
                         </p:column>
-                        <p:column width="20%" headerText="#{bundle['dashboard.list_users.tbl_header.email']}">
+                        <p:column width="20%" headerText="#{bundle['dashboard.list_users.tbl_header.email']}" sortBy="#{user.email}">
                             <h:outputText value="#{user.email}" />
                         </p:column>
-                        <p:column headerText="#{bundle['dashboard.list_users.tbl_header.affiliation']}">
+                        <p:column headerText="#{bundle['dashboard.list_users.tbl_header.affiliation']}" sortBy="#{user.affiliation}">
                             <h:outputText value="#{user.affiliation}" />
                         </p:column>
-                        <p:column width="12%" headerText="#{bundle['dashboard.list_users.tbl_header.authProviderFactoryAlias']}">
+                        <p:column width="12%" headerText="#{bundle['dashboard.list_users.tbl_header.authProviderFactoryAlias']}" sortBy="#{user.authProviderId}">
                             <h:outputText value="#{DashboardUsersPage.getAuthProviderFriendlyName(user.authProviderId)}" />
                         </p:column>
-                        <p:column headerText="#{bundle['dashboard.list_users.tbl_header.roles']}">
+                        <p:column headerText="#{bundle['dashboard.list_users.tbl_header.roles']}" sortBy="#{user.roles}">
                             <h:outputText value="#{user.roles}" />
                             <p:commandButton id="removeRolesButton" 
                                             rendered="#{!empty user.roles}" 
@@ -79,7 +79,7 @@
                                         update=":dashboardUsersForm:removeRolesConfirm"/>
                             </p:commandButton>
                         </p:column>
-                        <p:column width="9%" class="text-center" headerText="#{bundle['dashboard.list_users.tbl_header.isSuperuser']}">
+                        <p:column width="9%" class="text-center" headerText="#{bundle['dashboard.list_users.tbl_header.isSuperuser']}" sortBy="#{user.superuser}">
                             <!-- A simple implementation of the superuser status toggle - via a boolean checkbox with an immediate ajax update. -->
                             <!-- Uses our standard approach, of showing a confirmation popup ("are you sure you want to toggle this? ...") first,  -->
                             <!-- before saving the toggled value. -->


### PR DESCRIPTION
**What this PR does / why we need it**: It makes the Manage Users table sortable by clicking the column headings

**Which issue(s) this PR closes**: #4285

Closes #4285

**Special notes for your reviewer**: It is a user interface change in the xhtml file.

**Suggestions on how to test this**:  Right now I can not imagine other ways to test than build the war, log in as abministrator, go to Manage Users and click on the column headings.

**Does this PR introduce a user interface change?**: It makes the Manage Users table sortable by clicking the column headings

**Is there a release notes update needed for this change?**: It is a minor change, however as a site administrator I alaways wanted to know who are the new users, and I was not able to get than other than issue SQL query from the command line. Now sort users by user ID gives me an easy way to check new users.

**Additional documentation**: No
