### PR TITLE
allow changes to file metadata via API #6962

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/api/Files.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Files.java
@@ -392,6 +392,11 @@ public class Files extends AbstractApiBean {
                 javax.json.JsonObject jsonObject = jsonReader.readObject();
                 String label = jsonObject.getString("label", null);
                 String directoryLabel = jsonObject.getString("directoryLabel", null);
+                // If the user is trying to change the label/directoryLabel or not.
+                boolean labelChange = true;
+                if (label == null && directoryLabel == null) {
+                    labelChange = false;
+                }
                 String path = "";
                 if (directoryLabel != null) {
                     path = directoryLabel + "/";
@@ -399,7 +404,7 @@ public class Files extends AbstractApiBean {
                 if (label == null) {
                     label = df.getFileMetadata().getLabel();
                 }
-                if (IngestUtil.conflictsWithExistingFilenames(label, directoryLabel, fmdList, df)) {
+                if (labelChange && IngestUtil.conflictsWithExistingFilenames(label, directoryLabel, fmdList, df)) {
                     String incomingPathPlusFileName = path + label;
                     return error(BAD_REQUEST, BundleUtil.getStringFromBundle("files.api.metadata.update.duplicateFile", Arrays.asList(incomingPathPlusFileName)));
                 }

--- a/src/main/java/edu/harvard/iq/dataverse/api/Files.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Files.java
@@ -399,14 +399,14 @@ public class Files extends AbstractApiBean {
                 }
                 String oldLabel = df.getFileMetadata().getLabel();
                 String oldDirectoryLabel = df.getFileMetadata().getDirectoryLabel();
-                String oldPathPlusName = oldDirectoryLabel + oldLabel;
+                String oldPathPlusName = oldDirectoryLabel + "/" + oldLabel;
                 if (directoryLabel == null) {
                     directoryLabel = oldDirectoryLabel;
                 }
                 if (label == null) {
                     label = oldLabel;
                 }
-                String incomingPathPlusName = directoryLabel + label;
+                String incomingPathPlusName = directoryLabel + "/" + label;
                 if (oldPathPlusName.equals(incomingPathPlusName)) {
                     labelChange = false;
                 }

--- a/src/main/java/edu/harvard/iq/dataverse/api/Files.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Files.java
@@ -397,12 +397,19 @@ public class Files extends AbstractApiBean {
                 if (label == null && directoryLabel == null) {
                     labelChange = false;
                 }
+                String oldLabel = df.getFileMetadata().getLabel();
+                String oldDirectoryLabel = df.getFileMetadata().getDirectoryLabel();
+                String oldPathPlusName = oldDirectoryLabel + oldLabel;
+                String incomingPathPlusName = directoryLabel + label;
+                if (oldPathPlusName.equals(incomingPathPlusName)) {
+                    labelChange = false;
+                }
                 String path = "";
                 if (directoryLabel != null) {
                     path = directoryLabel + "/";
                 }
                 if (label == null) {
-                    label = df.getFileMetadata().getLabel();
+                    label = oldLabel;
                 }
                 if (labelChange && IngestUtil.conflictsWithExistingFilenames(label, directoryLabel, fmdList, df)) {
                     String incomingPathPlusFileName = path + label;

--- a/src/main/java/edu/harvard/iq/dataverse/api/Files.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Files.java
@@ -400,20 +400,24 @@ public class Files extends AbstractApiBean {
                 String oldLabel = df.getFileMetadata().getLabel();
                 String oldDirectoryLabel = df.getFileMetadata().getDirectoryLabel();
                 String oldPathPlusName = oldDirectoryLabel + oldLabel;
-                String incomingPathPlusName = directoryLabel + label;
-                if (oldPathPlusName.equals(incomingPathPlusName)) {
-                    labelChange = false;
-                }
-                String path = "";
-                if (directoryLabel != null) {
-                    path = directoryLabel + "/";
+                if (directoryLabel == null) {
+                    directoryLabel = oldDirectoryLabel;
                 }
                 if (label == null) {
                     label = oldLabel;
                 }
+                String incomingPathPlusName = directoryLabel + label;
+                if (oldPathPlusName.equals(incomingPathPlusName)) {
+                    labelChange = false;
+                }
                 if (labelChange && IngestUtil.conflictsWithExistingFilenames(label, directoryLabel, fmdList, df)) {
-                    String incomingPathPlusFileName = path + label;
-                    return error(BAD_REQUEST, BundleUtil.getStringFromBundle("files.api.metadata.update.duplicateFile", Arrays.asList(incomingPathPlusFileName)));
+                    String pathPlusFilename = "";
+                    if (directoryLabel != null) {
+                        pathPlusFilename = directoryLabel + "/" + label;
+                    } else {
+                        pathPlusFilename = label;
+                    }
+                    return error(BAD_REQUEST, BundleUtil.getStringFromBundle("files.api.metadata.update.duplicateFile", Arrays.asList(pathPlusFilename)));
                 }
 
                 optionalFileParams.addOptionalParams(upFmd);

--- a/src/main/java/edu/harvard/iq/dataverse/api/Files.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Files.java
@@ -394,9 +394,6 @@ public class Files extends AbstractApiBean {
                 String directoryLabel = jsonObject.getString("directoryLabel", null);
                 // If the user is trying to change the label/directoryLabel or not.
                 boolean labelChange = true;
-                if (label == null && directoryLabel == null) {
-                    labelChange = false;
-                }
                 String oldLabel = df.getFileMetadata().getLabel();
                 String oldDirectoryLabel = df.getFileMetadata().getDirectoryLabel();
                 String oldPathPlusName = oldDirectoryLabel + "/" + oldLabel;

--- a/src/main/java/edu/harvard/iq/dataverse/api/Files.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Files.java
@@ -407,6 +407,7 @@ public class Files extends AbstractApiBean {
                 if (oldPathPlusName.equals(incomingPathPlusName)) {
                     labelChange = false;
                 }
+                logger.fine("For file id " + df.getId() + " user is trying to change the label: " + labelChange);
                 if (labelChange && IngestUtil.conflictsWithExistingFilenames(label, directoryLabel, fmdList, df)) {
                     String pathPlusFilename = "";
                     if (directoryLabel != null) {

--- a/src/main/java/edu/harvard/iq/dataverse/ingest/IngestUtil.java
+++ b/src/main/java/edu/harvard/iq/dataverse/ingest/IngestUtil.java
@@ -102,37 +102,34 @@ public class IngestUtil {
     }
 
     /**
+     * Given an existing file that may or may not have a directoryLabel, take
+     * the incoming label and/or directory label and combine it with what's in
+     * the existing file, overwriting and filling in as necessary.
+     */
+    public static String getPathAndFileNameToCheck(String incomingLabel, String incomingDirectoryLabel, String existingLabel, String existingDirectoryLabel) {
+        String labelToReturn = existingLabel;
+        String directoryLabelToReturn = existingDirectoryLabel;
+        if (incomingLabel != null) {
+            labelToReturn = incomingLabel;
+        }
+        if (incomingDirectoryLabel != null) {
+            directoryLabelToReturn = incomingDirectoryLabel;
+        }
+        if (directoryLabelToReturn != null) {
+            return directoryLabelToReturn + "/" + labelToReturn;
+        } else {
+            return labelToReturn;
+        }
+    }
+
+    /**
      * Given a new proposed label or directoryLabel for a file, check against
      * existing files if a duplicate directoryLabel/label combination would be
      * created.
-     *
-     * @param label The new label (filename) that is being proposed. Can be
-     * null.
-     * @param directoryLabel The new directoryLabel (file path) that is being
-     * proposed. Can be null.
-     * @param fileMetadatas The list fileMetadatas to be compared against,
-     * probably from a draft.
-     * @param dataFile The file that is being updated with a new name or path.
-     * @return true if there is a conflict, false otherwise.
      */
-    public static boolean conflictsWithExistingFilenames(String label, String directoryLabel, List<FileMetadata> fileMetadatas, DataFile dataFile) {
+    public static boolean conflictsWithExistingFilenames(String pathPlusFilename, List<FileMetadata> fileMetadatas) {
         List<String> filePathsAndNames = getPathsAndFileNames(fileMetadatas);
-        if (label != null || directoryLabel != null) {
-            String path = "";
-            if (directoryLabel != null) {
-                path = directoryLabel + "/";
-            }
-            if (label == null) {
-                label = dataFile.getFileMetadata().getLabel();
-            }
-            String incomingPathPlusFileName = path + label;
-            logger.fine(filePathsAndNames.toString());
-            logger.fine("incomingPathName: " + incomingPathPlusFileName);
-            if (filePathsAndNames.contains(incomingPathPlusFileName)) {
-                return true;
-            }
-        }
-        return false;
+        return filePathsAndNames.contains(pathPlusFilename);
     }
 
     /**

--- a/src/test/java/edu/harvard/iq/dataverse/ingest/IngestUtilTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/ingest/IngestUtilTest.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
@@ -609,6 +610,27 @@ public class IngestUtilTest {
             Logger.getLogger(IngestUtilTest.class.getName()).log(Level.SEVERE, null, ex);
         }
         assertEquals("UNF:6:FWBO/a1GcxDnM3fNLdzrHw==", datasetUnfValue);
+    }
+
+    @Test
+    public void testPathPlusFilename() {
+        String incomingLabel = "incomingLabel";
+        String incomingDirectoryLabel = "incomingDirectoryLabel";
+        String existingLabel = "existingLabel";
+        String existingDirectoryLabel = "existingDirectoryLabel";
+        String pathPlusFilename = IngestUtil.getPathAndFileNameToCheck(incomingLabel, incomingDirectoryLabel, existingLabel, existingDirectoryLabel);
+        assertEquals("incomingDirectoryLabel/incomingLabel", pathPlusFilename);
+    }
+
+    @Test
+    public void renameFileToSameName() {
+        String pathPlusFilename = "README.md";
+        FileMetadata file1 = new FileMetadata();
+        file1.setLabel("README.md");
+        FileMetadata file2 = new FileMetadata();
+        file2.setLabel("README2.md");
+        List<FileMetadata> fileMetadatas = Arrays.asList(file1, file2);
+        assertTrue(IngestUtil.conflictsWithExistingFilenames(pathPlusFilename, fileMetadatas));
     }
 
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

A regression was introduced in pull request #6893 whereby modifying file metadata API failed with "Filename already exists". This bug is in develop, not production.

**Which issue(s) this PR closes**:

Closes #6962

**Special notes for your reviewer**:

None.

**Suggestions on how to test this**:

- Try updating file metadata via API in develop vs this pull request. Docs: http://guides.dataverse.org/en/4.20/api/native-api.html#updating-file-metadata
- Ensure the FilesIT is passing

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No.

**Is there a release notes update needed for this change?**:

No.

**Additional documentation**:

None.