### PR TITLE
changed f:viewParam to o:Param for editMode

### DIFF
--- a/src/main/webapp/editdatafiles.xhtml
+++ b/src/main/webapp/editdatafiles.xhtml
@@ -24,7 +24,7 @@
             <ui:define name="body">
                 <f:metadata>
                     <f:viewParam name="datasetId" value="#{EditDatafilesPage.dataset.id}"/>
-                    <f:viewParam name="mode" value="#{EditDatafilesPage.mode}"/>
+                    <o:viewParam name="mode" value="#{EditDatafilesPage.mode}"/>
                     <f:viewParam name="selectedFileIds" value="#{EditDatafilesPage.selectedFileIds}"/>
                     <f:viewParam name="versionString" value="#{EditDatafilesPage.versionString}"/>
                     <f:viewAction action="#{dataverseSession.updateLocaleInViewRoot}"/>


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes one last f:viewParam to o:viewParam
**Which issue(s) this PR closes**:

Closes #6230 

**Special notes for your reviewer**:
This was one more case where the editMode would change with an ajax call.

**Suggestions on how to test this**:
test the editdatafiles page, specifically editing metadata, then editing a tag within that page

**Does this PR introduce a user interface change?**:
no

**Is there a release notes update needed for this change?**:
no

**Additional documentation**:
