### PR TITLE
6865 index fix 1 for deadlocks

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/FinalizeDatasetPublicationCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/FinalizeDatasetPublicationCommand.java
@@ -204,7 +204,6 @@ public class FinalizeDatasetPublicationCommand extends AbstractPublishDatasetCom
             retVal = false;
         }
 
-        ctxt.solrIndex().indexPermissionsForOneDvObject(dataset);
         exportMetadata(dataset, ctxt.settings());
         ctxt.datasets().updateLastExportTimeStamp(dataset.getId());
         return retVal;

--- a/src/main/java/edu/harvard/iq/dataverse/search/SolrIndexServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/search/SolrIndexServiceBean.java
@@ -429,8 +429,8 @@ public class SolrIndexServiceBean {
              * @todo do something with this response
              */
             IndexResponse indexResponse = indexPermissionsForOneDvObject(dvObject);
-            updatePermissionTimeSuccessStatus.add(dvObject + ":" + updatePermissionTimeSuccessful);
         }
+        
         return new IndexResponse("Number of dvObject permissions indexed for " + definitionPoint
                 + ": " + dvObjectsToReindexPermissionsFor.size()
         );

--- a/src/main/java/edu/harvard/iq/dataverse/search/SolrIndexServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/search/SolrIndexServiceBean.java
@@ -423,7 +423,6 @@ public class SolrIndexServiceBean {
          */
         String response = reindexFilesInBatches(filesToReindexAsBatch);
 
-        List<String> updatePermissionTimeSuccessStatus = new ArrayList<>();
         for (DvObject dvObject : dvObjectsToReindexPermissionsFor) {
             /**
              * @todo do something with this response

--- a/src/main/java/edu/harvard/iq/dataverse/search/SolrIndexServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/search/SolrIndexServiceBean.java
@@ -405,8 +405,6 @@ public class SolrIndexServiceBean {
                 }
             }
         } else if (definitionPoint.isInstanceofDataset()) {
-            // index the dataset itself
-            indexPermissionsForOneDvObject(definitionPoint);
             dvObjectsToReindexPermissionsFor.add(definitionPoint);
             // index files
             Dataset dataset = (Dataset) definitionPoint;
@@ -431,16 +429,10 @@ public class SolrIndexServiceBean {
              * @todo do something with this response
              */
             IndexResponse indexResponse = indexPermissionsForOneDvObject(dvObject);
-            DvObject managedDefinitionPoint = dvObjectService.updatePermissionIndexTime(definitionPoint);
-            boolean updatePermissionTimeSuccessful = false;
-            if (managedDefinitionPoint != null) {
-                updatePermissionTimeSuccessful = true;
-            }
             updatePermissionTimeSuccessStatus.add(dvObject + ":" + updatePermissionTimeSuccessful);
         }
         return new IndexResponse("Number of dvObject permissions indexed for " + definitionPoint
-                + " (updatePermissionTimeSuccessful:" + updatePermissionTimeSuccessStatus
-                + "): " + dvObjectsToReindexPermissionsFor.size()
+                + ": " + dvObjectsToReindexPermissionsFor.size()
         );
     }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes some extraneous indexing that is not needed and has been a factor in the deadlocks

**Which issue(s) this PR closes**:

Helps with #6865

**Special notes for your reviewer**:
Confirm that these index calls were in fact extraneous and not needed.


**Suggestions on how to test this**:
Make sure indexing still works as expected, in particular in regards to permissions.


**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
no

**Is there a release notes update needed for this change?**:
no

**Additional documentation**:
Still need some more work for in order to close: #6865