### PR TITLE
#7009 Removed one of the redundant encoding functions.

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/harvest/client/oai/OaiHandler.java
+++ b/src/main/java/edu/harvard/iq/dataverse/harvest/client/oai/OaiHandler.java
@@ -66,11 +66,7 @@ public class OaiHandler implements Serializable {
         this.metadataPrefix = harvestingClient.getMetadataPrefix();
         
         if (!StringUtils.isEmpty(harvestingClient.getHarvestingSet())) {
-            try {
-                this.setName = URLEncoder.encode(harvestingClient.getHarvestingSet(), "UTF-8");
-            } catch (UnsupportedEncodingException uee) {
-                throw new OaiHandlerException("Harvesting set: unsupported (non-UTF8) encoding");
-            }
+            this.setName = harvestingClient.getHarvestingSet();
         }
         
         this.fromDate = harvestingClient.getLastNonEmptyHarvestTime();


### PR DESCRIPTION
**What this PR does / why we need it**: Fixes double set name encoding in the URL which creates a faulty URL

**Which issue(s) this PR closes**: 7009

Closes #7009 

**Special notes for your reviewer**: It's an amazing fix.

**Suggestions on how to test this**: You can try harvesting the repo https://easy.dans.knaw.nl/oai with the set name D20000:D26000 and the prefix oai_dc. The archive type should be Generic OAI archive. The faulty URL returned 0 results and the fix will minimally return 8 failed results. I'm looking into the failures for a possible next commit.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: No

**Is there a release notes update needed for this change?**: Yes, apparently there's quite some repo's that have issues so this will possibly solve quite some of these.

**Additional documentation**:
