### PR TITLE
update lastApiUseTime in a new transaction

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/UserServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/UserServiceBean.java
@@ -13,6 +13,8 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import javax.ejb.EJB;
 import javax.ejb.Stateless;
+import javax.ejb.TransactionAttribute;
+import javax.ejb.TransactionAttributeType;
 import javax.inject.Named;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
@@ -532,6 +534,7 @@ public class UserServiceBean {
         return save(user);
     }
 
+    @TransactionAttribute(TransactionAttributeType.REQUIRES_NEW)
     public AuthenticatedUser updateLastApiUseTime(AuthenticatedUser user) {
         //assumes that AuthenticatedUser user already exists
         user.setLastApiUseTime(new Timestamp(new Date().getTime()));


### PR DESCRIPTION
**What this PR does / why we need it**: Stops long-running API calls from blocking others from the same user

**Which issue(s) this PR closes**:

Closes #7061 

**Special notes for your reviewer**:

**Suggestions on how to test this**:  My testing involved uploading a large file (e.g. >1 GB), calling
curl -H X-Dataverse-key:<apiKey> -X POST http://localhost:8080/api/admin/validateDataFileHashValue/<fileId>
and, before it finishes, 
curl -H X-Dataverse-key:<sameApiKey> http://localhost:8080/api/datasets/2

Prior to this PR, the second call won't return an answer until the first finishes (A 1 GB file was giving me ~20-30 seconds to try other api calls). After the PR, it should return immediately. Both before and after the PR, using a different apiKey for the second call will cause it to return immediately.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: No

**Is there a release notes update needed for this change?**: No

**Additional documentation**: none
