### PR TITLE
adding support for changing sessionId at login

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DataverseSession.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DataverseSession.java
@@ -6,6 +6,7 @@ import edu.harvard.iq.dataverse.actionlogging.ActionLogRecord;
 import edu.harvard.iq.dataverse.actionlogging.ActionLogServiceBean;
 import edu.harvard.iq.dataverse.authorization.users.GuestUser;
 import edu.harvard.iq.dataverse.authorization.users.User;
+import edu.harvard.iq.dataverse.util.SessionUtil;
 import edu.harvard.iq.dataverse.util.SystemConfig;
 import java.io.IOException;
 import java.io.Serializable;
@@ -61,7 +62,8 @@ public class DataverseSession implements Serializable{
         logSvc.log( 
                 new ActionLogRecord(ActionLogRecord.ActionType.SessionManagement,(aUser==null) ? "logout" : "login")
                     .setUserIdentifier((aUser!=null) ? aUser.getIdentifier() : (user!=null ? user.getIdentifier() : "") ));
-        
+        //#3254 - change session id when user changes
+        SessionUtil.changeSessionId((HttpServletRequest) FacesContext.getCurrentInstance().getExternalContext().getRequest());
         this.user = aUser;
     }
 

--- a/src/main/java/edu/harvard/iq/dataverse/LoginPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/LoginPage.java
@@ -172,7 +172,6 @@ public class LoginPage implements java.io.Serializable {
             logger.log(Level.FINE, "User authenticated: {0}", r.getEmail());
             session.setUser(r);
             session.configureSessionTimeout();
-            SessionUtil.changeSessionId((HttpServletRequest) FacesContext.getCurrentInstance().getExternalContext().getRequest());
             if ("dataverse.xhtml".equals(redirectPage)) {
                 redirectPage = redirectToRoot();
             }

--- a/src/main/java/edu/harvard/iq/dataverse/LoginPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/LoginPage.java
@@ -13,6 +13,8 @@ import edu.harvard.iq.dataverse.authorization.users.AuthenticatedUser;
 import edu.harvard.iq.dataverse.settings.SettingsServiceBean;
 import edu.harvard.iq.dataverse.util.BundleUtil;
 import edu.harvard.iq.dataverse.util.JsfHelper;
+import edu.harvard.iq.dataverse.util.SessionUtil;
+
 import static edu.harvard.iq.dataverse.util.JsfHelper.JH;
 import edu.harvard.iq.dataverse.util.SystemConfig;
 import java.io.UnsupportedEncodingException;
@@ -29,6 +31,7 @@ import javax.faces.validator.ValidatorException;
 import javax.faces.view.ViewScoped;
 import javax.inject.Inject;
 import javax.inject.Named;
+import javax.servlet.http.HttpServletRequest;
 
 /**
  *
@@ -169,7 +172,7 @@ public class LoginPage implements java.io.Serializable {
             logger.log(Level.FINE, "User authenticated: {0}", r.getEmail());
             session.setUser(r);
             session.configureSessionTimeout();
-            
+            SessionUtil.changeSessionId((HttpServletRequest) FacesContext.getCurrentInstance().getExternalContext().getRequest());
             if ("dataverse.xhtml".equals(redirectPage)) {
                 redirectPage = redirectToRoot();
             }

--- a/src/main/java/edu/harvard/iq/dataverse/util/SessionUtil.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/SessionUtil.java
@@ -1,0 +1,32 @@
+package edu.harvard.iq.dataverse.util;
+
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map.Entry;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+
+public class SessionUtil {
+
+    /**
+	 * Changes the session id (jsessionId) - for use when the session's authority increases (i.e. at login)
+	 * Servlet 3.1 Note: This method is needed while using Servlets 2.0. 3.1 has a HttpServletRequest.chageSessionId(); method that can be used instead.
+	 * 
+	 * @param h the current HttpServletRequest
+     * e.g. for pages you can get this from (HttpServletRequest) FacesContext.getCurrentInstance().getExternalContext().getRequest();
+     */
+    public static void changeSessionId(HttpServletRequest h) {
+        HttpSession session = h.getSession(false);
+        HashMap<String, Object> sessionAttributes = new HashMap<String,Object>();
+        for(Enumeration<String> e = session.getAttributeNames();e.hasMoreElements();) {
+        	String name = e.nextElement();
+        	sessionAttributes.put(name, session.getAttribute(name));
+        }
+        h.getSession().invalidate();
+        session = h.getSession(true);
+        for(Entry<String, Object> entry: sessionAttributes.entrySet()) {
+        	session.setAttribute(entry.getKey(), entry.getValue());
+        }
+    }
+}


### PR DESCRIPTION
**What this PR does / why we need it**: Changes the sessionId at login

**Which issue(s) this PR closes**:

Closes #3254 

**Special notes for your reviewer**: The code changes here work for the standard login (e.g. as dataverseAdmin) but haven't been checked with other login types. @landreev was going to look for other places where the same sessionId change might be needed for alternate login methods. (FWIW: It does look like this login method calls multiple auth providers, so it may cover all or at least several.) I put the code to change the Id in a util class to make that easier. Nominally this PR doesn't fully close #3254 until it covers a all the login mechanisms. (edit: I was indeed wondering earlier whether this needed to be applied in several places; similar to how we call configureSessionTimeout() from all the different auth provider impls.; but that does not appear to be necessary here: when increasing the session timeout, we wanted to be sure we were doing it only once the user has successfully authenticated/logged in;  in this case, we are perfectly fine with issuing a new session before we try to authenticate - L.A.)

**Suggestions on how to test this**: Open the dev console and watch the jsessionId - cookie (usually) or in the URL -when you succeed in logging in, it should change, and the login should succeed as normal (i.e. no changes except to the session id)
Please test with different auth providers - Shib, etc. - in addition to the builtin provider. 

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: No

**Is there a release notes update needed for this change?**:

**Additional documentation**:
