### PR TITLE
#7051 Fix select version on publish

### DIFF
--- a/src/main/webapp/dataset.xhtml
+++ b/src/main/webapp/dataset.xhtml
@@ -1589,7 +1589,7 @@
                         </ui:fragment>
                         <div class="button-block">
                             <p:commandButton styleClass="btn btn-default" value="#{bundle.continue}" 
-                                             onclick="PF('publishDataset').hide();PF('blockDatasetForm').hide();" action="#{DatasetPage.releaseDataset}" immediate="true"/>
+                                             onclick="PF('publishDataset').hide();PF('blockDatasetForm').hide();" action="#{DatasetPage.releaseDataset}" />
                             <button class="btn btn-link" onclick="PF('publishDataset').hide();PF('blockDatasetForm').hide();" type="button">
                                 #{bundle.cancel}
                             </button>


### PR DESCRIPTION
**What this PR does / why we need it**:
In the case where the user is allowed to select the type of version on publish (minor v. major) selecting major wasn't working.

**Which issue(s) this PR closes**:

Closes #7051 Publish Dataset only minor version released even if major is selected.

**Special notes for your reviewer**:
My guess for what happened here was that when I consolidated the publish popups I used a continue button from a popup where there wasn't a choice of version to release so the immediate = true didn't matter, but it does matter when there is a choice and its presence was blocking the update of the radio button

**Suggestions on how to test this**:
Verify that all selection of type of release are working (even "update current version - only available to super users)

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
No
**Is there a release notes update needed for this change?**:
No

**Additional documentation**:
None