### PR TITLE
correct storageDrivers docs, fix formatting

### DIFF
--- a/doc/sphinx-guides/source/admin/dataverses-datasets.rst
+++ b/doc/sphinx-guides/source/admin/dataverses-datasets.rst
@@ -47,17 +47,17 @@ To direct new files (uploaded when datasets are created or edited) for all datas
  
     curl -H "X-Dataverse-key: $API_TOKEN" -X PUT -d $storageDriverLabel http://$SERVER/api/admin/dataverse/$dataverse-alias/storageDriver
     
-The current driver can be seen using:
+The current driver can be seen using::
 
     curl -H "X-Dataverse-key: $API_TOKEN" http://$SERVER/api/admin/dataverse/$dataverse-alias/storageDriver
 
-and can be reset to the default store with:
+and can be reset to the default store with::
 
     curl -H "X-Dataverse-key: $API_TOKEN" -X DELETE http://$SERVER/api/admin/dataverse/$dataverse-alias/storageDriver
     
-The available drivers can be listed with:
+The available drivers can be listed with::
 
-    curl -H "X-Dataverse-key: $API_TOKEN" http://$SERVER/api/admin/storageDrivers
+    curl -H "X-Dataverse-key: $API_TOKEN" http://$SERVER/api/admin/dataverse/storageDrivers
     
 
 Datasets


### PR DESCRIPTION
**What this PR does / why we need it**:

@jmjamison reported having trouble with the storageDrivers API. @qqmyers explained the fix. See https://groups.google.com/d/msg/dataverse-community/w_5FEN2UKSE/zKz_3B8dAgAJ

While fixing the typo I noticed that smart quotes (and no grey background) were in the HTML of some of the commands like below so I fixed that too. Here's how the docs looks as of Dataverse 4.20:

<img width="871" alt="Screen Shot 2020-06-02 at 9 56 17 AM" src="https://user-images.githubusercontent.com/21006/83529016-c89e2800-a4b7-11ea-99c7-099d9b2f9fa6.png">
 
**Which issue(s) this PR closes**:

Closes # (none)

**Special notes for your reviewer**:

I didn't take the time to convert these commands to the new style seen at http://guides.dataverse.org/en/4.20/api/getting-started.html#curl-examples-and-environment-variables . If we want this now I'm happy to do it. @pkiraly has been helping a lot with this (thanks!!).

**Suggestions on how to test this**:

Build the docs. It's probably a good idea to test the API endpoints but I only changed the last one about listing storage drivers.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No.

**Is there a release notes update needed for this change?**:

No.

**Additional documentation**:

None.