### PR TITLE
6915-feature-builtin-users-sendEmailNotification-new-optionalParameter

### DIFF
--- a/doc/sphinx-guides/source/api/native-api.rst
+++ b/doc/sphinx-guides/source/api/native-api.rst
@@ -2311,6 +2311,8 @@ Place this ``user-add.json`` file in your current directory and run the followin
 
   curl -d @user-add.json -H "Content-type:application/json" "$SERVER_URL/api/builtin-users?password=$NEWUSER_PASSWORD&key=$BUILTIN_USERS_KEY"
 
+Optionally, you may use a third query parameter "sendEmailNotification=false" to explicitly disable sending an email notification to the new user.
+
 Roles
 -----
 

--- a/src/main/java/edu/harvard/iq/dataverse/api/BuiltinUsers.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/BuiltinUsers.java
@@ -84,8 +84,8 @@ public class BuiltinUsers extends AbstractApiBean {
     //and use the values to create BuiltinUser/AuthenticatedUser.
     //--MAD 4.9.3
     @POST
-    public Response save(BuiltinUser user, @QueryParam("password") String password, @QueryParam("key") String key) {
-        return internalSave(user, password, key);
+    public Response save(BuiltinUser user, @QueryParam("password") String password, @QueryParam("key") String key, @DefaultValue("true") @QueryParam("sendEmailNotification") String sendEmailNotification) {
+        return internalSave(user, password, key, sendEmailNotification);
     }
 
     /**
@@ -105,9 +105,10 @@ public class BuiltinUsers extends AbstractApiBean {
         return internalSave(user, password, key);
     }
     
-    //TODO: detailed description 
     /**
-     * Created this for #6915....
+     * Created this new endpoint to resolve issue #6915, optionally preventing 
+     * the email notification to the new user on account creation by adding 
+     * "false" as the third path parameter.
      *
      * @param user
      * @param password

--- a/src/main/java/edu/harvard/iq/dataverse/api/BuiltinUsers.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/BuiltinUsers.java
@@ -105,7 +105,28 @@ public class BuiltinUsers extends AbstractApiBean {
         return internalSave(user, password, key);
     }
     
+    //TODO: detailed description 
+    /**
+     * Created this for #6915...
+     *
+     * @param user
+     * @param password
+     * @param key
+     * @param sendEmailNotification
+     * @return
+     */
+    @POST
+    @Path("{password}/{key}/{sendEmailNotification}")
+    public Response create(BuiltinUser user, @PathParam("password") String password, @PathParam("key") String key, @PathParam("sendEmailNotification") Boolean sendEmailNotification) {
+        return internalSave(user, password, key, sendEmailNotification);
+    }
+    
+    // internalSave without providing an explicit "sendEmailNotification"
     private Response internalSave(BuiltinUser user, String password, String key) {
+        return internalSave(user, password, key, true);
+    }
+    
+    private Response internalSave(BuiltinUser user, String password, String key, Boolean sendEmailNotification) {
         String expectedKey = settingsSvc.get(API_KEY_IN_SETTINGS);
         
         if (expectedKey == null) {
@@ -149,7 +170,7 @@ public class BuiltinUsers extends AbstractApiBean {
             } catch (Exception e) {
                 logger.info("The root dataverse is not present. Don't send a notification to dataverseAdmin.");
             }
-            if (rootDataversePresent) {
+            if (rootDataversePresent && sendEmailNotification) {
                 userNotificationSvc.sendNotification(au,
                         new Timestamp(new Date().getTime()),
                         UserNotification.Type.CREATEACC, null);
@@ -188,3 +209,12 @@ public class BuiltinUsers extends AbstractApiBean {
     }
 
 }
+
+
+
+
+
+
+
+
+

--- a/src/main/java/edu/harvard/iq/dataverse/api/BuiltinUsers.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/BuiltinUsers.java
@@ -84,7 +84,10 @@ public class BuiltinUsers extends AbstractApiBean {
     //and use the values to create BuiltinUser/AuthenticatedUser.
     //--MAD 4.9.3
     @POST
-    public Response save(BuiltinUser user, @QueryParam("password") String password, @QueryParam("key") String key, @DefaultValue("true") @QueryParam("sendEmailNotification") String sendEmailNotification) {
+    public Response save(BuiltinUser user, @QueryParam("password") String password, @QueryParam("key") String key, @QueryParam("sendEmailNotification") Boolean sendEmailNotification) {   
+        if( sendEmailNotification == null )
+            sendEmailNotification = true;
+        
         return internalSave(user, password, key, sendEmailNotification);
     }
 
@@ -210,6 +213,10 @@ public class BuiltinUsers extends AbstractApiBean {
     }
 
 }
+
+
+
+
 
 
 

--- a/src/main/java/edu/harvard/iq/dataverse/api/BuiltinUsers.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/BuiltinUsers.java
@@ -107,7 +107,7 @@ public class BuiltinUsers extends AbstractApiBean {
     
     //TODO: detailed description 
     /**
-     * Created this for #6915...
+     * Created this for #6915....
      *
      * @param user
      * @param password


### PR DESCRIPTION
**What this PR does / why we need it**:
Allow to disable sending an email for confirmation after creating a user.

**Which issue(s) this PR closes**:
Closes none, but solves part of #6915 

**Special notes for your reviewer**:
We don't have a dev server, so there was no local testing yet.

**Suggestions on how to test this**:
Create and edit users with the builtin-users API with and without explicitly submitting PathParam with 
@POST
@Path("{password}/{key}/{sendEmailNotification}")

and as QueryParam with

@POST
...and &sendEmailNotification=...

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
NO

**Is there a release notes update needed for this change?**:
could be a new small feature to mention

**Additional documentation**:
see doc/sphinx-guides/source/api/native-api.rst
