### PR TITLE
#7003 Fix log formatting and in particular the OAI URL.

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/harvest/client/ClientHarvestRun.java
+++ b/src/main/java/edu/harvard/iq/dataverse/harvest/client/ClientHarvestRun.java
@@ -44,7 +44,7 @@ public class ClientHarvestRun implements Serializable {
     
     private static String RESULT_LABEL_SUCCESS = "SUCCESS";
     private static String RESULT_LABEL_FAILURE = "FAILED";
-    private static String RESULT_LABEL_INPROGRESS = "INPROGRESS";
+    private static String RESULT_LABEL_INPROGRESS = "IN PROGRESS";
     private static String RESULT_DELETE_IN_PROGRESS = "DELETE IN PROGRESS";
     
     @ManyToOne

--- a/src/main/java/edu/harvard/iq/dataverse/harvest/client/HarvesterServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/harvest/client/HarvesterServiceBean.java
@@ -412,12 +412,12 @@ public class HarvesterServiceBean {
     public void logGetRecordException(Logger hdLogger, OaiHandler oaiHandler, String identifier, Throwable e) {
         String errMessage = "Exception processing getRecord(), oaiUrl=" 
                 +oaiHandler.getBaseOaiUrl() 
-                +",identifier=" 
+                +", identifier="
                 +identifier 
-                +" " 
+                +", "
                 +e.getClass().getName() 
                 //+" (exception message suppressed)";
-                +" " 
+                +", "
                 +e.getMessage();
         
             hdLogger.log(Level.SEVERE, errMessage);


### PR DESCRIPTION
**What this PR does / why we need it**: Fixes log formatting and in particular the OAI URL.

**Which issue(s) this PR closes**: 7003

Closes #7003 

**Special notes for your reviewer**: Very easy fix

**Suggestions on how to test this**: Run a harvesting client on the server https://dataverse.harvard.edu/oai for the set AfricaRice and metadataprefix Datacite. Then check the harvest log for a logGetRecordException.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: n/a

**Is there a release notes update needed for this change?**: No

**Additional documentation**:
