### PR TITLE
4597 Fix invalid identify response.

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/harvest/server/xoai/XdataProvider.java
+++ b/src/main/java/edu/harvard/iq/dataverse/harvest/server/xoai/XdataProvider.java
@@ -6,6 +6,7 @@ import com.lyncode.xoai.dataprovider.exceptions.*;
 import com.lyncode.xoai.dataprovider.handlers.*;
 import com.lyncode.xoai.exceptions.InvalidResumptionTokenException;
 import com.lyncode.xoai.dataprovider.model.Context;
+import com.lyncode.xoai.model.oaipmh.Identify;
 import com.lyncode.xoai.model.oaipmh.OAIPMH;
 import com.lyncode.xoai.model.oaipmh.Request;
 import com.lyncode.xoai.dataprovider.parameters.OAICompiledRequest;
@@ -76,7 +77,9 @@ public class XdataProvider {
 
             switch (request.getVerbType()) {
                 case Identify:
-                    response.withVerb(identifyHandler.handle(parameters));
+                    Identify identify = identifyHandler.handle(parameters);
+                    identify.getDescriptions().clear(); // We don't want to use the default description
+                    response.withVerb(identify);
                     break;
                 case ListSets:
                     response.withVerb(listSetsHandler.handle(parameters));


### PR DESCRIPTION
**What this PR does / why we need it**: Changes the Identify response for a OAI PMH request so it's XSD valid.

**Which issue(s) this PR closes**: 4597

Closes #4597 

**Special notes for your reviewer**: It's looking good

**Suggestions on how to test this**: Example call: https://dataverse.harvard.edu/oai?verb=Identify

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: No

**Is there a release notes update needed for this change?**: Perhaps

**Additional documentation**:
