### PR TITLE
7159 fix restassured etc

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DatasetServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetServiceBean.java
@@ -788,21 +788,22 @@ public class DatasetServiceBean implements java.io.Serializable {
      * Any failure notifications to users should be sent from inside the command.
      */
     @Asynchronous
+    @TransactionAttribute(TransactionAttributeType.SUPPORTS)
     public void callFinalizePublishCommandAsynchronously(Long datasetId, CommandContext ctxt, DataverseRequest request, boolean isPidPrePublished) {
 
         // Since we are calling the next command asynchronously anyway - sleep here 
         // for a few seconds, just in case, to make sure the database update of 
         // the dataset initiated by the PublishDatasetCommand has finished, 
         // to avoid any concurrency/optimistic lock issues. 
-        // Aug. 2020/v5.0: It appears to be working consistently without any 
+        // Aug. 2020/v5.0: It MAY be working consistently without any 
         // sleep here, after the call the method has been moved to the onSuccess()
         // portion of the PublishDatasetCommand. I'm going to leave the 1 second
-        // sleep commented-out below for now: -- L.A.
-        /*try {
+        // sleep below, for just in case reasons: -- L.A.
+        try {
             Thread.sleep(1000);
         } catch (Exception ex) {
-            logger.warning("Failed to sleep for 1 second.");
-        }*/
+            logger.warning("Failed to sleep for a second.");
+        }
         logger.fine("Running FinalizeDatasetPublicationCommand, asynchronously");
         Dataset theDataset = find(datasetId);
         try {

--- a/src/main/java/edu/harvard/iq/dataverse/DatasetServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetServiceBean.java
@@ -780,21 +780,36 @@ public class DatasetServiceBean implements java.io.Serializable {
         return workflowComment;
     }
     
+    /**
+     * This method used to throw CommandException, which was pretty pointless 
+     * seeing how it's called asynchronously. As of v5.0 any CommanExceptiom 
+     * thrown by the FinalizeDatasetPublicationCommand below will be caught 
+     * and we'll log it as a warning - which is the best we can do at this point.
+     * Any failure notifications to users should be sent from inside the command.
+     */
     @Asynchronous
-    public void callFinalizePublishCommandAsynchronously(Long datasetId, CommandContext ctxt, DataverseRequest request, boolean isPidPrePublished) throws CommandException {
+    public void callFinalizePublishCommandAsynchronously(Long datasetId, CommandContext ctxt, DataverseRequest request, boolean isPidPrePublished) {
 
         // Since we are calling the next command asynchronously anyway - sleep here 
         // for a few seconds, just in case, to make sure the database update of 
         // the dataset initiated by the PublishDatasetCommand has finished, 
         // to avoid any concurrency/optimistic lock issues. 
-        try {
-            Thread.sleep(15000);
+        // Aug. 2020/v5.0: It appears to be working consistently without any 
+        // sleep here, after the call the method has been moved to the onSuccess()
+        // portion of the PublishDatasetCommand. I'm going to leave the 1 second
+        // sleep commented-out below for now: -- L.A.
+        /*try {
+            Thread.sleep(1000);
         } catch (Exception ex) {
-            logger.warning("Failed to sleep for 15 seconds.");
-        }
+            logger.warning("Failed to sleep for 1 second.");
+        }*/
         logger.fine("Running FinalizeDatasetPublicationCommand, asynchronously");
         Dataset theDataset = find(datasetId);
-        commandEngine.submit(new FinalizeDatasetPublicationCommand(theDataset, request, isPidPrePublished));
+        try {
+            commandEngine.submit(new FinalizeDatasetPublicationCommand(theDataset, request, isPidPrePublished));
+        } catch (CommandException cex) {
+            logger.warning("CommandException caught when executing the asynchronous portion of the Dataset Publication Command.");
+        }
     }
     
     /*

--- a/src/main/java/edu/harvard/iq/dataverse/api/Datasets.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Datasets.java
@@ -1020,7 +1020,7 @@ public class Datasets extends AbstractApiBean {
             PublishDatasetResult res = execCommand(new PublishDatasetCommand(ds,
                         createDataverseRequest(user),
                     isMinor));
-            return res.isCompleted() ? ok(json(res.getDataset())) : accepted(json(res.getDataset()));
+            return res.isWorkflow() ? accepted(json(res.getDataset())) : ok(json(res.getDataset()));
             }
         } catch (WrappedResponse ex) {
             return ex.getResponse();

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/FinalizeDatasetPublicationCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/FinalizeDatasetPublicationCommand.java
@@ -213,7 +213,7 @@ public class FinalizeDatasetPublicationCommand extends AbstractPublishDatasetCom
         try {
             Future<String> indexString = ctxt.index().indexDataset(dataset, true);                   
         } catch (IOException | SolrServerException e) {    
-            String failureLogText = "Post-publication indexing failed. You can kickoff a re-index of this dataset with: \r\n curl http://localhost:8080/api/admin/index/datasets/" + dataset.getId().toString();
+            String failureLogText = "Post-publication indexing failed. You can kick off a re-index of this dataset with: \r\n curl http://localhost:8080/api/admin/index/datasets/" + dataset.getId().toString();
             failureLogText += "\r\n" + e.getLocalizedMessage();
             LoggingUtil.writeOnSuccessFailureLog(this, failureLogText,  dataset);
             retVal = false;

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/FinalizeDatasetPublicationCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/FinalizeDatasetPublicationCommand.java
@@ -190,6 +190,13 @@ public class FinalizeDatasetPublicationCommand extends AbstractPublishDatasetCom
             notifyUsersDatasetPublishStatus(ctxt, theDataset, UserNotification.Type.PUBLISHEDDS);
         }
         
+        // Finally, unlock the dataset:
+        ctxt.datasets().removeDatasetLocks(theDataset, DatasetLock.Reason.Workflow);
+        ctxt.datasets().removeDatasetLocks(theDataset, DatasetLock.Reason.finalizePublication);
+        if ( theDataset.isLockedFor(DatasetLock.Reason.InReview) ) {
+            ctxt.datasets().removeDatasetLocks(theDataset, DatasetLock.Reason.InReview);
+        }
+        
         return readyDataset;
     }
     
@@ -202,7 +209,7 @@ public class FinalizeDatasetPublicationCommand extends AbstractPublishDatasetCom
         } catch (ClassCastException e){
             dataset  = ((PublishDatasetResult) r).getDataset();
         }
-
+        
         try {
             Future<String> indexString = ctxt.index().indexDataset(dataset, true);                   
         } catch (IOException | SolrServerException e) {    
@@ -213,12 +220,6 @@ public class FinalizeDatasetPublicationCommand extends AbstractPublishDatasetCom
         }
 
         exportMetadata(dataset, ctxt.settings());
-        
-        ctxt.datasets().removeDatasetLocks(dataset, DatasetLock.Reason.Workflow);
-        ctxt.datasets().removeDatasetLocks(dataset, DatasetLock.Reason.finalizePublication);
-        if ( dataset.isLockedFor(DatasetLock.Reason.InReview) ) {
-            ctxt.datasets().removeDatasetLocks(dataset, DatasetLock.Reason.InReview);
-        }
                 
         ctxt.datasets().updateLastExportTimeStamp(dataset.getId());
 

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/PublishDatasetCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/PublishDatasetCommand.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.logging.Logger;
 import static java.util.stream.Collectors.joining;
+import static edu.harvard.iq.dataverse.engine.command.impl.PublishDatasetResult.Status;
 
 /**
  * Kick-off a dataset publication process. The process may complete immediately, 
@@ -91,7 +92,7 @@ public class PublishDatasetCommand extends AbstractPublishDatasetCommand<Publish
             theDataset = ctxt.em().merge(theDataset);
             ctxt.em().flush();
             ctxt.workflows().start(prePubWf.get(), buildContext(theDataset, TriggerType.PrePublishDataset, datasetExternallyReleased));
-            return new PublishDatasetResult(theDataset, false);
+            return new PublishDatasetResult(theDataset, Status.Workflow);
             
         } else{
             // We will skip trying to register the global identifiers for datafiles 
@@ -135,8 +136,10 @@ public class PublishDatasetCommand extends AbstractPublishDatasetCommand<Publish
             lock.setInfo(info);
             ctxt.datasets().addDatasetLock(theDataset, lock);
             theDataset = ctxt.em().merge(theDataset);
-            ctxt.datasets().callFinalizePublishCommandAsynchronously(theDataset.getId(), ctxt, request, datasetExternallyReleased);
-            return new PublishDatasetResult(theDataset, false);
+            // The call to FinalizePublicationCommand has been moved to the new @onSuccess()
+            // method:
+            //ctxt.datasets().callFinalizePublishCommandAsynchronously(theDataset.getId(), ctxt, request, datasetExternallyReleased);
+            return new PublishDatasetResult(theDataset, Status.Inprogress);
 
             /**
               * Code for for "synchronous" (while-you-wait) publishing 
@@ -144,7 +147,7 @@ public class PublishDatasetCommand extends AbstractPublishDatasetCommand<Publish
             } else {
                 // Synchronous publishing (no workflow involved)
                 theDataset = ctxt.engine().submit(new FinalizeDatasetPublicationCommand(theDataset, getRequest(),datasetExternallyReleased));
-                return new PublishDatasetResult(theDataset, true);
+                return new PublishDatasetResult(theDataset, Status.Completed);
             } */
         }
     }
@@ -196,6 +199,24 @@ public class PublishDatasetCommand extends AbstractPublishDatasetCommand<Publish
                 throw new IllegalCommandException("Cannot release as minor version. Re-try as major release.", this);
             }
         }
-    }   
+    }
+    
+    
+    @Override
+    public boolean onSuccess(CommandContext ctxt, Object r) {
+        Dataset dataset = null;
+        try{
+            dataset = (Dataset) r;
+        } catch (ClassCastException e){
+            dataset  = ((PublishDatasetResult) r).getDataset();
+        }
+
+        if (dataset != null) {
+            ctxt.datasets().callFinalizePublishCommandAsynchronously(dataset.getId(), ctxt, request, datasetExternallyReleased);
+            return true;
+        }
+        
+        return false;
+    }
     
 }

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/PublishDatasetResult.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/PublishDatasetResult.java
@@ -11,11 +11,21 @@ import edu.harvard.iq.dataverse.DatasetLock;
 public class PublishDatasetResult {
     
     private final Dataset dataset;
-    private final boolean isCompleted;
+    private final Status status;
+    
+    public enum Status {
+        /** Dataset has been published */
+        Completed,
+        /** Publish workflow is in progress */
+        Workflow,
+        /** Publishing is being finalized asynchronously */
+        Inprogress
+    }
+        
 
-    public PublishDatasetResult(Dataset dataset, boolean isCompleted) {
+    public PublishDatasetResult(Dataset dataset, Status status) {
         this.dataset = dataset;
-        this.isCompleted = isCompleted;
+        this.status = status;
     }
     
     /**
@@ -34,7 +44,14 @@ public class PublishDatasetResult {
      * @return {@code true} iff the publication process was completed. {@code false} otherwise.
      */
     public boolean isCompleted() {
-        return isCompleted;
+        return status == Status.Completed;
     }
     
+    public boolean isWorkflow() {
+        return status == Status.Workflow;
+    }
+    
+    public boolean isInProgress() {
+        return status == Status.Inprogress;
+    }
 }

--- a/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
@@ -51,7 +51,8 @@ public class UtilIT {
     private static final String BUILTIN_USER_KEY = "burrito";
     private static final String EMPTY_STRING = "";
     public static final int MAXIMUM_INGEST_LOCK_DURATION = 3;
-
+    public static final int MAXIMUM_PUBLISH_LOCK_DURATION = 15;
+    
     private static SwordConfigurationImpl swordConfiguration = new SwordConfigurationImpl();
     
     static Matcher<String> equalToCI( String value ) {
@@ -1017,10 +1018,14 @@ public class UtilIT {
     }
 
     static Response publishDatasetViaSword(String persistentId, String apiToken) {
-        return given()
+        Response publishResponse =  given()
                 .auth().basic(apiToken, EMPTY_STRING)
                 .header("In-Progress", "false")
                 .post(swordConfiguration.getBaseUrlPathCurrent() + "/edit/study/" + persistentId);
+        
+        // Wait for the dataset to get unlocked, if/as needed:
+        sleepForLock(persistentId, "finalizePublication", apiToken, UtilIT.MAXIMUM_INGEST_LOCK_DURATION);            
+        return publishResponse;
     }
 
     static Response publishDatasetViaNativeApi(String idOrPersistentId, String majorOrMinor, String apiToken) {
@@ -1036,7 +1041,12 @@ public class UtilIT {
                     .urlEncodingEnabled(false)
                     .header(UtilIT.API_TOKEN_HTTP_HEADER, apiToken);
         }
-        return requestSpecification.post("/api/datasets/" + idInPath + "/actions/:publish?type=" + majorOrMinor + optionalQueryParam);
+        Response publishResponse = requestSpecification.post("/api/datasets/" + idInPath + "/actions/:publish?type=" + majorOrMinor + optionalQueryParam);
+        
+        // Wait for the dataset to get unlocked, if/as needed:
+        sleepForLock(idOrPersistentId, "finalizePublication", apiToken, UtilIT.MAXIMUM_INGEST_LOCK_DURATION);            
+        
+        return publishResponse;
     }
 
     static Response publishDatasetViaNativeApiDeprecated(String persistentId, String majorOrMinor, String apiToken) {
@@ -1044,10 +1054,23 @@ public class UtilIT {
          * @todo This should be a POST rather than a GET:
          * https://github.com/IQSS/dataverse/issues/2431
          */
-        return given()
+        Response publishResponse = given()
                 .header(API_TOKEN_HTTP_HEADER, apiToken)
                 .urlEncodingEnabled(false)
                 .get("/api/datasets/:persistentId/actions/:publish?type=" + majorOrMinor + "&persistentId=" + persistentId);
+        
+        // Wait for the dataset to get unlocked, if/as needed:
+        sleepForLock(persistentId, "finalizePublication", apiToken, UtilIT.MAXIMUM_INGEST_LOCK_DURATION);            
+        
+        return publishResponse;
+    }
+   
+    // Compatibility method wrapper (takes Integer for the dataset id) 
+    // It used to use the GET version of the publish API; I'm switching it to 
+    // use the new POST variant. The explicitly marked @deprecated method above
+    // should be sufficient for testing the deprecated API call. 
+    static Response publishDatasetViaNativeApi(Integer datasetId, String majorOrMinor, String apiToken) {
+        return publishDatasetViaNativeApi(datasetId.toString(), majorOrMinor, apiToken);
     }
     
     static Response modifyDatasetPIDMetadataViaApi(String persistentId,  String apiToken) {
@@ -1059,17 +1082,6 @@ public class UtilIT {
                 .header(API_TOKEN_HTTP_HEADER, apiToken)
                 .urlEncodingEnabled(false)
                 .get("/api/datasets/:persistentId/&persistentId=" + persistentId);
-    }
-
-    static Response publishDatasetViaNativeApi(Integer datasetId, String majorOrMinor, String apiToken) {
-        /**
-         * @todo This should be a POST rather than a GET:
-         * https://github.com/IQSS/dataverse/issues/2431
-         */
-        return given()
-                .header(API_TOKEN_HTTP_HEADER, apiToken)
-                .urlEncodingEnabled(false)
-                .get("/api/datasets/" + datasetId + "/actions/:publish?type=" + majorOrMinor);
     }
 
     static Response publishDataverseViaSword(String alias, String apiToken) {
@@ -2187,13 +2199,20 @@ public class UtilIT {
     
     //Helper function that returns true if a given dataset locked for a  given reason is unlocked within
     // a given duration returns false if still locked after given duration
+    // (the version of the method that takes a long for the dataset id is 
+    // for backward compatibility with how the method is called for the 
+    // Ingest lock throughout the test code)
     static Boolean sleepForLock(long datasetId, String lockType, String apiToken, int duration) {
+        String datasetIdAsString = String.valueOf(datasetId);
+        return sleepForLock(datasetIdAsString, lockType, apiToken, duration);
+    }
 
-        Response lockedForIngest = UtilIT.checkDatasetLocks(datasetId, lockType, apiToken);
+    static Boolean sleepForLock(String idOrPersistentId, String lockType, String apiToken, int duration) {
+        Response lockedForIngest = UtilIT.checkDatasetLocks(idOrPersistentId, lockType, apiToken);
         int i = 0;
         do {
             try {
-                lockedForIngest = UtilIT.checkDatasetLocks(datasetId, lockType, apiToken);
+                lockedForIngest = UtilIT.checkDatasetLocks(idOrPersistentId, lockType, apiToken);
                 Thread.sleep(1000);
                 i++;
                 if (i > duration) {
@@ -2232,12 +2251,27 @@ public class UtilIT {
 
     }
     
-    
-    
+    // backward compatibility version of the method that takes long for the id:
     static Response checkDatasetLocks(long datasetId, String lockType, String apiToken) {
+        String datasetIdAsString = String.valueOf(datasetId);
+        return checkDatasetLocks(datasetIdAsString, lockType, apiToken);
+    }
+    
+    static Response checkDatasetLocks(String idOrPersistentId, String lockType, String apiToken) {
+        String idInPath = idOrPersistentId; // Assume it's a number.
+        String queryParams = ""; // If idOrPersistentId is a number we'll just put it in the path.
+        if (!NumberUtils.isNumber(idOrPersistentId)) {
+            idInPath = ":persistentId";
+            queryParams = "?persistentId=" + idOrPersistentId;
+        }
+        
+        if (lockType != null) {
+            queryParams = "".equals(queryParams) ? "?type="+lockType : queryParams+"&type="+lockType;
+        }
+        
         Response response = given()
             .header(API_TOKEN_HTTP_HEADER, apiToken)
-            .get("api/datasets/" + datasetId + "/locks" + (lockType == null ? "" : "?type="+lockType));
+            .get("api/datasets/" + idInPath + "/locks" + queryParams);
         return response;       
     }
     


### PR DESCRIPTION
**What this PR does / why we need it**:
The issue was opened initially because I forgot to check in some RestAssured code (UtilIT.java, etc.) that was needed for the tests to run. (The new publish mechanism involves waiting for the dataset to unlock, if locks are present; so that was missing). 
But we also discovered some non-test related issues that needed to be addressed: 
There was a massive sleep statement in the service bean before calling the async. portion of the command that we forgot about. In this PR I added an onSuccess() to the PublishDataset command; the second command call is made from there, and this appears to make any sleep delay unnecessary (per suggestion from @scolapasta)
Due to some weirdness in how the onSuccess() of the second command is executed, I also realized that even after all the changes in #6918 there was still a possibility for the dataset to become unlocked before the publication was finalized. (If the indexing and/or export are taking a long time, for ex.). This was addressed by moving the unlocking code to onSuccess(). 
Further simplified the RestAssured changes (only UtilIT.java is modified).
Modifed PublishDatasetResult to treat "publish workflow" and "asynchronous publishing in progress" as distinct states.



**Which issue(s) this PR closes**:

Closes #7159

**Special notes for your reviewer**:

**Suggestions on how to test this**:

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
