### PR TITLE
6865 no more deadlocks

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/AbstractCreateDatasetCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/AbstractCreateDatasetCommand.java
@@ -123,6 +123,7 @@ public abstract class AbstractCreateDatasetCommand extends AbstractDatasetComman
         // Now we need the acutal dataset id, so we can start indexing.
         ctxt.em().flush();
         
+        // TODO: this needs to be moved in to an onSuccess method; not adding to this PR as its out of scope
         // TODO: switch to asynchronous version when JPA sync works
         // ctxt.index().asyncIndexDataset(theDataset.getId(), true); 
         try{
@@ -132,9 +133,7 @@ public abstract class AbstractCreateDatasetCommand extends AbstractDatasetComman
             failureLogText += "\r\n" + e.getLocalizedMessage();
             LoggingUtil.writeOnSuccessFailureLog(null, failureLogText, theDataset);
         }
-         
-        ctxt.solrIndex().indexPermissionsOnSelfAndChildren(theDataset.getId());
-        
+                 
         return theDataset;
     }
 

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/MoveDataverseCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/MoveDataverseCommand.java
@@ -295,6 +295,7 @@ public class MoveDataverseCommand extends AbstractVoidCommand {
         long moveDvEnd = System.currentTimeMillis();
         logger.info("Dataverse move took " + (moveDvEnd - moveDvStart) + " milliseconds");
         
+	//TODO: indexing should be moved to an on Success method
         ctxt.indexBatch().indexDataverseRecursively(moved);
         
         //REindex datasets linked to moved dv

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/PublishDataverseCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/PublishDataverseCommand.java
@@ -61,9 +61,7 @@ public class PublishDataverseCommand extends AbstractCommand<Dataverse> {
     
     @Override
     public boolean onSuccess(CommandContext ctxt, Object r) {
-        Dataverse ret = (Dataverse) r;
-        ctxt.solrIndex().indexPermissionsOnSelfAndChildren(ret.getId());
-        return true;
+        return ctxt.dataverses().index((Dataverse) r,true);
     }
 
 }

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/RenameDataverseCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/RenameDataverseCommand.java
@@ -35,4 +35,9 @@ public class RenameDataverseCommand extends AbstractCommand<Dataverse>{
 		return ctxt.dataverses().save(renamed);
 	}
 	
+        @Override
+        public boolean onSuccess(CommandContext ctxt, Object r) {
+            return ctxt.dataverses().index((Dataverse) r);
+        }  	
+	
 }

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/UpdatePermissionRootCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/UpdatePermissionRootCommand.java
@@ -38,6 +38,13 @@ public class UpdatePermissionRootCommand extends AbstractCommand<Dataverse> {
 	}
 
     @Override
+    public boolean onSuccess(CommandContext ctxt, Object r) {  
+        return ctxt.dataverses().index((Dataverse) r,true);
+    }        
+
+
+    //TODO: Review this as this will never be an instance of Dataset, will it?
+    @Override
     public Map<String, Set<Permission>> getRequiredPermissions() {
         // for data file check permission on owning dataset
         return Collections.singletonMap("",

--- a/src/test/java/edu/harvard/iq/dataverse/api/DataversesIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/DataversesIT.java
@@ -2,7 +2,6 @@ package edu.harvard.iq.dataverse.api;
 
 import com.jayway.restassured.RestAssured;
 import static com.jayway.restassured.RestAssured.given;
-import com.jayway.restassured.path.json.JsonPath;
 import static com.jayway.restassured.path.json.JsonPath.with;
 import com.jayway.restassured.response.Response;
 import edu.harvard.iq.dataverse.Dataverse;
@@ -12,6 +11,7 @@ import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.util.Arrays;
 import java.util.List;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.json.Json;
 import javax.json.JsonObject;
@@ -21,9 +21,7 @@ import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
 import javax.ws.rs.core.Response.Status;
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static javax.ws.rs.core.Response.Status.OK;
-import static javax.ws.rs.core.Response.Status.UNAUTHORIZED;
 import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.fail;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -362,11 +360,28 @@ public class DataversesIT {
         moveResponse.prettyPrint();
         moveResponse.then().assertThat().statusCode(OK.getStatusCode());
         
-        Response search = UtilIT.search("id:dataverse_" + dataverseId + "&subtree=" + dataverseAlias2, apiToken);
-        search.prettyPrint();
-        search.then().assertThat()
-                .body("data.total_count", equalTo(1))
-                .statusCode(200);
+        // because indexing happens asynchronously, we'll wait first, and then retry a few times, before failing
+        int numberofAttempts = 0;
+        boolean checkIndex = true;
+        while (checkIndex) {
+            try {   
+                    try {
+                        Thread.sleep(2000);
+                    } catch (InterruptedException ex) {
+                    }                
+                Response search = UtilIT.search("id:dataverse_" + dataverseId + "&subtree=" + dataverseAlias2, apiToken);
+                search.prettyPrint();
+                search.then().assertThat()
+                        .body("data.total_count", equalTo(1))
+                        .statusCode(200);
+                checkIndex = false;
+            } catch (AssertionError ae) {
+                if (numberofAttempts++ > 5) {
+                    throw ae;
+                }
+            }
+        }
+
     }
     
     @Test

--- a/src/test/java/edu/harvard/iq/dataverse/engine/command/impl/CreateDataverseCommandTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/engine/command/impl/CreateDataverseCommandTest.java
@@ -73,6 +73,12 @@ public class CreateDataverseCommandTest {
             return dataverse;
         }
         
+        @Override
+        public boolean index(Dataverse dataverse) {
+            indexCalled=true;
+            return true;
+        }        
+        
     };
     
     DataverseRoleServiceBean roles = new DataverseRoleServiceBean(){
@@ -99,6 +105,11 @@ public class CreateDataverseCommandTest {
             assignments.add(assignment);
             return assignment;
         }
+        
+        @Override
+        public RoleAssignment save(RoleAssignment assignment, boolean index) {
+            return save (assignment);
+        }        
 
         @Override
         public List<RoleAssignment> directRoleAssignments(DvObject dvo) {

--- a/src/test/java/edu/harvard/iq/dataverse/engine/command/impl/UpdatePermissionRootCommandTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/engine/command/impl/UpdatePermissionRootCommandTest.java
@@ -30,6 +30,11 @@ public class UpdatePermissionRootCommandTest {
                 serviceBeanCalled = true;
                 return dv;
             }
+            @Override
+            public boolean index(Dataverse dataverse, boolean indexPermisions) {
+                    // no-op. The superclass accesses databases which we don't have.
+                    return true;
+            }            
         };
         testCommandContext = new TestCommandContext() {
             @Override


### PR DESCRIPTION
**What this PR does / why we need it**:
It cleans up some indexing code - it extracts the index call that was in the DataverseServiceBean save into separate helper methods that can be called my commands in their onSuccess methods; it also removes the indexing of role related permissions during execute (since the dataverse is indexed in the onSuccess), which appeared to be the cause of the deadlocks we were getting in the tests


**Which issue(s) this PR closes**:

Closes #6865 

**Special notes for your reviewer**:
The Commands that call the save are listed here and whether I added on success call. Please review these decisions carefully, in case I missed something.

CreateDataverseCommand - already had an onSuccess index call - so it was already doubling up
PublishDataverseCommand - already had a call to index the permissions on success
RenameDataverseCommand- added a call to re index object on success
UpdateDataverseCommand - already had a call to index the object and all child datasets (unsure why it needed, but kept same logic it had)
UpdatePermissionRootCommand - added a call to re index object and permissions on success (honestly wasn't sure when this command is needed so went the safe root)

MoveDataverseCommand - indexing is already happening in execute - should be moved to onSuccess, but out of scope for this change

UpdateDataverseDefaultContributorRoleCommand - doesn't need indexing 
UpdateDataverseGuestbookCommand - doesn't need indexing
UpdateDataverseGuestbookRootCommand - doesn't need indexing
UpdateDataverseTemplateRootCommand - doesn't need indexing
UpdateDataverseThemeCommand - doesn't need indexing

**Suggestions on how to test this**:
The straightforward thing to do would be test where each of the above commands are used, as they are the ones that will be affected by these changes. In particular that roles permissions are indexed correctly for CreateDataverseCommand.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
no

**Is there a release notes update needed for this change?**:
no

**Additional documentation**:
