### PR TITLE
7011 - Render logic for signup link on login page

### DIFF
--- a/src/main/webapp/loginpage.xhtml
+++ b/src/main/webapp/loginpage.xhtml
@@ -220,7 +220,7 @@
                                 </div>
                             </div>
                             
-                            <div id="signUpLink">
+                            <div id="signUpLink" jsf:rendered="#{dataverseHeaderFragment.signupAllowed}">
                                 <p class="help-block margin-top">
                                     <h:outputFormat value="#{bundle['login.signup.blurb']}" escape="false">
                                         <f:param value="#{dataverseHeaderFragment.getSignupUrl(navigationWrapper.redirectPage)}"/>


### PR DESCRIPTION
**What this PR does / why we need it**:

Users should not get confused about a non-existing, error 401 prone signup link on the login page.

**Which issue(s) this PR closes**:

Closes #7011

**Special notes for your reviewer**:
The underlying function has been used in various other places (e. g. [the header UI, hidding the very same link there](https://github.com/IQSS/dataverse/blob/6575273405f5089a4b4f90e5e95fa295233154e0/src/main/webapp/dataverse_header.xhtml#L111-L111)), so this is really straight forward.

**Suggestions on how to test this**:
1. Deploy
2. Disable signup
3. Goto Login page and check if link is not rendered anymore.
4. Enable signup
5. Goto Login page and check if link is rendered again.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
Yes. Please see the opening of #6170, where the initial link has been mocked. This is simply hidden again when signup is disabled.

**Is there a release notes update needed for this change?**:
I don't think so. It's a small fix.

**Additional documentation**:
Nada.