### PR TITLE
sphinx-build: fail on warning

### DIFF
--- a/doc/sphinx-guides/Makefile
+++ b/doc/sphinx-guides/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
+SPHINXOPTS    = -W
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = build


### PR DESCRIPTION
**What this PR does / why we need it**: a growing number of warnings during sphinx-build of guides

**Which issue(s) this PR closes**:

Closes #7092

**Special notes for your reviewer**: change made per https://documentation.help/Sphinx/invocation.html

**Suggestions on how to test this**: insert garbage into one of the guide files, expect sphinx-build to fail:

`Warning, treated as error:
/home/worker/workspace/OdumInstitute-Guides-PR_PR-37/doc/sphinx-guides/source/admin/index.rst:document isn't included in any toctree`

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: no

**Is there a release notes update needed for this change?**: no(?)

**Additional documentation**: none
