### PR TITLE
#6948 check file labels on new draft

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/Dataset.java
+++ b/src/main/java/edu/harvard/iq/dataverse/Dataset.java
@@ -336,6 +336,7 @@ public class Dataset extends DvObjectContainer {
                 newFm.setDataFile(fm.getDataFile());
                 newFm.setDatasetVersion(dsv);
                 newFm.setProvFreeForm(fm.getProvFreeForm());
+                newFm.setInPriorVersion(true);
 
                 //fmVarMet would be updated in DCT
                 if ((fmVarMet != null && !fmVarMet.getId().equals(fm.getId())) || (fmVarMet == null))  {

--- a/src/main/java/edu/harvard/iq/dataverse/FileMetadata.java
+++ b/src/main/java/edu/harvard/iq/dataverse/FileMetadata.java
@@ -449,6 +449,17 @@ public class FileMetadata implements Serializable {
     public void setVersion(Long version) {
         this.version = version;
     }
+    
+    @Transient
+    private boolean inPriorVersion;
+
+    public boolean isInPriorVersion() {
+        return inPriorVersion;
+    }
+
+    public void setInPriorVersion(boolean inPriorVersion) {
+        this.inPriorVersion = inPriorVersion;
+    }
 
     @Transient
     private boolean selected;

--- a/src/main/java/edu/harvard/iq/dataverse/ingest/IngestUtil.java
+++ b/src/main/java/edu/harvard/iq/dataverse/ingest/IngestUtil.java
@@ -248,9 +248,10 @@ public class IngestUtil {
         // create list of existing path names from all FileMetadata in the DatasetVersion
         // (skipping the one specified fileMetadata, if supplied. That's in order to 
         // be able to call this method 
+        // #6942 added proxy for existing files to a boolean set when dataset version copy is done
         for (Iterator<FileMetadata> fmIt = version.getFileMetadatas().iterator(); fmIt.hasNext();) {
             FileMetadata fm = fmIt.next();
-            if (fm.getId() != null && (fileMetadata == null || !fm.getId().equals(fileMetadata.getId()))) {
+            if ((fm.isInPriorVersion() || fm.getId() != null) && (fileMetadata == null || !fm.getId().equals(fileMetadata.getId()))) {
                 String existingName = fm.getLabel();
                 String existingDir = fm.getDirectoryLabel();
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a bug in which duplicate file names are allowed to saved in the case where the user is creating a new dataset version with the file upload.

**Which issue(s) this PR closes**:

Closes #6948 

**Special notes for your reviewer**:
Pretty simple, I added a transient boolean to the file metadata to mark a metadata as existing in the previous version - the code had relied on the file metadata id for this, but it is null when a new edit version is created.

**Suggestions on how to test this**:
Upload a file that has the same name as a file in the current version of a dataset (but not the same content, because we aren't allowing that in dev, yet) and see that the file gets a -1 or -2 etc as applicable. This should happen in the file upload is done to a published version or an existing draft version.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
No
**Is there a release notes update needed for this change?**:
No. It's a fairly minor bug fix

**Additional documentation**:
None