### PR TITLE
use primefaces to get ajax instead of reload

### DIFF
--- a/src/main/webapp/file-download-button-fragment.xhtml
+++ b/src/main/webapp/file-download-button-fragment.xhtml
@@ -36,12 +36,12 @@
             <!--external tools-->
             <ui:repeat var="tool" value="#{exploreTools}">
                 <li>
-                    <h:commandLink rendered="#{!downloadPopupRequired}"
+                    <p:commandLink rendered="#{!downloadPopupRequired}"
                                    styleClass="#{(fileMetadata.dataFile.ingestInProgress) ? 'disabled' : ''}"
                                    disabled="#{(fileMetadata.dataFile.ingestInProgress or lockedFromDownload) ? 'disabled' : ''}"
                                    action="#{fileDownloadService.explore(guestbookResponse, fileMetadata, tool )}">
                         #{tool.getDisplayNameLang()}
-                    </h:commandLink>
+                    </p:commandLink>
                     <!--The modifyDatafileAndFormat method below was added because on the dataset page, "tool" is null in the popup so we store it in the guestbookResponse because we know we'll need it later in the popup.-->
                     <p:commandLink rendered="#{downloadPopupRequired}"
                                    action="#{guestbookResponseService.modifyDatafileAndFormat(guestbookResponse, fileMetadata, 'externalTool', tool)}"


### PR DESCRIPTION
**What this PR does / why we need it**: This makes the call to Dataverse that starts launching an external tool into an ajax call, avoiding refreshing the whole page. (It also resolves an unreported issue that refreshing the dataset page after launching an external previewer repeats launching the previewer).

**Which issue(s) this PR closes**:

Closes #6908 

**Special notes for your reviewer**: a simple change to use Primefaces p:commandlink which is ajax by default.

**Suggestions on how to test this**: Should launch external tools/previewers as it works today, without having the original page refresh in the background.

**Does this PR introduce a user interface change?**: no

**Is there a release notes update needed for this change?**: no

**Additional documentation**: none
