### PR TITLE
quick fix to get test passing in FilesIT #6962

### DIFF
--- a/src/test/java/edu/harvard/iq/dataverse/api/FilesIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/FilesIT.java
@@ -638,7 +638,8 @@ public class FilesIT {
         String updateDescription = "New description.";
         String updateCategory = "New category";
         //"junk" passed below is to test that it is discarded
-        String updateJsonString = "{\"description\":\""+updateDescription+"\",\"categories\":[\""+updateCategory+"\"],\"forceReplace\":false ,\"junk\":\"junk\"}";
+        // label=foo.tsv is passed to avoid "Filename already exists at data.tsv" but should it be necessary?
+        String updateJsonString = "{\"description\":\""+updateDescription+"\",\"categories\":[\""+updateCategory+"\"],\"forceReplace\":false ,\"junk\":\"junk\",\"label\":\"foo.tsv\"}";
         Response updateMetadataFailResponse = UtilIT.updateFileMetadata(origFileId.toString(), updateJsonString, apiToken);
         assertEquals(BAD_REQUEST.getStatusCode(), updateMetadataFailResponse.getStatusCode());  
         
@@ -646,6 +647,7 @@ public class FilesIT {
         msg("Update file metadata for new file");
         //"junk" passed below is to test that it is discarded
         Response updateMetadataResponse = UtilIT.updateFileMetadata(String.valueOf(newDfId), updateJsonString, apiToken);
+        updateMetadataResponse.prettyPrint();
         assertEquals(OK.getStatusCode(), updateMetadataResponse.getStatusCode());  
         //String updateMetadataResponseString = updateMetadataResponse.body().asString();
         Response getUpdatedMetadataResponse = UtilIT.getDataFileMetadataDraft(newDfId, apiToken);


### PR DESCRIPTION
**What this PR does / why we need it**:

Gets the tests passing in FilesIT.

**Which issue(s) this PR closes**:

Closes #6962

**Special notes for your reviewer**:

I'm concerned that pull request #6893 may have introduced a change to the API behavior. ` files.api.metadata.update.duplicateFile=Filename already exists at {0}` is something I added in that pull request.

See #6962 for a screenshot from Netbeans.

**Suggestions on how to test this**:

Run the tests.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No.

**Is there a release notes update needed for this change?**:

No.

**Additional documentation**:

None.