### PR TITLE
add delay for direct S3 upload of tiny files

### DIFF
--- a/src/main/webapp/resources/js/fileupload.js
+++ b/src/main/webapp/resources/js/fileupload.js
@@ -49,7 +49,7 @@ function setupDirectUpload(enabled) {
     var callback = function(mutations) {
       mutations.forEach(function(mutation) {
         for(i=0; i<mutation.addedNodes.length;i++) {
-          //Add a listener on any replacedment file 'select' widget
+          //Add a listener on any replacement file 'select' widget
           if(mutation.addedNodes[i].id == 'datasetForm:fileUpload_input') {
             fileInput=mutation.addedNodes[i];
             mutation.addedNodes[i].addEventListener('change', function(event) {
@@ -214,7 +214,12 @@ async function handleDirectUpload(storageId, file, md5) {
   while(inDataverseCall === true) {
     await sleep(500);
   }
+
   inDataverseCall=true;
+  if(file.size < 1000) {
+	  //artificially slow reporting of the upload of tiny files to avoid problems with maintaining JSF state
+	  await sleep(500);
+  }
   //storageId is not the location - has a : separator and no path elements from dataset
   //(String uploadComponentId, String fullStorageIdentifier, String fileName, String contentType, String checksumType, String checksumValue)
   handleExternalUpload([{name:'uploadComponentId', value:'datasetForm:fileUpload'}, {name:'fullStorageIdentifier', value:storageId}, {name:'fileName', value:file.name}, {name:'contentType', value:file.type}, {name:'checksumType', value:'MD5'}, {name:'checksumValue', value:md5}]);

--- a/src/main/webapp/resources/js/fileupload.js
+++ b/src/main/webapp/resources/js/fileupload.js
@@ -24,6 +24,8 @@ var finishFile = (function () {
 function setupDirectUpload(enabled) {
   if(enabled) {
     directUploadEnabled=true;
+    //An indicator as to which version is being used - should keep updated.
+    console.log('Dataverse Direct Upload v4.20-beta-2');
     $('.ui-fileupload-upload').hide();
     $('.ui-fileupload-cancel').hide();
     //Catch files entered via upload dialog box. Since this 'select' widget is replaced by PF, we need to add a listener again when it is replaced
@@ -120,7 +122,8 @@ async function startRequestForDirectUploadUrl() {
   requestDirectUploadUrl();
 }
 
-function uploadFileDirectly(url, storageId) {
+async function uploadFileDirectly(url, storageId) {
+  await sleep(500);	
   inDataverseCall=false;
   
   if(directUploadEnabled) {
@@ -210,7 +213,7 @@ function reportUpload(storageId, file){
 }
 
 async function handleDirectUpload(storageId, file, md5) {
-  //Wait for each call to finish and update the DOM
+  //Wait for each call to finish and update the DOM	
   while(inDataverseCall === true) {
     await sleep(500);
   }
@@ -218,7 +221,7 @@ async function handleDirectUpload(storageId, file, md5) {
   inDataverseCall=true;
   if(file.size < 1000) {
 	  //artificially slow reporting of the upload of tiny files to avoid problems with maintaining JSF state
-	  await sleep(500);
+  //	  await sleep(500);
   }
   //storageId is not the location - has a : separator and no path elements from dataset
   //(String uploadComponentId, String fullStorageIdentifier, String fileName, String contentType, String checksumType, String checksumValue)
@@ -278,8 +281,8 @@ function uploadFinished(fileupload) {
     }
 }
 
-function directUploadFinished() {
-  inDataverseCall=false;
+async function directUploadFinished() {
+
   numDone = finishFile();
   var total = curFile;
   var inProgress = filesInProgress;
@@ -302,16 +305,22 @@ function directUploadFinished() {
       }
     }
   }
+  await sleep(500);
+
+  inDataverseCall=false;
 }
 
-function uploadFailure(jqXHR, upid, filename) {
+async function uploadFailure(jqXHR, upid, filename) {
   // This handles HTTP errors (non-20x reponses) such as 0 (no connection at all), 413 (Request too large),
   // and 504 (Gateway timeout) where the upload call to the server fails (the server doesn't receive the request)
   // It notifies the user and provides info about the error (status, statusText)
   // On some browsers, the status is available in an event: window.event.srcElement.status
   // but others, (Firefox) don't support this. The calls below retrieve the status and other info
   // from the call stack instead (arguments to the fail() method that calls onerror() that calls this function
-
+	
+  if(directUploadEnabled) {
+    await sleep(500);
+  }
   inDataverseCall=false;
   
   //Retrieve the error number (status) and related explanation (statusText)

--- a/src/main/webapp/resources/js/fileupload.js
+++ b/src/main/webapp/resources/js/fileupload.js
@@ -301,7 +301,7 @@ async function directUploadFinished() {
     }  else {
       if((inProgress < 4) && (inProgress < inList)) {
         filesInProgress= filesInProgress+1;
-        requestDirectUploadUrl();
+        startRequestForDirectUploadUrl();
       }
     }
   }

--- a/src/main/webapp/resources/js/fileupload.js
+++ b/src/main/webapp/resources/js/fileupload.js
@@ -1,6 +1,7 @@
 var fileList = [];
 var observer2=null;
 var numDone=0;
+var delay=200; //milliseconds
 
 //true indicates direct upload is being used, but cancel may set it back to false at which point direct upload functions should not do further work
 var directUploadEnabled=false;
@@ -114,7 +115,7 @@ function queueFileForDirectUpload(file) {
 async function startRequestForDirectUploadUrl() {
   //Wait for each call to finish and update the DOM
   while(inDataverseCall === true) {
-    await sleep(500);
+    await sleep(delay);
   }
   inDataverseCall=true;
   //storageId is not the location - has a : separator and no path elements from dataset
@@ -123,7 +124,7 @@ async function startRequestForDirectUploadUrl() {
 }
 
 async function uploadFileDirectly(url, storageId) {
-  await sleep(500);	
+  await sleep(delay);	
   inDataverseCall=false;
   
   if(directUploadEnabled) {
@@ -215,13 +216,13 @@ function reportUpload(storageId, file){
 async function handleDirectUpload(storageId, file, md5) {
   //Wait for each call to finish and update the DOM	
   while(inDataverseCall === true) {
-    await sleep(500);
+    await sleep(delay);
   }
 
   inDataverseCall=true;
   if(file.size < 1000) {
 	  //artificially slow reporting of the upload of tiny files to avoid problems with maintaining JSF state
-  //	  await sleep(500);
+  //	  await sleep(delay);
   }
   //storageId is not the location - has a : separator and no path elements from dataset
   //(String uploadComponentId, String fullStorageIdentifier, String fileName, String contentType, String checksumType, String checksumValue)
@@ -305,7 +306,7 @@ async function directUploadFinished() {
       }
     }
   }
-  await sleep(500);
+  await sleep(delay);
 
   inDataverseCall=false;
 }
@@ -319,7 +320,7 @@ async function uploadFailure(jqXHR, upid, filename) {
   // from the call stack instead (arguments to the fail() method that calls onerror() that calls this function
 	
   if(directUploadEnabled) {
-    await sleep(500);
+    await sleep(delay);
   }
   inDataverseCall=false;
   

--- a/src/main/webapp/resources/js/fileupload.js
+++ b/src/main/webapp/resources/js/fileupload.js
@@ -26,7 +26,7 @@ function setupDirectUpload(enabled) {
   if(enabled) {
     directUploadEnabled=true;
     //An indicator as to which version is being used - should keep updated.
-    console.log('Dataverse Direct Upload v4.20-beta-3');
+    console.log('Dataverse Direct Upload for v5.0');
     $('.ui-fileupload-upload').hide();
     $('.ui-fileupload-cancel').hide();
     //Catch files entered via upload dialog box. Since this 'select' widget is replaced by PF, we need to add a listener again when it is replaced

--- a/src/main/webapp/resources/js/fileupload.js
+++ b/src/main/webapp/resources/js/fileupload.js
@@ -25,7 +25,7 @@ function setupDirectUpload(enabled) {
   if(enabled) {
     directUploadEnabled=true;
     //An indicator as to which version is being used - should keep updated.
-    console.log('Dataverse Direct Upload v4.20-beta-2');
+    console.log('Dataverse Direct Upload v4.20-beta-3');
     $('.ui-fileupload-upload').hide();
     $('.ui-fileupload-cancel').hide();
     //Catch files entered via upload dialog box. Since this 'select' widget is replaced by PF, we need to add a listener again when it is replaced

--- a/src/main/webapp/resources/js/fileupload.js
+++ b/src/main/webapp/resources/js/fileupload.js
@@ -1,7 +1,7 @@
 var fileList = [];
 var observer2=null;
 var numDone=0;
-var delay=200; //milliseconds
+var delay=100; //milliseconds
 
 //true indicates direct upload is being used, but cancel may set it back to false at which point direct upload functions should not do further work
 var directUploadEnabled=false;

--- a/src/main/webapp/resources/js/fileupload.js
+++ b/src/main/webapp/resources/js/fileupload.js
@@ -83,7 +83,7 @@ async function cancelDatasetCreate() {
     directUploadEnabled=false;
     while(curFile!=numDone) {
       $("#cancelCreate").prop('onclick', null).text("Cancel In Progress...").prop('disabled', true);
-      $("#datasetSave").prop('disabled', true);
+      $("#datasetForm:save").prop('disabled', true);
       await sleep(1000);
     }
       cancelCreateCommand();

--- a/src/main/webapp/resources/js/fileupload.js
+++ b/src/main/webapp/resources/js/fileupload.js
@@ -83,7 +83,7 @@ async function cancelDatasetCreate() {
     directUploadEnabled=false;
     while(curFile!=numDone) {
       $("#cancelCreate").prop('onclick', null).text("Cancel In Progress...").prop('disabled', true);
-      $("#datasetForm:save").prop('disabled', true);
+      $("#datasetForm\\:save").prop('disabled', true);
       await sleep(1000);
     }
       cancelCreateCommand();


### PR DESCRIPTION
**What this PR does / why we need it**: slows down reporting uploads of time files to avoid concurrency issue(s) in Dataverse (see issue)

**Which issue(s) this PR closes**:

Closes #6930 

**Special notes for your reviewer**: the delay is currently 500 msec per file, could be made longer if the problem persists. In my testing 200 msec was too short (still saw issues sometimes) so it can't get shorter than that. FWIW, prior updates should have made sure that there is only one call from the fileupload.js to Dataverse at a time, so I'm assuming that there's some processing in Dataverse going on after the HTTP call returns, during which a new call still causes problems. If there are other ways to handle this, I'd be interested to know what else might be done. (This should be effective, but it would be nice not to just have an arbitrary delay.)

**Suggestions on how to test this**: same as for previous tests - with < 1K files (26 bytes is fine)

**Does this PR introduce a user interface change?**: No

**Is there a release notes update needed for this change?**: No

**Additional documentation**: None
