### PR TITLE
link "API Test Coverage" to correct report #6869

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Dataverse is a trademark of President and Fellows of Harvard College and is regi
 [![Dataverse Project logo](src/main/webapp/resources/images/dataverseproject_logo.jpg?raw=true "Dataverse Project")](http://dataverse.org)
 
 [![API Test Status](https://jenkins.dataverse.org/buildStatus/icon?job=IQSS-dataverse-develop&subject=API%20Test%20Status)](https://jenkins.dataverse.org/job/IQSS-dataverse-develop/)
-[![API Test Coverage](https://img.shields.io/jenkins/coverage/jacoco?jobUrl=https%3A%2F%2Fjenkins.dataverse.org%2Fjob%2FIQSS-dataverse-develop&label=API%20Test%20Coverage)](https://jenkins.dataverse.org/job/IQSS-dataverse-develop/ws/target/site/jacoco/index.html)
+[![API Test Coverage](https://img.shields.io/jenkins/coverage/jacoco?jobUrl=https%3A%2F%2Fjenkins.dataverse.org%2Fjob%2FIQSS-dataverse-develop&label=API%20Test%20Coverage)](https://jenkins.dataverse.org/job/IQSS-dataverse-develop/ws/target/coverage-it/index.html)
 [![Unit Test Status](https://img.shields.io/travis/IQSS/dataverse?label=Unit%20Test%20Status)](https://travis-ci.org/IQSS/dataverse)
 [![Unit Test Coverage](https://img.shields.io/coveralls/github/IQSS/dataverse?label=Unit%20Test%20Coverage)](https://coveralls.io/github/IQSS/dataverse?branch=develop)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The "API Test Coverage" button in the README points at the wrong report

**Which issue(s) this PR closes**:

Closes #6869

**Special notes for your reviewer**:

None.

**Suggestions on how to test this**:

Click on the old link and the new link. 

You can tell it's the right report in a couple ways:

- overall code coverage is much higher (~40% instead of ~20%)
- coverage for edu.harvard.iq.dataverse.engine.command.impl is much higher (commands are exercised by the API)

**Does this PR introduce a user interface change?**:

No.

**Is there a release notes update needed for this change?**:

No.

**Additional documentation**:

None.