### PR TITLE
Remove erroneous bit from codebook2-0.xsl (HTML Codebook stylesheet)

### DIFF
--- a/doc/release-notes/6959-html-codebook.md
+++ b/doc/release-notes/6959-html-codebook.md
@@ -1,0 +1,1 @@
+A small correction has been made to the stylesheet that generates the DDI HTML Codebook metadata export to remove a hard-coded reference to ICPSR. In order for previously published and exported datasets to reflect this correction, run ReExportAll as part of the upgrade process with `curl http://localhost:8080/api/admin/metadata/reExportAll`.

--- a/src/main/resources/edu/harvard/iq/dataverse/codebook2-0.xsl
+++ b/src/main/resources/edu/harvard/iq/dataverse/codebook2-0.xsl
@@ -177,7 +177,7 @@ font-size: 10pt;
             </head>
             <body bgcolor="#ffffff" lang="en-US">
                 <h1>
-                    <xsl:value-of select="stdyDscr/citation/titlStmt/titl"/> (ICPSR <xsl:value-of
+                    <xsl:value-of select="stdyDscr/citation/titlStmt/titl"/> (<xsl:value-of select="stdyDscr/citation/distStmt/distrbtr"/><xsl:text> </xsl:text><xsl:value-of
                         select="stdyDscr/citation/titlStmt/IDNo"/>)<xsl:if test="stdyDscr/citation/titlStmt/altTitl">
                         <br/>(<xsl:value-of select="stdyDscr/citation/titlStmt/altTitl"/>)</xsl:if>
                 </h1>

--- a/src/main/resources/edu/harvard/iq/dataverse/codebook2-0.xsl
+++ b/src/main/resources/edu/harvard/iq/dataverse/codebook2-0.xsl
@@ -177,7 +177,7 @@ font-size: 10pt;
             </head>
             <body bgcolor="#ffffff" lang="en-US">
                 <h1>
-                    <xsl:value-of select="stdyDscr/citation/titlStmt/titl"/> (<xsl:value-of select="stdyDscr/citation/distStmt/distrbtr"/><xsl:text> </xsl:text><xsl:value-of
+                    <xsl:value-of select="stdyDscr/citation/titlStmt/titl"/> (<xsl:value-of
                         select="stdyDscr/citation/titlStmt/IDNo"/>)<xsl:if test="stdyDscr/citation/titlStmt/altTitl">
                         <br/>(<xsl:value-of select="stdyDscr/citation/titlStmt/altTitl"/>)</xsl:if>
                 </h1>

--- a/src/test/resources/html/dct_codebook.html
+++ b/src/test/resources/html/dct_codebook.html
@@ -155,7 +155,7 @@ font-size: 10pt;
 				</style>
 </head>
 <body lang="en-US" bgcolor="#ffffff">
-<h1>dct html&nbsp;(ICPSR doi:10.5072/FK2/SOLYMR)</h1>
+<h1>dct html&nbsp;(doi:10.5072/FK2/SOLYMR)</h1>
 <table cellspacing="0" cellpadding="5" border="0">
 <tr>
 <td valign="top">


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes an irrelevant hardcoded value ("ICPSR") in the HTML Codebook stylesheet.

**Which issue(s) this PR closes**:

Closes #6959

**Special notes for your reviewer**:
This updates my earlier pull request, based on discussion on the issue. Hope I did this right!

**Suggestions on how to test this**:

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
No
**Is there a release notes update needed for this change?**:
No
**Additional documentation**:
