### PR TITLE
7052 Fix infinite IN PROGRESS and DELETE IN PROGRESS labels

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/harvest/client/ClientHarvestRun.java
+++ b/src/main/java/edu/harvard/iq/dataverse/harvest/client/ClientHarvestRun.java
@@ -5,9 +5,16 @@
  */
 package edu.harvard.iq.dataverse.harvest.client;
 
-import javax.persistence.*;
 import java.io.Serializable;
 import java.util.Date;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
 
 /**
  *

--- a/src/main/java/edu/harvard/iq/dataverse/harvest/client/HarvestingClientServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/harvest/client/HarvestingClientServiceBean.java
@@ -1,20 +1,28 @@
 package edu.harvard.iq.dataverse.harvest.client;
 
-import edu.harvard.iq.dataverse.*;
+import edu.harvard.iq.dataverse.DataFile;
+import edu.harvard.iq.dataverse.DataFileServiceBean;
+import edu.harvard.iq.dataverse.DataverseRequestServiceBean;
+import edu.harvard.iq.dataverse.DataverseServiceBean;
+import edu.harvard.iq.dataverse.EjbDataverseEngine;
 import edu.harvard.iq.dataverse.search.IndexServiceBean;
 import edu.harvard.iq.dataverse.timer.DataverseTimerServiceBean;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.logging.Logger;
+import javax.ejb.Asynchronous;
+import javax.ejb.EJB;
+import javax.ejb.Stateless;
+import javax.ejb.TransactionAttribute;
+import javax.ejb.TransactionAttributeType;
 
-import javax.ejb.*;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.persistence.EntityManager;
 import javax.persistence.NoResultException;
 import javax.persistence.NonUniqueResultException;
 import javax.persistence.PersistenceContext;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-import java.util.logging.Logger;
 
 /**
  *

--- a/src/main/java/edu/harvard/iq/dataverse/harvest/client/ResetHarvestInProgressBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/harvest/client/ResetHarvestInProgressBean.java
@@ -1,0 +1,23 @@
+package edu.harvard.iq.dataverse.harvest.client;
+
+import javax.annotation.PostConstruct;
+import javax.ejb.EJB;
+import javax.ejb.Singleton;
+import javax.ejb.Startup;
+
+@Singleton
+@Startup
+public class ResetHarvestInProgressBean {
+
+    @EJB
+    HarvestingClientServiceBean harvestingClientService;
+
+    @PostConstruct
+    public void init() {
+        for (HarvestingClient client : harvestingClientService.getAllHarvestingClients()) {
+            harvestingClientService.resetHarvestInProgress(client.getId());
+            harvestingClientService.resetDeleteInProgress(client.getId());
+        }
+    }
+
+}


### PR DESCRIPTION
**What this PR does / why we need it**: Fixes infinite IN PROGRESS and DELETE IN PROGRESS labels

**Which issue(s) this PR closes**: 7052

Closes #7052 

**Special notes for your reviewer**: People will be happy about this

**Suggestions on how to test this**: Run a harvesting client and delete another one at the same time, then restart Glassfish immediately when you see the IN PROGRESS and DELETE IN PROGRESS labels. After you're done restarting you'll see the RUN FAILED AND DELETE FAILED labels instead of the old ones and you can edit the client again. So you can rerun or delete like normally.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: Yes

![image](https://user-images.githubusercontent.com/16444164/86504188-e19b4100-bdb5-11ea-83a5-5b9fc877c4a8.png)


**Is there a release notes update needed for this change?**: Yes, it's a noticeable change.

**Additional documentation**: N/A
