### PR TITLE
5467 Return useful error message for DDI upload.

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/api/Dataverses.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Dataverses.java
@@ -102,7 +102,7 @@ import java.text.MessageFormat;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.Optional;
-import javax.persistence.NoResultException;
+import javax.xml.stream.XMLStreamException;
 
 /**
  * A REST API for dataverses.
@@ -325,7 +325,7 @@ public class Dataverses extends AbstractApiBean {
     // TODO decide if I merge importddi with import just below (xml and json on same api, instead of 2 api)
     @POST
     @Path("{identifier}/datasets/:importddi")
-    public Response importDatasetDdi(String xml, @PathParam("identifier") String parentIdtf, @QueryParam("pid") String pidParam, @QueryParam("release") String releaseParam) throws ImportException {
+    public Response importDatasetDdi(String xml, @PathParam("identifier") String parentIdtf, @QueryParam("pid") String pidParam, @QueryParam("release") String releaseParam) {
         try {
             User u = findUserOrDie();
             if (!u.isSuperuser()) {
@@ -335,9 +335,12 @@ public class Dataverses extends AbstractApiBean {
             Dataset ds = null;
             try {
                 ds = jsonParser().parseDataset(importService.ddiToJson(xml));
-            }
-            catch (JsonParseException jpe) {
-                return badRequest("Error parsing datas as Json: "+jpe.getMessage());
+            } catch (JsonParseException jpe) {
+                return badRequest("Error parsing data as Json: "+jpe.getMessage());
+            } catch (ImportException e) {
+                return badRequest("Invalid DOI found in the XML: "+e.getMessage());
+            } catch (XMLStreamException e) {
+                return badRequest("Invalid file content: "+e.getMessage());
             }
             ds.setOwner(owner);
             if (nonEmpty(pidParam)) {

--- a/src/main/java/edu/harvard/iq/dataverse/api/imports/ImportDDIServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/imports/ImportDDIServiceBean.java
@@ -171,12 +171,15 @@ public class ImportDDIServiceBean {
     }
     
     private void processDDI(ImportType importType, XMLStreamReader xmlr, DatasetDTO datasetDTO, Map<String, String> filesMap) throws XMLStreamException, ImportException {
-       
         // make sure we have a codeBook
         //while ( xmlr.next() == XMLStreamConstants.COMMENT ); // skip pre root comments
-        xmlr.nextTag();
-        xmlr.require(XMLStreamConstants.START_ELEMENT, null, "codeBook");
-
+        try {
+            xmlr.nextTag();
+            xmlr.require(XMLStreamConstants.START_ELEMENT, null, "codeBook");
+        } catch( XMLStreamException e) {
+            throw new XMLStreamException("It doesn't start with the XML element <codeBook>");
+        }
+        
         // Some DDIs provide an ID in the <codeBook> section.
         // We are going to treat it as just another otherId.
         // (we've seen instances where this ID was the only ID found in

--- a/src/main/java/edu/harvard/iq/dataverse/api/imports/ImportServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/imports/ImportServiceBean.java
@@ -390,14 +390,8 @@ public class ImportServiceBean {
         return importedDataset;
     }
 
-    public JsonObject ddiToJson(String xmlToParse) throws ImportException{
-        DatasetDTO dsDTO = null;
-
-        try {
-            dsDTO = importDDIService.doImport(ImportType.IMPORT, xmlToParse);
-        } catch (XMLStreamException e) {
-            throw new ImportException("XMLStreamException" + e);
-        }
+    public JsonObject ddiToJson(String xmlToParse) throws ImportException, XMLStreamException {
+        DatasetDTO dsDTO = importDDIService.doImport(ImportType.IMPORT, xmlToParse);
         // convert DTO to Json,
         Gson gson = new GsonBuilder().setPrettyPrinting().create();
         String json = gson.toJson(dsDTO);


### PR DESCRIPTION
**What this PR does / why we need it**: Makes the error message more useful when uploading an invalid DDI XML

**Which issue(s) this PR closes**: 5467

Closes #5467 

**Special notes for your reviewer**: In Dataverses.java I removed the exception from the method signature and handled it in a try catch, where I return a useful message. In ImportDDIServiceBean I added a try catch with a specific error message for the `<codebook>` element. In ImportServiceBean I removed the message "XMLStreamException" which isn't useful.

**Suggestions on how to test this**: Upload a pdf or invalid DDI XML and you will see a useful error message. If you upload a valid DDI XML starting from the `<codebook>` element, you will get a success message. If you upload a DDI XML where you remove the slashes from the identifier in the <IDNo> elements, you will get the invalid DOI error (make sure to do it for all occurrences of the identifier). I added the command and screenshots below. The success message is just to verify all is still working.

COMMAND
```
curl -H X-Dataverse-key:xxxxxxxxxxxx -X POST http://localhost:8080/api/dataverses/root/datasets/:importddi --upload-file test.xml
```

SUCCESS
![image](https://user-images.githubusercontent.com/16444164/88121256-7b8c2780-cbc5-11ea-9a02-4836332ef7e6.png)

FAIL
![image](https://user-images.githubusercontent.com/16444164/88121327-b1311080-cbc5-11ea-82e3-b6697e532a93.png)

BAD DOI
![image](https://user-images.githubusercontent.com/16444164/88128815-01649e80-cbd7-11ea-9b61-736e46d982a2.png)

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: No

**Is there a release notes update needed for this change?**: It's not a big change so no

**Additional documentation**:
