### PR TITLE
reorder links to get firefox to use larger favicon

### DIFF
--- a/src/main/webapp/dataverse_template.xhtml
+++ b/src/main/webapp/dataverse_template.xhtml
@@ -25,8 +25,8 @@
 	    <ui:insert name="jsonld_header"></ui:insert>
         </f:facet>
         <link rel="apple-touch-icon" sizes="180x180" href="#{resource['images/fav/apple-touch-icon.png']}"/>
-        <link rel="icon" type="image/png" sizes="32x32" href="#{resource['images/fav/favicon-32x32.png']}"/>
         <link rel="icon" type="image/png" sizes="16x16" href="#{resource['images/fav/favicon-16x16.png']}"/>
+        <link rel="icon" type="image/png" sizes="32x32" href="#{resource['images/fav/favicon-32x32.png']}"/>
         <link rel="manifest" href="#{resource['images/fav/site.webmanifest']}"/>
         <link rel="mask-icon" href="#{resource['images/fav/safari-pinned-tab.svg']}" color="#da532c"/>
         <meta name="msapplication-TileColor" content="#da532c"/>


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=751712

**What this PR does / why we need it**: works-around a firefox bug to display better favicon

**Which issue(s) this PR closes**:

Closes #6965

**Special notes for your reviewer**:

**Suggestions on how to test this**: Firefox only as far as I know. The code change is just to put the 32 pixel favicon line in the source after the 16 pixel one. So you can check the source. That should also change the favicon itself but that could potentially be cached in your browser.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: just shows better favicon

**Is there a release notes update needed for this change?**: no

**Additional documentation**:
