### PR TITLE
5886 link harvested datasets via api

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/LinkDatasetCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/LinkDatasetCommand.java
@@ -41,8 +41,8 @@ public class LinkDatasetCommand extends AbstractCommand<DatasetLinkingDataverse>
     @Override
     public DatasetLinkingDataverse execute(CommandContext ctxt) throws CommandException {
         
-        if (!linkedDataset.isReleased()) {
-            throw new IllegalCommandException(BundleUtil.getStringFromBundle("dataset.link.not.published"), this);
+        if (!linkedDataset.isReleased() && !linkedDataset.isHarvested()) {
+            throw new IllegalCommandException(BundleUtil.getStringFromBundle("dataset.link.not.available"), this);
         }       
         if (linkedDataset.getOwner().equals(linkingDataverse)) {           
             throw new IllegalCommandException(BundleUtil.getStringFromBundle("dataset.link.not.to.owner"), this);

--- a/src/main/java/propertyFiles/Bundle.properties
+++ b/src/main/java/propertyFiles/Bundle.properties
@@ -753,6 +753,7 @@ dataset.link.save=Save Linked Dataset
 dataset.link.not.to.owner=Can't link a dataset to its dataverse
 dataset.link.not.to.parent.dataverse=Can't link a dataset to its parent dataverses
 dataset.link.not.published=Can't link a dataset that has not been published
+dataset.link.not.available=Can't link a dataset that has not been published or is not harvested
 dataverse.link.dataverse.choose=Choose which of your dataverses you would like to link this dataverse to.
 dataverse.link.dataset.choose=Enter the name of the dataverse you would like to link this dataset to. If you need to remove this link in the future, please contact {0}.
 dataverse.link.dataset.none=No linkable dataverses available.

--- a/src/test/java/edu/harvard/iq/dataverse/api/DatasetsIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/DatasetsIT.java
@@ -67,20 +67,6 @@ public class DatasetsIT {
 
     private static final Logger logger = Logger.getLogger(DatasetsIT.class.getCanonicalName());
     
-    @PersistenceContext(unitName = "VDCNet-ejbPU")
-    private EntityManager em;
-    
-    private EntityManagerFactory entityManagerFactory;
-
-    @Before
-    public void init() {
-        entityManagerFactory = Persistence.createEntityManagerFactory( "VDCNet-ejbPU" );
-    }
-
-    @After
-    public void destroy() {
-        entityManagerFactory.close();
-    }
     
 
     @BeforeClass

--- a/src/test/java/edu/harvard/iq/dataverse/api/DatasetsIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/DatasetsIT.java
@@ -1948,7 +1948,7 @@ public class DatasetsIT {
 
     }
     
-        @Test
+    @Test
     public void testLinkingDatasets() {
 
         Response createUser = UtilIT.createRandomUser();
@@ -1993,26 +1993,23 @@ public class DatasetsIT {
 
         UtilIT.publishDataverseViaNativeApi(dataverse1Alias, apiToken).then().assertThat()
                 .statusCode(OK.getStatusCode());
-        
-        
+
         // Link dataset to second dataverse.
         //should fail if dataset is not published
         Response linkDataset = UtilIT.linkDataset(datasetPid, dataverse2Alias, superuserApiToken);
         linkDataset.prettyPrint();
         linkDataset.then().assertThat()
-                .body("message", equalTo( BundleUtil.getStringFromBundle("dataset.link.not.available")))
+                .body("message", equalTo(BundleUtil.getStringFromBundle("dataset.link.not.available")))
                 .statusCode(FORBIDDEN.getStatusCode());
-        
-        
+
         UtilIT.publishDatasetViaNativeApi(datasetPid, "major", apiToken).then().assertThat()
                 .statusCode(OK.getStatusCode());
-        
+
         //Once published you should be able to link it
         linkDataset = UtilIT.linkDataset(datasetPid, dataverse2Alias, superuserApiToken);
         linkDataset.prettyPrint();
         linkDataset.then().assertThat()
                 .statusCode(OK.getStatusCode());
-
 
 //Experimental code for trying to trick test into thinking the dataset has been harvested
 /*
@@ -2041,9 +2038,7 @@ createDataset = UtilIT.createRandomDatasetViaNativeApi(dataverse1Alias, apiToken
         linkDataset.prettyPrint();
         linkDataset.then().assertThat()
                 .statusCode(OK.getStatusCode());
- */
+         */
     }
 
-
-    
 }

--- a/src/test/java/edu/harvard/iq/dataverse/api/DatasetsIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/DatasetsIT.java
@@ -26,14 +26,15 @@ import edu.harvard.iq.dataverse.authorization.DataverseRole;
 import edu.harvard.iq.dataverse.authorization.users.PrivateUrlUser;
 import edu.harvard.iq.dataverse.settings.SettingsServiceBean;
 import java.util.UUID;
-import static javax.ws.rs.core.Response.Status.NO_CONTENT;
 import org.apache.commons.lang.StringUtils;
 import com.jayway.restassured.parsing.Parser;
 import static com.jayway.restassured.path.json.JsonPath.with;
 import com.jayway.restassured.path.xml.XmlPath;
+import edu.harvard.iq.dataverse.Dataset;
 import static edu.harvard.iq.dataverse.api.UtilIT.equalToCI;
 import static edu.harvard.iq.dataverse.authorization.AuthenticationResponse.Status.ERROR;
 import edu.harvard.iq.dataverse.authorization.groups.impl.builtin.AuthenticatedUsers;
+import edu.harvard.iq.dataverse.util.BundleUtil;
 import edu.harvard.iq.dataverse.util.SystemConfig;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -41,6 +42,10 @@ import java.util.HashMap;
 import javax.json.Json;
 import javax.json.JsonArray;
 import javax.json.JsonObjectBuilder;
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.Persistence;
+import javax.persistence.PersistenceContext;
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static javax.ws.rs.core.Response.Status.CREATED;
 import static javax.ws.rs.core.Response.Status.FORBIDDEN;
@@ -50,18 +55,38 @@ import static javax.ws.rs.core.Response.Status.UNAUTHORIZED;
 import static junit.framework.Assert.assertEquals;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.nullValue;
+import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import org.junit.Before;
 import static org.junit.matchers.JUnitMatchers.containsString;
 
 public class DatasetsIT {
 
     private static final Logger logger = Logger.getLogger(DatasetsIT.class.getCanonicalName());
+    
+    @PersistenceContext(unitName = "VDCNet-ejbPU")
+    private EntityManager em;
+    
+    private EntityManagerFactory entityManagerFactory;
+
+    @Before
+    public void init() {
+        entityManagerFactory = Persistence.createEntityManagerFactory( "VDCNet-ejbPU" );
+    }
+
+    @After
+    public void destroy() {
+        entityManagerFactory.close();
+    }
+    
 
     @BeforeClass
     public static void setUpClass() {
+        
+        
         RestAssured.baseURI = UtilIT.getRestAssuredBaseUri();
 
         Response removeIdentifierGenerationStyle = UtilIT.deleteSetting(SettingsServiceBean.Key.IdentifierGenerationStyle);
@@ -1936,6 +1961,103 @@ public class DatasetsIT {
         System.out.println("Author username/password: " + authorUsername);
 
     }
+    
+        @Test
+    public void testLinkingDatasets() {
+
+        Response createUser = UtilIT.createRandomUser();
+        createUser.prettyPrint();
+        createUser.then().assertThat()
+                .statusCode(OK.getStatusCode());
+        String username = UtilIT.getUsernameFromResponse(createUser);
+        String apiToken = UtilIT.getApiTokenFromResponse(createUser);
+
+        Response createSuperUser = UtilIT.createRandomUser();
+        createSuperUser.prettyPrint();
+        createSuperUser.then().assertThat()
+                .statusCode(OK.getStatusCode());
+        String superuserUsername = UtilIT.getUsernameFromResponse(createSuperUser);
+        String superuserApiToken = UtilIT.getApiTokenFromResponse(createSuperUser);
+        Response makeSuperuser = UtilIT.makeSuperUser(superuserUsername);
+        makeSuperuser.prettyPrint();
+        makeSuperuser.then().assertThat()
+                .statusCode(OK.getStatusCode());
+
+        Response createDataverse1 = UtilIT.createRandomDataverse(apiToken);
+        createDataverse1.prettyPrint();
+        createDataverse1.then().assertThat()
+                .statusCode(CREATED.getStatusCode());
+        String dataverse1Alias = UtilIT.getAliasFromResponse(createDataverse1);
+
+        Response createDataset = UtilIT.createRandomDatasetViaNativeApi(dataverse1Alias, apiToken);
+        createDataset.prettyPrint();
+        createDataset.then().assertThat()
+                .statusCode(CREATED.getStatusCode());
+
+        Integer datasetId = UtilIT.getDatasetIdFromResponse(createDataset);
+        String datasetPid = JsonPath.from(createDataset.asString()).getString("data.persistentId");
+
+        Response createDataverse2 = UtilIT.createRandomDataverse(apiToken);
+        createDataverse2.prettyPrint();
+        createDataverse2.then().assertThat()
+                .statusCode(CREATED.getStatusCode());
+        String dataverse2Alias = UtilIT.getAliasFromResponse(createDataverse2);
+        Integer dataverse2Id = UtilIT.getDatasetIdFromResponse(createDataverse2);
+        String dataverse2Name = JsonPath.from(createDataverse2.asString()).getString("data.name");
+
+        UtilIT.publishDataverseViaNativeApi(dataverse1Alias, apiToken).then().assertThat()
+                .statusCode(OK.getStatusCode());
+        
+        
+        // Link dataset to second dataverse.
+        //should fail if dataset is not published
+        Response linkDataset = UtilIT.linkDataset(datasetPid, dataverse2Alias, superuserApiToken);
+        linkDataset.prettyPrint();
+        linkDataset.then().assertThat()
+                .body("message", equalTo( BundleUtil.getStringFromBundle("dataset.link.not.available")))
+                .statusCode(FORBIDDEN.getStatusCode());
+        
+        
+        UtilIT.publishDatasetViaNativeApi(datasetPid, "major", apiToken).then().assertThat()
+                .statusCode(OK.getStatusCode());
+        
+        //Once published you should be able to link it
+        linkDataset = UtilIT.linkDataset(datasetPid, dataverse2Alias, superuserApiToken);
+        linkDataset.prettyPrint();
+        linkDataset.then().assertThat()
+                .statusCode(OK.getStatusCode());
+
+
+//Experimental code for trying to trick test into thinking the dataset has been harvested
+/*
+createDataset = UtilIT.createRandomDatasetViaNativeApi(dataverse1Alias, apiToken);
+        createDataset.prettyPrint();
+        createDataset.then().assertThat()
+                .statusCode(CREATED.getStatusCode());
+
+        Integer datasetId2 = UtilIT.getDatasetIdFromResponse(createDataset);
+        String datasetPid2 = JsonPath.from(createDataset.asString()).getString("data.persistentId");
+        
+        linkDataset = UtilIT.linkDataset(datasetPid2, dataverse2Alias, superuserApiToken);
+        linkDataset.prettyPrint();
+        linkDataset.then().assertThat()
+                .body("message", equalTo( BundleUtil.getStringFromBundle("dataset.link.not.available")))
+                .statusCode(FORBIDDEN.getStatusCode());
+                EntityManager entityManager = entityManagerFactory.createEntityManager();
+        entityManager.getTransaction().begin();
+        // Do stuff...
+        entityManager.createNativeQuery("UPDATE dataset SET harvestingclient_id=1 WHERE id="+datasetId2).executeUpdate();
+        entityManager.getTransaction().commit();
+        entityManager.close();
+
+        
+        UtilIT.linkDataset(datasetId2.toString(), dataverse2Alias, superuserApiToken);
+        linkDataset.prettyPrint();
+        linkDataset.then().assertThat()
+                .statusCode(OK.getStatusCode());
+ */
+    }
+
 
     
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows a user to link a harvested dataset via the api. Previously there was a test that required that the dataset be published before it could be linked. This expands the test to allow datasets that haven't been published but are harvested to be linked

**Which issue(s) this PR closes**:

Closes #5886 

**Special notes for your reviewer**:
I wasn't able to come up with a way to test this in the integration test. Any suggestions here would be welcome. (I tested by manually giving an unpublished dataset a dummy harvesting client id)

**Suggestions on how to test this**:

**Does this PR introduce a user interface change?**:
no

**Is there a release notes update needed for this change?**:
no

**Additional documentation**:
None