### PR TITLE
Fixed render logic to add DRAFT to dataset links [ref #3038]

### DIFF
--- a/src/main/webapp/mydata_templates/cards_minimum.html
+++ b/src/main/webapp/mydata_templates/cards_minimum.html
@@ -18,9 +18,13 @@
             <span class="icon-dataverse text-brand pull-right" title="Dataverse"></span>
             <a href="/dataverse/{{ card_info.identifier }}"><span style="padding:4px 0;">{{ card_info.name }}</span></a>
            {# <span class="text-muted">(<em>Affiliation</em>)</span>#}
- {% elif card_info.type == "dataset" %}
+  {% elif card_info.type == "dataset" %}
             <span class="icon-dataset text-info pull-right" title="Dataset"></span>
+        {% if card_info.is_draft_state %}
+            <a href="/dataset.xhtml?persistentId={{ card_info.global_id }}&version=DRAFT"><span style="padding:4px 0;">{{ card_info.name }}</span></a>
+        {% else %}
             <a href="/dataset.xhtml?persistentId={{ card_info.global_id }}"><span style="padding:4px 0;">{{ card_info.name }}</span></a>
+        {% endif %}
  {% elif card_info.type == "file" %}
             <span class="icon-file text-muted pull-right" title="File"></span>
             <a href="/file.xhtml?fileId={{ card_info.entity_id }}"><span style="padding:4px 0;">{{ card_info.name }}</span></a>

--- a/src/main/webapp/mydata_templates/cards_minimum.html
+++ b/src/main/webapp/mydata_templates/cards_minimum.html
@@ -60,7 +60,11 @@
 
  {% elif card_info.type == "dataset" %}
             <div class="card-preview-icon-block text-center">
+                {% if card_info.is_draft_state %}
+                <a href="/dataset.xhtml?persistentId={{ card_info.global_id }}&version=DRAFT"><span class="icon-dataset text-info"></span></a>
+                {% else %}
                 <a href="/dataset.xhtml?persistentId={{ card_info.global_id }}"><span class="icon-dataset text-info"></span></a>
+                {% endif %}
             </div>
             <span class="text-muted">{{ card_info.date_to_display_on_card }}
                 - <a href="/dataverse/{{ card_info.parent_alias }}">{{ card_info.parentName }}</a>


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the links (both title link AND icon link) on dataset cards on My Data pg so if it is a DRAFT you land on the draft version and not the latest published version.

**Which issue(s) this PR closes**:

Closes #3038 Draft Version URL Problem in "My Data"

**Special notes for your reviewer**:

My community mtg gift...

**Suggestions on how to test this**:

Log in as user who has access to a draft version of a dataset, that also has a published version, so that there are two cards displaying on My Data pg.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No, it if fixes a UI bug.

**Is there a release notes update needed for this change?**:

"My Data is not dead yet."

**Additional documentation**:

N/A
