### PR TITLE
#7176 add testing for null host DV on DS Create

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
@@ -1270,6 +1270,9 @@ public class DatasetPage implements java.io.Serializable {
         return permissionsWrapper.canUpdateDataset(dvRequestService.getDataverseRequest(), this.dataset);
     }
     public boolean canPublishDataverse() {
+        if (dataset.getOwner() == null){
+            return false;
+        }
         return permissionsWrapper.canIssuePublishDataverseCommand(dataset.getOwner());
     }
 
@@ -1623,6 +1626,9 @@ public class DatasetPage implements java.io.Serializable {
      *
      */    
      private void updateDatasetFieldInputLevels() {
+         if(dataset.getOwner() == null){
+             return;
+         }
          Long dvIdForInputLevel = ownerId;
         
          // OPTIMIZATION (?): replaced "dataverseService.find(ownerId)" with 
@@ -1864,7 +1870,9 @@ public class DatasetPage implements java.io.Serializable {
                 //retrieveDatasetVersionResponse = datasetVersionService.retrieveDatasetVersionByVersionId(versionId);
 
             }
-            this.maxFileUploadSizeInBytes = systemConfig.getMaxFileUploadSizeForStore(dataset.getOwner().getEffectiveStorageDriverId());
+            if (dataset.getOwner() != null) {
+                this.maxFileUploadSizeInBytes = systemConfig.getMaxFileUploadSizeForStore(dataset.getOwner().getEffectiveStorageDriverId());
+            }
 
 
             if (retrieveDatasetVersionResponse == null) {
@@ -3948,12 +3956,15 @@ public class DatasetPage implements java.io.Serializable {
     
     public boolean publishDatasetPopup(){
         if (!dataset.isReleased()) {
-            return dataset.getOwner().isReleased();
+            return dataset.getOwner() != null && dataset.getOwner().isReleased();
         }
        return false; 
     }
     
     public boolean publishBothPopup() {
+        if (dataset.getOwner() == null){
+            return false;
+        }
         if (!dataset.getOwner().isReleased()) {
             if (canPublishDataverse()) {
                 if (dataset.getOwner().getOwner() == null

--- a/src/main/java/edu/harvard/iq/dataverse/EditDatafilesPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/EditDatafilesPage.java
@@ -3082,7 +3082,8 @@ public class EditDatafilesPage implements java.io.Serializable {
     	// ToDo - rsync was written before multiple store support and currently is hardcoded to use the "s3" store. 
     	// When those restrictions are lifted/rsync can be configured per store, this test should check that setting
     	// instead of testing for the 's3" store.
-    	return settingsWrapper.isRsyncUpload() && dataset.getDataverseContext().getEffectiveStorageDriverId().equals("s3");
+    	return settingsWrapper.isRsyncUpload() && dataset.getDataverseContext() != null &&
+                dataset.getDataverseContext().getEffectiveStorageDriverId().equals("s3");
     }
     
     


### PR DESCRIPTION
**What this PR does / why we need it**:
For recent button updates we moved some of the render logic to the DatasetPage bean. This logic assumes that the dataset has an owner (host dataverse). if on create the user decides to null out the host dataverse this logic breaks and the page fails to render. This PR updates the render logic to guard against a null host dataverse.

**Which issue(s) this PR closes**:

Closes #7176 Create Dataset Validation fails etc.

**Special notes for your reviewer**:

**Suggestions on how to test this**:

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
No
**Is there a release notes update needed for this change?**:
No

**Additional documentation**:
None