### PR TITLE
Fix stored procedure issue for #7069

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/Dataset.java
+++ b/src/main/java/edu/harvard/iq/dataverse/Dataset.java
@@ -74,7 +74,7 @@ import edu.harvard.iq.dataverse.util.StringUtil;
         name = "Dataset.generateIdentifierAsSequentialNumber",
         procedureName = "generateIdentifierAsSequentialNumber",
         parameters = {
-            @StoredProcedureParameter(mode = ParameterMode.OUT, type = Integer.class, name = "identifier")
+            @StoredProcedureParameter(mode = ParameterMode.OUT, type = Integer.class)
         }
 )
 @Entity


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes failing tests.

**Which issue(s) this PR closes**:

Closes #7069 

**Special notes for your reviewer**:
I removed the name parameter - from what I can tell it is optional and it is the only thing we are returning, so I don't expect it is needed

**Suggestions on how to test this**:
Set identifer types to sequential and verify they still work

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
No

**Is there a release notes update needed for this change?**:
No

**Additional documentation**:

Issue seems to have been introduced with latest upgrade to Payara (5.2020-2). They upgraded EclipseLink and the newer version uses CallableStatement. Callable Statements with named parameters are not supported by JDBC. 

Some reference links for the curious:
Payara / Eclipse Link upgrade ref: https://github.com/payara/Payara/pull/4643

The specific commit that is new: https://github.com/payara/patched-src-eclipselink/commit/9e0c28228c3e23e64c87fdc3e9369f4f8dcd88fd#diff-5667a25c13f2822ab368e675ef8287f8

A quote from: https://vladmihalcea.com/how-to-call-postgresql-functions-from-hibernate/

"When calling a PostgreSQL function through the JDBC API, parameters must be supplied by index and not by name, as otherwise the following exception is thrown:

 java.sql.SQLFeatureNotSupportedException: Method org.postgresql.jdbc4.Jdbc4CallableStatement.registerOutParameter(String,int) is not yet implemented."




