### PR TITLE
Fix for #7060 direct download causes RedirectException

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/api/BundleDownloadInstanceWriter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/BundleDownloadInstanceWriter.java
@@ -12,12 +12,12 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.IOException;
 
+import javax.ws.rs.InternalServerErrorException;
+import javax.ws.rs.NotFoundException;
 import javax.ws.rs.WebApplicationException;
 
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.core.Response;
-
 import javax.ws.rs.ext.MessageBodyWriter;
 import javax.ws.rs.ext.Provider;
 
@@ -196,10 +196,10 @@ public class BundleDownloadInstanceWriter implements MessageBodyWriter<BundleDow
                 }
             }
         } catch (IOException ioex) {
-            throw new WebApplicationException(Response.Status.INTERNAL_SERVER_ERROR);
+            throw new InternalServerErrorException();
         }
 
-        throw new WebApplicationException(Response.Status.NOT_FOUND);
+        throw new NotFoundException();
 
     }
 

--- a/src/main/java/edu/harvard/iq/dataverse/api/DownloadInstanceWriter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/DownloadInstanceWriter.java
@@ -244,7 +244,7 @@ public class DownloadInstanceWriter implements MessageBodyWriter<DownloadInstanc
                         }
                         
                         if (redirect_url_str == null) {
-                            throw new WebApplicationException(new ServiceUnavailableException());
+                            throw new ServiceUnavailableException();
                         }
                         
                         logger.fine("Data Access API: direct S3 url: "+redirect_url_str);
@@ -274,7 +274,7 @@ public class DownloadInstanceWriter implements MessageBodyWriter<DownloadInstanc
                             logger.fine("Issuing redirect to the file location on S3.");
                             throw new RedirectionException(response);
                         }
-                        throw new WebApplicationException(new ServiceUnavailableException());
+                        throw new ServiceUnavailableException();
                     }
                 }
                 
@@ -368,7 +368,7 @@ public class DownloadInstanceWriter implements MessageBodyWriter<DownloadInstanc
             }
         }
         
-        throw new WebApplicationException(Response.Status.NOT_FOUND);
+        throw new NotFoundException();
 
     }
     

--- a/src/main/java/edu/harvard/iq/dataverse/api/errorhandlers/InternalServerErrorExceptionHandler.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/errorhandlers/InternalServerErrorExceptionHandler.java
@@ -1,0 +1,39 @@
+package edu.harvard.iq.dataverse.api.errorhandlers;
+
+import java.util.UUID;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.json.Json;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.InternalServerErrorException;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+/**
+ * Produces custom 500 messages for the API.
+ * @author qqmyers
+ */
+@Provider
+public class InternalServerErrorExceptionHandler implements ExceptionMapper<InternalServerErrorException>{
+    
+    private static final Logger logger = Logger.getLogger(InternalServerErrorExceptionHandler.class.getName());
+    
+    @Context
+    HttpServletRequest request;
+    
+    @Override
+    public Response toResponse(InternalServerErrorException ex){
+        String incidentId = UUID.randomUUID().toString();
+        logger.log(Level.SEVERE, "API internal error " + incidentId +": " + ex.getMessage(), ex);
+        return Response.status(500)
+                .entity( Json.createObjectBuilder()
+                             .add("status", "ERROR")
+                             .add("code", 500)
+                             .add("message", "Internal server error. More details available at the server logs.")
+                             .add("incidentId", incidentId)
+                        .build())
+                .type("application/json").build();
+    }
+}

--- a/src/main/java/edu/harvard/iq/dataverse/api/errorhandlers/RedirectionExceptionHandler.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/errorhandlers/RedirectionExceptionHandler.java
@@ -1,0 +1,32 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package edu.harvard.iq.dataverse.api.errorhandlers;
+
+import edu.harvard.iq.dataverse.util.BundleUtil;
+import javax.json.Json;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.RedirectionException;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+/**
+ *
+ * @author qqmyers
+ */
+@Provider
+public class RedirectionExceptionHandler implements ExceptionMapper<RedirectionException> {
+    
+    @Context
+    HttpServletRequest request;
+
+    @Override
+    public Response toResponse(RedirectionException ex) {
+        return ex.getResponse();
+    }
+    
+}


### PR DESCRIPTION
**What this PR does / why we need it**: Allows download redirects

**Which issue(s) this PR closes**:

Closes #7060 direct download causes RedirectException

**Special notes for your reviewer**: Don't know why this is needed now and wasn't needed in 4.20

**Suggestions on how to test this**: Use S3, turn on download redirects - it should work (and won't without this PR)

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: no

**Is there a release notes update needed for this change?**: no

**Additional documentation**:
