### PR TITLE
6881, 6882 delete on cancel and queue handle upload requests

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
@@ -115,6 +115,7 @@ import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.lang3.mutable.MutableBoolean;
 import org.apache.commons.io.IOUtils;
 
 import org.primefaces.component.tabview.TabView;
@@ -246,6 +247,9 @@ public class DatasetPage implements java.io.Serializable {
     private Long versionId;
     private int selectedTabIndex;
     private List<DataFile> newFiles = new ArrayList<>();
+    private List<DataFile> uploadedFiles = new ArrayList<>();
+    private MutableBoolean uploadInProgress = new MutableBoolean(false);
+
     private DatasetVersion workingVersion;
     private DatasetVersion clone;
     private int releaseRadio = 1;
@@ -1112,6 +1116,22 @@ public class DatasetPage implements java.io.Serializable {
     
     public void setNewFiles(List<DataFile> newFiles) {
         this.newFiles = newFiles;
+    }
+    
+    public List<DataFile> getUploadedFiles() {
+        return uploadedFiles;
+    }
+    
+    public void setUploadedFiles(List<DataFile> uploadedFiles) {
+        this.uploadedFiles = uploadedFiles;
+    }
+    
+    public MutableBoolean getUploadInProgress() {
+        return uploadInProgress;
+    }
+    
+    public void setUploadInProgress(MutableBoolean inProgress) {
+        this.uploadInProgress = inProgress;
     }
     
     public Dataverse getLinkingDataverse() {
@@ -3554,6 +3574,34 @@ public class DatasetPage implements java.io.Serializable {
 
     public String cancel() {
         return  returnToLatestVersion();
+    }
+    
+    public void cancelCreate() {
+    	//Stop any uploads in progress (so that uploadedFiles doesn't change)
+    	uploadInProgress.setValue(false);
+
+    	logger.fine("Cancelling: " + newFiles.size() + " : " + uploadedFiles.size());
+
+    	//Files that have been finished and are now in the lower list on the page
+    	for (DataFile newFile : newFiles.toArray(new DataFile[0])) {
+    		FileUtil.deleteTempFile(newFile, dataset, ingestService);
+    	}
+    	logger.fine("Deleted newFiles");
+
+    	//Files in the upload process but not yet finished
+    	//ToDo - if files are added to uploadFiles after we access it, those files are not being deleted. With uploadInProgress being set false above, this should be a fairly rare race condition.
+    	for (DataFile newFile : uploadedFiles.toArray(new DataFile[0])) {
+    		FileUtil.deleteTempFile(newFile, dataset, ingestService);
+    	}
+    	logger.fine("Deleted uploadedFiles");
+
+    	try {
+    		String alias = dataset.getOwner().getAlias();
+    		logger.info("alias: " + alias);
+    		FacesContext.getCurrentInstance().getExternalContext().redirect("/dataverse.xhtml?alias=" + alias);
+    	} catch (IOException ex) {
+    		logger.info("Failed to issue a redirect to file download url.");
+    	}
     }
 
     private HttpClient getClient() {

--- a/src/main/java/edu/harvard/iq/dataverse/EditDatafilesPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/EditDatafilesPage.java
@@ -19,7 +19,6 @@ import edu.harvard.iq.dataverse.datacapturemodule.DataCaptureModuleUtil;
 import edu.harvard.iq.dataverse.datacapturemodule.ScriptRequestResponse;
 import edu.harvard.iq.dataverse.dataset.DatasetThumbnail;
 import edu.harvard.iq.dataverse.engine.command.Command;
-import edu.harvard.iq.dataverse.engine.command.CommandContext;
 import edu.harvard.iq.dataverse.engine.command.exception.CommandException;
 import edu.harvard.iq.dataverse.engine.command.exception.IllegalCommandException;
 import edu.harvard.iq.dataverse.engine.command.impl.RequestRsyncScriptCommand;
@@ -28,7 +27,6 @@ import edu.harvard.iq.dataverse.engine.command.impl.UpdateDatasetVersionCommand;
 import edu.harvard.iq.dataverse.ingest.IngestRequest;
 import edu.harvard.iq.dataverse.ingest.IngestServiceBean;
 import edu.harvard.iq.dataverse.ingest.IngestUtil;
-import edu.harvard.iq.dataverse.search.FileView;
 import edu.harvard.iq.dataverse.search.IndexServiceBean;
 import edu.harvard.iq.dataverse.settings.SettingsServiceBean;
 import edu.harvard.iq.dataverse.util.FileUtil;
@@ -37,16 +35,11 @@ import edu.harvard.iq.dataverse.util.SystemConfig;
 import edu.harvard.iq.dataverse.util.BundleUtil;
 import edu.harvard.iq.dataverse.util.EjbUtil;
 import static edu.harvard.iq.dataverse.util.JsfHelper.JH;
-import static edu.harvard.iq.dataverse.util.StringUtil.isEmpty;
-
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringReader;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -70,7 +63,6 @@ import javax.json.JsonReader;
 import org.apache.commons.httpclient.HttpClient;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.httpclient.methods.GetMethod;
-import java.text.DateFormat;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Set;
@@ -80,6 +72,7 @@ import javax.faces.event.FacesEvent;
 import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServletResponse;
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.mutable.MutableBoolean;
 import org.primefaces.PrimeFaces;
 
 /**
@@ -167,6 +160,9 @@ public class EditDatafilesPage implements java.io.Serializable {
 
     private Long maxFileUploadSizeInBytes = null;
     private Integer multipleUploadFilesLimit = null; 
+    
+    //MutableBoolean so it can be passed from DatasetPage, supporting DatasetPage.cancelCreate()
+    private MutableBoolean uploadInProgress = null;
     
     private final int NUMBER_OF_SCROLL_ROWS = 25;
     
@@ -420,7 +416,7 @@ public class EditDatafilesPage implements java.io.Serializable {
         this.versionId = versionId;
     }
 
-    public String initCreateMode(String modeToken, DatasetVersion version, List<DataFile> newFilesList, List<FileMetadata> selectedFileMetadatasList) {
+    public String initCreateMode(String modeToken, DatasetVersion version, MutableBoolean inProgress, List<DataFile> newFilesList, List<DataFile> uploadedFilesList, List<FileMetadata> selectedFileMetadatasList) {
         if (modeToken == null) {
             logger.fine("Request to initialize Edit Files page with null token (aborting).");
             return null;
@@ -440,8 +436,9 @@ public class EditDatafilesPage implements java.io.Serializable {
         workingVersion = version; 
         dataset = version.getDataset();
         mode = FileEditMode.CREATE;
+        uploadInProgress= inProgress;
         newFiles = newFilesList;
-        uploadedFiles = new ArrayList<>();
+        uploadedFiles = uploadedFilesList;
         selectedFiles = selectedFileMetadatasList;
         
         this.maxFileUploadSizeInBytes = systemConfig.getMaxFileUploadSizeForStore(dataset.getOwner().getEffectiveStorageDriverId());
@@ -461,7 +458,8 @@ public class EditDatafilesPage implements java.io.Serializable {
         }
         
         newFiles = new ArrayList<>();
-        uploadedFiles = new ArrayList<>(); 
+        uploadedFiles = new ArrayList<>();
+        uploadInProgress= new MutableBoolean(false);
         
         if (dataset.getId() != null){
             // Set Working Version and Dataset by Datasaet Id and Version
@@ -940,7 +938,7 @@ public class EditDatafilesPage implements java.io.Serializable {
                 
                 removeDataFileFromList(dataset.getFiles(), markedForDelete.getDataFile());
                 removeDataFileFromList(newFiles, markedForDelete.getDataFile());
-                deleteTempFile(markedForDelete.getDataFile());
+                FileUtil.deleteTempFile(markedForDelete.getDataFile(), dataset, ingestService);
                 // Also remove checksum from the list of newly uploaded checksums (perhaps odd
                 // to delete and then try uploading the same file again, but it seems like it
                 // should be allowed/the checksum list is part of the state to clean-up
@@ -956,65 +954,6 @@ public class EditDatafilesPage implements java.io.Serializable {
                     }
                 }
                 
-    private void deleteTempFile(DataFile dataFile) {
-    	// Before we remove the file from the list and forget about 
-    	// it:
-    	// The physical uploaded file is still sitting in the temporary
-    	// directory. If it were saved, it would be moved into its 
-    	// permanent location. But since the user chose not to save it,
-    	// we have to delete the temp file too. 
-    	// 
-    	// Eventually, we will likely add a dedicated mechanism
-    	// for managing temp files, similar to (or part of) the storage 
-    	// access framework, that would allow us to handle specialized
-    	// configurations - highly sensitive/private data, that 
-    	// has to be kept encrypted even in temp files, and such. 
-    	// But for now, we just delete the file directly on the 
-    	// local filesystem: 
-
-    	try {
-    		List<Path> generatedTempFiles = ingestService.listGeneratedTempFiles(
-    				Paths.get(FileUtil.getFilesTempDirectory()), dataFile.getStorageIdentifier());
-    		if (generatedTempFiles != null) {
-    			for (Path generated : generatedTempFiles) {
-    				logger.fine("(Deleting generated thumbnail file " + generated.toString() + ")");
-    				try {
-    					Files.delete(generated);
-    				} catch (IOException ioex) {
-    					logger.warning("Failed to delete generated file " + generated.toString());
-    				}
-    			}
-    		}
-    		String si = dataFile.getStorageIdentifier();
-    		if (si.contains("://")) {
-    			//Direct upload files will already have a store id in their storageidentifier
-    			//but they need to be associated with a dataset for the overall storagelocation to be calculated
-    			//so we temporarily set the owner
-    			if(dataFile.getOwner()!=null) {
-    				logger.warning("Datafile owner was not null as expected");
-    			}
-    			dataFile.setOwner(dataset);
-    			//Use one StorageIO to get the storageLocation and then create a direct storage storageIO class to perform the delete 
-    			// (since delete is forbidden except for direct storage)
-    			String sl = DataAccess.getStorageIO(dataFile).getStorageLocation();
-    			DataAccess.getDirectStorageIO(sl).delete();
-    			dataFile.setOwner(null);
-    		} else {
-    			//Temp files sent to this method have no prefix, not even "tmp://"
-    			Files.delete(Paths.get(FileUtil.getFilesTempDirectory() + "/" + dataFile.getStorageIdentifier()));
-    		}
-    	} catch (IOException ioEx) {
-    		// safe to ignore - it's just a temp file. 
-    		logger.warning(ioEx.getMessage());
-    		if(dataFile.getStorageIdentifier().contains("://")) {
-    			logger.warning("Failed to delete temporary file " + dataFile.getStorageIdentifier());
-    		} else {
-    			logger.warning("Failed to delete temporary file " + FileUtil.getFilesTempDirectory() + "/"
-    					+ dataFile.getStorageIdentifier());
-    		}
-    	}
-    }
-
     private void removeFileMetadataFromList(List<FileMetadata> fmds, FileMetadata fmToDelete) {
         Iterator<FileMetadata> fmit = fmds.iterator();
         while (fmit.hasNext()) {
@@ -1370,18 +1309,19 @@ public class EditDatafilesPage implements java.io.Serializable {
 
     
     public String cancel() {
-        uploadInProgress = false;
-        if (mode == FileEditMode.SINGLE || mode == FileEditMode.SINGLE_REPLACE ) {
-            return returnToFileLandingPage();
-        }
+        uploadInProgress.setValue(false);
         //Files that have been finished and are now in the lower list on the page
         for (DataFile newFile : newFiles) {
-            deleteTempFile(newFile);
+            FileUtil.deleteTempFile(newFile, dataset, ingestService);
         }
 
         //Files in the upload process but not yet finished
         for (DataFile newFile : uploadedFiles) {
-            deleteTempFile(newFile);
+            FileUtil.deleteTempFile(newFile, dataset, ingestService);
+        }
+
+        if (mode == FileEditMode.SINGLE || mode == FileEditMode.SINGLE_REPLACE ) {
+            return returnToFileLandingPage();
         }
         if (workingVersion.getId() != null) {
             return returnToDraftVersion();
@@ -1505,8 +1445,8 @@ public class EditDatafilesPage implements java.io.Serializable {
      * @param event
      */
     public void handleDropBoxUpload(ActionEvent event) {
-        if (!uploadInProgress) {
-            uploadInProgress = true;
+        if (uploadInProgress.isFalse()) {
+            uploadInProgress.setValue(true);
         }
         logger.fine("handleDropBoxUpload");
         uploadComponentId = event.getComponent().getClientId();
@@ -1635,10 +1575,10 @@ public class EditDatafilesPage implements java.io.Serializable {
                      }
                 }*/
             }
-            if(!uploadInProgress) {
+            if(uploadInProgress.isFalse()) {
                 logger.warning("Upload in progress cancelled");
                 for (DataFile newFile : datafiles) {
-                    deleteTempFile(newFile);
+                    FileUtil.deleteTempFile(newFile, dataset, ingestService);
                 }
             }
         }
@@ -1658,7 +1598,7 @@ public class EditDatafilesPage implements java.io.Serializable {
         // (either through drag-and-drop or select menu). 
         logger.fine("upload started");
         
-        uploadInProgress = true;        
+        uploadInProgress.setValue(true);        
     }
     
     
@@ -1798,9 +1738,9 @@ public class EditDatafilesPage implements java.io.Serializable {
         }
         
        
-        if(uploadInProgress) {
-            uploadedFiles = new ArrayList<>();
-            uploadInProgress = false;
+        if(uploadInProgress.isTrue()) {
+            uploadedFiles.clear();
+            uploadInProgress.setValue(false);
         }
         // refresh the warning message below the upload component, if exists:
         if (uploadComponentId != null) {
@@ -1952,8 +1892,8 @@ public class EditDatafilesPage implements java.io.Serializable {
      */
     public void handleFileUpload(FileUploadEvent event) throws IOException {
         
-        if (!uploadInProgress) {
-            uploadInProgress = true;
+        if (uploadInProgress.isFalse()) {
+            uploadInProgress.setValue(true);
         }
         
         if (event == null){
@@ -2018,10 +1958,10 @@ public class EditDatafilesPage implements java.io.Serializable {
             uploadComponentId = event.getComponent().getClientId();
         }
         
-        if(!uploadInProgress) {
+        if(uploadInProgress.isFalse()) {
             logger.warning("Upload in progress cancelled");
             for (DataFile newFile : dFileList) {
-                deleteTempFile(newFile);
+                FileUtil.deleteTempFile(newFile, dataset, ingestService);
             }
         }
     }
@@ -2044,8 +1984,8 @@ public class EditDatafilesPage implements java.io.Serializable {
         
         int lastColon = fullStorageIdentifier.lastIndexOf(':');
         String storageLocation= fullStorageIdentifier.substring(0,lastColon) + "/" + dataset.getAuthorityForFileStorage() + "/" + dataset.getIdentifierForFileStorage() + "/" + fullStorageIdentifier.substring(lastColon+1);
-    	if (!uploadInProgress) {
-    		uploadInProgress = true;
+    	if (uploadInProgress.isFalse()) {
+    		uploadInProgress.setValue(true);
     	}
     	logger.fine("handleExternalUpload");
     	
@@ -2114,10 +2054,10 @@ public class EditDatafilesPage implements java.io.Serializable {
     				// -----------------------------------------------------------
     				uploadWarningMessage = processUploadedFileList(datafiles);
     			}
-    			if(!uploadInProgress) {
+    			if(uploadInProgress.isFalse()) {
     				logger.warning("Upload in progress cancelled");
     				for (DataFile newFile : datafiles) {
-    					deleteTempFile(newFile);
+    					FileUtil.deleteTempFile(newFile, dataset, ingestService);
     				}
     			}
     		}
@@ -2143,7 +2083,6 @@ public class EditDatafilesPage implements java.io.Serializable {
     private String dupeFileNamesNew = null;
     private boolean multipleDupesExisting = false;
     private boolean multipleDupesNew = false;
-    private boolean uploadInProgress = false;
     
     private String processUploadedFileList(List<DataFile> dFileList) {
         if (dFileList == null) {
@@ -2188,7 +2127,7 @@ public class EditDatafilesPage implements java.io.Serializable {
                     multipleDupesExisting = true;
                 }
                 // remove temp file
-                deleteTempFile(dataFile);
+                FileUtil.deleteTempFile(dataFile, dataset, ingestService);
             } else if (isFileAlreadyUploaded(dataFile)) {
                 if (dupeFileNamesNew == null) {
                     dupeFileNamesNew = dataFile.getFileMetadata().getLabel();
@@ -2197,7 +2136,7 @@ public class EditDatafilesPage implements java.io.Serializable {
                     multipleDupesNew = true;
                 }
                 // remove temp file
-                deleteTempFile(dataFile);
+                FileUtil.deleteTempFile(dataFile, dataset, ingestService);
             } else {
                 // OK, this one is not a duplicate, we want it. 
                 // But let's check if its filename is a duplicate of another 

--- a/src/main/java/edu/harvard/iq/dataverse/util/FileUtil.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/FileUtil.java
@@ -35,6 +35,7 @@ import edu.harvard.iq.dataverse.dataset.DatasetThumbnail;
 import edu.harvard.iq.dataverse.datasetutility.FileExceedsMaxSizeException;
 import static edu.harvard.iq.dataverse.datasetutility.FileSizeChecker.bytesToHumanReadable;
 import edu.harvard.iq.dataverse.ingest.IngestReport;
+import edu.harvard.iq.dataverse.ingest.IngestServiceBean;
 import edu.harvard.iq.dataverse.ingest.IngestServiceShapefileHelper;
 import edu.harvard.iq.dataverse.ingest.IngestableDataChecker;
 import java.awt.image.BufferedImage;
@@ -1773,6 +1774,67 @@ public class FileUtil implements java.io.Serializable  {
     	int driverEnd = location.indexOf("://") + 3;
     	int bucketEnd = driverEnd + location.substring(driverEnd).indexOf("/");
     	return location.substring(0,bucketEnd) + ":" + location.substring(location.lastIndexOf("/") + 1);
+    }
+    
+    public static void deleteTempFile(DataFile dataFile, Dataset dataset, IngestServiceBean ingestService) {
+    	logger.info("Deleting " + dataFile.getStorageIdentifier());
+    	// Before we remove the file from the list and forget about 
+    	// it:
+    	// The physical uploaded file is still sitting in the temporary
+    	// directory. If it were saved, it would be moved into its 
+    	// permanent location. But since the user chose not to save it,
+    	// we have to delete the temp file too. 
+    	// 
+    	// Eventually, we will likely add a dedicated mechanism
+    	// for managing temp files, similar to (or part of) the storage 
+    	// access framework, that would allow us to handle specialized
+    	// configurations - highly sensitive/private data, that 
+    	// has to be kept encrypted even in temp files, and such. 
+    	// But for now, we just delete the file directly on the 
+    	// local filesystem: 
+
+    	try {
+    		List<Path> generatedTempFiles = ingestService.listGeneratedTempFiles(
+    				Paths.get(getFilesTempDirectory()), dataFile.getStorageIdentifier());
+    		if (generatedTempFiles != null) {
+    			for (Path generated : generatedTempFiles) {
+    				logger.fine("(Deleting generated thumbnail file " + generated.toString() + ")");
+    				try {
+    					Files.delete(generated);
+    				} catch (IOException ioex) {
+    					logger.warning("Failed to delete generated file " + generated.toString());
+    				}
+    			}
+    		}
+    		String si = dataFile.getStorageIdentifier();
+    		if (si.contains("://")) {
+    			//Direct upload files will already have a store id in their storageidentifier
+    			//but they need to be associated with a dataset for the overall storagelocation to be calculated
+    			//so we temporarily set the owner
+    			if(dataFile.getOwner()!=null) {
+    				logger.warning("Datafile owner was not null as expected");
+    			}
+    			dataFile.setOwner(dataset);
+    			//Use one StorageIO to get the storageLocation and then create a direct storage storageIO class to perform the delete 
+    			// (since delete is forbidden except for direct storage)
+    			String sl = DataAccess.getStorageIO(dataFile).getStorageLocation();
+    			DataAccess.getDirectStorageIO(sl).delete();
+    		} else {
+    			//Temp files sent to this method have no prefix, not even "tmp://"
+    			Files.delete(Paths.get(FileUtil.getFilesTempDirectory() + "/" + dataFile.getStorageIdentifier()));
+    		}
+    	} catch (IOException ioEx) {
+    		// safe to ignore - it's just a temp file. 
+    		logger.warning(ioEx.getMessage());
+    		if(dataFile.getStorageIdentifier().contains("://")) {
+    			logger.warning("Failed to delete temporary file " + dataFile.getStorageIdentifier());
+    		} else {
+    			logger.warning("Failed to delete temporary file " + FileUtil.getFilesTempDirectory() + "/"
+    					+ dataFile.getStorageIdentifier());
+    		}
+    	} finally {
+    		dataFile.setOwner(null);
+    	}
     }
 
 }

--- a/src/main/webapp/dataset.xhtml
+++ b/src/main/webapp/dataset.xhtml
@@ -72,7 +72,7 @@
                     <f:viewAction action="#{dataverseSession.updateLocaleInViewRoot}"/>
                     <f:viewAction action="#{DatasetPage.init}" rendered="true"/>
                     <f:viewAction action="#{dataverseHeaderFragment.initBreadcrumbs(DatasetPage.dataset)}"/>
-                    <f:viewAction action="#{EditDatafilesPage.initCreateMode(DatasetPage.editMode, DatasetPage.workingVersion, DatasetPage.newFiles, DatasetPage.selectedFiles)}"/>
+                    <f:viewAction action="#{EditDatafilesPage.initCreateMode(DatasetPage.editMode, DatasetPage.workingVersion, DatasetPage.uploadInProgress, DatasetPage.newFiles, DatasetPage.uploadedFiles, DatasetPage.selectedFiles)}"/>
                 </f:metadata>
                 <h:form id="datasetForm">
                     <!-- View infoMode -->
@@ -755,7 +755,8 @@
                         <p:commandButton id="cancel" styleClass="btn btn-link" value="#{bundle.cancel}" action="#{DatasetPage.cancel}" process="@this" update="@form" rendered="#{DatasetPage.editMode != 'CREATE'}" oncomplete="javascript:bind_bsui_components();">
                             <f:setPropertyActionListener target="#{DatasetPage.selectedTabIndex}" value="#{DatasetPage.editMode == 'METADATA' ? 1 : DatasetPage.selectedTabIndex}"/>
                         </p:commandButton>
-                        <p:button id="cancelCreate" styleClass="btn btn-link" value="#{bundle.cancel}" outcome="/dataverse.xhtml?alias=#{DatasetPage.dataset.owner.alias}" rendered="#{DatasetPage.editMode == 'CREATE'}"/>
+                        <button id="cancelCreate" styleClass="btn btn-link" value="#{bundle.cancel}" onclick="cancelDatasetCreate();return false;" rendered="#{DatasetPage.editMode == 'CREATE'}">#{bundle.cancel}</button>
+                        <p:remoteCommand name="cancelCreateCommand" process="@this" partialSubmit="true" async="true" update="" action="#{DatasetPage.cancelCreate}" rendered="#{DatasetPage.editMode == 'CREATE'}"/>     
                         <p:commandButton value="Direct" id="datasetSave"
                                          style="display:none"
                                          update=":datasetForm,:messagePanel"

--- a/src/main/webapp/editFilesFragment.xhtml
+++ b/src/main/webapp/editFilesFragment.xhtml
@@ -521,7 +521,7 @@
     </div>
     <!-- END: Static Tab Layout -->
     <p:remoteCommand  name="returnToDatasetPage" partialSubmit="true" async="true" update="" action="#{EditDatafilesPage.returnToDatasetOnly()}"  />
-    <p:remoteCommand  name="requestDirectUploadUrl" partialSubmit="true" async="true" update="" action="#{EditDatafilesPage.requestDirectUploadUrl()}" onerror="javascript:uploadFailure();" />
+    <p:remoteCommand  name="requestDirectUploadUrl" partialSubmit="true" async="true" update="@none" action="#{EditDatafilesPage.requestDirectUploadUrl()}" onerror="javascript:uploadFailure();" />
     <p:remoteCommand  name="handleExternalUpload" partialSubmit="true" async="true"  update="@none" action="#{EditDatafilesPage.handleExternalUpload()}" oncomplete="javascript:bind_bsui_components();directUploadFinished();" onerror="javascript:uploadFailure();" />
     <!-- TODO: a message panel informing the unauthorized, or unauthenticated user that they don't have permission - should it be here? L.A. 4.2 -->
 


### PR DESCRIPTION
**What this PR does / why we need it**: It adds logic to delete of temp files when a dataset creation is cancelled and, for direct uploads, avoids parallel calls to handleExternalUploads which seems to cause intermittent failures in Payara. 

**Which issue(s) this PR closes**:

Closes #6881
Closes #6882 

**Special notes for your reviewer**: The #6882 fix is just with the new handlingUpload flag and the wait loop to make sure only one is sent at a time. I made 1 PR since both involve using the await sleep call and since I've been testing them together (probably good for formal testing as well).

**Suggestions on how to test this**:For #6682, I think the problem was caused by a second call to handleExternalUpload() occurring while the first was updating the bean state. I think this causes the NPE in the Payara/JSF code, but there is no detail to confirm that. So, I think the only way to test is to just watch for the recurrence of the NPE listed in the issue.
For 6881, the general idea is to hit create dataset, add some files, and hit cancel - the temp files should go away. Since direct and normal uploads  work differently, both should be tested. Similarly, since new temp files are in two lists - basically corresponding to the initial upload list and the list after uploads complete (with the description, path, etc.) - testing when there are files in both lists would be good. There is a difference between direct and normal in how I've fixed this. With normal, cancel is called immediately and all temp files are purged - uploads in progress might throw an exception in the log (since cancelling sends you from the dataset page back to the parent dataverse page, but I think the logic still removes the temp files properly. With directupload,  I've opted to, once the cancel button is hit, to wait for any uploads to S3 to finish so that Dataverse can be told about them and then delete them as with normal upload. If that takes more than ~1 second, I'm disabling the save button and changing cancel to be disabled and say 'cancel in progress'. (A different design might avoid this, but it would involve being able to cancel S3 uploads in progress and detecting whether they indeed were cancelled or finished (and left a file)). In both cases, the user should be redirected to the parent dataverse page and no temp files should remain.


**Does this PR introduce a user interface change?**: button label change and disabling during cancel operation - see the discussion above about direct uploads being cancelled and waiting for more than 1 second. (Potentially could always do this - having someone hit save after cancel would always be bad, but only cancelling direct upload is likely to take enough time that someone might try, but we could always disable save/cancel after one is hit if that's preferable.) 

**Is there a release notes update needed for this change?**: Don't think so - things work basically the same for the user, but temp file cleanup is better.

**Additional documentation**:
