### PR TITLE
7054 payara bom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,11 +26,8 @@
         <skipUnitTests>false</skipUnitTests>
     
         <jakartaee-api.version>8.0.0</jakartaee-api.version>
-        <!-- Make this correspond to the version used in Payara: 5.201 uses (patched) 2.3.14 -->
-        <mojarra.version>2.3.14</mojarra.version>
+        <payara.version>5.2020.2</payara.version>
         <aws.version>1.11.762</aws.version>
-        <!-- Should always correspond with Payara bundled version: 5.201 uses 2.10.2 -->
-        <jackson.version>2.10.2</jackson.version>
         <commons.logging.version>1.2</commons.logging.version>
         <httpcomponents.client.version>4.5.5</httpcomponents.client.version>
         <junit.version>4.12</junit.version>
@@ -90,24 +87,35 @@
             <name>Local repository for hosting jars not available from network repositories.</name>
             <url>file://${project.basedir}/local_lib</url>
         </repository>
+        <repository>
+            <id>payara-patched-externals</id>
+            <name>Payara Patched Externals</name>
+            <url>https://raw.github.com/payara/Payara_PatchedProjects/master</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
     </repositories>
     <!-- Transitive dependencies, bigger library "bill of materials" (BOM) and
          versions of dependencies used both directly and transitive are managed here. -->
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>fish.payara.api</groupId>
+                <artifactId>payara-bom</artifactId>
+                <version>${payara.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
                 <groupId>com.amazonaws</groupId>
                 <artifactId>aws-java-sdk-bom</artifactId>
                 <version>${aws.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson</groupId>
-                <artifactId>jackson-bom</artifactId>
-                <version>${jackson.version}</version>
-                <scope>import</scope>
-                <type>pom</type>
             </dependency>
             <dependency>
                 <groupId>commons-logging</groupId>
@@ -268,7 +276,6 @@
         <dependency>
             <groupId>org.glassfish</groupId>
             <artifactId>jakarta.faces</artifactId>
-            <version>${mojarra.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,17 @@
         This isn't well documented and seems to change between maven versions -MAD 4.9.4 -->
     <repositories>
         <repository>
+            <id>payara-patched-externals</id>
+            <name>Payara Patched Externals</name>
+            <url>https://raw.github.com/payara/Payara_PatchedProjects/master</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+        <repository>
             <id>central-repo</id>
             <name>Central Repository</name>
             <url>https://repo1.maven.org/maven2</url>
@@ -86,17 +97,6 @@
             <id>dvn.private</id>
             <name>Local repository for hosting jars not available from network repositories.</name>
             <url>file://${project.basedir}/local_lib</url>
-        </repository>
-        <repository>
-            <id>payara-patched-externals</id>
-            <name>Payara Patched Externals</name>
-            <url>https://raw.github.com/payara/Payara_PatchedProjects/master</url>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
         </repository>
     </repositories>
     <!-- Transitive dependencies, bigger library "bill of materials" (BOM) and


### PR DESCRIPTION
**What this PR does / why we need it**:
A lot of libraries used by us (and again by those libs) are provided by the Payara application server.

There is no need to bundle those in our WAR (making it smaller) and it's always a good idea to keep things inline with each other, to avoid conflicts between libraries. The newly released Payara BOM is making this significantly easier for basic libraries as Jackson, Jakarta, etc.

Also, our application server maintains a few patched versions of libraries. A good example is the JSF patch recently removed (see #7036), now being bundled with the upstream installation. This change to `pom.xml` includes the repository of these patched versions, so we use them locally and during tests, too.

**Which issue(s) this PR closes**:

Closes #7054 

**Special notes for your reviewer**:
The Jackson BOM has been removed due to the fact that the Payara BOM already provides that one.

**Suggestions on how to test this**:
Nada. Usual things. I didn't move much (the deps cleanup is still to come), so this should not have a bigger impact.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
Nada.

**Is there a release notes update needed for this change?**:
Nada.

**Additional documentation**:
https://blog.payara.fish/align-dependencies-with-payara-bom