### PR TITLE
7127 Move <sumDscr> and <dataAccs> child elements to the right sequence

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/export/ddi/DdiExportUtil.java
+++ b/src/main/java/edu/harvard/iq/dataverse/export/ddi/DdiExportUtil.java
@@ -246,21 +246,6 @@ public class DdiExportUtil {
 
     private static void writeDataAccess(XMLStreamWriter xmlw , DatasetVersionDTO version) throws XMLStreamException {
         xmlw.writeStartElement("dataAccs");
-        if (version.getTermsOfUse() != null && !version.getTermsOfUse().trim().equals("")) {
-            xmlw.writeStartElement("notes");
-            writeAttribute(xmlw, "type", NOTE_TYPE_TERMS_OF_USE);
-            writeAttribute(xmlw, "level", LEVEL_DV);
-            xmlw.writeCharacters(version.getTermsOfUse());
-            xmlw.writeEndElement(); //notes
-        }
-        if (version.getTermsOfAccess() != null && !version.getTermsOfAccess().trim().equals("")) {
-            xmlw.writeStartElement("notes");
-            writeAttribute(xmlw, "type", NOTE_TYPE_TERMS_OF_ACCESS);
-            writeAttribute(xmlw, "level", LEVEL_DV);
-            xmlw.writeCharacters(version.getTermsOfAccess());
-            xmlw.writeEndElement(); //notes
-        }
-
         xmlw.writeStartElement("setAvail");
         writeFullElement(xmlw, "accsPlac", version.getDataAccessPlace());
         writeFullElement(xmlw, "origArch", version.getOriginalArchive());
@@ -278,6 +263,20 @@ public class DdiExportUtil {
         writeFullElement(xmlw, "conditions", version.getConditions());
         writeFullElement(xmlw, "disclaimer", version.getDisclaimer());
         xmlw.writeEndElement(); //useStmt
+        if (version.getTermsOfUse() != null && !version.getTermsOfUse().trim().equals("")) {
+            xmlw.writeStartElement("notes");
+            writeAttribute(xmlw, "type", NOTE_TYPE_TERMS_OF_USE);
+            writeAttribute(xmlw, "level", LEVEL_DV);
+            xmlw.writeCharacters(version.getTermsOfUse());
+            xmlw.writeEndElement(); //notes
+        }
+        if (version.getTermsOfAccess() != null && !version.getTermsOfAccess().trim().equals("")) {
+            xmlw.writeStartElement("notes");
+            writeAttribute(xmlw, "type", NOTE_TYPE_TERMS_OF_ACCESS);
+            writeAttribute(xmlw, "level", LEVEL_DV);
+            xmlw.writeCharacters(version.getTermsOfAccess());
+            xmlw.writeEndElement(); //notes
+        }
         xmlw.writeEndElement(); //dataAccs
     }
     
@@ -339,137 +338,156 @@ public class DdiExportUtil {
     
     private static void writeSummaryDescriptionElement(XMLStreamWriter xmlw, DatasetVersionDTO datasetVersionDTO) throws XMLStreamException {
         xmlw.writeStartElement("sumDscr");
-        for (Map.Entry<String, MetadataBlockDTO> entry : datasetVersionDTO.getMetadataBlocks().entrySet()) {
-            String key = entry.getKey();
-            MetadataBlockDTO value = entry.getValue();
-            if ("citation".equals(key)) {
-                Integer per = 0;
-                Integer coll = 0;
-                for (FieldDTO fieldDTO : value.getFields()) {
-                    if (DatasetFieldConstant.timePeriodCovered.equals(fieldDTO.getTypeName())) {
-                        String dateValStart = "";
-                        String dateValEnd = "";
-                        for (HashSet<FieldDTO> foo : fieldDTO.getMultipleCompound()) {
-                            per++;
-                            for (Iterator<FieldDTO> iterator = foo.iterator(); iterator.hasNext();) {
-                                FieldDTO next = iterator.next();
-                                if (DatasetFieldConstant.timePeriodCoveredStart.equals(next.getTypeName())) {
-                                    dateValStart = next.getSinglePrimitive();
-                                }
-                                if (DatasetFieldConstant.timePeriodCoveredEnd.equals(next.getTypeName())) {
-                                    dateValEnd = next.getSinglePrimitive();
-                                }
+        Map<String, MetadataBlockDTO> metadataBlocks = datasetVersionDTO.getMetadataBlocks();
+        MetadataBlockDTO citation = metadataBlocks.get("citation");
+        if (citation != null) {
+            Integer per = 0;
+            Integer coll = 0;
+            for (FieldDTO fieldDTO : citation.getFields()) {
+                if (DatasetFieldConstant.timePeriodCovered.equals(fieldDTO.getTypeName())) {
+                    String dateValStart = "";
+                    String dateValEnd = "";
+                    for (HashSet<FieldDTO> foo : fieldDTO.getMultipleCompound()) {
+                        per++;
+                        for (Iterator<FieldDTO> iterator = foo.iterator(); iterator.hasNext(); ) {
+                            FieldDTO next = iterator.next();
+                            if (DatasetFieldConstant.timePeriodCoveredStart.equals(next.getTypeName())) {
+                                dateValStart = next.getSinglePrimitive();
                             }
-                            if (!dateValStart.isEmpty()) {
-                                writeDateElement(xmlw, "timePrd", "P"+ per.toString(), "start", dateValStart );
-                            }
-                            if (!dateValEnd.isEmpty()) {
-                                writeDateElement(xmlw, "timePrd",  "P"+ per.toString(), "end", dateValEnd );
+                            if (DatasetFieldConstant.timePeriodCoveredEnd.equals(next.getTypeName())) {
+                                dateValEnd = next.getSinglePrimitive();
                             }
                         }
-                    }
-                    if (DatasetFieldConstant.dateOfCollection.equals(fieldDTO.getTypeName())) {
-                        String dateValStart = "";
-                        String dateValEnd = "";
-                        for (HashSet<FieldDTO> foo : fieldDTO.getMultipleCompound()) {
-                            coll++;
-                            for (Iterator<FieldDTO> iterator = foo.iterator(); iterator.hasNext();) {
-                                FieldDTO next = iterator.next();
-                                if (DatasetFieldConstant.dateOfCollectionStart.equals(next.getTypeName())) {
-                                    dateValStart = next.getSinglePrimitive();
-                                }
-                                if (DatasetFieldConstant.dateOfCollectionEnd.equals(next.getTypeName())) {
-                                    dateValEnd = next.getSinglePrimitive();
-                                }
-                            }
-                            if (!dateValStart.isEmpty()) {
-                                writeDateElement(xmlw, "collDate",  "P"+ coll.toString(), "start", dateValStart );
-                            }
-                            if (!dateValEnd.isEmpty()) {
-                                writeDateElement(xmlw,  "collDate",  "P"+ coll.toString(), "end", dateValEnd );
-                            }
+                        if (!dateValStart.isEmpty()) {
+                            writeDateElement(xmlw, "timePrd", "P" + per.toString(), "start", dateValStart);
+                        }
+                        if (!dateValEnd.isEmpty()) {
+                            writeDateElement(xmlw, "timePrd", "P" + per.toString(), "end", dateValEnd);
                         }
                     }
-                    if (DatasetFieldConstant.kindOfData.equals(fieldDTO.getTypeName())) {
-                        writeMultipleElement(xmlw, "dataKind", fieldDTO);                     
+                }
+                if (DatasetFieldConstant.dateOfCollection.equals(fieldDTO.getTypeName())) {
+                    String dateValStart = "";
+                    String dateValEnd = "";
+                    for (HashSet<FieldDTO> foo : fieldDTO.getMultipleCompound()) {
+                        coll++;
+                        for (Iterator<FieldDTO> iterator = foo.iterator(); iterator.hasNext(); ) {
+                            FieldDTO next = iterator.next();
+                            if (DatasetFieldConstant.dateOfCollectionStart.equals(next.getTypeName())) {
+                                dateValStart = next.getSinglePrimitive();
+                            }
+                            if (DatasetFieldConstant.dateOfCollectionEnd.equals(next.getTypeName())) {
+                                dateValEnd = next.getSinglePrimitive();
+                            }
+                        }
+                        if (!dateValStart.isEmpty()) {
+                            writeDateElement(xmlw, "collDate", "P" + coll.toString(), "start", dateValStart);
+                        }
+                        if (!dateValEnd.isEmpty()) {
+                            writeDateElement(xmlw, "collDate", "P" + coll.toString(), "end", dateValEnd);
+                        }
                     }
                 }
             }
-            
-            if("geospatial".equals(key)){                
-                for (FieldDTO fieldDTO : value.getFields()) {
-                    if (DatasetFieldConstant.geographicCoverage.equals(fieldDTO.getTypeName())) {
+        }
 
-                        for (HashSet<FieldDTO> foo : fieldDTO.getMultipleCompound()) {
-                            HashMap<String, String> geoMap = new HashMap<>();
-                            for (Iterator<FieldDTO> iterator = foo.iterator(); iterator.hasNext();) {
-                                FieldDTO next = iterator.next();
-                                if (DatasetFieldConstant.country.equals(next.getTypeName())) {
-                                    geoMap.put("country", next.getSinglePrimitive());
-                                }
-                                if (DatasetFieldConstant.city.equals(next.getTypeName())) {
-                                    geoMap.put("city", next.getSinglePrimitive());
-                                }
-                                if (DatasetFieldConstant.state.equals(next.getTypeName())) {
-                                    geoMap.put("state", next.getSinglePrimitive());
-                                } 
-                                if (DatasetFieldConstant.otherGeographicCoverage.equals(next.getTypeName())) {
-                                    geoMap.put("otherGeographicCoverage", next.getSinglePrimitive());
-                                } 
+        MetadataBlockDTO geospatial = metadataBlocks.get("geospatial");
+        if (geospatial != null) {    
+            for (FieldDTO fieldDTO : geospatial.getFields()) {
+                if (DatasetFieldConstant.geographicCoverage.equals(fieldDTO.getTypeName())) {
+                    for (HashSet<FieldDTO> foo : fieldDTO.getMultipleCompound()) {
+                        for (Iterator<FieldDTO> iterator = foo.iterator(); iterator.hasNext(); ) {
+                            FieldDTO next = iterator.next();
+                            if (DatasetFieldConstant.country.equals(next.getTypeName())) {
+                                writeFullElement(xmlw, "nation", next.getSinglePrimitive());
                             }
-
-                            if (geoMap.get("country") != null) {
-                                writeFullElement(xmlw, "nation", geoMap.get("country"));
-                            }
-                            if (geoMap.get("city") != null) {
-                                writeFullElement(xmlw, "geogCover", geoMap.get("city"));
-                            }
-                            if (geoMap.get("state") != null) {
-                                writeFullElement(xmlw, "geogCover", geoMap.get("state"));
-                            }
-                            if (geoMap.get("otherGeographicCoverage") != null) {
-                                writeFullElement(xmlw, "geogCover", geoMap.get("otherGeographicCoverage"));
-                            }
-
                         }
-                    }
-                    if (DatasetFieldConstant.geographicBoundingBox.equals(fieldDTO.getTypeName())) {
-
-                        for (HashSet<FieldDTO> foo : fieldDTO.getMultipleCompound()) {
-                            xmlw.writeStartElement("geoBndBox");
-                            for (Iterator<FieldDTO> iterator = foo.iterator(); iterator.hasNext();) {
-                                FieldDTO next = iterator.next();
-                                if (DatasetFieldConstant.westLongitude.equals(next.getTypeName())) {
-                                    writeFullElement(xmlw, "westBL", next.getSinglePrimitive());
-                                }
-                                if (DatasetFieldConstant.eastLongitude.equals(next.getTypeName())) {
-                                    writeFullElement(xmlw, "eastBL", next.getSinglePrimitive());
-                                }
-                                if (DatasetFieldConstant.northLatitude.equals(next.getTypeName())) {
-                                    writeFullElement(xmlw, "northBL", next.getSinglePrimitive());
-                                }  
-                                if (DatasetFieldConstant.southLatitude.equals(next.getTypeName())) {
-                                    writeFullElement(xmlw, "southBL", next.getSinglePrimitive());
-                                }                               
-
-                            }
-                            xmlw.writeEndElement();
-                        }
-
                     }
                 }
-                    writeFullElementList(xmlw, "geogUnit", dto2PrimitiveList(datasetVersionDTO, DatasetFieldConstant.geographicUnit));
             }
+            for (FieldDTO fieldDTO : geospatial.getFields()) {
+                if (DatasetFieldConstant.geographicCoverage.equals(fieldDTO.getTypeName())) {
+                    for (HashSet<FieldDTO> foo : fieldDTO.getMultipleCompound()) {
+                        HashMap<String, String> geoMap = new HashMap<>();
+                        for (Iterator<FieldDTO> iterator = foo.iterator(); iterator.hasNext(); ) {
+                            FieldDTO next = iterator.next();
+                            if (DatasetFieldConstant.city.equals(next.getTypeName())) {
+                                geoMap.put("city", next.getSinglePrimitive());
+                            }
+                            if (DatasetFieldConstant.state.equals(next.getTypeName())) {
+                                geoMap.put("state", next.getSinglePrimitive());
+                            }
+                            if (DatasetFieldConstant.otherGeographicCoverage.equals(next.getTypeName())) {
+                                geoMap.put("otherGeographicCoverage", next.getSinglePrimitive());
+                            }
+                        }
+                        if (geoMap.get("city") != null) {
+                            writeFullElement(xmlw, "geogCover", geoMap.get("city"));
+                        }
+                        if (geoMap.get("state") != null) {
+                            writeFullElement(xmlw, "geogCover", geoMap.get("state"));
+                        }
+                        if (geoMap.get("otherGeographicCoverage") != null) {
+                            writeFullElement(xmlw, "geogCover", geoMap.get("otherGeographicCoverage"));
+                        }
+                    }
+                }
+            }
+            writeFullElementList(xmlw, "geogUnit", dto2PrimitiveList(datasetVersionDTO, DatasetFieldConstant.geographicUnit));
+            for (FieldDTO fieldDTO : geospatial.getFields()) {
+                if (DatasetFieldConstant.geographicBoundingBox.equals(fieldDTO.getTypeName())) {
+                    for (HashSet<FieldDTO> foo : fieldDTO.getMultipleCompound()) {
+                        xmlw.writeStartElement("geoBndBox");
+                        for (Iterator<FieldDTO> iterator = foo.iterator(); iterator.hasNext(); ) {
+                            FieldDTO next = iterator.next();
+                            if (DatasetFieldConstant.westLongitude.equals(next.getTypeName())) {
+                                writeFullElement(xmlw, "westBL", next.getSinglePrimitive());
+                            }
+                        }
+                        for (Iterator<FieldDTO> iterator = foo.iterator(); iterator.hasNext(); ) {
+                            FieldDTO next = iterator.next();
+                            if (DatasetFieldConstant.eastLongitude.equals(next.getTypeName())) {
+                                writeFullElement(xmlw, "eastBL", next.getSinglePrimitive());
+                            }
+                        }
+                        for (Iterator<FieldDTO> iterator = foo.iterator(); iterator.hasNext(); ) {
+                            FieldDTO next = iterator.next();
+                            if (DatasetFieldConstant.southLatitude.equals(next.getTypeName())) {
+                                writeFullElement(xmlw, "southBL", next.getSinglePrimitive());
+                            }
+                        }
+                        for (Iterator<FieldDTO> iterator = foo.iterator(); iterator.hasNext(); ) {
+                            FieldDTO next = iterator.next();
+                            if (DatasetFieldConstant.northLatitude.equals(next.getTypeName())) {
+                                writeFullElement(xmlw, "northBL", next.getSinglePrimitive());
+                            }
+                        }
+                        xmlw.writeEndElement();
+                    }
 
-            if("socialscience".equals(key)){                
-                for (FieldDTO fieldDTO : value.getFields()) {
-                    if (DatasetFieldConstant.universe.equals(fieldDTO.getTypeName())) {
-                        writeMultipleElement(xmlw, "universe", fieldDTO);
-                    }
-                    if (DatasetFieldConstant.unitOfAnalysis.equals(fieldDTO.getTypeName())) {
-                        writeMultipleElement(xmlw, "anlyUnit", fieldDTO);                     
-                    }
-                }              
+                }
+            }
+        }
+
+        MetadataBlockDTO socialScience = metadataBlocks.get("socialscience");
+        if (socialScience != null) {
+            for (FieldDTO fieldDTO : socialScience.getFields()) {
+                if (DatasetFieldConstant.unitOfAnalysis.equals(fieldDTO.getTypeName())) {
+                    writeMultipleElement(xmlw, "anlyUnit", fieldDTO);
+                }
+            }
+            for (FieldDTO fieldDTO : socialScience.getFields()) {
+                if (DatasetFieldConstant.universe.equals(fieldDTO.getTypeName())) {
+                    writeMultipleElement(xmlw, "universe", fieldDTO);
+                }
+            }
+        }
+
+        if (citation != null) {
+            for (FieldDTO fieldDTO : citation.getFields()) {
+                if (DatasetFieldConstant.kindOfData.equals(fieldDTO.getTypeName())) {
+                    writeMultipleElement(xmlw, "dataKind", fieldDTO);
+                }
             }
         }
         xmlw.writeEndElement(); //sumDscr     

--- a/src/test/java/edu/harvard/iq/dataverse/export/ddi/dataset-finch1.xml
+++ b/src/test/java/edu/harvard/iq/dataverse/export/ddi/dataset-finch1.xml
@@ -44,17 +44,17 @@
         <timePrd cycle="P1" event="end" date="20160630">20160630</timePrd>
         <collDate cycle="P1" event="start" date="20070831">20070831</collDate>
         <collDate cycle="P1" event="end" date="20130630">20130630</collDate>
-        <dataKind>Kind of Data</dataKind>
         <nation>USA</nation>
         <geogCover>Cambridge</geogCover>
         <geogCover>MA</geogCover>
         <geogCover>Other Geographic Coverage</geogCover>
         <geoBndBox>
-          <southBL>41.6</southBL>
           <westBL>60.3</westBL>
           <eastBL>59.8</eastBL>
+          <southBL>41.6</southBL>
           <northBL>43.8</northBL>
         </geoBndBox>
+        <dataKind>Kind of Data</dataKind>
       </sumDscr>
     </stdyInfo>
     <method>

--- a/src/test/java/edu/harvard/iq/dataverse/export/ddi/exportfull.xml
+++ b/src/test/java/edu/harvard/iq/dataverse/export/ddi/exportfull.xml
@@ -77,34 +77,34 @@
         <collDate cycle="P1" event="end" date="1006-01-01">1006-01-01</collDate>
         <collDate cycle="P2" event="start" date="1006-02-01">1006-02-01</collDate>
         <collDate cycle="P2" event="end" date="1006-02-02">1006-02-02</collDate>
-        <dataKind>KindOfData1</dataKind>
-        <dataKind>KindOfData2</dataKind>
         <nation>Afghanistan</nation>
+        <nation>Albania</nation>
         <geogCover>GeographicCoverageCity1</geogCover>
         <geogCover>GeographicCoverageStateProvince1</geogCover>
         <geogCover>GeographicCoverageOther1</geogCover>
-        <nation>Albania</nation>
         <geogCover>GeographicCoverageCity2</geogCover>
         <geogCover>GeographicCoverageStateProvince2</geogCover>
         <geogCover>GeographicCoverageOther2</geogCover>
+        <geogUnit>GeographicUnit1</geogUnit>
+        <geogUnit>GeographicUnit2</geogUnit>
         <geoBndBox>
           <westBL>10</westBL>
           <eastBL>20</eastBL>
-          <northBL>30</northBL>
           <southBL>40</southBL>
+          <northBL>30</northBL>
         </geoBndBox>
         <geoBndBox>
+          <westBL>50</westBL>
+          <eastBL>60</eastBL>
           <southBL>80</southBL>
           <northBL>70</northBL>
-          <eastBL>60</eastBL>
-          <westBL>50</westBL>
         </geoBndBox>
-        <geogUnit>GeographicUnit1</geogUnit>
-        <geogUnit>GeographicUnit2</geogUnit>
         <anlyUnit>UnitOfAnalysis1</anlyUnit>
         <anlyUnit>UnitOfAnalysis2</anlyUnit>
         <universe>Universe1</universe>
         <universe>Universe2</universe>
+        <dataKind>KindOfData1</dataKind>
+        <dataKind>KindOfData2</dataKind>
       </sumDscr>
       <notes>Notes1</notes>
     </stdyInfo>
@@ -143,8 +143,6 @@
       <notes type="NotesType" subject="NotesSubject">NotesText</notes>
     </method>
     <dataAccs>
-      <notes type="DVN:TOU" level="dv">CC0 Waiver</notes>
-      <notes type="DVN:TOA" level="dv">Terms of Access</notes>
       <setAvail>
         <accsPlac>Data Access Place</accsPlac>
         <origArch>Original Archive</origArch>
@@ -162,6 +160,8 @@
         <conditions>Conditions </conditions>
         <disclaimer>Disclaimer</disclaimer>
       </useStmt>
+      <notes type="DVN:TOU" level="dv">CC0 Waiver</notes>
+      <notes type="DVN:TOA" level="dv">Terms of Access</notes>
     </dataAccs>
     <othrStdyMat>
       <relMat>RelatedMaterial1</relMat>


### PR DESCRIPTION
**What this PR does / why we need it**: Improves the DDI export

**Which issue(s) this PR closes**: 7127

Closes #7127 

**Special notes for your reviewer**: Looking good

**Suggestions on how to test this**: Make a DDI export for a dataset with geospatial data, then run the XML through a validator. You can validate here https://www.freeformatter.com/xml-validator-xsd.html with this XSD https://ddialliance.org/Specification/DDI-Codebook/2.5/XMLSchema/codebook.xsd. You do need to fix the import elements first. These are the correct ones:
```
<xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="https://ddialliance.org/Specification/DDI-Codebook/2.5/XMLSchema/xml.xsd"/>
<xs:import namespace="http://www.w3.org/1999/xhtml" schemaLocation="https://ddialliance.org/Specification/DDI-Codebook/2.5/XMLSchema/ddi-xhtml11.xsd"/>
<xs:import namespace="http://purl.org/dc/terms/" schemaLocation="https://ddialliance.org/Specification/DDI-Codebook/2.5/XMLSchema/dcterms.xsd"/>
``` 

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: No

**Is there a release notes update needed for this change?**: No

**Additional documentation**: