### PR TITLE
Optional use of header to get user IP address

### DIFF
--- a/doc/release-notes/6970-ip-addresses-behind-proxy
+++ b/doc/release-notes/6970-ip-addresses-behind-proxy
@@ -1,0 +1,6 @@
+### Tracking users' IP addresses behind an address-masking proxy
+
+It is now possible to collect real user IP addresses in MDC logs 
+and/or set up an IP group on a system running behind a proxy/load balancer 
+that hides the addresses of incoming requests. See "Recording User IP 
+Addresses" in the Configuration section of the Installation Guide.

--- a/doc/sphinx-guides/source/installation/config.rst
+++ b/doc/sphinx-guides/source/installation/config.rst
@@ -1188,10 +1188,11 @@ dataverse.useripaddresssourceheader
 **Make sure** to read the section about the :ref:`Security Implications 
 <user-ip-addresses-proxy-security>` of using this option earlier in the guide!
 
-If set, specifies an HTTP Header such as X-Forwarded-For to use to retrieve the user's IP address. Useful in cases 
-such as running Dataverse behind load balancers where the default option of getting the Remote Address from the servlet isn't correct 
-(e.g. it would be the load balancer IP address). Note that unless your installation always sets the header you configure here, this 
-could be used as a way to spoof the user's address. Allowed values are: 
+If set, specifies an HTTP Header such as X-Forwarded-For to use to retrieve the user's IP address. For example:
+
+``./asadmin create-jvm-options '-Ddataverse.useripaddresssourceheader=X-Forwarded-For'``
+
+This setting is useful in cases such as running Dataverse behind load balancers where the default option of getting the Remote Address from the servlet isn't correct (e.g. it would be the load balancer IP address). Note that unless your installation always sets the header you configure here, this could be used as a way to spoof the user's address. Allowed values are: 
 
 .. code::
 

--- a/doc/sphinx-guides/source/installation/config.rst
+++ b/doc/sphinx-guides/source/installation/config.rst
@@ -39,6 +39,12 @@ Forcing HTTPS
 
 To avoid having your users send credentials in the clear, it's strongly recommended to force all web traffic to go through HTTPS (port 443) rather than HTTP (port 80). The ease with which one can install a valid SSL cert into Apache compared with the same operation in Payara might be a compelling enough reason to front Payara with Apache. In addition, Apache can be configured to rewrite HTTP to HTTPS with rules such as those found at https://wiki.apache.org/httpd/RewriteHTTPToHTTPS or in the section on :doc:`shibboleth`.
 
+Recording User IP Addresses
++++++++++++++++++++++++++++
+
+By default, Dataverse captures the IP address from which requests originate. This is used for multiple purposes including blocking access to the admin API and Make Data Count reporting. When Dataverse is configured behind a proxy such as a load balancer, the default setting may not capture the correct IP address. ...(Leonid to expand...) 
+
+
 .. _PrivacyConsiderations:
 
 Privacy Considerations
@@ -1149,6 +1155,28 @@ By default, download URLs to files will be included in Schema.org JSON-LD output
 Please note that there are other reasons why download URLs may not be included for certain files such as if a guestbook entry is required or if the file is restricted.
 
 For more on Schema.org JSON-LD, see the :doc:`/admin/metadataexport` section of the Admin Guide.
+
+dataverse.useripaddresssourceheader
++++++++++++++++++++++++++++++++++++
+
+
+If set, specifies an HTTP Header such as X-Forwarded-For to use to retrieve the user's IP address. Useful in cases 
+such as running Dataverse behind load balancers where the default option of getting the Remote Address from the servlet isn't correct 
+(e.g. it would be the load balancer IP address). Note that unless your installation always sets the header you configure here, this 
+could be used as a way to spoof the user's address. Allowed values are: ``"X-Forwarded-For",
+            "Proxy-Client-IP",
+            "WL-Proxy-Client-IP",
+            "HTTP_X_FORWARDED_FOR",
+            "HTTP_X_FORWARDED",
+            "HTTP_X_CLUSTER_CLIENT_IP",
+            "HTTP_CLIENT_IP",
+            "HTTP_FORWARDED_FOR",
+            "HTTP_FORWARDED",
+            "HTTP_VIA",
+            "REMOTE_ADDR"``
+
+        
+
 
 .. _database-settings:
 

--- a/doc/sphinx-guides/source/installation/config.rst
+++ b/doc/sphinx-guides/source/installation/config.rst
@@ -1178,18 +1178,10 @@ dataverse.useripaddresssourceheader
 If set, specifies an HTTP Header such as X-Forwarded-For to use to retrieve the user's IP address. Useful in cases 
 such as running Dataverse behind load balancers where the default option of getting the Remote Address from the servlet isn't correct 
 (e.g. it would be the load balancer IP address). Note that unless your installation always sets the header you configure here, this 
-could be used as a way to spoof the user's address. Allowed values are: ``"X-Forwarded-For",
-            "Proxy-Client-IP",
-            "WL-Proxy-Client-IP",
-            "HTTP_X_FORWARDED_FOR",
-            "HTTP_X_FORWARDED",
-            "HTTP_X_CLUSTER_CLIENT_IP",
-            "HTTP_CLIENT_IP",
-            "HTTP_FORWARDED_FOR",
-            "HTTP_FORWARDED",
-            "HTTP_VIA",
-            "REMOTE_ADDR"``
+could be used as a way to spoof the user's address. Allowed values are: 
+``"X-Forwarded-For", "Proxy-Client-IP", "WL-Proxy-Client-IP", "HTTP_X_FORWARDED_FOR", "HTTP_X_FORWARDED", "HTTP_X_CLUSTER_CLIENT_IP", "HTTP_CLIENT_IP", "HTTP_FORWARDED_FOR", "HTTP_FORWARDED", "HTTP_VIA", "REMOTE_ADDR"``
 
+``./asadmin create-jvm-options '-Ddataverse.useripaddresssourceheader=X-Forwarded-For'``
         
 
 

--- a/doc/sphinx-guides/source/installation/config.rst
+++ b/doc/sphinx-guides/source/installation/config.rst
@@ -45,14 +45,21 @@ To avoid having your users send credentials in the clear, it's strongly recommen
 Recording User IP Addresses
 +++++++++++++++++++++++++++
 
-By default, Dataverse captures the IP address from which requests originate. This is used for multiple purposes including controlling access to the admin API, IP-based user groups and Make Data Count reporting. When Dataverse is configured behind a proxy such as a load balancer, this default setup may not capture the correct IP address. In this case all the incoming requests will be logged in the access logs, MDC logs etc., as if they are all coming from the IP address(es) of the load balancer itself. Proxies usually save the original address in an added HTTP header, from which it can be extracted. For example, AWS LB records the "true" original address in the standard `X-Forwarded-For` header. If your Dataverse is running behind an IP-masking proxy, but you would like to use IP groups, or record the true geographical location of the incoming requests with Make Data Count, you may enable the IP address lookup from the proxy header using the JVM option  `dataverse.useripaddresssourceheader`, described further below. 
-Before doing so however, you must absolutely **consider the security risks involved**! This option must be enabled **only** on a Dataverse that is in fact fully behind a proxy that properly, and consistently, adds the `X-Forwarded-For` (or a similar) header to every request it forwards. Consider the implications of activating this option on a Dataverse that is not running behind a proxy, *or running behind one, but still accessible from the insecure locations bypassing the proxy*: Anyone can now add the header above to an incoming reqest, supplying an arbitrary IP address that Dataverse will trust as the true origin of  the call. Thus giving an attacker an easy way to, for example, get in a privileged IP group. The implications could be even more severe if an attacker were able to pretend to be coming from `localhost`, if Dataverse is configured to trust localhost connections for unrestricted access to the admin API! We have addressed this by making it so that Dataverse should never accept `localhost`, `127.0.0.1`, `0:0:0:0:0:0:0:1` etc. when supplied in such a header. But if you have reasons to still find this risk unacceptable, you may want to consider turning open localhost access to the API off (See :ref:`Securing Your Installation <securing-your-installation>` for more information.)
-This is how to verify that your proxy or load balancer, etc. is handling the originating address headers properly and securely: Make sure access logging is enabled in your application server (Payara) configuration. (`<http-service access-logging-enabled="true">` in the `domain.xml`). Add the address header to the access log format. For example, on a system behind AWS ELB, you may want to use something like `%client.name% %datetime% %request% %status% %response.length% %header.referer% %header.x-forwarded-for%`. Once enabled, access the Dataverse from outside the LB. You should now see the real IP address of your remote client in the access log. For example, something like: 
-`"1.2.3.4" "01/Jun/2020:12:00:00 -0500" "GET /dataverse.xhtml HTTP/1.1" 200 81082  "NULL-REFERER" "128.64.32.16"` 
-In this example, `128.64.32.16` is your remote address (that you should verify), and `1.2.3.4` is the address of your LB. If you're not seeing your remote address in the log, do not activate the JVM option! Also, verify that all the entries in the log have this header populated. The only entries in the access log that you should be seeing without this header (logged as `"NULL-HEADER-X-FORWARDED-FOR"`) are local requests, made from localhost, etc. In this case, since the request is not coming through the proxy, the local IP address should be logged as the primary one (as the first value in the log entry, `%client.name%`). If you see any requests coming in from remote, insecure subnets without this header - do not use the JVM option! 
-Once you are ready, enable the :ref:`JVM option <useripaddresssourceheader>`. Verify that the remote locations are properly tracked in your MDC metrics, and/or your IP groups are working. As a final test, if your Dataverse is allowing unrestricted localhost access to the admin API, imitate an attack in which a malicious request is pretending to be coming from `127.0.0.1`. Try the following from a remote, insecure location:
-`curl https://your.dataverse.edu/api/admin/settings --header "X-FORWARDED-FOR: 127.0.0.1"`
-First of all, confirm that access is denied! If you are in fact able to access the settings api from a location outside the proxy, **something is seriously wrong**, so please let us know, and stop using the JVM option.  Otherwise check the access log entry for the header value. What you should see is something like `"127.0.0.1, 128.64.32.16"`. Where the second address should be the real IP of your remote client. The fact that the "fake" `127.0.0.1` you sent over is present in the header is perfectly ok. This is the proper proxy behavior - it preserves any incoming values in the X-Forwarded-Header, if supplied, and adds the detected incoming address to it, *on the right*. It is only this rightmost comma-separated value that Dataverse should ever be using. 
+By default, Dataverse captures the IP address from which requests originate. This is used for multiple purposes including controlling access to the admin API, IP-based user groups and Make Data Count reporting. When Dataverse is configured behind a proxy such as a load balancer, this default setup may not capture the correct IP address. In this case all the incoming requests will be logged in the access logs, MDC logs etc., as if they are all coming from the IP address(es) of the load balancer itself. Proxies usually save the original address in an added HTTP header, from which it can be extracted. For example, AWS LB records the "true" original address in the standard ``X-Forwarded-For`` header. If your Dataverse is running behind an IP-masking proxy, but you would like to use IP groups, or record the true geographical location of the incoming requests with Make Data Count, you may enable the IP address lookup from the proxy header using the JVM option  ``dataverse.useripaddresssourceheader``, described further below. 
+
+Before doing so however, you must absolutely **consider the security risks involved**! This option must be enabled **only** on a Dataverse that is in fact fully behind a proxy that properly, and consistently, adds the ``X-Forwarded-For`` (or a similar) header to every request it forwards. Consider the implications of activating this option on a Dataverse that is not running behind a proxy, *or running behind one, but still accessible from the insecure locations bypassing the proxy*: Anyone can now add the header above to an incoming reqest, supplying an arbitrary IP address that Dataverse will trust as the true origin of  the call. Thus giving an attacker an easy way to, for example, get in a privileged IP group. The implications could be even more severe if an attacker were able to pretend to be coming from ``localhost``, if Dataverse is configured to trust localhost connections for unrestricted access to the admin API! We have addressed this by making it so that Dataverse should never accept ``localhost``, ``127.0.0.1``, ``0:0:0:0:0:0:0:1`` etc. when supplied in such a header. But if you have reasons to still find this risk unacceptable, you may want to consider turning open localhost access to the API off (See :ref:`Securing Your Installation <securing-your-installation>` for more information.)
+
+This is how to verify that your proxy or load balancer, etc. is handling the originating address headers properly and securely: Make sure access logging is enabled in your application server (Payara) configuration. (``<http-service access-logging-enabled="true">`` in the ``domain.xml``). Add the address header to the access log format. For example, on a system behind AWS ELB, you may want to use something like ``%client.name% %datetime% %request% %status% %response.length% %header.referer% %header.x-forwarded-for%``. Once enabled, access the Dataverse from outside the LB. You should now see the real IP address of your remote client in the access log. For example, something like: 
+``"1.2.3.4" "01/Jun/2020:12:00:00 -0500" "GET /dataverse.xhtml HTTP/1.1" 200 81082  "NULL-REFERER" "128.64.32.16"`` 
+
+In this example, ``128.64.32.16`` is your remote address (that you should verify), and ``1.2.3.4`` is the address of your LB. If you're not seeing your remote address in the log, do not activate the JVM option! Also, verify that all the entries in the log have this header populated. The only entries in the access log that you should be seeing without this header (logged as ``"NULL-HEADER-X-FORWARDED-FOR"``) are local requests, made from localhost, etc. In this case, since the request is not coming through the proxy, the local IP address should be logged as the primary one (as the first value in the log entry, ``%client.name%``). If you see any requests coming in from remote, insecure subnets without this header - do not use the JVM option! 
+
+Once you are ready, enable the :ref:`JVM option <useripaddresssourceheader>`. Verify that the remote locations are properly tracked in your MDC metrics, and/or your IP groups are working. As a final test, if your Dataverse is allowing unrestricted localhost access to the admin API, imitate an attack in which a malicious request is pretending to be coming from ``127.0.0.1``. Try the following from a remote, insecure location:
+
+``curl https://your.dataverse.edu/api/admin/settings --header "X-FORWARDED-FOR: 127.0.0.1"``
+
+First of all, confirm that access is denied! If you are in fact able to access the settings api from a location outside the proxy, **something is seriously wrong**, so please let us know, and stop using the JVM option.  Otherwise check the access log entry for the header value. What you should see is something like ``"127.0.0.1, 128.64.32.16"``. Where the second address should be the real IP of your remote client. The fact that the "fake" ``127.0.0.1`` you sent over is present in the header is perfectly ok. This is the proper proxy behavior - it preserves any incoming values in the ``X-Forwarded-Header``, if supplied, and adds the detected incoming address to it, *on the right*. It is only this rightmost comma-separated value that Dataverse should ever be using. 
+
 Still feel like activating this option in your configuration? - Have fun and be safe!
 
 
@@ -258,12 +265,12 @@ Note that the "\-Ddataverse.files.directory", if defined, continues to control w
 
 If you wish to change which store is used by default, you'll need to delete the existing default storage driver and set a new one using jvm options.
 
-::
+.. code-block::
 
-  ./asadmin $ASADMIN_OPTS delete-jvm-options "-Ddataverse.files.storage-driver-id=file"
-  ./asadmin $ASADMIN_OPTS create-jvm-options "-Ddataverse.files.storage-driver-id=<id>"
+	./asadmin $ASADMIN_OPTS delete-jvm-options "-Ddataverse.files.storage-driver-id=file"
+	./asadmin $ASADMIN_OPTS create-jvm-options "-Ddataverse.files.storage-driver-id=<id>"
 
-  It is also possible to set maximum file upload size limits per store. See the :ref:`:MaxFileUploadSizeInBytes` setting below.
+It is also possible to set maximum file upload size limits per store. See the :ref:`:MaxFileUploadSizeInBytes` setting below.
 
 File Storage
 ++++++++++++
@@ -332,7 +339,7 @@ In this example, you would be setting the expiration length for one hour.
 
 
 Setting up Compute with Swift
-#############################
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Once you have configured a Swift Object Storage backend, you also have the option of enabling a connection to a computing environment. To do so, you need to configure the database settings for :ref:`:ComputeBaseUrl` and  :ref:`:CloudEnvironmentName`.
 
@@ -555,6 +562,7 @@ Migrating from Local Storage to S3
 ##################################
 
 Is currently documented on the :doc:`/developers/deployment` page.
+
 
 .. _Branding Your Installation:
 
@@ -831,9 +839,9 @@ Once this configuration is complete, you, as a user with the *PublishDataset* pe
 
 where:
 
-{id} is the DatasetId (or :persistentId with the ?persistentId="\<DOI\>" parameter), and
+``{id}`` is the DatasetId (or ``:persistentId`` with the ``?persistentId="<DOI>"`` parameter), and
 
-{version} is the friendly version number, e.g. "1.2".
+``{version}`` is the friendly version number, e.g. "1.2".
 
 The submitDataVersionToArchive API (and the workflow discussed below) attempt to archive the dataset version via an archive specific method. For Chronopolis, a DuraCloud space named for the dataset (it's DOI with ':' and '.' replaced with '-') is created and two files are uploaded to it: a version-specific datacite.xml metadata file and a BagIt bag containing the data and an OAI-ORE map file. (The datacite.xml file, stored outside the Bag as well as inside is intended to aid in discovery while the ORE map file is 'complete', containing all user-entered metadata and is intended as an archival record.)
 
@@ -843,7 +851,8 @@ PostPublication Workflow
 ++++++++++++++++++++++++
 
 To automate the submission of archival copies to an archive as part of publication, one can setup a Dataverse Workflow using the "archiver" workflow step - see the :doc:`/developers/workflows` guide.
-. The archiver step uses the configuration information discussed above including the :ArchiverClassName setting. The workflow step definition should include the set of properties defined in \:ArchiverSettings in the workflow definition.
+
+The archiver step uses the configuration information discussed above including the :ArchiverClassName setting. The workflow step definition should include the set of properties defined in \:ArchiverSettings in the workflow definition.
 
 To active this workflow, one must first install a workflow using the archiver step. A simple workflow that invokes the archiver step configured to submit to DuraCloud as its only action is included in dataverse at /scripts/api/data/workflows/internal-archiver-workflow.json.
 
@@ -957,19 +966,23 @@ If the Dataverse server has multiple DNS names, this option specifies the one to
 
 The password reset feature requires ``dataverse.fqdn`` to be configured.
 
-| Do note that whenever the system needs to form a service URL, by default, it will be formed with ``https://`` and port 443. I.e.,
-| ``https://{dataverse.fqdn}/``
-| If that does not suit your setup, you can define an additional option, ``dataverse.siteUrl``, explained below.
+.. note::
+
+	Do note that whenever the system needs to form a service URL, by default, it will be formed with ``https://`` and port 443. I.e.,
+	``https://{dataverse.fqdn}/``
+	If that does not suit your setup, you can define an additional option, ``dataverse.siteUrl``, explained below.
 
 .. _dataverse.siteUrl:
 
 dataverse.siteUrl
 +++++++++++++++++
 
-| and specify the protocol and port number you would prefer to be used to advertise the URL for your Dataverse.
-| For example, configured in domain.xml:
-| ``<jvm-options>-Ddataverse.fqdn=dataverse.example.edu</jvm-options>``
-| ``<jvm-options>-Ddataverse.siteUrl=http://${dataverse.fqdn}:8080</jvm-options>``
+.. note::
+
+	and specify the protocol and port number you would prefer to be used to advertise the URL for your Dataverse.
+	For example, configured in domain.xml:
+	``<jvm-options>-Ddataverse.fqdn=dataverse.example.edu</jvm-options>``
+	``<jvm-options>-Ddataverse.siteUrl=http://${dataverse.fqdn}:8080</jvm-options>``
 
 dataverse.files.directory
 +++++++++++++++++++++++++
@@ -1179,11 +1192,20 @@ If set, specifies an HTTP Header such as X-Forwarded-For to use to retrieve the 
 such as running Dataverse behind load balancers where the default option of getting the Remote Address from the servlet isn't correct 
 (e.g. it would be the load balancer IP address). Note that unless your installation always sets the header you configure here, this 
 could be used as a way to spoof the user's address. Allowed values are: 
-``"X-Forwarded-For", "Proxy-Client-IP", "WL-Proxy-Client-IP", "HTTP_X_FORWARDED_FOR", "HTTP_X_FORWARDED", "HTTP_X_CLUSTER_CLIENT_IP", "HTTP_CLIENT_IP", "HTTP_FORWARDED_FOR", "HTTP_FORWARDED", "HTTP_VIA", "REMOTE_ADDR"``
 
-``./asadmin create-jvm-options '-Ddataverse.useripaddresssourceheader=X-Forwarded-For'``
-        
+.. code::
 
+	"X-Forwarded-For",
+	"Proxy-Client-IP",
+	"WL-Proxy-Client-IP",
+	"HTTP_X_FORWARDED_FOR",
+	"HTTP_X_FORWARDED",
+	"HTTP_X_CLUSTER_CLIENT_IP",
+	"HTTP_CLIENT_IP",
+	"HTTP_FORWARDED_FOR",
+	"HTTP_FORWARDED",
+	"HTTP_VIA",
+	"REMOTE_ADDR"
 
 .. _database-settings:
 
@@ -1882,31 +1904,32 @@ The Shibboleth affiliation attribute holds information about the affiliation of 
 
 If the attribute is not yet set for the Shibboleth, please consult the Shibboleth Administrators at your institution. Typically it requires changing of the `/etc/shibboleth/attribute-map.xml` file by adding an attribute request, e.g.
 
-```
+.. code::
+
     <Attribute name="urn:oid:2.5.4.11" id="ou">
         <AttributeDecoder xsi:type="StringAttributeDecoder" caseSensitive="false"/>
     </Attribute>
-```
+
 
 In order to implement the change, you should restart Shibboleth and Apache2 services:
 
-```
-sudo service shibd restart
-sudo service apache2 restart
-```
+.. code::
+
+	sudo service shibd restart
+	sudo service apache2 restart
 
 To check if the attribute is sent, you should log in again to Dataverse and check Shibboleth's transaction log. You should see something like this:
 
-```
-INFO Shibboleth-TRANSACTION [25]: Cached the following attributes with session (ID: _9d1f34c0733b61c0feb0ca7596ef43b2) for (applicationId: default) {
-INFO Shibboleth-TRANSACTION [25]: 	givenName (1 values)
-INFO Shibboleth-TRANSACTION [25]: 	ou (1 values)
-INFO Shibboleth-TRANSACTION [25]: 	sn (1 values)
-INFO Shibboleth-TRANSACTION [25]: 	eppn (1 values)
-INFO Shibboleth-TRANSACTION [25]: 	mail (1 values)
-INFO Shibboleth-TRANSACTION [25]: 	displayName (1 values)
-INFO Shibboleth-TRANSACTION [25]: }
-```
+.. code::
+
+	INFO Shibboleth-TRANSACTION [25]: Cached the following attributes with session (ID: _9d1f34c0733b61c0feb0ca7596ef43b2) for (applicationId: default) {
+	INFO Shibboleth-TRANSACTION [25]: 	givenName (1 values)
+	INFO Shibboleth-TRANSACTION [25]: 	ou (1 values)
+	INFO Shibboleth-TRANSACTION [25]: 	sn (1 values)
+	INFO Shibboleth-TRANSACTION [25]: 	eppn (1 values)
+	INFO Shibboleth-TRANSACTION [25]: 	mail (1 values)
+	INFO Shibboleth-TRANSACTION [25]: 	displayName (1 values)
+	INFO Shibboleth-TRANSACTION [25]: }
 
 If you see the attribue you requested in this list, you can set the attribute in Dataverse.
 

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/DataverseRequest.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/DataverseRequest.java
@@ -113,24 +113,25 @@ public class DataverseRequest {
                         }
                     }
                 }
-                /*
-                 * If there was no header/no usable value from the header, use the
-                 * remoteAddress.
-                 * 
-                 */
-                if (address == null) {
-                    // use the request remote address
-                    String remoteAddressFromRequest = aHttpServletRequest.getRemoteAddr();
-                    if (remoteAddressFromRequest != null) {
-                        String remoteAddressStr = remoteAddressFromRequest;
-                        try {
-                            address = IpAddress.valueOf(remoteAddressStr);
-                        } catch (IllegalArgumentException iae) {
-                            address = IpAddress.valueOf(undefined);
-                        }
+            }
+            /*
+             * If there was no header/no usable value from the header, use the
+             * remoteAddress.
+             * 
+             */
+            if (address == null) {
+                // use the request remote address
+                String remoteAddressFromRequest = aHttpServletRequest.getRemoteAddr();
+                if (remoteAddressFromRequest != null) {
+                    String remoteAddressStr = remoteAddressFromRequest;
+                    try {
+                        address = IpAddress.valueOf(remoteAddressStr);
+                    } catch (IllegalArgumentException iae) {
+                        address = IpAddress.valueOf(undefined);
                     }
                 }
             }
+
         }
         sourceAddress = address;
     }

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/DataverseRequest.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/DataverseRequest.java
@@ -46,7 +46,7 @@ public class DataverseRequest {
         String header = System.getProperty("dataverse.useripaddresssourceheader");
         // Security check - make sure any supplied header is one that is used to forward
         // IP addresses (case insensitive)
-        if(ALLOWED_HEADERS.contains(header.toLowerCase())) {
+        if((header!=null) && (ALLOWED_HEADERS.contains(header.toLowerCase()))) {
             headerToUse=header;
         }
     }

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/DataverseRequest.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/DataverseRequest.java
@@ -1,10 +1,14 @@
 package edu.harvard.iq.dataverse.engine.command;
 
+import edu.harvard.iq.dataverse.api.batchjob.FileRecordJobResource;
 import edu.harvard.iq.dataverse.authorization.groups.impl.ipaddress.ip.IpAddress;
 import edu.harvard.iq.dataverse.authorization.users.AuthenticatedUser;
 import edu.harvard.iq.dataverse.authorization.users.User;
 import java.util.Arrays;
+import java.util.Enumeration;
 import java.util.HashSet;
+import java.util.logging.Logger;
+
 import javax.servlet.http.HttpServletRequest;
 
 /**
@@ -22,55 +26,111 @@ public class DataverseRequest {
     private final static String undefined = "0.0.0.0";
     private final static String localhost = "127.0.0.1";
     
+    private static final Logger logger = Logger.getLogger(DataverseRequest.class.getName());
+    
     private static String headerToUse = System.getProperty("dataverse.useripaddresssourceheader");
     
     private static final HashSet<String> ALLOWED_HEADERS = new HashSet<String>(Arrays.asList( 
-            "X-Forwarded-For",
-            "Proxy-Client-IP",
-            "WL-Proxy-Client-IP",
-            "HTTP_X_FORWARDED_FOR",
-            "HTTP_X_FORWARDED",
-            "HTTP_X_CLUSTER_CLIENT_IP",
-            "HTTP_CLIENT_IP",
-            "HTTP_FORWARDED_FOR",
-            "HTTP_FORWARDED",
-            "HTTP_VIA",
-            "REMOTE_ADDR" ));
+            "x-forwarded-for",
+            "proxy-client-ip",
+            "wl-proxy-client-ip",
+            "http_x_forwarded_for",
+            "http_x_forwarded",
+            "http_x_cluster_client_ip",
+            "http_client_ip",
+            "http_forwarded_for",
+            "http_forwarded",
+            "http_via",
+            "remote_addr" ));
      
     
     public DataverseRequest(User aUser, HttpServletRequest aHttpServletRequest) {
         this.user = aUser;
 
-
         String saneDefault = undefined;
         String remoteAddressStr = saneDefault;
 
+        IpAddress address = null;
+
         if (aHttpServletRequest != null) {
-            //Security check - make sure any supplied header is one that is used to forward IP addresses
-            if (headerToUse != null && ALLOWED_HEADERS.contains(headerToUse)) {
-                String ip = "Not Found";
-                ip = aHttpServletRequest.getHeader(headerToUse);
-                if (ip != null && ip.length() != 0 && !"unknown".equalsIgnoreCase(ip)) {
-                    remoteAddressStr = ip;
+
+            // Security check - make sure any supplied header is one that is used to forward
+            // IP addresses (case insensitive)
+            if (headerToUse != null && ALLOWED_HEADERS.contains(headerToUse.toLowerCase())) {
+                /*
+                 * The optional case of using a header to determine the IP address is discussed
+                 * at length in https://github.com/IQSS/dataverse/pull/6973 and the related
+                 * issue.
+                 * 
+                 * The code here is intended to support the use case of a single proxy (load
+                 * balancer, etc.) as well as providing partial support for the case where two
+                 * proxies exist (e.g. a campus proxy and an AWS load balancer). In this case,
+                 * the IP address returned should be that of the proxy nearer the user which
+                 * would be the correct address to use for making IPGroup access control
+                 * determinations. This does limit the accuracy of any Make Data Count
+                 * geolocation determined since it is the proxy's IP that would be geolocated.
+                 * For a campus proxy, this may be acceptable. This code should be safe in that
+                 * it won't pick up a spoofed address in any case, but beyond the two proxy
+                 * case, it is unlikely to provide useful results (why would you want the IP of
+                 * an intermediate proxy?).
+                 */
+                // One can have multiple instances of a given header. They SHOULD be in order.
+                Enumeration<String> ipEnumeration = aHttpServletRequest.getHeaders(headerToUse);
+                if (ipEnumeration.hasMoreElements()) {
+                    // Always get the last header, which SHOULD be from the proxy closest to
+                    // Dataverse
+                    String ip = ipEnumeration.nextElement();
+                    while (ipEnumeration.hasMoreElements()) {
+                        ip = ipEnumeration.nextElement();
+                    }
+                    // Always get the last value if more than one in the string, which should be the
+                    // IP address closest to the reporting proxy
+                    int index = ip.indexOf(',');
+                    if (index >= 0) {
+                        ip = ip.substring(index + 1);
+                    }
+                    /*
+                     * We should have a valid, single IP address string here. The IpAddress.valueOf
+                     * call will throw an exception if it can't be parsed into a valid address (e.g.
+                     * 4 '.' separated short ints for v4), so we just check for null here
+                     */
+                    if (ip != null) {
+                        // This conversion will throw an IllegalArgumentException if it can't be parsed.
+                        try {
+                            address = IpAddress.valueOf(ip);
+                        } catch (IllegalArgumentException iae) {
+                            logger.warning("Ignoring invalid IP address received in header " + headerToUse + " : " + ip);
+                            address = null;
+                        }
+                        if (address!= null && address.isLocalhost()) {
+                            // Not allowed since it is hard to image why a localhost request would be
+                            // proxied and we want to protect
+                            // the internal admin apis that can be restricted to localhost access
+                            logger.warning("Ignoring localhost received as IP address in header " + headerToUse + " : " + ip);
+                            address = null;
+                        }
+                    }
                 }
-            }
-            /*
-             * If there was no header/no value from the header, or the header claims the
-             * request is from localhost, use the remoteAddress. (Hard to imagine a
-             * legitimate case where a header would be localhost, but misconfiguration could
-             * allow a nefarious agent to try spoofing a localhost address via the header
-             * (e.g. to gain access to admin functions.)
-             * 
-             */
-            if (remoteAddressStr.equals(saneDefault) || remoteAddressStr.equals(localhost)) {
-                // use the request remote address
-                String remoteAddressFromRequest = aHttpServletRequest.getRemoteAddr();
-                if (remoteAddressFromRequest != null) {
-                    remoteAddressStr = remoteAddressFromRequest;
+                /*
+                 * If there was no header/no usable value from the header, use the
+                 * remoteAddress.
+                 * 
+                 */
+                if (address == null) {
+                    // use the request remote address
+                    String remoteAddressFromRequest = aHttpServletRequest.getRemoteAddr();
+                    if (remoteAddressFromRequest != null) {
+                        remoteAddressStr = remoteAddressFromRequest;
+                        try {
+                            address = IpAddress.valueOf(remoteAddressStr);
+                        } catch (IllegalArgumentException iae) {
+                            address = IpAddress.valueOf(saneDefault);
+                        }
+                    }
                 }
             }
         }
-        sourceAddress = IpAddress.valueOf( remoteAddressStr );
+        sourceAddress = address;
     }
 
     public DataverseRequest( User aUser, IpAddress aSourceAddress ) {

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/DataverseRequest.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/DataverseRequest.java
@@ -3,6 +3,8 @@ package edu.harvard.iq.dataverse.engine.command;
 import edu.harvard.iq.dataverse.authorization.groups.impl.ipaddress.ip.IpAddress;
 import edu.harvard.iq.dataverse.authorization.users.AuthenticatedUser;
 import edu.harvard.iq.dataverse.authorization.users.User;
+import java.util.Arrays;
+import java.util.HashSet;
 import javax.servlet.http.HttpServletRequest;
 
 /**
@@ -13,21 +15,59 @@ import javax.servlet.http.HttpServletRequest;
  * @author michael
  */
 public class DataverseRequest {
-    
+
     private final User user;
     private final IpAddress sourceAddress;
+    
+    private final static String undefined = "0.0.0.0";
+    private final static String localhost = "127.0.0.1";
+    
+    private static String headerToUse = System.getProperty("dataverse.useripaddresssourceheader");
+    
+    private static final HashSet<String> ALLOWED_HEADERS = new HashSet<String>(Arrays.asList( 
+            "X-Forwarded-For",
+            "Proxy-Client-IP",
+            "WL-Proxy-Client-IP",
+            "HTTP_X_FORWARDED_FOR",
+            "HTTP_X_FORWARDED",
+            "HTTP_X_CLUSTER_CLIENT_IP",
+            "HTTP_CLIENT_IP",
+            "HTTP_FORWARDED_FOR",
+            "HTTP_FORWARDED",
+            "HTTP_VIA",
+            "REMOTE_ADDR" ));
+     
     
     public DataverseRequest(User aUser, HttpServletRequest aHttpServletRequest) {
         this.user = aUser;
 
-        final String undefined = "0.0.0.0";
+
         String saneDefault = undefined;
         String remoteAddressStr = saneDefault;
 
         if (aHttpServletRequest != null) {
-            String remoteAddressFromRequest = aHttpServletRequest.getRemoteAddr();
-            if (remoteAddressFromRequest != null) {
-                remoteAddressStr = remoteAddressFromRequest;
+            //Security check - make sure any supplied header is one that is used to forward IP addresses
+            if (headerToUse != null && ALLOWED_HEADERS.contains(headerToUse)) {
+                String ip = "Not Found";
+                ip = aHttpServletRequest.getHeader(headerToUse);
+                if (ip != null && ip.length() != 0 && !"unknown".equalsIgnoreCase(ip)) {
+                    remoteAddressStr = ip;
+                }
+            }
+            /*
+             * If there was no header/no value from the header, or the header claims the
+             * request is from localhost, use the remoteAddress. (Hard to imagine a
+             * legitimate case where a header would be localhost, but misconfiguration could
+             * allow a nefarious agent to try spoofing a localhost address via the header
+             * (e.g. to gain access to admin functions.)
+             * 
+             */
+            if (remoteAddressStr.equals(saneDefault) || remoteAddressStr.equals(localhost)) {
+                // use the request remote address
+                String remoteAddressFromRequest = aHttpServletRequest.getRemoteAddr();
+                if (remoteAddressFromRequest != null) {
+                    remoteAddressStr = remoteAddressFromRequest;
+                }
             }
         }
         sourceAddress = IpAddress.valueOf( remoteAddressStr );


### PR DESCRIPTION
**What this PR does / why we need it**: Allows optional specification of an HTTP header as the source of user ip addresses. This is needed to get valid ip addresses for MDC and IP based access control when running Dataverse behind a proxy/load balancer

**Which issue(s) this PR closes**:

Closes #6970 

**Special notes for your reviewer**:  There are security implications if the ip can be spoofed. The header is explicitly not used/ignored if it reports a localhost (127.0.0.1) address

**Suggestions on how to test this**: This should work with/without a header set on a 'normal' test instance (since the header should be null, and should change the reported IP (e.g. as reported in the mdc logs) on a server behind an AWS load balancer when you use 'X-Forwarded-For' from the IP of the load balancer to the correct user IP address. 

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: No

**Is there a release notes update needed for this change?**: Yes? Since it affects MDC reporting.

**Additional documentation**: 
