### PR TITLE
#7023 Replace xml response substring in logging with URL parameters. …

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/harvest/client/FastGetRecord.java
+++ b/src/main/java/edu/harvard/iq/dataverse/harvest/client/FastGetRecord.java
@@ -385,7 +385,7 @@ public class FastGetRecord {
             } catch (XMLStreamException ex) {
                 //Logger.getLogger("global").log(Level.SEVERE, null, ex);
                 if (this.errorMessage == null) {
-                    this.errorMessage = "Malformed GetRecord response: " + oaiResponseHeader;
+                    this.errorMessage = "Malformed GetRecord response; baseURL=" + baseURL + ", identifier=" + identifier + ", metadataPrefix=" + metadataPrefix;
                 }
 
                 // delete the temp metadata file; we won't need it:
@@ -413,10 +413,7 @@ public class FastGetRecord {
             }
 
             if (!(metadataWritten) && !(this.isDeleted())) {
-                if (oaiResponseHeader.length() > 64) {
-                    oaiResponseHeader = oaiResponseHeader.substring(0, 32) + "...";
-                }
-                this.errorMessage = "Failed to parse GetRecord response; "+oaiResponseHeader;
+                this.errorMessage = "Failed to parse GetRecord response; baseURL=" + baseURL + ", identifier=" + identifier + ", metadataPrefix=" + metadataPrefix;
                 //savedMetadataFile.delete();
             }
 


### PR DESCRIPTION
…Couldn't write the whole URL because the "&" gets written as the character entity "\&amp;" as the log is an XML.

**What this PR does / why we need it**: Improve logging for debugging purposes

**Which issue(s) this PR closes**: 7023

Closes #7023 

**Special notes for your reviewer**: Already tested it locally.

**Suggestions on how to test this**: Run a harvest on https://dataverse.nl/oai with oai_dc as prefix and dataversenl as set. Around line 68642 of the log you will see the line. Search for "Error calling GetRecord - Failed to parse GetRecord response".

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: No

**Is there a release notes update needed for this change?**: No

**Additional documentation**:
