### PR TITLE
6970 proxy client ip

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/authorization/ProxyRequestWrapper.java
+++ b/src/main/java/edu/harvard/iq/dataverse/authorization/ProxyRequestWrapper.java
@@ -1,0 +1,19 @@
+package edu.harvard.iq.dataverse.authorization;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+
+public class ProxyRequestWrapper extends HttpServletRequestWrapper {
+    
+    String realIP;
+    
+    public ProxyRequestWrapper(HttpServletRequest request, String realIP) {
+        super(request);
+        this.realIP = realIP;
+    }
+    
+    @Override
+    public String getRemoteAddr() {
+        return this.realIP;
+    }
+}

--- a/src/main/java/edu/harvard/iq/dataverse/authorization/ReverseProxyFilter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/authorization/ReverseProxyFilter.java
@@ -1,0 +1,114 @@
+package edu.harvard.iq.dataverse.authorization;
+
+import edu.harvard.iq.dataverse.util.SystemConfig;
+import org.apache.commons.lang3.StringUtils;
+
+import javax.inject.Inject;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebFilter;
+import javax.servlet.http.HttpFilter;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+
+@WebFilter( filterName = "reverse-proxy", urlPatterns = "/*")
+public class ReverseProxyFilter extends HttpFilter {
+    
+    @Inject
+    SystemConfig systemConfig;
+    
+    String headerField;
+    
+    private static final Logger logger = Logger.getLogger(ReverseProxyFilter.class.getName());
+    private static final String X_FORWARDED_FOR = "X-Forwarded-For"; // de-facto standard
+    private static final String RFC7239_FORWARDED = "Forwarded";
+    private static HashSet<String> ALLOWED_HEADERS = new HashSet<String>(Arrays.asList(
+        X_FORWARDED_FOR,
+        RFC7239_FORWARDED,
+        "Proxy-Client-IP",
+        "WL-Proxy-Client-IP",
+        "HTTP_X_FORWARDED_FOR",
+        "HTTP_X_FORWARDED",
+        "HTTP_X_CLUSTER_CLIENT_IP",
+        "HTTP_CLIENT_IP",
+        "HTTP_FORWARDED_FOR",
+        "HTTP_FORWARDED",
+        "HTTP_VIA",
+        "REMOTE_ADDR" ));
+    
+    @Override
+    protected void doFilter(HttpServletRequest req, HttpServletResponse res, FilterChain chain) throws IOException, ServletException {
+        HttpServletRequest proxy = req;
+        
+        // process headers and try to find an ip if a header field is present (=configured)
+        if (headerField != null) {
+            String proxiedIp;
+            
+            // get header(s) matching the field and process if not empty (= not present in request)
+            List<String> headers = Collections.list(req.getHeaders(headerField));
+            logger.log(Level.FINER, "Header(s) \""+headerField+"\": "+StringUtils.join(", "));
+            
+            if ( ! headers.isEmpty()) {
+                // special parsing for X-Forwarded-For de-facto standard
+                if (headerField.equals(X_FORWARDED_FOR)) {
+                    proxiedIp = parseXForwardedFor(headers);
+                }
+                // special parsing for RFC 7239 "Forwarded" syntax
+                else if (headerField.equals(RFC7239_FORWARDED)) {
+                    proxiedIp = parseRFC7239Forwarded(headers);
+                }
+                // otherwise get last header (if multiple), which should have been added by the proxy the client hits
+                // *first*, thus being the real client (and not an intermediate proxy). we assume headers are in order.
+                else {
+                    proxiedIp = validateIp(headers.get(headers.size()-1));
+                }
+                
+                // the ip has been found and verified/validated, let's create a usefull proxied request, allowing
+                // to use getRemoteAddr() and retrieve clients instead of proxies ip.
+                if (proxiedIp != null) {
+                    logger.log(Level.FINE, "Real client IP: \""+proxiedIp+"\"");
+                    proxy = new ProxyRequestWrapper(req, proxiedIp);
+                }
+            }
+        }
+        
+        super.doFilter(proxy, res, chain);
+    }
+    
+    String parseXForwardedFor(List<String> headers) {
+       return null;
+    }
+    
+    String parseRFC7239Forwarded(List<String> headers) {
+        return null;
+    }
+    
+    String validateIp(String ip) {
+        return null;
+    }
+    
+    
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {
+        String field = systemConfig.getUserIpAddressSourceHeaderField();
+        if (! ALLOWED_HEADERS.contains(field)) {
+            throw new ServletException("\""+field+"\" is not a valid header field name to retrieve a client IP from. Choose one of "+ALLOWED_HEADERS.toString()+".");
+        }
+        this.headerField = field;
+    }
+    
+    @Override
+    public void destroy() {
+        // intentionally left blank - no deconstruction needed.
+    }
+}

--- a/src/main/java/edu/harvard/iq/dataverse/authorization/groups/impl/ipaddress/ip/IpAddress.java
+++ b/src/main/java/edu/harvard/iq/dataverse/authorization/groups/impl/ipaddress/ip/IpAddress.java
@@ -7,7 +7,14 @@ package edu.harvard.iq.dataverse.authorization.groups.impl.ipaddress.ip;
  */
 public abstract class IpAddress {
     
+    /**
+     * Parse a given string into a IPv4 or IPv6 address.
+     * @param s IP address as string representation
+     * @return An object to interact with an IP. If s is null will return null.
+     * @throws IllegalArgumentException if s is not a valid ip
+     */
     public static IpAddress valueOf( String s ) {
+        if ( s == null ) return null;
         if ( s.contains(".") ) {
             if ( s.contains(":") ){
                 return IPv6Address.valueOfMapped(s);
@@ -17,6 +24,22 @@ public abstract class IpAddress {
             
         } else {
             return IPv6Address.valueOf( s );
+        }
+    }
+    
+    /**
+     * Parse a given string into a IPv4 or IPv6 address or return default.
+     * @param s IP address as string representation
+     * @param def A default value to return if s is null or fails to parse.
+     * @return An object to interact with an IP, either the parsed one or the default value.
+     * @throws IllegalArgumentException if def is null.
+     */
+    public static IpAddress valueOf(String s, IpAddress def) {
+        if (def == null) { throw new IllegalArgumentException("Default IP address may not be null."); }
+        try {
+            return valueOf(s);
+        } catch (IllegalArgumentException ex) {
+            return def;
         }
     }
     

--- a/src/main/java/edu/harvard/iq/dataverse/util/SystemConfig.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/SystemConfig.java
@@ -1056,4 +1056,8 @@ public class SystemConfig {
 	public boolean directUploadEnabled(Dataset dataset) {
     	return Boolean.getBoolean("dataverse.files." + dataset.getDataverseContext().getEffectiveStorageDriverId() + ".upload-redirect");
 	}
+	
+	public String getUserIpAddressSourceHeaderField() {
+        return System.getProperty("dataverse.useripaddresssourceheader", null);
+    }
 }

--- a/src/test/java/edu/harvard/iq/dataverse/authorization/groups/impl/ipaddress/ip/IpAddressTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/authorization/groups/impl/ipaddress/ip/IpAddressTest.java
@@ -2,6 +2,7 @@ package edu.harvard.iq.dataverse.authorization.groups.impl.ipaddress.ip;
 
 import java.util.Arrays;
 import org.junit.Test;
+
 import static org.junit.Assert.*;
 
 /**
@@ -9,6 +10,11 @@ import static org.junit.Assert.*;
  * @author michael
  */
 public class IpAddressTest {
+    
+    @Test
+    public void testNullSafety() {
+        assertNull(IpAddress.valueOf(null));
+    }
     
     @Test
     public void testValueOfIPv4() {
@@ -41,6 +47,17 @@ public class IpAddressTest {
             assertEquals( IpAddress.valueOf(tp[1]), IpAddress.valueOf(tp[0]));
         }
         
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void testDefaultNull() throws IllegalArgumentException {
+        IpAddress.valueOf("127.0.0.1", null);
+    }
+    
+    @Test
+    public void testDefault() {
+        IpAddress test = new IPv4Address(127,0,0,1);
+        assertEquals(test, IpAddress.valueOf("IM.NOT.AN.IP", test));
     }
 
 }


### PR DESCRIPTION
## :exclamation: THIS IS A DRAFT PR
1. This is just a proof of concept, not yet doing any real work due to stubs.
2. It lacks documentation.
3. It lacks more tests.

**:repeat: This is an alternative solution based on feedback to #6973**

**What this PR does / why we need it**:

Allows optional specification of an HTTP header as the source of user ip addresses. This is needed to get valid ip addresses for MDC and IP based access control when running Dataverse behind a proxy/load balancer

**Which issue(s) this PR closes:**

Closes #6970
Closes #6456

**Special notes for your reviewer**:

Nada right now.

**Suggestions on how to test this**:

- Deploy Dataverse with a reverse proxy
- Configure the system property to match your proxies headers to forward your IP
- Tune log level to fine and watch it log your IP.
- Maybe add an IP group to test if the mangling works as expected.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

Nope.

**Is there a release notes update needed for this change?**:

Maybe it should be mentioned.

**Additional documentation**:

Not yet done. Needs big fat warnings in the admin guide.
