### PR TITLE
restore code from #2471, changes to merge that with new pid api

### DIFF
--- a/doc/sphinx-guides/source/api/native-api.rst
+++ b/doc/sphinx-guides/source/api/native-api.rst
@@ -2594,7 +2594,7 @@ The fully expanded example above (without environment variables) looks like this
 Delete a PID
 ~~~~~~~~~~~~
 
-Delete PID from DataCite (this is only possible for PIDs that are in the "draft" state) and within Dataverse, set ``globalidcreatetime`` to null and ``identifierregistered`` to false. A superuser API token is required.
+Delete PID (this is only possible for PIDs that are in the "draft" state) and within Dataverse, set ``globalidcreatetime`` to null and ``identifierregistered`` to false. A superuser API token is required.
 
 .. note:: See :ref:`curl-examples-and-environment-variables` if you are unfamiliar with the use of export below.
 

--- a/src/main/java/edu/harvard/iq/dataverse/DOIDataCiteServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DOIDataCiteServiceBean.java
@@ -187,14 +187,11 @@ public class DOIDataCiteServiceBean extends AbstractGlobalIdServiceBean {
     public void deleteIdentifier(DvObject dvObject) throws IOException, HttpException {
         logger.log(Level.FINE,"deleteIdentifier");
         String identifier = getIdentifier(dvObject);
-        Map<String, String> doiMetadata = new HashMap<>();
-        try {
-            doiMetadata = doiDataCiteRegisterService.getMetadata(identifier);
-        } catch (Exception e) {
-            logger.log(Level.WARNING, "deleteIdentifier: get matadata failed. " + e.getMessage(), e);
-        }
-
-        String idStatus = doiMetadata.get("_status");
+        //ToDo - PidUtils currently has a DataCite API call that would get the status at DataCite for this identifier - that could be more accurate than assuming based on whether the dvObject has been published
+        String idStatus = DRAFT;
+        if(dvObject.isReleased()) {
+        	idStatus = PUBLIC;
+        } 
         if ( idStatus != null ) {
             switch ( idStatus ) {
                 case RESERVED:

--- a/src/main/java/edu/harvard/iq/dataverse/SettingsWrapper.java
+++ b/src/main/java/edu/harvard/iq/dataverse/SettingsWrapper.java
@@ -251,6 +251,15 @@ public class SettingsWrapper implements java.io.Serializable {
         }
     }
 
+    public boolean isDataCiteInstallation() {
+        String protocol = getValueForKey(SettingsServiceBean.Key.DoiProvider);
+        if ("DataCite".equals(protocol)) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
     public boolean isMakeDataCountDisplayEnabled() {
         boolean safeDefaultIfKeyNotFound = (getValueForKey(SettingsServiceBean.Key.MDCLogPath)!=null); //Backward compatible
         return isTrueForKey(SettingsServiceBean.Key.DisplayMDCMetrics, safeDefaultIfKeyNotFound);

--- a/src/main/java/edu/harvard/iq/dataverse/SettingsWrapper.java
+++ b/src/main/java/edu/harvard/iq/dataverse/SettingsWrapper.java
@@ -251,15 +251,6 @@ public class SettingsWrapper implements java.io.Serializable {
         }
     }
 
-    public boolean isDataCiteInstallation() {
-        String protocol = getValueForKey(SettingsServiceBean.Key.DoiProvider);
-        if ("DataCite".equals(protocol)) {
-            return true;
-        } else {
-            return false;
-        }
-    }
-
     public boolean isMakeDataCountDisplayEnabled() {
         boolean safeDefaultIfKeyNotFound = (getValueForKey(SettingsServiceBean.Key.MDCLogPath)!=null); //Backward compatible
         return isTrueForKey(SettingsServiceBean.Key.DisplayMDCMetrics, safeDefaultIfKeyNotFound);

--- a/src/main/java/edu/harvard/iq/dataverse/api/Pids.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Pids.java
@@ -104,6 +104,12 @@ public class Pids extends AbstractApiBean {
     public Response deletePid(@PathParam("id") String idSupplied) {
         try {
             Dataset dataset = findDatasetOrDie(idSupplied);
+            //Restrict to never-published datasets (that should have draft/nonpublic pids). The underlying code will invalidate
+            //pids that have been made public by a pid-specific method, but it's not clear that invalidating such a pid via an api that doesn't
+            //destroy the dataset is a good idea.
+            if(dataset.isReleased()) {
+            	return badRequest("Not allowed for Datasets that have been published.");
+            }
             execCommand(new DeletePidCommand(createDataverseRequest(findUserOrDie()), dataset));
             return ok(BundleUtil.getStringFromBundle("pids.api.deletePid.success", Arrays.asList(dataset.getGlobalId().asString())));
         } catch (WrappedResponse ex) {

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/DeletePidCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/DeletePidCommand.java
@@ -46,22 +46,13 @@ public class DeletePidCommand extends AbstractVoidCommand {
         String protocol = ctxt.settings().getValueForKey(SettingsServiceBean.Key.Protocol, nonNullDefaultIfKeyNotFound);
         GlobalIdServiceBean idServiceBean = GlobalIdServiceBean.getBean(protocol, ctxt);
         try {
-            // idServiceBean.deleteIdentifier(dataset); // didn't work
-            String baseUrl = System.getProperty("doi.baseurlstringnext");
-            String username = System.getProperty("doi.username");
-            String password = System.getProperty("doi.password");
-            int result = PidUtil.deleteDoi(dataset.getGlobalId().asString(), baseUrl, username, password);
-            if (result == 204) {
-                // Success! Clear the create time, etc.
-                dataset.setGlobalIdCreateTime(null);
-                dataset.setIdentifierRegistered(false);
-                ctxt.datasets().merge(dataset);
-            } else {
-                String message = BundleUtil.getStringFromBundle("pids.commands.deletePid.failureExpected", Arrays.asList(dataset.getId().toString(), Integer.toString(result)));
-                throw new IllegalCommandException(message, this);
-            }
-        } catch (IOException ex) {
-            String message = BundleUtil.getStringFromBundle("pids.commands.deletePid.failureOther", Arrays.asList(dataset.getId().toString(), ex.getLocalizedMessage()));
+            idServiceBean.deleteIdentifier(dataset); 
+            // Success! Clear the create time, etc.
+            dataset.setGlobalIdCreateTime(null);
+            dataset.setIdentifierRegistered(false);
+            ctxt.datasets().merge(dataset);
+        } catch (Exception ex) {
+            String message = BundleUtil.getStringFromBundle("pids.deletePid.failureOther", Arrays.asList(dataset.getGlobalId().asString(), ex.getLocalizedMessage()));
             logger.info(message);
             throw new IllegalCommandException(message, this);
         }

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/DeletePidCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/DeletePidCommand.java
@@ -19,6 +19,10 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.logging.Logger;
 
+import javax.xml.ws.http.HTTPException;
+
+import org.apache.commons.httpclient.HttpStatus;
+
 /**
  * No required permissions because we check for superuser status.
  */
@@ -51,8 +55,12 @@ public class DeletePidCommand extends AbstractVoidCommand {
             dataset.setGlobalIdCreateTime(null);
             dataset.setIdentifierRegistered(false);
             ctxt.datasets().merge(dataset);
+        } catch (HTTPException hex) {
+        	String message = BundleUtil.getStringFromBundle("pids.deletePid.failureExpected", Arrays.asList(dataset.getGlobalId().asString(), Integer.toString(hex.getStatusCode())));
+            logger.info(message);
+            throw new IllegalCommandException(message, this);
         } catch (Exception ex) {
-            String message = BundleUtil.getStringFromBundle("pids.deletePid.failureOther", Arrays.asList(dataset.getGlobalId().asString(), ex.getLocalizedMessage()));
+        	String message = BundleUtil.getStringFromBundle("pids.deletePid.failureOther", Arrays.asList(dataset.getGlobalId().asString(), ex.getLocalizedMessage()));
             logger.info(message);
             throw new IllegalCommandException(message, this);
         }

--- a/src/main/java/edu/harvard/iq/dataverse/pidproviders/PidUtil.java
+++ b/src/main/java/edu/harvard/iq/dataverse/pidproviders/PidUtil.java
@@ -83,26 +83,4 @@ public class PidUtil {
         }
         return globalId.getAuthority() + "/" + globalId.getIdentifier();
     }
-
-    /**
-     * Deletes the DOI from DataCite if it can. Returns 204 if PID was deleted
-     * (only possible for "draft" DOIs), 405 (method not allowed) if the DOI
-     * wasn't deleted (because it's in "findable" state, for example, 404 if the
-     * DOI wasn't found, and possibly other status codes such as 500 if DataCite
-     * is down.
-     */
-    public static int deleteDoi(String persistentId, String baseUrl, String username, String password) throws IOException {
-        String doi = acceptOnlyDoi(persistentId);
-        URL url = new URL(baseUrl + "/dois/" + doi);
-        HttpURLConnection connection = null;
-        connection = (HttpURLConnection) url.openConnection();
-        connection.setRequestMethod("DELETE");
-        String userpass = username + ":" + password;
-        String basicAuth = "Basic " + new String(Base64.getEncoder().encode(userpass.getBytes()));
-        connection.setRequestProperty("Authorization", basicAuth);
-        int status = connection.getResponseCode();
-        logger.fine("deleteDoi status for " + persistentId + ": " + status);
-        return status;
-    }
-
 }

--- a/src/main/java/propertyFiles/Bundle.properties
+++ b/src/main/java/propertyFiles/Bundle.properties
@@ -2544,8 +2544,8 @@ api.admin.datasetfield.load.GeneralErrorMessage=Error parsing metadata block in 
 #PIDs
 pids.api.reservePid.success=PID reserved for {0}
 pids.api.deletePid.success=PID deleted for {0}
-pids.commands.deletePid.failureExpected=Unable to delete PID for dataset id {0}. Status code: {1}.
-pids.commands.deletePid.failureOther=Problem deleting PID for dataset id {0}: {1}
+pids.deletePid.failureExpected=Unable to delete PID {0}. Status code: {1}.
+pids.deletePid.failureOther=Problem deleting PID {0}: {1}
 pids.commands.reservePid.failure=Problem reserving PID for dataset id {0}: {1}.
 pids.datacite.errors.noErrorStream=No error stream.
 pids.datacite.errors.DoiOnly=Only doi: is supported.

--- a/src/test/java/edu/harvard/iq/dataverse/pidproviders/PidUtilTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/pidproviders/PidUtilTest.java
@@ -24,16 +24,4 @@ public class PidUtilTest {
         System.out.println("out: " + out);
     }
 
-    @Ignore
-    @Test
-    public void testDeleteDoi() throws IOException {
-        String username = System.getenv("DataCiteUsername");
-        String password = System.getenv("DataCitePassword");
-        String baseUrl = "https://api.test.datacite.org";
-        String pid = "";
-        pid = "doi:10.70122/FK2/UAESPI";
-        int result = PidUtil.deleteDoi(pid, baseUrl, username, password);
-        System.out.println("out: " + result);
-    }
-
 }


### PR DESCRIPTION
**What this PR does / why we need it**: restores PIDS being invalidated when a dataset is destroyed

**Which issue(s) this PR closes**:

Closes #7078

**Special notes for your reviewer**: Tried to make minimal changes. #6901 created a separate delete method in PidUtils which I was able to move back into the DataCiteServiecBean code so that the Pids delete api isn't DataCIte specific any more. I did leave the API as only delete PIDs for unpublished Datasets though (with the assumption that, for DataCite, they have draft DOIs). 

**Suggestions on how to test this**: The API should work as before (except delete would also work for EZID and Handles (to the extent that their delete code is correct). The change this PR should make is the same as for #6060 - publish a dataset, and destroy it via the API and you should see the DataCite DOI change from findable to registered and have it's metadata replaced with :unav entries. (4.20 should already work this way, the 5.0 dev branch no longer did).

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: No

**Is there a release notes update needed for this change?**:

**Additional documentation**:
