### PR TITLE
issue #870: fix PostgreSQL file location

### DIFF
--- a/conf/docker-aio/c7.dockerfile
+++ b/conf/docker-aio/c7.dockerfile
@@ -1,6 +1,6 @@
 FROM centos:7
 # OS dependencies
-RUN yum install -y https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/pgdg-centos96-9.6-3.noarch.rpm
+RUN yum install -y https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm
 #RUN yum install -y java-1.8.0-openjdk-headless postgresql-server sudo epel-release unzip perl curl httpd
 RUN yum install -y java-1.8.0-openjdk-devel postgresql96-server sudo epel-release unzip perl curl httpd
 RUN yum install -y jq lsof awscli


### PR DESCRIPTION
**What this PR does / why we need it**: The PostgreSQL file which is referenced from the Docker AIO Dockerfile is not available any more, so it is not possible to build Docker. This PR fixes the file location.

**Which issue(s) this PR closes**: #6870 

Closes #6870

**Special notes for your reviewer**: No

**Suggestions on how to test this**:

Run `./conf/docker-aio/prep_it.bash` and check if the Docker environment is built.

**Does this PR introduce a user interface change?**: No

**Is there a release notes update needed for this change?**: No

**Additional documentation**: No
