### PR TITLE
only iterate over current files in latest published version

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/CuratePublishedDatasetVersionCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/CuratePublishedDatasetVersionCommand.java
@@ -85,18 +85,26 @@ public class CuratePublishedDatasetVersionCommand extends AbstractDatasetCommand
         Dataset tempDataset = ctxt.em().merge(getDataset());
 
         // Look for file metadata changes and update published metadata if needed
-        for (DataFile dataFile : tempDataset.getFiles()) {
-            List<FileMetadata> fmdList = dataFile.getFileMetadatas();
+        List<FileMetadata> pubFmds = updateVersion.getFileMetadatas();
+        int pubFileCount = pubFmds.size();
+        int newFileCount = tempDataset.getEditVersion().getFileMetadatas().size();
+        if (pubFileCount != newFileCount) {
+            logger.severe("Draft version of dataset: " + tempDataset.getId() + " has: " + newFileCount + " while last published version has " + pubFileCount);
+            throw new IllegalCommandException("Different number of files in draft version", this);
+        }
+        for (FileMetadata publishedFmd : pubFmds) {
+            DataFile dataFile = publishedFmd.getDataFile();
             FileMetadata draftFmd = dataFile.getLatestFileMetadata();
-            FileMetadata publishedFmd = null;
-            for (FileMetadata fmd : fmdList) {
-                if (fmd.getDatasetVersion().equals(updateVersion)) {
-                    publishedFmd = fmd;
-                    break;
-                }
-            }
             boolean metadataUpdated = false;
-            if (draftFmd != null && publishedFmd != null) {
+            if (draftFmd == null || draftFmd.getDatasetVersion().equals(updateVersion)) {
+                if (draftFmd == null) {
+                    logger.severe("Unable to find latest FMD for file id: " + dataFile.getId());
+                } else {
+                    logger.severe("No filemetadata for file id: " + dataFile.getId() + " in draft version");
+                }
+                throw new IllegalCommandException("Cannot change files in the dataset", this);
+            } else {
+
                 if (!draftFmd.getLabel().equals(publishedFmd.getLabel())) {
                     publishedFmd.setLabel(draftFmd.getLabel());
                     metadataUpdated = true;
@@ -131,8 +139,6 @@ public class CuratePublishedDatasetVersionCommand extends AbstractDatasetCommand
                 }
                 publishedFmd.copyVarGroups(draftFmd.getVarGroups());
 
-            } else {
-                throw new IllegalCommandException("Cannot change files in the dataset", this);
             }
             if (metadataUpdated) {
                 dataFile.setModificationTime(getTimestamp());

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/CuratePublishedDatasetVersionCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/CuratePublishedDatasetVersionCommand.java
@@ -9,6 +9,7 @@ import edu.harvard.iq.dataverse.engine.command.exception.CommandException;
 import edu.harvard.iq.dataverse.engine.command.exception.IllegalCommandException;
 import edu.harvard.iq.dataverse.export.ExportException;
 import edu.harvard.iq.dataverse.export.ExportService;
+import edu.harvard.iq.dataverse.util.BundleUtil;
 import edu.harvard.iq.dataverse.workflows.WorkflowComment;
 import edu.harvard.iq.dataverse.Dataset;
 import edu.harvard.iq.dataverse.DatasetVersion;
@@ -88,9 +89,12 @@ public class CuratePublishedDatasetVersionCommand extends AbstractDatasetCommand
         List<FileMetadata> pubFmds = updateVersion.getFileMetadatas();
         int pubFileCount = pubFmds.size();
         int newFileCount = tempDataset.getEditVersion().getFileMetadatas().size();
+        /* The policy for this command is that it should only be used when the change is a 'minor update' with no file changes.
+         * Nominally we could call .isMinorUpdate() for that but we're making the same checks as we go through the update here. 
+         */
         if (pubFileCount != newFileCount) {
             logger.severe("Draft version of dataset: " + tempDataset.getId() + " has: " + newFileCount + " while last published version has " + pubFileCount);
-            throw new IllegalCommandException("Different number of files in draft version", this);
+            throw new IllegalCommandException(BundleUtil.getStringFromBundle("datasetversion.update.failure"), this);
         }
         for (FileMetadata publishedFmd : pubFmds) {
             DataFile dataFile = publishedFmd.getDataFile();
@@ -102,7 +106,7 @@ public class CuratePublishedDatasetVersionCommand extends AbstractDatasetCommand
                 } else {
                     logger.severe("No filemetadata for file id: " + dataFile.getId() + " in draft version");
                 }
-                throw new IllegalCommandException("Cannot change files in the dataset", this);
+                throw new IllegalCommandException(BundleUtil.getStringFromBundle("datasetversion.update.failure"), this);
             } else {
 
                 if (!draftFmd.getLabel().equals(publishedFmd.getLabel())) {


### PR DESCRIPTION
**What this PR does / why we need it**: Fixes the ability to re-publish without updating the version on datasets where files have been deleted in prior versions.

**Which issue(s) this PR closes**:

Closes #7014 

**Special notes for your reviewer**: a flaw in my original logic

**Suggestions on how to test this**: This class is used for the admin only 'Update Current Version' option under the publish menu that is available when there are metadata only changes. That option should work as before for all datasets. The fix is that, prior to this fix, if you have a dataset in, for example, v2 with fewer/different files than v1 had, when you make a metadata update (update the description) for v2 and try to 'Update Current Version' it would fail and after this PR it should work.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: No

**Is there a release notes update needed for this change?**: No

**Additional documentation**:
