### PR TITLE
6936 Implement email domain based groups

### DIFF
--- a/doc/sphinx-guides/source/admin/index.rst
+++ b/doc/sphinx-guides/source/admin/index.rst
@@ -26,6 +26,7 @@ This guide documents the functionality only available to superusers (such as "da
    dataverses-datasets
    solr-search-index
    ip-groups
+   mail-groups
    monitoring
    reporting-tools-and-queries
    maintenance

--- a/doc/sphinx-guides/source/admin/mail-groups.rst
+++ b/doc/sphinx-guides/source/admin/mail-groups.rst
@@ -1,0 +1,82 @@
+Mail Domain Groups
+==================
+
+Groups can be defined based on the domain part of users (verified) email addresses. Email addresses that match
+one or more groups configuration will add the user to them.
+
+Within the scientific community, in many cases users will use a institutional email address for their account in a
+Dataverse installation. This might offer a simple solution for building groups of people, as the domain part can be
+seen as a selector for group membership.
+
+Some use cases: installations that like to avoid Shibboleth, enable self sign up, offer multi-tenancy or can't use
+:doc:`ip-groups` plus many more.
+
+.. hint:: Please be aware that non-verified mail addresses will exclude the user even if matching. This is to avoid
+          privilege escalation.
+
+Listing Mail Domain Groups
+--------------------------
+
+Mail Domain Groups can be listed with the following curl command:
+
+``curl http://localhost:8080/api/admin/groups/domain``
+
+Listing a specific Mail Domain Group
+------------------------------------
+
+Let's say you used "domainGroup1" as the alias of the Mail Domain Group you created below.
+To list just that Mail Domain Group, you can include the alias in the curl command like this:
+
+``curl http://localhost:8080/api/admin/groups/domain/domainGroup1``
+
+
+Creating a Mail Domain Group
+----------------------------
+
+Mail Domain Groups can be created with a simple JSON file:
+
+.. code-block:: json
+   :caption: domainGroup1.json
+   :name: domainGroup1.json
+
+    {
+      "name": "Users from @example.org",
+      "alias": "exampleorg",
+      "description": "Any verified user from Example Org will be included in this group.",
+      "domains": ["example.org"]
+    }
+
+Giving a ``description`` is optional. The ``name`` will be visible in the permission UI, so be sure to pick a sensible
+value.
+
+The ``domains`` field is mandatory to be an array. This enables creation of multi-domain groups, too.
+
+Obviously you can create as many of these groups you might like, as long as the ``alias`` is unique.
+
+To load it into your Dataverse installation, either use a ``POST`` or ``PUT`` request (see below):
+
+``curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/groups/domain --upload-file domainGroup1.json``
+
+Updating a Mail Domain Group
+----------------------------
+
+Editing a group is done by replacing it. Grab your group definition like the :ref:`above example <domainGroup1.json>`,
+change it as you like and ``PUT`` it into your installation:
+
+``curl -X PUT -H 'Content-type: application/json' http://localhost:8080/api/admin/groups/domain/domainGroup1 --upload-file domainGroup1.json``
+
+Please make sure that the alias of the group you want to change is included in the path. You also need to ensure
+that this alias matches with the one given in your JSON file.
+
+.. hint:: This is an idempotent call, so it will create the group given if not present.
+
+Deleting a Mail Domain Group
+----------------------------
+
+To delete a Mail Domain Group with an alias of "domainGroup1", use the curl command below:
+
+``curl -X DELETE http://localhost:8080/api/admin/groups/domain/domainGroup1``
+
+Please note: it is not recommended to delete a Mail Domain Group that has been assigned roles. If you want to delete
+a Mail Domain Group, you should first remove its permissions.
+

--- a/src/main/java/edu/harvard/iq/dataverse/api/Groups.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Groups.java
@@ -228,7 +228,7 @@ public class Groups extends AbstractApiBean {
      */
     @POST
     @Path("domain")
-    public Response createMailDomainGroup( JsonObject dto ) throws JsonParseException {
+    public Response createMailDomainGroup(JsonObject dto) throws JsonParseException {
         MailDomainGroup grp = new JsonParser().parseMailDomainGroup(dto);
         mailDomainGroupPrv.saveOrUpdate(Optional.empty(), grp);
 
@@ -237,23 +237,23 @@ public class Groups extends AbstractApiBean {
     
     /**
      * Creates or updates the {@link MailDomainGroup} named {@code groupName}.
-     * @param groupName Name of the group.
+     * @param groupAlias Name of the group.
      * @param dto data of the group.
      * @return Response describing the created group or the error that prevented
      *         that group from being created.
      */
     @PUT
-    @Path("domain/{groupName}")
-    public Response updateMailDomainGroups(@PathParam("groupName") String groupName, JsonObject dto ) throws JsonParseException {
-        if ( groupName == null || groupName.trim().isEmpty() ) {
+    @Path("domain/{groupAlias}")
+    public Response updateMailDomainGroups(@PathParam("groupAlias") String groupAlias, JsonObject dto) throws JsonParseException {
+        if ( groupAlias == null || groupAlias.trim().isEmpty() ) {
             return badRequest("Group name cannot be empty");
         }
-        if ( ! legalGroupName.matcher(groupName).matches() ) {
+        if ( ! legalGroupName.matcher(groupAlias).matches() ) {
             return badRequest("Group name can contain only letters, digits, and the chars '-' and '_'");
         }
         
         MailDomainGroup grp = new JsonParser().parseMailDomainGroup(dto);
-        mailDomainGroupPrv.saveOrUpdate(Optional.of(groupName), grp);
+        mailDomainGroupPrv.saveOrUpdate(Optional.of(groupAlias), grp);
         
         return created("/groups/domain/" + grp.getPersistedGroupAlias(), json(grp) );
     }
@@ -266,37 +266,17 @@ public class Groups extends AbstractApiBean {
     }
     
     @GET
-    @Path("domain/{groupIdtf}")
-    public Response getMailDomainGroup( @PathParam("groupIdtf") String groupIdtf ) {
-        MailDomainGroup grp = mailDomainGroupPrv.get(groupIdtf);
-        return (grp == null) ? notFound( "Group " + groupIdtf + " not found") : ok(json(grp));
+    @Path("domain/{groupAlias}")
+    public Response getMailDomainGroup(@PathParam("groupAlias") String groupAlias) {
+        MailDomainGroup grp = mailDomainGroupPrv.get(groupAlias);
+        return (grp == null) ? notFound( "Group " + groupAlias + " not found") : ok(json(grp));
     }
     
-    /*
     @DELETE
-    @Path("domain/{groupIdtf}")
-    public Response deleteMailDomainGroup( @PathParam("groupIdtf") String groupIdtf ) {
-        MailDomainGroup grp = mailDomainGroupPrv.get(groupIdtf);
-        if (grp == null) return notFound( "Group " + groupIdtf + " not found");
-        
-        try {
-            mailDomainGroupPrv.deleteGroup(grp);
-            return ok("Group " + grp.getAlias() + " deleted.");
-        } catch ( Exception topExp ) {
-            // get to the cause (unwraps EJB exception wrappers).
-            Throwable e = topExp;
-            while ( e.getCause() != null ) {
-                e = e.getCause();
-            }
-            
-            if ( e instanceof IllegalArgumentException ) {
-                return error(Response.Status.BAD_REQUEST, e.getMessage());
-            } else {
-                throw topExp;
-            }
-        }
+    @Path("domain/{groupAlias}")
+    public Response deleteMailDomainGroup(@PathParam("groupAlias") String groupAlias) {
+        mailDomainGroupPrv.delete(groupAlias);
+        return ok("Group " + groupAlias + " deleted.");
     }
-    
-     */
 
 }

--- a/src/main/java/edu/harvard/iq/dataverse/api/Groups.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Groups.java
@@ -6,9 +6,11 @@ import edu.harvard.iq.dataverse.authorization.groups.impl.maildomain.MailDomainG
 import edu.harvard.iq.dataverse.authorization.groups.impl.maildomain.MailDomainGroupProvider;
 import edu.harvard.iq.dataverse.authorization.groups.impl.shib.ShibGroup;
 import edu.harvard.iq.dataverse.authorization.groups.impl.shib.ShibGroupProvider;
+import edu.harvard.iq.dataverse.util.json.JsonParseException;
 import edu.harvard.iq.dataverse.util.json.JsonParser;
 
 import javax.ejb.Stateless;
+import javax.interceptor.Interceptors;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.core.Response;
@@ -226,17 +228,11 @@ public class Groups extends AbstractApiBean {
      */
     @POST
     @Path("domain")
-    public Response createMailDomainGroup( JsonObject dto ){
-        try {
-            MailDomainGroup grp = new JsonParser().parseMailDomainGroup(dto);
-            mailDomainGroupPrv.saveOrUpdate(Optional.empty(), grp);
-    
-            return created("/groups/domain/" + grp.getPersistedGroupAlias(), json(grp) );
-    
-        } catch ( Exception e ) {
-            logger.log( Level.WARNING, "Error while updating a mail domain group: " + e.getMessage(), e);
-            return error(Response.Status.INTERNAL_SERVER_ERROR, "Error: " + e.getMessage() );
-        }
+    public Response createMailDomainGroup( JsonObject dto ) throws JsonParseException {
+        MailDomainGroup grp = new JsonParser().parseMailDomainGroup(dto);
+        mailDomainGroupPrv.saveOrUpdate(Optional.empty(), grp);
+
+        return created("/groups/domain/" + grp.getPersistedGroupAlias(), json(grp) );
     }
     
     /**
@@ -248,24 +244,18 @@ public class Groups extends AbstractApiBean {
      */
     @PUT
     @Path("domain/{groupName}")
-    public Response updateMailDomainGroups(@PathParam("groupName") String groupName, JsonObject dto ){
-        try {
-            if ( groupName == null || groupName.trim().isEmpty() ) {
-                return badRequest("Group name cannot be empty");
-            }
-            if ( ! legalGroupName.matcher(groupName).matches() ) {
-                return badRequest("Group name can contain only letters, digits, and the chars '-' and '_'");
-            }
-            
-            MailDomainGroup grp = new JsonParser().parseMailDomainGroup(dto);
-            mailDomainGroupPrv.saveOrUpdate(Optional.of(groupName), grp);
-            
-            return created("/groups/domain/" + grp.getPersistedGroupAlias(), json(grp) );
-            
-        } catch ( Exception e ) {
-            logger.log( Level.WARNING, "Error while updating a mail domain group: " + e.getMessage(), e);
-            return error(Response.Status.INTERNAL_SERVER_ERROR, "Error: " + e.getMessage() );
+    public Response updateMailDomainGroups(@PathParam("groupName") String groupName, JsonObject dto ) throws JsonParseException {
+        if ( groupName == null || groupName.trim().isEmpty() ) {
+            return badRequest("Group name cannot be empty");
         }
+        if ( ! legalGroupName.matcher(groupName).matches() ) {
+            return badRequest("Group name can contain only letters, digits, and the chars '-' and '_'");
+        }
+        
+        MailDomainGroup grp = new JsonParser().parseMailDomainGroup(dto);
+        mailDomainGroupPrv.saveOrUpdate(Optional.of(groupName), grp);
+        
+        return created("/groups/domain/" + grp.getPersistedGroupAlias(), json(grp) );
     }
     
     @GET

--- a/src/main/java/edu/harvard/iq/dataverse/api/errorhandlers/ConstraintViolationExceptionHandler.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/errorhandlers/ConstraintViolationExceptionHandler.java
@@ -1,0 +1,64 @@
+package edu.harvard.iq.dataverse.api.errorhandlers;
+
+import edu.harvard.iq.dataverse.util.json.JsonPrinter;
+
+import javax.json.Json;
+import javax.json.JsonArray;
+import javax.json.JsonArrayBuilder;
+import javax.json.JsonObject;
+import javax.validation.ConstraintViolation;
+import javax.validation.ConstraintViolationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Provider
+public class ConstraintViolationExceptionHandler implements ExceptionMapper<ConstraintViolationException> {
+    
+    public class ValidationError {
+        private String path;
+        private String message;
+        
+        public String getPath() { return path; }
+        public void setPath(String path) { this.path = path; }
+        public String getMessage() { return message; }
+        public void setMessage(String message) { this.message = message; }
+    }
+    
+    @Override
+    public Response toResponse(ConstraintViolationException exception) {
+        
+        List<ValidationError> errors = exception.getConstraintViolations().stream()
+            .map(this::toValidationError)
+            .collect(Collectors.toList());
+        
+        return Response.status(Response.Status.BAD_REQUEST)
+                       .entity( Json.createObjectBuilder()
+                           .add("status", "ERROR")
+                           .add("code", Response.Status.BAD_REQUEST.getStatusCode())
+                           .add("message", "JPA validation constraints failed persistence. See list of violations for details.")
+                           .add("violations", toJsonArray(errors))
+                           .build())
+                       .type(MediaType.APPLICATION_JSON_TYPE).build();
+    }
+    
+    private ValidationError toValidationError(ConstraintViolation constraintViolation) {
+        ValidationError error = new ValidationError();
+        error.setPath(constraintViolation.getPropertyPath().toString());
+        error.setMessage(constraintViolation.getMessage());
+        return error;
+    }
+    
+    private JsonArray toJsonArray(List<ValidationError> list) {
+        JsonArrayBuilder builder = Json.createArrayBuilder();
+        list.stream()
+            .forEach(error -> builder.add(
+                Json.createObjectBuilder()
+                    .add("path", error.getPath())
+                    .add("message", error.getMessage())));
+        return builder.build();
+    }
+}

--- a/src/main/java/edu/harvard/iq/dataverse/api/errorhandlers/JsonParseExceptionHandler.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/errorhandlers/JsonParseExceptionHandler.java
@@ -1,0 +1,37 @@
+package edu.harvard.iq.dataverse.api.errorhandlers;
+
+import edu.harvard.iq.dataverse.util.json.JsonParseException;
+
+import javax.json.Json;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+import java.util.UUID;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Make a failing JSON parsing request appear to be a BadRequest (error code 400)
+ * and send a message what just failed...
+ */
+@Provider
+public class JsonParseExceptionHandler implements ExceptionMapper<JsonParseException>{
+    
+    @Context
+    HttpServletRequest request;
+    
+    @Override
+    public Response toResponse(JsonParseException ex){
+        return Response.status(Response.Status.BAD_REQUEST)
+                       .entity( Json.createObjectBuilder()
+                           .add("status", "ERROR")
+                           .add("code", Response.Status.BAD_REQUEST.getStatusCode())
+                           .add("message", ex.getMessage())
+                           .build())
+                       .type(MediaType.APPLICATION_JSON_TYPE).build();
+    }
+}

--- a/src/main/java/edu/harvard/iq/dataverse/api/errorhandlers/ThrowableHandler.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/errorhandlers/ThrowableHandler.java
@@ -1,0 +1,70 @@
+package edu.harvard.iq.dataverse.api.errorhandlers;
+
+import javax.annotation.Priority;
+import javax.json.Json;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+import java.util.UUID;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Produces a generic 500 message for the API, being a fallback handler for not specially treated exceptions.
+ */
+@Provider
+public class ThrowableHandler implements ExceptionMapper<Throwable>{
+    
+    private static final Logger logger = Logger.getLogger(ThrowableHandler.class.getName());
+    
+    @Context
+    HttpServletRequest request;
+    
+    @Override
+    public Response toResponse(Throwable ex){
+        String incidentId = UUID.randomUUID().toString();
+        logger.log(Level.SEVERE, "Uncaught REST API exception:\n"+
+                                 "    Incident: " + incidentId +"\n"+
+                                 "    URL: "+getOriginalURL(request)+"\n"+
+                                 "    Method: "+request.getMethod(), ex);
+        return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                .entity( Json.createObjectBuilder()
+                             .add("status", "ERROR")
+                             .add("code", Response.Status.INTERNAL_SERVER_ERROR.getStatusCode())
+                             .add("type", ex.getClass().getSimpleName())
+                             .add("message", "Internal server error. More details available at the server logs.")
+                             .add("incidentId", incidentId)
+                        .build())
+                .type(MediaType.APPLICATION_JSON_TYPE).build();
+    }
+    
+    private String getOriginalURL(HttpServletRequest req) {
+        // Rebuild the original request URL: http://stackoverflow.com/a/5212336/356408
+        String scheme = req.getScheme();             // http
+        String serverName = req.getServerName();     // hostname.com
+        int serverPort = req.getServerPort();        // 80
+        String contextPath = req.getContextPath();   // /mywebapp
+        String servletPath = req.getServletPath();   // /servlet/MyServlet
+        String pathInfo = req.getPathInfo();         // /a/b;c=123
+        String queryString = req.getQueryString();   // d=789
+        
+        // Reconstruct original requesting URL
+        StringBuilder url = new StringBuilder();
+        url.append(scheme).append("://").append(serverName);
+        if (serverPort != 80 && serverPort != 443) {
+            url.append(":").append(serverPort);
+        }
+        url.append(contextPath).append(servletPath);
+        if (pathInfo != null) {
+            url.append(pathInfo);
+        }
+        if (queryString != null) {
+            url.append("?").append(queryString);
+        }
+        
+        return url.toString();
+    }
+}

--- a/src/main/java/edu/harvard/iq/dataverse/authorization/AuthenticationServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/authorization/AuthenticationServiceBean.java
@@ -293,6 +293,7 @@ public class AuthenticationServiceBean {
             if (apiToken != null) {
                 em.remove(apiToken);
             }
+            // @todo: this should be handed down to the service instead of doing it here.
             ConfirmEmailData confirmEmailData = confirmEmailService.findSingleConfirmEmailDataByUser(user);
             if (confirmEmailData != null) {
                 /**

--- a/src/main/java/edu/harvard/iq/dataverse/authorization/groups/GroupServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/authorization/groups/GroupServiceBean.java
@@ -9,6 +9,8 @@ import edu.harvard.iq.dataverse.authorization.groups.impl.explicit.ExplicitGroup
 import edu.harvard.iq.dataverse.authorization.groups.impl.explicit.ExplicitGroupServiceBean;
 import edu.harvard.iq.dataverse.authorization.groups.impl.ipaddress.IpGroupProvider;
 import edu.harvard.iq.dataverse.authorization.groups.impl.ipaddress.IpGroupsServiceBean;
+import edu.harvard.iq.dataverse.authorization.groups.impl.maildomain.MailDomainGroupProvider;
+import edu.harvard.iq.dataverse.authorization.groups.impl.maildomain.MailDomainGroupServiceBean;
 import edu.harvard.iq.dataverse.authorization.groups.impl.shib.ShibGroupProvider;
 import edu.harvard.iq.dataverse.authorization.groups.impl.shib.ShibGroupServiceBean;
 import edu.harvard.iq.dataverse.engine.command.DataverseRequest;
@@ -24,6 +26,7 @@ import java.util.stream.Stream;
 import javax.annotation.PostConstruct;
 import javax.ejb.EJB;
 import javax.ejb.Stateless;
+import javax.inject.Inject;
 import javax.inject.Named;
 
 /**
@@ -41,12 +44,15 @@ public class GroupServiceBean {
     ShibGroupServiceBean shibGroupService;
     @EJB
     ExplicitGroupServiceBean explicitGroupService;
+    @EJB
+    MailDomainGroupServiceBean mailDomainGroupService;
     
     private final Map<String, GroupProvider> groupProviders = new HashMap<>();
     
     private IpGroupProvider ipGroupProvider;
     private ShibGroupProvider shibGroupProvider;
     private ExplicitGroupProvider explicitGroupProvider;
+    private MailDomainGroupProvider mailDomainGroupProvider;
     
     @EJB
     RoleAssigneeServiceBean roleAssigneeSvc;
@@ -57,6 +63,7 @@ public class GroupServiceBean {
         addGroupProvider( ipGroupProvider = new IpGroupProvider(ipGroupsService) );
         addGroupProvider( shibGroupProvider = new ShibGroupProvider(shibGroupService) );
         addGroupProvider( explicitGroupProvider = explicitGroupService.getProvider() );
+        addGroupProvider( mailDomainGroupProvider = mailDomainGroupService.getProvider() );
         Logger.getLogger(GroupServiceBean.class.getName()).log(Level.INFO, null, "PostConstruct group service call");
     }
 
@@ -76,6 +83,10 @@ public class GroupServiceBean {
 
     public ShibGroupProvider getShibGroupProvider() {
         return shibGroupProvider;
+    }
+    
+    public MailDomainGroupProvider getMailDomainGroupProvider() {
+        return mailDomainGroupProvider;
     }
     
     /**
@@ -109,7 +120,7 @@ public class GroupServiceBean {
      * groups a Role assignee belongs to as advertised but this method comes
      * closer.
      *
-     * @param au An AuthenticatedUser.
+     * @param ra An AuthenticatedUser.
      * @return As many groups as we can find for the AuthenticatedUser.
      * 
      * @deprecated Does not look into IP Groups. Use {@link #groupsFor(edu.harvard.iq.dataverse.engine.command.DataverseRequest)}

--- a/src/main/java/edu/harvard/iq/dataverse/authorization/groups/impl/maildomain/MailDomainGroup.java
+++ b/src/main/java/edu/harvard/iq/dataverse/authorization/groups/impl/maildomain/MailDomainGroup.java
@@ -40,10 +40,6 @@ public class MailDomainGroup extends PersistedGlobalGroup {
      */
     protected MailDomainGroup() {}
     
-    public MailDomainGroup(MailDomainGroupProvider prv) {
-        provider = prv;
-    }
-    
     public void setEmailDomains(String domains) {
         this.emailDomains = domains;
     }
@@ -113,6 +109,6 @@ public class MailDomainGroup extends PersistedGlobalGroup {
     
     @Override
     public String toString() {
-        return "[MailDomainGroup " + this.getPersistedGroupAlias() + "]";
+        return "[MailDomainGroup " + this.getPersistedGroupAlias() + ": " + this.emailDomains + "]";
     }
 }

--- a/src/main/java/edu/harvard/iq/dataverse/authorization/groups/impl/maildomain/MailDomainGroup.java
+++ b/src/main/java/edu/harvard/iq/dataverse/authorization/groups/impl/maildomain/MailDomainGroup.java
@@ -1,0 +1,118 @@
+package edu.harvard.iq.dataverse.authorization.groups.impl.maildomain;
+
+import edu.harvard.iq.dataverse.authorization.groups.impl.PersistedGlobalGroup;
+import edu.harvard.iq.dataverse.engine.command.DataverseRequest;
+import org.hibernate.validator.constraints.NotEmpty;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import javax.persistence.Entity;
+import javax.persistence.NamedQueries;
+import javax.persistence.NamedQuery;
+import javax.persistence.Transient;
+;
+
+/**
+ * A group that explicitly lists email address domains that a user might have to belong to this group.
+ */
+@NamedQueries({
+    @NamedQuery(name="MailDomainGroup.findAll",
+        query="SELECT g FROM MailDomainGroup g"),
+    @NamedQuery(name="MailDomainGroup.findByPersistedGroupAlias",
+        query="SELECT g FROM MailDomainGroup g WHERE g.persistedGroupAlias=:persistedGroupAlias"),
+})
+@Entity
+public class MailDomainGroup extends PersistedGlobalGroup {
+    
+    /**
+     * All the email address domains that make users belong
+     * to this group, concatenated with ";" (thus avoiding another relation)
+     */
+    @NotEmpty
+    private String emailDomains;
+    
+    @Transient
+    private MailDomainGroupProvider provider;
+    
+    /**
+     * Empty Constructor for JPA.
+     */
+    protected MailDomainGroup() {}
+    
+    public MailDomainGroup(MailDomainGroupProvider prv) {
+        provider = prv;
+    }
+    
+    public void setEmailDomains(String domains) {
+        this.emailDomains = domains;
+    }
+    public void setEmailDomains(List<String> domains) {
+        this.emailDomains = String.join(";", domains);
+    }
+    
+    public String getEmailDomains() {
+        return this.emailDomains;
+    }
+    public List<String> getEmailDomainsAsList() {
+        return Arrays.asList(this.emailDomains.split(";"));
+    }
+    
+    @Override
+    public MailDomainGroupProvider getGroupProvider() {
+        return provider;
+    }
+    public void setGroupProvider(MailDomainGroupProvider pvd) {
+        this.provider = pvd;
+    }
+    
+    /**
+     * This will throw an UnsupportOperationException if called.
+     * Due to the necessity of checking if the mail adress is confirmed,
+     * this cannot be decided in the entity class, but has to happen in the
+     * provider.
+     * @param aRequest The request whose inclusion we test
+     */
+    @Override
+    public boolean contains(DataverseRequest aRequest) {
+        throw new UnsupportedOperationException("This cannot be supported.");
+    }
+    
+    /**
+     * This will throw an UnsupportOperationException if called.
+     * We will not allow edits of this via UI due to it's static nature. Can be changed via API.
+     */
+    @Override
+    public boolean isEditable() {
+        throw new UnsupportedOperationException("This is not supported.");
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 7;
+        hash = 53 * hash + Objects.hashCode(this.getId());
+        hash = 53 * hash + Objects.hashCode(this.emailDomains);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if ( ! (obj instanceof MailDomainGroup)) {
+            return false;
+        }
+        final MailDomainGroup other = (MailDomainGroup) obj;
+        if ( this.getId() != null && other.getId() != null) {
+            return Objects.equals(this.getId(), other.getId());
+        } else {
+            return Objects.equals(this.emailDomains, other.getEmailDomains());
+        }
+    }
+    
+    @Override
+    public String toString() {
+        return "[MailDomainGroup " + this.getPersistedGroupAlias() + "]";
+    }
+}

--- a/src/main/java/edu/harvard/iq/dataverse/authorization/groups/impl/maildomain/MailDomainGroup.java
+++ b/src/main/java/edu/harvard/iq/dataverse/authorization/groups/impl/maildomain/MailDomainGroup.java
@@ -111,4 +111,13 @@ public class MailDomainGroup extends PersistedGlobalGroup {
     public String toString() {
         return "[MailDomainGroup " + this.getPersistedGroupAlias() + ": id=" + this.getId() + " domains="+this.emailDomains+" ]";
     }
+    
+    public MailDomainGroup update(MailDomainGroup src) {
+        setPersistedGroupAlias(src.getPersistedGroupAlias());
+        setDisplayName(src.getDisplayName());
+        setDescription(src.getDescription());
+        setEmailDomains(src.getEmailDomains());
+        setGroupProvider(src.getGroupProvider());
+        return this;
+    }
 }

--- a/src/main/java/edu/harvard/iq/dataverse/authorization/groups/impl/maildomain/MailDomainGroup.java
+++ b/src/main/java/edu/harvard/iq/dataverse/authorization/groups/impl/maildomain/MailDomainGroup.java
@@ -38,7 +38,7 @@ public class MailDomainGroup extends PersistedGlobalGroup {
     /**
      * Empty Constructor for JPA.
      */
-    protected MailDomainGroup() {}
+    public MailDomainGroup() {}
     
     public void setEmailDomains(String domains) {
         this.emailDomains = domains;
@@ -109,6 +109,6 @@ public class MailDomainGroup extends PersistedGlobalGroup {
     
     @Override
     public String toString() {
-        return "[MailDomainGroup " + this.getPersistedGroupAlias() + ": " + this.emailDomains + "]";
+        return "[MailDomainGroup " + this.getPersistedGroupAlias() + ": id=" + this.getId() + " domains="+this.emailDomains+" ]";
     }
 }

--- a/src/main/java/edu/harvard/iq/dataverse/authorization/groups/impl/maildomain/MailDomainGroupProvider.java
+++ b/src/main/java/edu/harvard/iq/dataverse/authorization/groups/impl/maildomain/MailDomainGroupProvider.java
@@ -92,13 +92,17 @@ public class MailDomainGroupProvider implements GroupProvider<MailDomainGroup> {
     
     /**
      * Update an existing instance (if found) or create a new (if groupName = null).
-     * @param groupName String with the group alias of the group to update or empty if new entity
+     * @param groupAlias String with the group alias of the group to update or empty if new entity
      * @param grp The group to update or add
      * @return The saved entity, including updated group provider attribute
      */
-    public MailDomainGroup saveOrUpdate(Optional<String> groupName, MailDomainGroup grp) {
+    public MailDomainGroup saveOrUpdate(Optional<String> groupAlias, MailDomainGroup grp) {
         grp.setGroupProvider(this);
-        return emailGroupSvc.saveOrUpdate(groupName, grp);
+        return emailGroupSvc.saveOrUpdate(groupAlias, grp);
+    }
+    
+    public void delete(String groupAlias) {
+        emailGroupSvc.delete(groupAlias);
     }
     
     /**

--- a/src/main/java/edu/harvard/iq/dataverse/authorization/groups/impl/maildomain/MailDomainGroupProvider.java
+++ b/src/main/java/edu/harvard/iq/dataverse/authorization/groups/impl/maildomain/MailDomainGroupProvider.java
@@ -1,0 +1,119 @@
+package edu.harvard.iq.dataverse.authorization.groups.impl.maildomain;
+
+import edu.harvard.iq.dataverse.DvObject;
+import edu.harvard.iq.dataverse.authorization.RoleAssignee;
+import edu.harvard.iq.dataverse.authorization.groups.GroupProvider;
+import edu.harvard.iq.dataverse.authorization.users.AuthenticatedUser;
+import edu.harvard.iq.dataverse.engine.command.DataverseRequest;
+
+import java.util.*;
+import java.util.logging.Logger;
+
+/**
+ * Creates and manages mail domain based groups
+ */
+public class MailDomainGroupProvider implements GroupProvider<MailDomainGroup> {
+    
+    private static final Logger logger = Logger.getLogger(MailDomainGroupProvider.class.getName());
+    
+    private final MailDomainGroupServiceBean emailGroupSvc;
+
+    public MailDomainGroupProvider(MailDomainGroupServiceBean emailGroupSvc) {
+        this.emailGroupSvc = emailGroupSvc;
+    }
+       
+    @Override
+    public String getGroupProviderAlias() {
+        return "maildomain";
+    }
+
+    @Override
+    public String getGroupProviderInfo() {
+        return "Groups users by their email address domain.";
+    }
+    
+    /**
+     * This method is meant for group management. This is a global, unmanageable thing, so this will just result in an empty set.
+     * @return empty set
+     */
+    @Override
+    public Set<MailDomainGroup> groupsFor(RoleAssignee ra, DvObject o) {
+        return Collections.emptySet();
+    }
+    
+    /**
+     * This method is meant for group management. This is a global, unmanageable thing, so this will just result in an empty set.
+     * @return empty set
+     */
+    @Override
+    public Set<MailDomainGroup> groupsFor(RoleAssignee ra) {
+        return Collections.emptySet();
+    }
+    
+    /**
+     * Lookup for a request. We don't need the context, so just move to groupsFor(DataverseRequest)
+     * @param req The request whose group memberships we evaluate.
+     * @param dvo the DvObject which is the context for the groups. May be {@code null}.
+     * @return A set of groups, if any.
+     */
+    @Override
+    public Set<MailDomainGroup> groupsFor(DataverseRequest req, DvObject dvo ) {
+        return groupsFor(req);
+    }
+    
+    /**
+     * Lookup the user group on each request by using the email address domain.
+     * @param req
+     * @return
+     */
+    @Override
+    public Set<MailDomainGroup> groupsFor(DataverseRequest req) {
+        AuthenticatedUser user = req.getAuthenticatedUser();
+        if ( user != null ) {
+            return updateProvider(emailGroupSvc.findAllWithDomain(user) );
+        } else {
+            return Collections.emptySet();
+        }
+    }
+    
+    @Override
+    public MailDomainGroup get(String groupAlias) {
+        return updateProvider(emailGroupSvc.findByAlias(groupAlias).orElse(null));
+    }
+
+    /**
+     * Find all email groups available
+     * @return empty set.
+     */
+    @Override
+    public Set<MailDomainGroup> findGlobalGroups() {
+        return updateProvider( new HashSet<>(emailGroupSvc.findAll()) );
+    }
+    
+    /**
+     * Sets the provider of the passed explicit group to {@code this}.
+     * @param eg the collection
+     * @return the passed group, updated.
+     */
+    MailDomainGroup updateProvider(MailDomainGroup eg ) {
+        if (eg == null) {
+            return null; 
+        }
+        eg.setGroupProvider(this);
+        return eg;
+    }
+    
+    /**
+     * Sets the provider of the explicit groups to {@code this}.
+     * @param <T> Collection's type
+     * @param mdgs the collection
+     * @return the collection, with all the groups updated.
+     */
+    <T extends Collection<MailDomainGroup>> T updateProvider(T mdgs ) {
+        for ( MailDomainGroup mdg : mdgs ) {
+            updateProvider(mdg);
+        }
+        return mdgs;
+    }
+}
+

--- a/src/main/java/edu/harvard/iq/dataverse/authorization/groups/impl/maildomain/MailDomainGroupProvider.java
+++ b/src/main/java/edu/harvard/iq/dataverse/authorization/groups/impl/maildomain/MailDomainGroupProvider.java
@@ -91,6 +91,17 @@ public class MailDomainGroupProvider implements GroupProvider<MailDomainGroup> {
     }
     
     /**
+     * Update an existing instance (if found) or create a new (if groupName = null).
+     * @param groupName String with the group alias of the group to update or empty if new entity
+     * @param grp The group to update or add
+     * @return The saved entity, including updated group provider attribute
+     */
+    public MailDomainGroup saveOrUpdate(Optional<String> groupName, MailDomainGroup grp) {
+        grp.setGroupProvider(this);
+        return emailGroupSvc.saveOrUpdate(groupName, grp);
+    }
+    
+    /**
      * Sets the provider of the passed explicit group to {@code this}.
      * @param eg the collection
      * @return the passed group, updated.

--- a/src/main/java/edu/harvard/iq/dataverse/authorization/groups/impl/maildomain/MailDomainGroupServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/authorization/groups/impl/maildomain/MailDomainGroupServiceBean.java
@@ -9,6 +9,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.annotation.PostConstruct;
 import javax.ejb.Stateless;
 import javax.inject.Inject;
@@ -63,11 +65,10 @@ public class MailDomainGroupServiceBean {
             
             // get all groups and filter
             List<MailDomainGroup> rs = em.createNamedQuery("MailDomainGroup.findAll", MailDomainGroup.class).getResultList();
-            for(MailDomainGroup g : rs) {
-                if ( g.getEmailDomainsAsList().contains(domain) == false ) rs.remove(g);
-            }
-            
-            return new HashSet<>(rs);
+    
+            return rs.stream()
+                .filter(mg -> mg.getEmailDomainsAsList().contains(domain))
+                .collect(Collectors.toSet());
         }
         return Collections.emptySet();
     }

--- a/src/main/java/edu/harvard/iq/dataverse/authorization/groups/impl/maildomain/MailDomainGroupServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/authorization/groups/impl/maildomain/MailDomainGroupServiceBean.java
@@ -129,7 +129,7 @@ public class MailDomainGroupServiceBean {
      * @param email
      * @return Domain part or empty Optional
      */
-    Optional<String> getDomainFromMail(String email) {
+    static Optional<String> getDomainFromMail(String email) {
         String[] parts = email.split("@");
         if (parts.length < 2) { return Optional.empty(); }
         return Optional.of(parts[parts.length-1]);

--- a/src/main/java/edu/harvard/iq/dataverse/authorization/groups/impl/maildomain/MailDomainGroupServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/authorization/groups/impl/maildomain/MailDomainGroupServiceBean.java
@@ -1,0 +1,114 @@
+package edu.harvard.iq.dataverse.authorization.groups.impl.maildomain;
+
+import edu.harvard.iq.dataverse.authorization.users.AuthenticatedUser;
+import edu.harvard.iq.dataverse.confirmemail.ConfirmEmailServiceBean;
+
+import java.util.*;
+import java.util.logging.Logger;
+import javax.annotation.PostConstruct;
+import javax.ejb.Stateless;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.persistence.EntityManager;
+import javax.persistence.NoResultException;
+import javax.persistence.PersistenceContext;
+
+/**
+ * A bean providing the {@link MailDomainGroupProvider}s with container services, such as database connectivity.
+ * Also containing the business logic to decide about matching groups.
+ */
+@Named
+@Stateless
+public class MailDomainGroupServiceBean {
+    
+    private static final Logger logger = Logger.getLogger(edu.harvard.iq.dataverse.authorization.groups.impl.explicit.ExplicitGroupServiceBean.class.getName());
+    
+    @PersistenceContext(unitName = "VDCNet-ejbPU")
+    protected EntityManager em;
+    
+    @Inject
+    ConfirmEmailServiceBean confirmEmailSvc;
+	
+    MailDomainGroupProvider provider;
+    
+    @PostConstruct
+    void setup() {
+        provider = new MailDomainGroupProvider(this);
+    }
+    
+    public MailDomainGroupProvider getProvider() {
+        return provider;
+    }
+    
+    /**
+     * Find groups for users mail when email has a domain and is verified
+     * @param user
+     * @return
+     */
+    public Set<MailDomainGroup> findAllWithDomain(AuthenticatedUser user) {
+        
+        // if the mail address is not verified, escape...
+        if (!confirmEmailSvc.hasVerifiedEmail(user)) { return Collections.emptySet(); }
+        
+        // otherwise start to bisect the mail and lookup groups.
+        Optional<String> oDomain = getDomainFromMail(user.getEmail());
+        if ( oDomain.isPresent() ) {
+            List<MailDomainGroup> rs = em.createNamedQuery("MailDomainGroup.findAll", MailDomainGroup.class).getResultList();
+            for(MailDomainGroup g : rs) {
+                if ( g.getEmailDomainsAsList().contains(oDomain.get()) == false ) rs.remove(g);
+            }
+            return new HashSet<>(rs);
+        }
+        return Collections.emptySet();
+    }
+    
+    public List<MailDomainGroup> findAll() {
+        return em.createNamedQuery("MailDomainGroup.findAll", MailDomainGroup.class).getResultList();
+    }
+    
+    Optional<MailDomainGroup> findByAlias(String groupAlias) {
+        try  {
+            return Optional.of(
+                em.createNamedQuery("MailDomainGroup.findByPersistedGroupAlias", MailDomainGroup.class)
+                    .setParameter("persistedGroupAlias", groupAlias)
+                    .getSingleResult());
+        } catch ( NoResultException nre ) {
+            return Optional.empty();
+        }
+    }
+    
+    /*
+    public MailDomainGroup persist( MailDomainGroup g ) {
+        if ( g.getId() == null ) {
+            em.persist( g );
+            return g;
+        } else {
+            // clean stale data once in a while
+            if ( Math.random() >= 0.5 ) {
+                Set<String> stale = new TreeSet<>();
+                for ( String idtf : g.getContainedRoleAssignees()) {
+                    if ( roleAssigneeSvc.getRoleAssignee(idtf) == null ) {
+                        stale.add(idtf);
+                    }
+                }
+                if ( ! stale.isEmpty() ) {
+                    g.getContainedRoleAssignees().removeAll(stale);
+                }
+            }
+            
+            return em.merge( g );
+        }
+    }
+    */
+    
+    public void removeGroup(MailDomainGroup mailDomainGroup) {
+        em.remove( mailDomainGroup );
+    }
+    
+    Optional<String> getDomainFromMail(String email) {
+        String[] parts = email.split("@");
+        if (parts.length < 2) { return Optional.empty(); }
+        return Optional.of(parts[parts.length-1]);
+    }
+    
+}

--- a/src/main/java/edu/harvard/iq/dataverse/authorization/providers/builtin/DataverseUserPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/authorization/providers/builtin/DataverseUserPage.java
@@ -546,6 +546,7 @@ public class DataverseUserPage implements java.io.Serializable {
     
     /**
      * Determines whether the button to send a verification email appears on user page
+     * TODO: cant this be refactored to use confirmEmailService.hasVerifiedEmail(currentUser) ?
      * @return 
      */ 
     public boolean showVerifyEmailButton() {
@@ -557,12 +558,11 @@ public class DataverseUserPage implements java.io.Serializable {
     }
 
     public boolean isEmailIsVerified() {
-
-        return currentUser.getEmailConfirmed() != null && confirmEmailService.findSingleConfirmEmailDataByUser(currentUser) == null;
+        return confirmEmailService.hasVerifiedEmail(currentUser);
     }
 
     public boolean isEmailNotVerified() {
-        return currentUser.getEmailConfirmed() == null || confirmEmailService.findSingleConfirmEmailDataByUser(currentUser) != null;
+        return !confirmEmailService.hasVerifiedEmail(currentUser);
     }
 
     public boolean isEmailGrandfathered() {

--- a/src/main/java/edu/harvard/iq/dataverse/confirmemail/ConfirmEmailServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/confirmemail/ConfirmEmailServiceBean.java
@@ -34,7 +34,7 @@ public class ConfirmEmailServiceBean {
     private static final Logger logger = Logger.getLogger(ConfirmEmailServiceBean.class.getCanonicalName());
 
     @EJB
-    AuthenticationServiceBean dataverseUserService;
+    AuthenticationServiceBean authenticationService;
 
     @EJB
     MailServiceBean mailService;
@@ -46,6 +46,19 @@ public class ConfirmEmailServiceBean {
 
     @PersistenceContext(unitName = "VDCNet-ejbPU")
     private EntityManager em;
+    
+    /**
+     * A simple interface to check if a user email has been verified or not.
+     * @param user
+     * @return true if verified, false otherwise
+     */
+    public boolean hasVerifiedEmail(AuthenticatedUser user) {
+        boolean hasTimestamp = user.getEmailConfirmed() != null;
+        boolean hasNoStaleVerificationTokens = this.findSingleConfirmEmailDataByUser(user) == null;
+        boolean isVerifiedByAuthProvider = authenticationService.lookupProvider(user).isEmailVerified();
+        
+        return (hasTimestamp && hasNoStaleVerificationTokens) || isVerifiedByAuthProvider;
+    }
 
     /**
      * Initiate the email confirmation process.

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/MergeInAccountCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/MergeInAccountCommand.java
@@ -155,6 +155,7 @@ public class MergeInAccountCommand extends AbstractVoidCommand {
         
         //ConfirmEmailData  
         
+        // todo: the deletion should be handed down to the service!
         ConfirmEmailData confirmEmailData = ctxt.confirmEmail().findSingleConfirmEmailDataByUser(consumedAU); 
         if (confirmEmailData != null){
             ctxt.em().remove(confirmEmailData);

--- a/src/main/java/edu/harvard/iq/dataverse/util/json/JsonParser.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/json/JsonParser.java
@@ -256,6 +256,8 @@ public class JsonParser {
                     .map(JsonString::getString)
                     .filter(d -> DomainValidator.getInstance().isValid(d))
                     .collect(Collectors.toList());
+            if (domains.isEmpty())
+                throw new JsonParseException("Field domains may not be an empty array or contain invalid domains.");
             grp.setEmailDomains(domains);
         } else {
             throw new JsonParseException("Field domains is mandatory.");

--- a/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
@@ -16,6 +16,7 @@ import edu.harvard.iq.dataverse.DataverseContact;
 import edu.harvard.iq.dataverse.DataverseFacet;
 import edu.harvard.iq.dataverse.DataverseTheme;
 import edu.harvard.iq.dataverse.authorization.DataverseRole;
+import edu.harvard.iq.dataverse.authorization.groups.impl.maildomain.MailDomainGroup;
 import edu.harvard.iq.dataverse.authorization.providers.builtin.BuiltinUser;
 import edu.harvard.iq.dataverse.FileMetadata;
 import edu.harvard.iq.dataverse.GlobalId;
@@ -184,6 +185,16 @@ public class JsonPrinter {
                 .add("attribute", grp.getAttribute())
                 .add("pattern", grp.getPattern())
                 .add("id", grp.getId());
+    }
+    
+    public static JsonObjectBuilder json(MailDomainGroup grp) {
+        JsonObjectBuilder bld = jsonObjectBuilder()
+            .add("alias", grp.getPersistedGroupAlias() )
+            .add("id", grp.getId() )
+            .add("name", grp.getDisplayName() )
+            .add("description", grp.getDescription() )
+            .add("domains", asJsonArray(grp.getEmailDomainsAsList()) );
+        return bld;
     }
 
     public static JsonArrayBuilder rolesToJson(List<DataverseRole> role) {

--- a/src/main/resources/db/migration/V4.20.0.4__6936-maildomain-groups.sql
+++ b/src/main/resources/db/migration/V4.20.0.4__6936-maildomain-groups.sql
@@ -1,0 +1,1 @@
+ALTER TABLE persistedglobalgroup ADD COLUMN IF NOT EXISTS emaildomains text;

--- a/src/test/java/edu/harvard/iq/dataverse/authorization/groups/impl/maildomain/MailDomainGroupProviderTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/authorization/groups/impl/maildomain/MailDomainGroupProviderTest.java
@@ -1,0 +1,100 @@
+package edu.harvard.iq.dataverse.authorization.groups.impl.maildomain;
+
+import edu.harvard.iq.dataverse.Dataset;
+import edu.harvard.iq.dataverse.authorization.groups.impl.ipaddress.ip.IPv4Address;
+import edu.harvard.iq.dataverse.authorization.users.AuthenticatedUser;
+import edu.harvard.iq.dataverse.engine.command.DataverseRequest;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class MailDomainGroupProviderTest {
+    
+    MailDomainGroupServiceBean svc = Mockito.mock(MailDomainGroupServiceBean.class);
+    
+    @Test
+    void testUserMatched() {
+        // given
+        MailDomainGroupProvider pvd = new MailDomainGroupProvider(svc);
+        
+        MailDomainGroup t = new MailDomainGroup();
+        t.setEmailDomains("foobar.com");
+        Set<MailDomainGroup> set = new HashSet<>();
+        set.add(t);
+        
+        AuthenticatedUser u = new AuthenticatedUser();
+        when(svc.findAllWithDomain(u)).thenReturn(set);
+        
+        DataverseRequest req = new DataverseRequest(u, new IPv4Address(192,168,0,1));
+        
+        // when
+        Set<MailDomainGroup> result = pvd.groupsFor(req);
+        
+        // then
+        assertTrue(result.contains(t));
+        assertEquals(pvd, t.getGroupProvider());
+    }
+    
+    @Test
+    void testUserNotPresent() {
+        // given
+        MailDomainGroupProvider pvd = new MailDomainGroupProvider(svc);
+        AuthenticatedUser u = null;
+        DataverseRequest req = new DataverseRequest(u, new IPv4Address(192,168,0,1));
+        
+        // when & then
+        assertEquals(Collections.emptySet(), pvd.groupsFor(req));
+    }
+    
+    @Test
+    void testContextIgnored() {
+        // given
+        MailDomainGroupProvider pvd = Mockito.spy(new MailDomainGroupProvider(svc));
+        AuthenticatedUser u = null;
+        DataverseRequest req = new DataverseRequest(u, new IPv4Address(192,168,0,1));
+        Dataset a = new Dataset();
+        
+        // when
+        pvd.groupsFor(req, a);
+        // then
+        verify(pvd, times(1)).groupsFor(req);
+    }
+    
+    @Test
+    void testUnsupportedAsEmpty() {
+        // given
+        MailDomainGroupProvider pvd = new MailDomainGroupProvider(svc);
+        
+        // when & then
+        assertEquals(Collections.emptySet(), pvd.groupsFor(new AuthenticatedUser(), new Dataset()));
+        assertEquals(Collections.emptySet(), pvd.groupsFor(new AuthenticatedUser()));
+    }
+    
+    @Test
+    void testUpdateProvider() {
+        // given
+        MailDomainGroupProvider pvd = new MailDomainGroupProvider(svc);
+        // include a null value to ensure null safety of the functions
+        List<MailDomainGroup> test = Arrays.asList(new MailDomainGroup(), new MailDomainGroup(), null);
+        for (MailDomainGroup mdg : test) {
+            if ( mdg != null ) {
+                assertNull(mdg.getGroupProvider());
+            }
+        }
+        
+        // when
+        pvd.updateProvider(test);
+        
+        // then
+        for (MailDomainGroup mdg : test) {
+            if ( mdg != null ) {
+                assertEquals(pvd, mdg.getGroupProvider());
+            }
+        }
+        
+    }
+}

--- a/src/test/java/edu/harvard/iq/dataverse/authorization/groups/impl/maildomain/MailDomainGroupServiceBeanTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/authorization/groups/impl/maildomain/MailDomainGroupServiceBeanTest.java
@@ -1,0 +1,129 @@
+package edu.harvard.iq.dataverse.authorization.groups.impl.maildomain;
+
+import edu.harvard.iq.dataverse.authorization.users.AuthenticatedUser;
+import edu.harvard.iq.dataverse.confirmemail.ConfirmEmailServiceBean;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import javax.persistence.EntityManager;
+import javax.persistence.TypedQuery;
+import java.util.*;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class MailDomainGroupServiceBeanTest {
+    
+    @Mock
+    ConfirmEmailServiceBean confirmEmailSvc;
+    @Mock
+    EntityManager em;
+    
+    MailDomainGroupServiceBean svc;
+    
+    @BeforeEach
+    void setup() {
+        svc = new MailDomainGroupServiceBean();
+        svc.em = em;
+        svc.confirmEmailSvc = confirmEmailSvc;
+    }
+    
+    @Test
+    void testFindWithVerifiedEmail() {
+        // given
+        List<MailDomainGroup> db = new ArrayList<>(Arrays.asList(MailDomainGroupTest.genGroup(),MailDomainGroupTest.genGroup(),MailDomainGroupTest.genGroup()));
+        MailDomainGroup test = MailDomainGroupTest.genGroup();
+        test.setEmailDomains("foobar.com");
+        db.add(test);
+        mockQuery("MailDomainGroup.findAll", db);
+        
+        AuthenticatedUser u = new AuthenticatedUser();
+        u.setEmail("test@foobar.com");
+        when(confirmEmailSvc.hasVerifiedEmail(u)).thenReturn(true);
+    
+        // when
+        Set<MailDomainGroup> result = svc.findAllWithDomain(u);
+        
+        // then
+        Set<MailDomainGroup> expected = new HashSet<>(Arrays.asList(test));
+        assertEquals(expected, result);
+    }
+    
+    @Test
+    void testFindWithUnverifiedEmail() {
+        // given
+        AuthenticatedUser u = new AuthenticatedUser();
+        u.setEmail("test@foobar.com");
+        when(confirmEmailSvc.hasVerifiedEmail(u)).thenReturn(false);
+        
+        // when & then
+        assertEquals(Collections.emptySet(), svc.findAllWithDomain(u));
+    }
+    
+    // however this case might ever happen... its a branch in the function, we should test it.
+    @Test
+    void testFindWithInvalidEmail() {
+        // given
+        AuthenticatedUser u = new AuthenticatedUser();
+        u.setEmail("testfoobar.com");
+        when(confirmEmailSvc.hasVerifiedEmail(u)).thenReturn(true);
+        
+        // when & then
+        assertEquals(Collections.emptySet(), svc.findAllWithDomain(u));
+    }
+    
+    @Test
+    void findAll() {
+        // given
+        List<MailDomainGroup> db = Arrays.asList(MailDomainGroupTest.genGroup(),MailDomainGroupTest.genGroup(),MailDomainGroupTest.genGroup());
+        mockQuery("MailDomainGroup.findAll", db);
+        
+        // when & then
+        assertEquals(db, svc.findAll());
+    }
+    
+    @Test
+    void findByAlias() {
+        // given
+        MailDomainGroup mg = MailDomainGroupTest.genGroup();
+        mockQuery("MailDomainGroup.findByPersistedGroupAlias", mg, "persistedGroupAlias", mg.getPersistedGroupAlias());
+        
+        // when & then
+        assertEquals(Optional.of(mg), svc.findByAlias(mg.getPersistedGroupAlias()));
+    }
+    
+    private static Stream<Arguments> mailExamples() {
+        return Stream.of(
+            Arguments.of("foo@bar.com", Optional.of("bar.com")),
+            Arguments.of("foo@foo@bar.com", Optional.of("bar.com")),
+            Arguments.of("foobar.com", Optional.empty()));
+    }
+    
+    @ParameterizedTest
+    @MethodSource("mailExamples")
+    void getDomainFromMail(String mail, Optional<String> expected) {
+        assertEquals(expected, MailDomainGroupServiceBean.getDomainFromMail(mail));
+    }
+    
+    void mockQuery(String name, List<MailDomainGroup> results) {
+        TypedQuery mockedQuery = mock(TypedQuery.class);
+        when(mockedQuery.getResultList()).thenReturn(results);
+        when(this.svc.em.createNamedQuery(name, MailDomainGroup.class)).thenReturn(mockedQuery);
+    }
+    
+    void mockQuery(String name, MailDomainGroup result, String parameter, String value) {
+        TypedQuery mockedQuery = mock(TypedQuery.class);
+        when(mockedQuery.getSingleResult()).thenReturn(result);
+        when(mockedQuery.setParameter(parameter, value)).thenReturn(mockedQuery);
+        when(this.svc.em.createNamedQuery(name, MailDomainGroup.class)).thenReturn(mockedQuery);
+    }
+}

--- a/src/test/java/edu/harvard/iq/dataverse/authorization/groups/impl/maildomain/MailDomainGroupTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/authorization/groups/impl/maildomain/MailDomainGroupTest.java
@@ -1,11 +1,13 @@
 package edu.harvard.iq.dataverse.authorization.groups.impl.maildomain;
 
 import edu.harvard.iq.dataverse.engine.command.DataverseRequest;
+import org.apache.commons.lang.RandomStringUtils;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Random;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -72,5 +74,15 @@ class MailDomainGroupTest {
         // when & then
         assertEquals(a, c);
         assertNotEquals(a, b);
+    }
+    
+    static Random rnd = new Random();
+    static MailDomainGroup genGroup() {
+        MailDomainGroup t = new MailDomainGroup();
+        t.setId(rnd.nextLong());
+        t.setPersistedGroupAlias(RandomStringUtils.randomAlphanumeric(12));
+        t.setDisplayName(RandomStringUtils.randomAlphanumeric(12));
+        t.setEmailDomains(RandomStringUtils.randomAlphanumeric(5)+"."+RandomStringUtils.randomAlphanumeric(2)+";"+RandomStringUtils.randomAlphanumeric(5)+"."+RandomStringUtils.randomAlphanumeric(3));
+        return t;
     }
 }

--- a/src/test/java/edu/harvard/iq/dataverse/authorization/groups/impl/maildomain/MailDomainGroupTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/authorization/groups/impl/maildomain/MailDomainGroupTest.java
@@ -11,7 +11,7 @@ import java.util.Random;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-class MailDomainGroupTest {
+public class MailDomainGroupTest {
     
     DataverseRequest dvr = Mockito.mock(DataverseRequest.class);
     
@@ -77,12 +77,13 @@ class MailDomainGroupTest {
     }
     
     static Random rnd = new Random();
-    static MailDomainGroup genGroup() {
+    public static MailDomainGroup genGroup() {
         MailDomainGroup t = new MailDomainGroup();
         t.setId(rnd.nextLong());
-        t.setPersistedGroupAlias(RandomStringUtils.randomAlphanumeric(12));
-        t.setDisplayName(RandomStringUtils.randomAlphanumeric(12));
-        t.setEmailDomains(RandomStringUtils.randomAlphanumeric(5)+"."+RandomStringUtils.randomAlphanumeric(2)+";"+RandomStringUtils.randomAlphanumeric(5)+"."+RandomStringUtils.randomAlphanumeric(3));
+        t.setPersistedGroupAlias(RandomStringUtils.randomAlphanumeric(4));
+        t.setDisplayName(RandomStringUtils.randomAlphanumeric(8));
+        t.setDescription(RandomStringUtils.randomAlphanumeric(8));
+        t.setEmailDomains(RandomStringUtils.randomAlphanumeric(5)+".com;"+RandomStringUtils.randomAlphanumeric(5)+".co.uk");
         return t;
     }
 }

--- a/src/test/java/edu/harvard/iq/dataverse/authorization/groups/impl/maildomain/MailDomainGroupTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/authorization/groups/impl/maildomain/MailDomainGroupTest.java
@@ -1,0 +1,76 @@
+package edu.harvard.iq.dataverse.authorization.groups.impl.maildomain;
+
+import edu.harvard.iq.dataverse.engine.command.DataverseRequest;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class MailDomainGroupTest {
+    
+    DataverseRequest dvr = Mockito.mock(DataverseRequest.class);
+    
+    @Test
+    void testEmailDomains() {
+        // given
+        MailDomainGroup mdg = new MailDomainGroup();
+        List<String> domains = Arrays.asList("test.de", "foo.com", "bar.com");
+        String domainsStr = "test.de;foo.com;bar.com";
+        
+        // when
+        mdg.setEmailDomains(domainsStr);
+        // then
+        assertEquals(domains, mdg.getEmailDomainsAsList());
+        assertEquals(domainsStr, mdg.getEmailDomains());
+        
+        // when 2
+        mdg.setEmailDomains(domains);
+        // then 2
+        assertEquals(domains, mdg.getEmailDomainsAsList());
+        assertEquals(domainsStr, mdg.getEmailDomains());
+    }
+    
+    @Test
+    void testUnsupported() {
+        // given
+        MailDomainGroup a = new MailDomainGroup();
+        // when, then
+        assertThrows(UnsupportedOperationException.class, () -> { a.isEditable(); } );
+        assertThrows(UnsupportedOperationException.class, () -> { a.contains(dvr); } );
+    }
+    
+    @Test
+    void testHashCode() {
+        // given
+        MailDomainGroup a = new MailDomainGroup();
+        a.setEmailDomains("test.de;test2.de");
+        MailDomainGroup b = new MailDomainGroup();
+        a.setEmailDomains("test3.de;test4.de");
+        MailDomainGroup c = new MailDomainGroup();
+        c.setEmailDomains("test.de;test2.de");
+        
+        // when & then
+        assertNotEquals(a, b);
+        assertNotEquals(a, c);
+        assertNotEquals(a.hashCode(), b.hashCode());
+        assertNotEquals(a.hashCode(), c.hashCode());
+    }
+    
+    @Test
+    void testEquals() {
+        // given
+        MailDomainGroup a = new MailDomainGroup();
+        a.setEmailDomains("test.de;test2.de");
+        MailDomainGroup b = new MailDomainGroup();
+        b.setEmailDomains("foo.de;bar.de");
+        MailDomainGroup c = new MailDomainGroup();
+        c.setEmailDomains("test.de;test2.de");
+        
+        // when & then
+        assertEquals(a, c);
+        assertNotEquals(a, b);
+    }
+}

--- a/src/test/java/edu/harvard/iq/dataverse/util/json/JsonParserTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/util/json/JsonParserTest.java
@@ -20,6 +20,8 @@ import edu.harvard.iq.dataverse.authorization.groups.impl.ipaddress.ip.IpAddress
 import edu.harvard.iq.dataverse.authorization.groups.impl.ipaddress.ip.IpAddressRange;
 import edu.harvard.iq.dataverse.DataverseTheme.Alignment;
 import edu.harvard.iq.dataverse.FileMetadata;
+import edu.harvard.iq.dataverse.authorization.groups.impl.maildomain.MailDomainGroup;
+import edu.harvard.iq.dataverse.authorization.groups.impl.maildomain.MailDomainGroupTest;
 import edu.harvard.iq.dataverse.authorization.users.GuestUser;
 import edu.harvard.iq.dataverse.engine.command.DataverseRequest;
 import edu.harvard.iq.dataverse.mocks.MockDatasetFieldSvc;
@@ -530,6 +532,38 @@ public class JsonParserTest {
         assertFalse( parsed.contains( new DataverseRequest(GuestUser.get(), IpAddress.valueOf("fe79::22c9:d0ff:fe48:ce61")) ));
         assertFalse( parsed.contains( new DataverseRequest(GuestUser.get(), IpAddress.valueOf("2.1.1.1")) ));
         
+    }
+    
+    @Test
+    public void testValidMailDomainGroup() throws JsonParseException {
+        // given
+        MailDomainGroup test = MailDomainGroupTest.genGroup();
+        
+        // when
+        JsonObject serialized = JsonPrinter.json(test).build();
+        MailDomainGroup parsed = new JsonParser().parseMailDomainGroup(serialized);
+        
+        // then
+        assertEquals(test, parsed);
+        assertEquals(test.hashCode(), parsed.hashCode());
+    }
+    
+    @Test(expected = JsonParseException.class)
+    public void testMailDomainGroupMissingName() throws JsonParseException {
+        // given
+        String noname = "{ \"id\": 1, \"alias\": \"test\", \"domains\": [] }";
+        JsonObject obj = Json.createReader(new StringReader(noname)).readObject();
+        // when && then
+        MailDomainGroup parsed = new JsonParser().parseMailDomainGroup(obj);
+    }
+    
+    @Test(expected = JsonParseException.class)
+    public void testMailDomainGroupMissingDomains() throws JsonParseException {
+        // given
+        String noname = "{ \"name\": \"test\", \"alias\": \"test\" }";
+        JsonObject obj = Json.createReader(new StringReader(noname)).readObject();
+        // when && then
+        MailDomainGroup parsed = new JsonParser().parseMailDomainGroup(obj);
     }
 
     @Test


### PR DESCRIPTION
**What this PR does / why we need it**:
Next to explicit groups, IP groups and Shibboleth groups, there is another valuable source of information to which association a user belongs to: a verified email.

Based on the domain part of the email, it's very easy to create groups based on affiliations. This might be handy for installations like the one from Leuven, where different universities share one instance (multi-tenancy). Our use case @ FZJ is to be able to open up for collaboration while automatically granting some rights to staff.

As this is independent from Shibboleth, this might be good for other instances like WZB (ping @RightInTwo), that create users via API.

**Which issue(s) this PR closes**:

Closes #6936 

**Special notes for your reviewer**:

This is not only introducing a new group provider, but also refactors some other places in the codebase. Some noteable places:

- Add a simpler verification check function for email addresses and make use of it. It's much easier to understand now and easier to extend (looking at #6694).
-  Extend the usage of `ExceptionMapper`s in REST API endpoints. There are a lot of places with lots of boilerplate and catch all like try-catch code. This makes the code more verbose and violates [DRY principle](https://dzone.com/articles/software-design-principles-dry-and-kiss). Obviously I didn't touch too much of other code to keep the scope of this PR as small as possible. (But didn't want to encourage the use of catch-alls any further...)

**Suggestions on how to test this**:

- Deploy, but don't yet publish the root dataverse.
- Create a new mail domain group
- Add the group as member or similar to the root dataverse
- Create a user with a group-matching mail address
- Verify user email
- Get access to the root dataverse
- Delete the permission
- Verify permission is gone

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

Nope.

**Is there a release notes update needed for this change?**:

It should be mentioned this is a new option to create groups of people.

**Additional documentation**:

Nada.