### PR TITLE
point Jenkinsfile at GlobalDataverseCommunityConsortium/dataver…

### DIFF
--- a/tests/jenkins/ec2/Jenkinsfile
+++ b/tests/jenkins/ec2/Jenkinsfile
@@ -24,9 +24,9 @@ pipeline {
             env.EC2_REPO = env.GIT_URL
           }
         }
-	sh '/usr/bin/curl -O https://raw.githubusercontent.com/IQSS/dataverse-ansible/master/ec2/ec2-create-instance.sh'
+	sh '/usr/bin/curl -O https://raw.githubusercontent.com/GlobalDataverseCommunityConsortium/dataverse-ansible/master/ec2/ec2-create-instance.sh'
 	sh '/bin/rm -f groupvars.yml'
-	sh '/usr/bin/curl -o groupvars.yml https://raw.githubusercontent.com/IQSS/dataverse-ansible/master/tests/group_vars/jenkins.yml'
+	sh '/usr/bin/curl -o groupvars.yml https://raw.githubusercontent.com/GlobalDataverseCommunityConsortium/dataverse-ansible/master/tests/group_vars/jenkins.yml'
 	sh '/usr/bin/bash ec2-create-instance.sh -b ${CHANGE_BRANCH} -r ${EC2_REPO} -t jenkins_delete_me -l target -g groupvars.yml -s t2.large -d'
       }
     }


### PR DESCRIPTION
**What this PR does / why we need it**: As a community-supported project, dataverse-ansible has moved to the GlobalDataverseCommunityConsortium GitHub organization. 

**Which issue(s) this PR closes**:

Closes #7034

**Special notes for your reviewer**: none

**Suggestions on how to test this**: check https://jenkins.dataverse.org/job/IQSS-Dataverse-Develop-PR/

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: no

**Is there a release notes update needed for this change?**: no

**Additional documentation**: none
