### PR TITLE
Destroy Dataset with a Mapped DataFile

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DataFile.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DataFile.java
@@ -19,6 +19,7 @@ import edu.harvard.iq.dataverse.util.BundleUtil;
 import edu.harvard.iq.dataverse.util.FileUtil;
 import edu.harvard.iq.dataverse.util.ShapefileHandler;
 import edu.harvard.iq.dataverse.util.StringUtil;
+import edu.harvard.iq.dataverse.worldmapauth.WorldMapToken;
 import java.io.IOException;
 import java.util.List;
 import java.util.ArrayList;
@@ -213,6 +214,13 @@ public class DataFile extends DvObject implements Comparable {
     public void setGuestbookResponses(List<GuestbookResponse> guestbookResponses) {
         this.guestbookResponses = guestbookResponses;
     }
+    
+    // The WorldMap LayerMetadata and AuthToken are here to facilitate a
+    // clean cascade delete when the DataFile is deleted:
+    @OneToOne(mappedBy="dataFile", orphanRemoval = true, cascade={CascadeType.REMOVE, CascadeType.MERGE, CascadeType.PERSIST})
+    private MapLayerMetadata mapLayerMetadata;    
+    @OneToMany(mappedBy="dataFile", orphanRemoval = true, cascade={CascadeType.REMOVE, CascadeType.MERGE, CascadeType.PERSIST})
+    private List<WorldMapToken> worldMapTokens;
     
     private char ingestStatus = INGEST_STATUS_NONE; 
     

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/DeleteDataFileCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/DeleteDataFileCommand.java
@@ -24,6 +24,9 @@ import java.util.Collections;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import edu.harvard.iq.dataverse.GlobalIdServiceBean;
+import edu.harvard.iq.dataverse.UserNotification;
+import java.sql.Timestamp;
+import java.util.Date;
 
 /**
  * Deletes a data file, both DB entity and filesystem object.
@@ -209,6 +212,31 @@ public class DeleteDataFileCommand extends AbstractVoidCommand {
             }
         } catch (Exception e) {
             logger.log(Level.WARNING, "Identifier deletion was not successfull:", e.getMessage());
+        }
+        
+        // If there is a Map Layer associated with this file, we may need to 
+        // try and remove the layer data on the WorldMap side. 
+        if (ctxt.mapLayerMetadata().findMetadataByDatafile(doomed) != null) {
+            // (We need an AuthenticatedUser in order to produce a WorldMap token!)
+            String id = getUser().getIdentifier();
+            id = id.startsWith("@") ? id.substring(1) : id;
+            AuthenticatedUser authenticatedUser = ctxt.authentication().getAuthenticatedUser(id);
+            try {
+                ctxt.mapLayerMetadata().deleteMapLayerFromWorldMap(doomed, authenticatedUser);
+
+                // We have the dedicatd command DeleteMapLayerMetadataCommand, but 
+                // there's no need to use it explicitly, since the Dataverse-side
+                // MapLayerMetadata entity will be deleted by the database 
+                // cascade on the DataFile. -- L.A. Apr. 2020
+
+            } catch (Exception ex) {
+                // We are not going to treat it as a fatal condition and bail out, 
+                // but we will send a notification to the user, warning them 
+                // there may still be some data associated with the mapped layer, 
+                // on the WorldMap side, un-deleted:
+                ctxt.notifications().sendNotification(authenticatedUser, new Timestamp(new Date().getTime()), UserNotification.Type.MAPLAYERDELETEFAILED, doomed.getFileMetadata().getId());
+            }
+
         }
         DataFile doomedAndMerged = ctxt.em().merge(doomed);
         ctxt.em().remove(doomedAndMerged);


### PR DESCRIPTION
**What this PR does / why we need it**:

Self-explanatory; see issue. 

**Which issue(s) this PR closes**:

Closes #4093

**Special notes for your reviewer**:

It implements cascade delete on both the map layer and tokens; as in the original PR 2.5 yrs ago. In addition, the code is added to the DeleteDataFileCommand, that deletes any data associated with the layer that may exist on the WorldMap side. 

**Suggestions on how to test this**:

Deploy on demo, destroy all those old, as of now un-destroyable datasets. 

**Does this PR introduce a user interface change?**:
no 
**Is there a release notes update needed for this change?**:
no
**Additional documentation**:
