### PR TITLE
get memory tests running on Payara, 5.0 RC #7089

### DIFF
--- a/scripts/tests/ec2-memory-benchmark/README.md
+++ b/scripts/tests/ec2-memory-benchmark/README.md
@@ -13,9 +13,7 @@ All the other pieces will be downloaded automatically (from the
 either locally, where you're running the script, or on the newly
 created instance.
 
-The script downloads an Ansible config file called `main.yml` which you
-should copy to `main2.yml` and edit to enable "sampledata". This config
-file changes often enough upstream that it's better to make changes locally.
+The main reason a dedicated Ansible config file is used is to enable "sampledata".
 
 Run the script as follows: 
 

--- a/scripts/tests/ec2-memory-benchmark/README.md
+++ b/scripts/tests/ec2-memory-benchmark/README.md
@@ -13,6 +13,10 @@ All the other pieces will be downloaded automatically (from the
 either locally, where you're running the script, or on the newly
 created instance.
 
+The script downloads an Ansible config file called `main.yml` which you
+should copy to `main2.yml` and edit to enable "sampledata". This config
+file changes often enough upstream that it's better to make changes locally.
+
 Run the script as follows: 
 
 ```

--- a/scripts/tests/ec2-memory-benchmark/ec2-memory-benchmark-remote.sh
+++ b/scripts/tests/ec2-memory-benchmark/ec2-memory-benchmark-remote.sh
@@ -5,23 +5,25 @@ then
     EC2_HTTP_LOCATION="<EC2 INSTANCE HTTP ADDRESS>"
 fi
 
-DATAVERSE_APP_DIR=/usr/local/glassfish4/glassfish/domains/domain1/applications/dataverse; export DATAVERSE_APP_DIR
+DATAVERSE_APP_DIR=/usr/local/payara5/glassfish/domains/domain1/applications/dataverse; export DATAVERSE_APP_DIR
 
-# restart glassfish: 
+# restart app server
 
-echo "Restarting Glassfish..."
+echo "Restarting app server..."
+
+# still "glassfish" until Ansible is updated
 
 systemctl restart glassfish
 
 echo "done."
 
-# obtain the pid of the running glassfish process:
+# obtain the pid of the running app server process:
 
-GLASSFISH_PID=`ps awux | grep ^glassfi | awk '{print $2}' `; export GLASSFISH_PID 
+APP_SERVER_PID=`ps awux | grep ^dataver | awk '{print $2}' `; export APP_SERVER_PID
 
-if [ ${GLASSFISH_PID}"x" = "x" ]
+if [ ${APP_SERVER_PID}"x" = "x" ]
 then
-    echo "Failed to obtain the process id of the running Glassfish process!"
+    echo "Failed to obtain the process id of the running app server process!"
     exit 1;
 fi
 
@@ -34,7 +36,7 @@ yum -y install gnuplot >/dev/null
 
 GPLOT=gplot-1.11/gplot.pl; export GPLOT
 GPLOTDIST=https://pilotfiber.dl.sourceforge.net/project/gplot/gplot/gplot-1.11.tar.gz; export GPLOTDIST
-(cd /tmp; curl --insecure ${GPLOTDIST} 2>/dev/null | tar xzf - ${GPLOT} >/dev/null)
+(cd /tmp; curl -L --insecure ${GPLOTDIST} 2>/dev/null | tar xzf - ${GPLOT} >/dev/null)
 
 
 # Bombard the application with some GET requests. 
@@ -97,7 +99,7 @@ do
 
         # after every {repeat_outer} number of GETs, run jmap and save the output in a temp file:
 
-	sudo -u glassfish jmap -histo ${GLASSFISH_PID} > /tmp/jmap.histo.out
+	sudo -u dataverse jmap -histo ${APP_SERVER_PID} > /tmp/jmap.histo.out
 	
         # select the dataverse classes from the histo output: 
 	#grep '  edu\.harvard\.iq\.dataverse' /tmp/jmap.histo.out
@@ -119,7 +121,7 @@ do
 	echo 
 
         # run jstat to check on GC: 
-	sudo -u glassfish jstat -gcutil ${GLASSFISH_PID} 1000 1 2>/dev/null
+	sudo -u dataverse jstat -gcutil ${APP_SERVER_PID} 1000 1 2>/dev/null
 
 	echo 
 

--- a/scripts/tests/ec2-memory-benchmark/ec2-memory-benchmark.sh
+++ b/scripts/tests/ec2-memory-benchmark/ec2-memory-benchmark.sh
@@ -12,10 +12,10 @@ curl -O https://raw.githubusercontent.com/GlobalDataverseCommunityConsortium/dat
 chmod 755 ec2-create-instance.sh
 
 # download the sample data ec2 config: 
-curl -O https://raw.githubusercontent.com/IQSS/dataverse-sample-data/memory-monitoring-experiments/ec2config_memory_test.yaml
+curl -O https://raw.githubusercontent.com/GlobalDataverseCommunityConsortium/dataverse-ansible/master/defaults/main.yml
 
 # run the script: 
-./ec2-create-instance.sh -a ec2-memory-benchmark -b ${dataverse_branch} -r https://github.com/IQSS/dataverse.git -g ec2config_memory_test.yaml 2>&1 | tee create-instance.log
+./ec2-create-instance.sh -b ${dataverse_branch} -r https://github.com/IQSS/dataverse.git -g main2.yml 2>&1 | tee create-instance.log
 
 # obtain the address of the new instance, and the ssh key: 
 

--- a/scripts/tests/ec2-memory-benchmark/ec2-memory-benchmark.sh
+++ b/scripts/tests/ec2-memory-benchmark/ec2-memory-benchmark.sh
@@ -12,10 +12,10 @@ curl -O https://raw.githubusercontent.com/GlobalDataverseCommunityConsortium/dat
 chmod 755 ec2-create-instance.sh
 
 # download the sample data ec2 config: 
-curl -O https://raw.githubusercontent.com/GlobalDataverseCommunityConsortium/dataverse-ansible/master/defaults/main.yml
+curl -O https://raw.githubusercontent.com/GlobalDataverseCommunityConsortium/dataverse-ansible/master/tests/group_vars/memorytests.yml
 
 # run the script: 
-./ec2-create-instance.sh -b ${dataverse_branch} -r https://github.com/IQSS/dataverse.git -g main2.yml 2>&1 | tee create-instance.log
+./ec2-create-instance.sh -b ${dataverse_branch} -r https://github.com/IQSS/dataverse.git -g memorytests.yml 2>&1 | tee create-instance.log
 
 # obtain the address of the new instance, and the ssh key: 
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the memory test script so they run on Payara

**Which issue(s) this PR closes**:

Closes #7089

**Special notes for your reviewer**:

~~Because dataverse-ansible changes so quickly, I don't think it's wise to continue maintaining a fork of the config file in the sample data repo. To get it working, I downloaded the latest `main.yml` and edited to enable sample data, as explained in the readme.~~ There is a new dedicated Ansible config file in the dataverse-ansible repo.

The other changes are related to switching from Glassfish to Payara and should be pretty straightforward.

The actual results are interesting but probably out of scope for this pull request, where I'm simply getting the scripts to work. As of 78527a291 in 5.0 (release candidate), the dataset page does not show the sawtooth pattern of garbage collection that we want. Here's a visual comparison:

![7089](https://user-images.githubusercontent.com/21006/89076557-8e81c300-d34e-11ea-89b8-f14ac04da415.png)


**Suggestions on how to test this**:

Follow the README, which I made a slight edit to.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No.

**Is there a release notes update needed for this change?**:

No.

**Additional documentation**:
