### PR TITLE
6753 Fixed dataset metadata table width

### DIFF
--- a/src/main/webapp/resources/css/structure.css
+++ b/src/main/webapp/resources/css/structure.css
@@ -649,9 +649,9 @@ div.form-col-container.edit-compound-field div.form-col-container {margin-bottom
 div.panel-group div.panel {margin-bottom:1em;}
 div.panel div.panel-body div.form-group {overflow: hidden;}
 div.edit-field div.ui-message {margin:6px 0;}
-.metadata-container table.metadata {border-collapse:separate;margin:0 4px;}
+.metadata-container table.metadata {border-collapse:separate;margin:0 4px;width:100%;}
 .metadata-container table.metadata th {width:25%;vertical-align:top;padding:6px 12px;}
-.metadata-container table.metadata td {padding:6px 12px;}
+.metadata-container table.metadata td {padding:6px 12px;vertical-align:top;}
 @media(max-width:767px){
     .metadata-container table.metadata th, .metadata-container table.metadata td {display:block;width:100%;}
     .metadata-container table.metadata th {padding-bottom:0;}


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes inconsistent dataset metadata table width, which resulted in inconsistent label column widths.

**Which issue(s) this PR closes**:

Closes #6753 Geospatial Metadata fields not properly indented compared to other fields 

**Special notes for your reviewer**:

Small CSS change in the stylesheet to fix width and resolve minor vertical align inconsistency.

**Suggestions on how to test this**:

Add a whole bunch of metadata to a bunch of different blocks and see how it looks on the dataset pg.

**Does this PR introduce a user interface change?**:

No, it cleans up current UI.

**Is there a release notes update needed for this change?**:

N/A

**Additional documentation**:

N/A
