### PR TITLE
7117 metadata field type uri_no

### DIFF
--- a/doc/sphinx-guides/source/admin/metadatacustomization.rst
+++ b/doc/sphinx-guides/source/admin/metadatacustomization.rst
@@ -197,6 +197,7 @@ Each of the three main sections own sets of properties:
 |                       | is meant to contain.  | | \• text              |
 |                       |                       | | \• textbox           |
 |                       |                       | | \• url               |
+|                       |                       | | \• uri_no            |
 |                       |                       | | \• int               |
 |                       |                       | | \• float             |
 |                       |                       | | \• See below for     |
@@ -418,7 +419,18 @@ FieldType definitions
 |                                   | Management page in the User Guide.|
 +-----------------------------------+-----------------------------------+
 | url                               | If not empty, field must contain  |
-|                                   | a valid URL.                      |
+|                                   | a valid URL, restricted to schemes|
+|                                   | ``http``, ``https``,              |
+|                                   | ``file``, ``jar``. (A limitation  |
+|                                   | of `Java URL class`_.)            |
++-----------------------------------+-----------------------------------+
+| uri_no                            | If not empty, field must contain  |
+|                                   | a valid, non-opaque, absolute URI.|
+|                                   | (Meaning an URL.)                 |
+|                                   | See also :rfc:`3986`,             |
+|                                   | `Good practices for URIs`_,       |
+|                                   | `W3C Axioms`_,                    |
+|                                   | `W3C URI Clarification`_.         |
 +-----------------------------------+-----------------------------------+
 | int                               | An integer value destined for a   |
 |                                   | numeric field.                    |
@@ -426,6 +438,11 @@ FieldType definitions
 | float                             | A floating point number destined  |
 |                                   | for a numeric field.              |
 +-----------------------------------+-----------------------------------+
+
+.. _Java URL class: https://docs.oracle.com/javase/8/docs/api/java/net/URL.html#URL-java.lang.String-java.lang.String-int-java.lang.String-
+.. _Good practices for URIs: https://www.ebi.ac.uk/rdf/documentation/good_practice_uri
+.. _W3C Axioms: https://www.w3.org/DesignIssues/Axioms.html
+.. _W3C URI Clarification: https://www.w3.org/TR/uri-clarification
 
 displayFormat variables
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/main/java/edu/harvard/iq/dataverse/DatasetFieldType.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetFieldType.java
@@ -35,7 +35,7 @@ public class DatasetFieldType implements Serializable, Comparable<DatasetFieldTy
      * The set of possible metatypes of the field. Used for validation and layout.
      */
     public enum FieldType {
-        TEXT, TEXTBOX, DATE, EMAIL, URL, FLOAT, INT, NONE
+        TEXT, TEXTBOX, DATE, EMAIL, URL, URI_NO, FLOAT, INT, NONE
     };    
     
     @Id
@@ -167,14 +167,14 @@ public class DatasetFieldType implements Serializable, Comparable<DatasetFieldTy
     }
     
     public Boolean isSanitizeHtml(){
-        if (this.fieldType.equals(FieldType.URL)){
+        if (this.fieldType.equals(FieldType.URL) || this.fieldType.equals(FieldType.URI_NO)){
             return true;
         }
         return this.fieldType.equals(FieldType.TEXTBOX);
     }
     
     public Boolean isEscapeOutputText(){
-        if (this.fieldType.equals(FieldType.URL)){
+        if (this.fieldType.equals(FieldType.URL) || this.fieldType.equals(FieldType.URI_NO) ){
             return false;
         }
         if (this.fieldType.equals(FieldType.TEXTBOX)){

--- a/src/main/java/edu/harvard/iq/dataverse/DatasetFieldValueValidator.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetFieldValueValidator.java
@@ -7,6 +7,8 @@ package edu.harvard.iq.dataverse;
 
 import edu.harvard.iq.dataverse.DatasetFieldType.FieldType;
 import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -176,6 +178,20 @@ public class DatasetFieldValueValidator implements ConstraintValidator<ValidateD
 
                 }
 
+                return false;
+            }
+        }
+    
+        if (fieldType.equals(FieldType.URI_NO) && !lengthOnly) {
+            try {
+                URI uri = new URI(value.getValue());
+                if (! uri.isAbsolute() || uri.isOpaque()) {
+                    throw new URISyntaxException(value.getValue(), "Has to be absolute and non opaque (but may contain a fragment).");
+                }
+            } catch (URISyntaxException e) {
+                try {
+                    context.buildConstraintViolationWithTemplate(dsfType.getDisplayName() + " " + value.getValue() + "  is not a valid URL.").addConstraintViolation();
+                } catch (NullPointerException npe) {}
                 return false;
             }
         }

--- a/src/main/webapp/datasetFieldForEditFragment.xhtml
+++ b/src/main/webapp/datasetFieldForEditFragment.xhtml
@@ -18,6 +18,7 @@
                              or dsfv.datasetField.datasetFieldType.fieldType == 'INT'
                              or dsfv.datasetField.datasetFieldType.fieldType == 'FLOAT'
                              or dsfv.datasetField.datasetFieldType.fieldType == 'URL'
+                             or dsfv.datasetField.datasetFieldType.fieldType == 'URI_NO'
                              or dsfv.datasetField.datasetFieldType.fieldType == 'DATE'
                              or dsfv.datasetField.datasetFieldType.fieldType == 'EMAIL')}"/>
     <p:watermark for="inputText" value="#{dsfv.datasetField.datasetFieldType.localeWatermark}"></p:watermark>

--- a/src/test/java/edu/harvard/iq/dataverse/DatasetFieldValueValidatorTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/DatasetFieldValueValidatorTest.java
@@ -53,7 +53,20 @@ public class DatasetFieldValueValidatorTest {
     
             // URL
             Arguments.of(DatasetFieldType.FieldType.URL, "http://foo.bar", true),
-            Arguments.of(DatasetFieldType.FieldType.URL, "foo.bar", false)
+            Arguments.of(DatasetFieldType.FieldType.URL, "foo.bar", false),
+            Arguments.of(DatasetFieldType.FieldType.URL, "rsync://foo.bar", false),
+    
+            // non-opaque URIs (being URLs), see #7117
+            Arguments.of(DatasetFieldType.FieldType.URI_NO, "fish://foo.bar", true),
+            Arguments.of(DatasetFieldType.FieldType.URI_NO, "http://foo.bar/hello", true),
+            Arguments.of(DatasetFieldType.FieldType.URI_NO, "http://foo.bar/hello#rack-1", true),
+            Arguments.of(DatasetFieldType.FieldType.URI_NO, "http://foo.bar/hello?whoami=peter", true),
+            Arguments.of(DatasetFieldType.FieldType.URI_NO, "http://foo.bar/hello?whoami=peter#test", true),
+            Arguments.of(DatasetFieldType.FieldType.URI_NO, "rsync://foo.bar/target", true),
+            Arguments.of(DatasetFieldType.FieldType.URI_NO, "smb://foo.bar/share/folder/file.csv", true),
+            Arguments.of(DatasetFieldType.FieldType.URI_NO, "foo.bar", false),
+            Arguments.of(DatasetFieldType.FieldType.URI_NO, "scheme:foo.bar", false),
+            Arguments.of(DatasetFieldType.FieldType.URI_NO, "urn:isbn:1234567890", false)
         );
     }
     

--- a/src/test/java/edu/harvard/iq/dataverse/DatasetFieldValueValidatorTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/DatasetFieldValueValidatorTest.java
@@ -58,10 +58,10 @@ public class DatasetFieldValueValidatorTest {
     
             // non-opaque URIs (being URLs), see #7117
             Arguments.of(DatasetFieldType.FieldType.URI_NO, "fish://foo.bar", true),
-            Arguments.of(DatasetFieldType.FieldType.URI_NO, "http://foo.bar/hello", true),
-            Arguments.of(DatasetFieldType.FieldType.URI_NO, "http://foo.bar/hello#rack-1", true),
-            Arguments.of(DatasetFieldType.FieldType.URI_NO, "http://foo.bar/hello?whoami=peter", true),
-            Arguments.of(DatasetFieldType.FieldType.URI_NO, "http://foo.bar/hello?whoami=peter#test", true),
+            Arguments.of(DatasetFieldType.FieldType.URI_NO, "ftp://foo.bar/hello", true),
+            Arguments.of(DatasetFieldType.FieldType.URI_NO, "s3://foo.bar/hello#rack-1", true),
+            Arguments.of(DatasetFieldType.FieldType.URI_NO, "swift://foo.bar/hello?whoami=peter", true),
+            Arguments.of(DatasetFieldType.FieldType.URI_NO, "wtf://foo.bar/hello?whoami=peter#test", true),
             Arguments.of(DatasetFieldType.FieldType.URI_NO, "rsync://foo.bar/target", true),
             Arguments.of(DatasetFieldType.FieldType.URI_NO, "smb://foo.bar/share/folder/file.csv", true),
             Arguments.of(DatasetFieldType.FieldType.URI_NO, "foo.bar", false),


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds a new metadata field type `uri_no`, providing support for any kind of URL instead of HTTP/S only. It's really small and more about the why can be found in the issue (which is again very small)

**Which issue(s) this PR closes**:

Closes #7117

**Special notes for your reviewer**:

Nada.

**Suggestions on how to test this**:

Deploy with this PR applied. Create a metadata schema with the new field type in use. Deploy schema, activate in a Dataverse. Create a Dataset and try to insert any kind of URL.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No. Or at least only very very minimal, as URL support existed before, but was limited to HTTP/S.

**Is there a release notes update needed for this change?**:

I don't think so. Maybe. Don't know. It's a small thing.

**Additional documentation**:

Nada.