### PR TITLE
Iqss/4977 - Reorder Publication Year Facet Chronologically

### DIFF
--- a/doc/release-notes/4977-facet-sort-setting
+++ b/doc/release-notes/4977-facet-sort-setting
@@ -1,0 +1,5 @@
+New setting for Dataverse Admins:
+
+The new :ChronologicalDateFacets setting. Default to true. 
+
+Facets with Date/Year are sorted chronologically by default, with the most recent value first. To have them sorted by number of hits, e.g. with the year with the most results first, set this to false 

--- a/doc/sphinx-guides/source/installation/config.rst
+++ b/doc/sphinx-guides/source/installation/config.rst
@@ -2051,7 +2051,7 @@ If you don’t want to allow CORS for your installation, set:
 ``curl -X PUT -d 'false' http://localhost:8080/api/admin/settings/:AllowCors``
 
 :ChronologicalDateFacets
-+++++++++++++++
+++++++++++++++++++++++++
 
 Unlike other facets, those indexed by Date/Year are sorted chronologically by default, with the most recent value first. To have them sorted by number of hits, e.g. with the year with the most results first, set this to false 
 

--- a/doc/sphinx-guides/source/installation/config.rst
+++ b/doc/sphinx-guides/source/installation/config.rst
@@ -2049,3 +2049,12 @@ Allows Cross-Origin Resource sharing(CORS). By default this setting is absent an
 If you don’t want to allow CORS for your installation, set:
 
 ``curl -X PUT -d 'false' http://localhost:8080/api/admin/settings/:AllowCors``
+
+:ChronologicalDateFacets
++++++++++++++++
+
+Unlike other facets, those indexed by Date/Year are sorted chronologically by default, with the most recent value first. To have them sorted by number of hits, e.g. with the year with the most results first, set this to false 
+
+If you don’t want date facets to be sorted chronologically, set:
+
+``curl -X PUT -d 'false' http://localhost:8080/api/admin/settings/:ChronologicalDateFacets``

--- a/src/main/java/edu/harvard/iq/dataverse/SettingsWrapper.java
+++ b/src/main/java/edu/harvard/iq/dataverse/SettingsWrapper.java
@@ -265,6 +265,12 @@ public class SettingsWrapper implements java.io.Serializable {
         return isTrueForKey(SettingsServiceBean.Key.DisplayMDCMetrics, safeDefaultIfKeyNotFound);
     
     }
+    
+    public boolean sortDateFacets() {
+        //Defaults to true
+        return isTrueForKey(SettingsServiceBean.Key.SortDateFacets, true);
+    
+    }
 
 }
 

--- a/src/main/java/edu/harvard/iq/dataverse/SettingsWrapper.java
+++ b/src/main/java/edu/harvard/iq/dataverse/SettingsWrapper.java
@@ -266,9 +266,9 @@ public class SettingsWrapper implements java.io.Serializable {
     
     }
     
-    public boolean sortDateFacets() {
+    public boolean displayChronologicalDateFacets() {
         //Defaults to true
-        return isTrueForKey(SettingsServiceBean.Key.SortDateFacets, true);
+        return isTrueForKey(SettingsServiceBean.Key.ChronologicalDateFacets, true);
     
     }
 

--- a/src/main/java/edu/harvard/iq/dataverse/search/FacetLabel.java
+++ b/src/main/java/edu/harvard/iq/dataverse/search/FacetLabel.java
@@ -3,7 +3,7 @@ package edu.harvard.iq.dataverse.search;
 import javax.inject.Named;
 
 @Named
-public class FacetLabel {
+public class FacetLabel implements Comparable<FacetLabel>{
 
     private String name;
     private Long count;
@@ -44,6 +44,11 @@ public class FacetLabel {
 
     public void setFilterQuery(String filterQuery) {
         this.filterQuery = filterQuery;
+    }
+
+    @Override
+    public int compareTo(FacetLabel otherFacetLabel) {
+        return name.compareTo(otherFacetLabel.getName());
     }
 
 }

--- a/src/main/java/edu/harvard/iq/dataverse/search/FacetLabel.java
+++ b/src/main/java/edu/harvard/iq/dataverse/search/FacetLabel.java
@@ -48,11 +48,10 @@ public class FacetLabel implements Comparable<FacetLabel>{
 
     @Override
     public int compareTo(FacetLabel otherFacetLabel) {
+        // This is used to 'chronologically' order entries in the Publication Year facet
+        // display. That should work for 4 digit years (until 10K AD), but this could be
+        // changed to do a real numberical comparison instead.
         return name.compareTo(otherFacetLabel.getName());
-    }
-    
-    public String toString() {
-        return getName() + "(" + getCount() + ")";
     }
 
 }

--- a/src/main/java/edu/harvard/iq/dataverse/search/FacetLabel.java
+++ b/src/main/java/edu/harvard/iq/dataverse/search/FacetLabel.java
@@ -50,5 +50,9 @@ public class FacetLabel implements Comparable<FacetLabel>{
     public int compareTo(FacetLabel otherFacetLabel) {
         return name.compareTo(otherFacetLabel.getName());
     }
+    
+    public String toString() {
+        return getName() + "(" + getCount() + ")";
+    }
 
 }

--- a/src/main/java/edu/harvard/iq/dataverse/search/SearchIncludeFragment.java
+++ b/src/main/java/edu/harvard/iq/dataverse/search/SearchIncludeFragment.java
@@ -453,6 +453,7 @@ public class SearchIncludeFragment implements java.io.Serializable {
             
             //Sort Pub Year Chronologically (alphabetically descending - works until 10000 AD)
             for(FacetCategory fc: facetCategoryList) {
+                logger.info("Found facet: " + fc.getName());
                 if(fc.getName()==SearchFields.PUBLICATION_YEAR) {
                     Collections.sort(fc.getFacetLabel(), Collections.reverseOrder());        
                 }

--- a/src/main/java/edu/harvard/iq/dataverse/search/SearchIncludeFragment.java
+++ b/src/main/java/edu/harvard/iq/dataverse/search/SearchIncludeFragment.java
@@ -33,6 +33,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -449,6 +450,14 @@ public class SearchIncludeFragment implements java.io.Serializable {
             }
             
             setDisplayCardValues();
+            
+            //Sort Pub Year Chronologically (alphabetically descending - works until 10000 AD)
+            for(FacetCategory fc: facetCategoryList) {
+                if(fc.getName()==SearchFields.PUBLICATION_YEAR) {
+                    Collections.sort(fc.getFacetLabel(), Collections.reverseOrder());        
+                }
+            }
+            
             
             dataversePage.setQuery(query);
             dataversePage.setFacetCategoryList(facetCategoryList);

--- a/src/main/java/edu/harvard/iq/dataverse/search/SearchIncludeFragment.java
+++ b/src/main/java/edu/harvard/iq/dataverse/search/SearchIncludeFragment.java
@@ -454,7 +454,7 @@ public class SearchIncludeFragment implements java.io.Serializable {
             
             setDisplayCardValues();
             
-            if (settingsWrapper.sortDateFacets()) {
+            if (settingsWrapper.displayChronologicalDateFacets()) {
                 Set<String> facetsToSort = new HashSet<String>();
                 facetsToSort.add(SearchFields.PUBLICATION_YEAR);
                 List<DataverseFacet> facets = dataversePage.getDataverse().getDataverseFacets();

--- a/src/main/java/edu/harvard/iq/dataverse/search/SearchIncludeFragment.java
+++ b/src/main/java/edu/harvard/iq/dataverse/search/SearchIncludeFragment.java
@@ -461,15 +461,15 @@ public class SearchIncludeFragment implements java.io.Serializable {
                 for (DataverseFacet facet : facets) {
                     DatasetFieldType dft = facet.getDatasetFieldType();
                     if (dft.getFieldType() == FieldType.DATE) {
-                        facetsToSort.add(dft.getName());
-                        logger.info("Adding facet to sort: " + dft.getName());
+                        // Currently all date fields are stored in solr as strings and so get an "_s" appended. 
+                        // If these someday are indexed as dates, this should change
+                        facetsToSort.add(dft.getName()+"_s");
                     }
                 }
 
                 // Sort Pub Year Chronologically (alphabetically descending - works until 10000
                 // AD)
                 for (FacetCategory fc : facetCategoryList) {
-                    logger.info("Found facet: " + fc.getName());
                     if (facetsToSort.contains(fc.getName())) {
                         Collections.sort(fc.getFacetLabel(), Collections.reverseOrder());
                     }

--- a/src/main/java/edu/harvard/iq/dataverse/search/SearchIncludeFragment.java
+++ b/src/main/java/edu/harvard/iq/dataverse/search/SearchIncludeFragment.java
@@ -462,12 +462,14 @@ public class SearchIncludeFragment implements java.io.Serializable {
                     DatasetFieldType dft = facet.getDatasetFieldType();
                     if (dft.getFieldType() == FieldType.DATE) {
                         facetsToSort.add(dft.getName());
+                        logger.info("Adding facet to sort: " + dft.getName());
                     }
                 }
 
                 // Sort Pub Year Chronologically (alphabetically descending - works until 10000
                 // AD)
                 for (FacetCategory fc : facetCategoryList) {
+                    logger.info("Found facet: " + fc.getName());
                     if (facetsToSort.contains(fc.getName())) {
                         Collections.sort(fc.getFacetLabel(), Collections.reverseOrder());
                     }

--- a/src/main/java/edu/harvard/iq/dataverse/search/SearchIncludeFragment.java
+++ b/src/main/java/edu/harvard/iq/dataverse/search/SearchIncludeFragment.java
@@ -5,9 +5,12 @@ import edu.harvard.iq.dataverse.DataFileServiceBean;
 import edu.harvard.iq.dataverse.DataFileTag;
 import edu.harvard.iq.dataverse.DataTable;
 import edu.harvard.iq.dataverse.Dataset;
+import edu.harvard.iq.dataverse.DatasetFieldType;
+import edu.harvard.iq.dataverse.DatasetFieldType.FieldType;
 import edu.harvard.iq.dataverse.DatasetServiceBean;
 import edu.harvard.iq.dataverse.DatasetVersionServiceBean;
 import edu.harvard.iq.dataverse.Dataverse;
+import edu.harvard.iq.dataverse.DataverseFacet;
 import edu.harvard.iq.dataverse.DataversePage;
 import edu.harvard.iq.dataverse.DataverseServiceBean;
 import edu.harvard.iq.dataverse.DataverseSession;
@@ -451,13 +454,27 @@ public class SearchIncludeFragment implements java.io.Serializable {
             
             setDisplayCardValues();
             
-            //Sort Pub Year Chronologically (alphabetically descending - works until 10000 AD)
-            for(FacetCategory fc: facetCategoryList) {
-                if(fc.getName().equals(SearchFields.PUBLICATION_YEAR)) {
-                    Collections.sort(fc.getFacetLabel(), Collections.reverseOrder());     
+            if (settingsWrapper.sortDateFacets()) {
+                Set<String> facetsToSort = new HashSet<String>();
+                facetsToSort.add(SearchFields.PUBLICATION_YEAR);
+                List<DataverseFacet> facets = dataversePage.getDataverse().getDataverseFacets();
+                for (DataverseFacet facet : facets) {
+                    DatasetFieldType dft = facet.getDatasetFieldType();
+                    if (dft.getFieldType() == FieldType.DATE) {
+                        facetsToSort.add(dft.getName());
+                    }
+                }
+
+                // Sort Pub Year Chronologically (alphabetically descending - works until 10000
+                // AD)
+                for (FacetCategory fc : facetCategoryList) {
+                    if (facetsToSort.contains(fc.getName())) {
+                        Collections.sort(fc.getFacetLabel(), Collections.reverseOrder());
+                    }
                 }
             }
             
+
             
             dataversePage.setQuery(query);
             dataversePage.setFacetCategoryList(facetCategoryList);

--- a/src/main/java/edu/harvard/iq/dataverse/search/SearchIncludeFragment.java
+++ b/src/main/java/edu/harvard/iq/dataverse/search/SearchIncludeFragment.java
@@ -454,7 +454,7 @@ public class SearchIncludeFragment implements java.io.Serializable {
             //Sort Pub Year Chronologically (alphabetically descending - works until 10000 AD)
             for(FacetCategory fc: facetCategoryList) {
                 logger.info("Found facet: " + fc.getName());
-                if(fc.getName()==SearchFields.PUBLICATION_YEAR) {
+                if(fc.getName().equals(SearchFields.PUBLICATION_YEAR)) {
                     logger.info("Before: " + fc.getFacetLabel().toString());
                     Collections.sort(fc.getFacetLabel(), Collections.reverseOrder());     
                     logger.info("After: " + fc.getFacetLabel().toString());

--- a/src/main/java/edu/harvard/iq/dataverse/search/SearchIncludeFragment.java
+++ b/src/main/java/edu/harvard/iq/dataverse/search/SearchIncludeFragment.java
@@ -455,7 +455,9 @@ public class SearchIncludeFragment implements java.io.Serializable {
             for(FacetCategory fc: facetCategoryList) {
                 logger.info("Found facet: " + fc.getName());
                 if(fc.getName()==SearchFields.PUBLICATION_YEAR) {
-                    Collections.sort(fc.getFacetLabel(), Collections.reverseOrder());        
+                    logger.info("Before: " + fc.getFacetLabel().toString());
+                    Collections.sort(fc.getFacetLabel(), Collections.reverseOrder());     
+                    logger.info("After: " + fc.getFacetLabel().toString());
                 }
             }
             

--- a/src/main/java/edu/harvard/iq/dataverse/search/SearchIncludeFragment.java
+++ b/src/main/java/edu/harvard/iq/dataverse/search/SearchIncludeFragment.java
@@ -453,11 +453,8 @@ public class SearchIncludeFragment implements java.io.Serializable {
             
             //Sort Pub Year Chronologically (alphabetically descending - works until 10000 AD)
             for(FacetCategory fc: facetCategoryList) {
-                logger.info("Found facet: " + fc.getName());
                 if(fc.getName().equals(SearchFields.PUBLICATION_YEAR)) {
-                    logger.info("Before: " + fc.getFacetLabel().toString());
                     Collections.sort(fc.getFacetLabel(), Collections.reverseOrder());     
-                    logger.info("After: " + fc.getFacetLabel().toString());
                 }
             }
             

--- a/src/main/java/edu/harvard/iq/dataverse/settings/SettingsServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/settings/SettingsServiceBean.java
@@ -430,7 +430,12 @@ public class SettingsServiceBean {
         /**
          * Validate physical files for all the datafiles in the dataset when publishing
          */
-        FileValidationOnPublishEnabled
+        FileValidationOnPublishEnabled,
+        /**
+         * Sort Date Facets Chronologically instead or presenting them in order of # of hits as other facets are. Default is true
+         */
+        SortDateFacets
+        
         ;
 
         @Override

--- a/src/main/java/edu/harvard/iq/dataverse/settings/SettingsServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/settings/SettingsServiceBean.java
@@ -434,7 +434,7 @@ public class SettingsServiceBean {
         /**
          * Sort Date Facets Chronologically instead or presenting them in order of # of hits as other facets are. Default is true
          */
-        SortDateFacets
+        ChronologicalDateFacets
         
         ;
 


### PR DESCRIPTION
**What this PR does / why we need it**: This reorders the results for the Publication Year facet to be chronological

**Which issue(s) this PR closes**:

Closes #4977

**Special notes for your reviewer**: FWIW: This PR doesn't resolve the underlying issue that the results for all facets are coming back form solr in order of # of counts. I'm simply reordering the results for this one facet. Since the number of years is not large, sorting should be reasonable. The other shortcut I made is to just use alphabetical sorting since the years are strings. That could be changed too, either in solr, or in the sorting compareTo method I wrote. I'd be happy to do the latter if desired but I don't have the time/expertise to dig into any changes requiring updates to solr itself.

**Suggestions on how to test this**: The Publication Year facet should show years in chronological descending order.  I don't have a repo with more than 5 years available so if there is one, it would be good to test that this works even with the limit of displaying 5 and then having to ask for more. (It should).

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: Just the change in order of the entries which is what the issue is about.

**Is there a release notes update needed for this change?**: No

**Additional documentation**: None
