### PR TITLE
add message when DataCite DOI has not been reserved #7102

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
@@ -2128,6 +2128,15 @@ public class DatasetPage implements java.io.Serializable {
                     BundleUtil.getStringFromBundle("dataset.locked.ingest.message"));
             lockedDueToIngestVar = true;
         }
+
+        // With DataCite, we try to reserve the DOI when the dataset is created. Sometimes this
+        // fails because DataCite is down. We show the message below to set expectations that the
+        // "Publish" button won't work until the DOI has been reserved using the "Reserve PID" API.
+        if (settingsWrapper.isDataCiteInstallation() && dataset.getGlobalIdCreateTime() == null) {
+            JH.addMessage(FacesMessage.SEVERITY_WARN, BundleUtil.getStringFromBundle("dataset.locked.pidNotReserved.message"),
+                    BundleUtil.getStringFromBundle("dataset.locked.pidNotReserved.message.details"));
+        }
+
     }
     
     private Boolean fileTreeViewRequired = null; 

--- a/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
@@ -2132,7 +2132,7 @@ public class DatasetPage implements java.io.Serializable {
         // With DataCite, we try to reserve the DOI when the dataset is created. Sometimes this
         // fails because DataCite is down. We show the message below to set expectations that the
         // "Publish" button won't work until the DOI has been reserved using the "Reserve PID" API.
-        if (settingsWrapper.isDataCiteInstallation() && dataset.getGlobalIdCreateTime() == null) {
+        if (settingsWrapper.isDataCiteInstallation() && dataset.getGlobalIdCreateTime() == null && editMode != EditMode.CREATE) {
             JH.addMessage(FacesMessage.SEVERITY_WARN, BundleUtil.getStringFromBundle("dataset.locked.pidNotReserved.message"),
                     BundleUtil.getStringFromBundle("dataset.locked.pidNotReserved.message.details"));
         }

--- a/src/main/java/propertyFiles/Bundle.properties
+++ b/src/main/java/propertyFiles/Bundle.properties
@@ -1322,8 +1322,8 @@ dataset.locked.ingest.message=The tabular data files uploaded are being processe
 dataset.unlocked.ingest.message=The tabular files have been ingested.
 dataset.locked.editInProgress.message=Edit In Progress
 dataset.locked.editInProgress.message.details=Additional edits cannot be made at this time. Contact {0} if this status persists.
-dataset.locked.pidNotReserved.message=Dataset Locked
-dataset.locked.pidNotReserved.message.details=The DOI displayed in the citation for this dataset has not yet been registered with DataCite. Please do not share this DOI until it has been registered.
+dataset.locked.pidNotReserved.message=Dataset DOI Not Reserved
+dataset.locked.pidNotReserved.message.details=The DOI displayed in the citation for this dataset has not yet been reserved with DataCite. Please do not share this DOI until it has been reserved.
 dataset.publish.error=This dataset may not be published due to an error when contacting the <a href=\{1} target=\"_blank\"/> {0} </a> Service. Please try again.
 dataset.publish.error.doi=This dataset may not be published because the DOI update failed.
 dataset.publish.file.validation.error.message=Failed to Publish Dataset

--- a/src/main/java/propertyFiles/Bundle.properties
+++ b/src/main/java/propertyFiles/Bundle.properties
@@ -1322,6 +1322,8 @@ dataset.locked.ingest.message=The tabular data files uploaded are being processe
 dataset.unlocked.ingest.message=The tabular files have been ingested.
 dataset.locked.editInProgress.message=Edit In Progress
 dataset.locked.editInProgress.message.details=Additional edits cannot be made at this time. Contact {0} if this status persists.
+dataset.locked.pidNotReserved.message=Dataset Locked
+dataset.locked.pidNotReserved.message.details=The DOI displayed in the citation for this dataset has not yet been registered with DataCite. Please do not share this DOI until it has been registered.
 dataset.publish.error=This dataset may not be published due to an error when contacting the <a href=\{1} target=\"_blank\"/> {0} </a> Service. Please try again.
 dataset.publish.error.doi=This dataset may not be published because the DOI update failed.
 dataset.publish.file.validation.error.message=Failed to Publish Dataset


### PR DESCRIPTION
**What this PR does / why we need it**:

Here's the problem scenario:

- DataCite was down when the dataset was created, meaning that the DOI was never reserved on the DataCite side.
- When the user tries to publish, they get a somewhat confusing error: "Cannot publish dataset because its persistent identifier has not been reserved." (screenshot below).

<img width="741" alt="Screen Shot 2020-07-23 at 11 25 56 AM" src="https://user-images.githubusercontent.com/21006/88305283-4d970800-ccd7-11ea-98c7-d47764f1fd35.png">

To help explain what's going on, this pull request add a message to the top of the dataset page:

<img width="1262" alt="Screen Shot 2020-07-23 at 11 17 42 AM" src="https://user-images.githubusercontent.com/21006/88305369-67d0e600-ccd7-11ea-9811-be8900b0216b.png">

**Which issue(s) this PR closes**:

Closes #7102

**Special notes for your reviewer**:

- ~~I copied and pasted the text that was given to me but I would prefer to use the word "reserved" rather than "registered" because we already use the former throughout our documentation and code.~~ Fixed in fee17726d.
- ~~I used "Dataset Locked" as the short message before the long explanation but we can certainly change this to whatever we want.~~ Changed to "Dataset DOI Not Reserved" in fee17726d.
- I made use of the the "displayLockInfo" infrastructure even though this message isn't a true DatasetLock.

**Suggestions on how to test this**:

The message should only appear for DataCite installations. In addition, the message should only appear for datasets with a null value for GlobalIdCreateTime (dvobject table), which is what we use to indicate if a DOI is reserved. It's the time the PID was created on the remote system.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

Yes, please see screenshots, above.

**Is there a release notes update needed for this change?**:

No, I think it falls under the umbrella of Dataverse 5 allowing DOIs to be reserved.

**Additional documentation**:

None.