### PR TITLE
use POST for file download to avoid url length limits

### DIFF
--- a/doc/sphinx-guides/source/api/dataaccess.rst
+++ b/doc/sphinx-guides/source/api/dataaccess.rst
@@ -67,6 +67,8 @@ Multiple File ("bundle") download
 
 ``/api/access/datafiles/$id1,$id2,...$idN``
 
+Alternate Form: POST to ``/api/access/datafiles`` with a ``fileIds`` input field containing the same comma separated list of file ids. This is most useful when your list of files surpasses the allowed URL length (varies but can be ~2000 characters).  
+
 Returns the files listed, zipped. 
 
 .. note:: If the request can only be completed partially - if only *some* of the requested files can be served (because of the permissions and/or size restrictions), the file MANIFEST.TXT included in the zipped bundle will have entries specifying the reasons the missing files could not be downloaded. IN THE FUTURE the API will return a 207 status code to indicate that the result was a partial success. (As of writing this - v.4.11 - this hasn't been implemented yet)

--- a/src/main/java/edu/harvard/iq/dataverse/FileDownloadServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/FileDownloadServiceBean.java
@@ -182,6 +182,7 @@ public class FileDownloadServiceBean implements java.io.Serializable {
             mdcLogService.logEntry(entry);
         } catch (CommandException e) {
             //if an error occurs here then download won't happen no need for response recs...
+            logger.warning("Exception writing GuestbookResponse for file: " + guestbookResponse.getDataFile().getId() + " : " + e.getLocalizedMessage());
         }
     }
     
@@ -203,7 +204,7 @@ public class FileDownloadServiceBean implements java.io.Serializable {
     // to the API.
     private void redirectToBatchDownloadAPI(String multiFileString, Boolean guestbookRecordsAlreadyWritten, Boolean downloadOriginal){
 
-        String fileDownloadUrl = "/api/access/datafiles/" + multiFileString;
+        String fileDownloadUrl = "/api/access/datafiles";
         if (guestbookRecordsAlreadyWritten && !downloadOriginal){
             fileDownloadUrl += "?gbrecs=true";
         } else if (guestbookRecordsAlreadyWritten && downloadOriginal){
@@ -212,11 +213,7 @@ public class FileDownloadServiceBean implements java.io.Serializable {
             fileDownloadUrl += "?format=original";
         }
         
-        try {
-            FacesContext.getCurrentInstance().getExternalContext().redirect(fileDownloadUrl);
-        } catch (IOException ex) {
-            logger.info("Failed to issue a redirect to file download url.");
-        }
+        PrimeFaces.current().executeScript("downloadFiles('"+fileDownloadUrl + "','"+ multiFileString+"');");
 
     }
 

--- a/src/main/java/edu/harvard/iq/dataverse/api/Access.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Access.java
@@ -103,9 +103,11 @@ import javax.ws.rs.core.UriInfo;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 import javax.ws.rs.BadRequestException;
+import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.ForbiddenException;
 import javax.ws.rs.NotFoundException;
+import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.ServiceUnavailableException;
@@ -525,15 +527,38 @@ public class Access extends AbstractApiBean {
     }
     
     /* 
-     * API method for downloading zipped bundles of multiple files:
+     * API method for downloading zipped bundles of multiple files. Uses POST to avoid long lists of file IDs that can make the URL longer than what's supported by browsers/servers
     */
     
-    // TODO: Rather than only supporting looking up files by their database IDs, consider supporting persistent identifiers.
+    // TODO: Rather than only supporting looking up files by their database IDs,
+    // consider supporting persistent identifiers.
+    @Path("datafiles")
+    @POST
+    @Consumes("text/plain")
+    @Produces({ "application/zip" })
+    public Response postDownloadDatafiles(String fileIds, @QueryParam("gbrecs") boolean gbrecs, @QueryParam("key") String apiTokenParam, @Context UriInfo uriInfo, @Context HttpHeaders headers, @Context HttpServletResponse response) throws WebApplicationException {
+        
+        fileIds = fileIds.substring(8); // String "fileIds=" from the front
+        /* Note - fileIds also has a ',' after the last file id number and before a
+         * final '\n' - the latter appears to stop the last item from being parsed in
+         * the fileIds.split(","); line below.
+         */
+        return downloadDatafiles(fileIds, gbrecs, apiTokenParam, uriInfo, headers, response);
+    }
+    /*
+     * API method for downloading zipped bundles of multiple files:
+     */
+
+    // TODO: Rather than only supporting looking up files by their database IDs,
+    // consider supporting persistent identifiers.
     @Path("datafiles/{fileIds}")
     @GET
     @Produces({"application/zip"})
-    public Response datafiles(@PathParam("fileIds") String fileIds,  @QueryParam("gbrecs") boolean gbrecs, @QueryParam("key") String apiTokenParam, @Context UriInfo uriInfo, @Context HttpHeaders headers, @Context HttpServletResponse response) throws WebApplicationException /*throws NotFoundException, ServiceUnavailableException, PermissionDeniedException, AuthorizationRequiredException*/ {
+    public Response datafiles(@PathParam("fileIds") String fileIds, @QueryParam("gbrecs") boolean gbrecs, @QueryParam("key") String apiTokenParam, @Context UriInfo uriInfo, @Context HttpHeaders headers, @Context HttpServletResponse response) throws WebApplicationException {
+        return downloadDatafiles(fileIds, gbrecs, apiTokenParam, uriInfo, headers, response);
+    }
 
+    private Response downloadDatafiles(String fileIds, boolean gbrecs, String apiTokenParam, UriInfo uriInfo, HttpHeaders headers, HttpServletResponse response) throws WebApplicationException /* throws NotFoundException, ServiceUnavailableException, PermissionDeniedException, AuthorizationRequiredException*/ {
         long setLimit = systemConfig.getZipDownloadLimit();
         if (!(setLimit > 0L)) {
             setLimit = DataFileZipper.DEFAULT_ZIPFILE_LIMIT;

--- a/src/main/webapp/file-download-button-fragment.xhtml
+++ b/src/main/webapp/file-download-button-fragment.xhtml
@@ -277,4 +277,13 @@
         <!-- 4.2.1 - TODO: retest this on a dataset with fileRequest enabled and with some files restricted to the user -->
         <span class="glyphicon glyphicon-bullhorn"/> #{fileMetadata.dataFile.fileAccessRequesters.contains(dataverseSession.user) ? bundle['file.accessRequested'] : bundle['file.requestAccess']}
     </p:commandLink>
+    <script type="text/javascript">
+      function downloadFiles(url, filelist) {
+        filelist=filelist + ','; //Prevents last file from being dropped on server
+        var form = $('<form></form>').attr('action', url).attr('method', 'post').attr('enctype','text/plain');
+        form.append($("<input></input>").attr('type', 'hidden').attr('name', 'fileIds').attr('value', filelist));
+        //Submit and then remove form
+        form.appendTo('body').submit().remove();
+      }
+    </script>
 </ui:composition>


### PR DESCRIPTION
**What this PR does / why we need it**: uses POST for file download requests, avoiding problems with limits on the url length for requests for large numbers of files

**Which issue(s) this PR closes**:

Closes #6943 

**Special notes for your reviewer**: We've used this on QDR since last May, but I just tried to compare with that fork to pull things over - haven't tested this commit. 

**Suggestions on how to test this**: Nominally, if any download works, this is working. To verify that it's better than the prior code, you'll need to have enough files to have caused trouble. That was 1061 in the issue but I'd suggest a larger number for a test or make sure your test DB uses ids with the same number of digits because the issue is line length and ids in production will be longer than on a new test machine starting with id 1.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: No

**Is there a release notes update needed for this change?**: No

**Additional documentation**:
