### PR TITLE
The sample ejb-jar.xml file had a bad version number that would preve…

### DIFF
--- a/doc/sphinx-guides/source/_static/admin/ejb-jar.xml
+++ b/doc/sphinx-guides/source/_static/admin/ejb-jar.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ejb-jar xmlns = "http://java.sun.com/xml/ns/javaee" 
-         version = "3.2"
+         version = "3.1"
          xmlns:xsi = "http://www.w3.org/2001/XMLSchema-instance" 
          xsi:schemaLocation = "http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/ejb-jar_3_1.xsd">
     <enterprise-beans>

--- a/doc/sphinx-guides/source/admin/timers.rst
+++ b/doc/sphinx-guides/source/admin/timers.rst
@@ -69,25 +69,25 @@ This job is automatically scheduled to run once a week at 12:30AM local time on 
 
 * Alternatively, you can insert an ejb-jar.xml file into a provided dataverse war file without building the application.
 
-    * Check if there is already an ejb-jar.xml file in the war file 
+  * Check if there is already an ejb-jar.xml file in the war file 
 
-        * jar tvf $DATAVERSE-WAR-FILENAME | grep ejb-jar.xml
+    * jar tvf $DATAVERSE-WAR-FILENAME | grep ejb-jar.xml
 
-            * if the response includes " WEB-INF/ejb-jar.xml", you will need to extract the ejb-jar.xml file for editing
+      * if the response includes " WEB-INF/ejb-jar.xml", you will need to extract the ejb-jar.xml file for editing
 
-                * jar xvf $DATAVERSE-WAR-FILENAME WEB-INF/ejb-jar.xml 
+        * jar xvf $DATAVERSE-WAR-FILENAME WEB-INF/ejb-jar.xml 
 
-                    * edit the extracted WEB-INF/ejb-jar.xml, following the :download:`sample file <../_static/admin/ejb-jar.xml>` provided.
+          * edit the extracted WEB-INF/ejb-jar.xml, following the :download:`sample file <../_static/admin/ejb-jar.xml>` provided.
 
-            * if the response is empty, create a WEB-INF directory and create en ejb-jar.xml file in it, following the :download:`sample file <../_static/admin/ejb-jar.xml>` provided.
+        * if the response is empty, create a WEB-INF directory and create en ejb-jar.xml file in it, following the :download:`sample file <../_static/admin/ejb-jar.xml>` provided.
 
-                * edit the parameters in the <schedule> section of the WEB-INF/ejb-jar.xml to suit your preferred schedule
+          * edit the parameters in the <schedule> section of the WEB-INF/ejb-jar.xml to suit your preferred schedule
 
-        * Insert the edited WEB-INF/ejb-jar.xml into the dataverse war file
+    * Insert the edited WEB-INF/ejb-jar.xml into the dataverse war file
 
-            * jar uvf $DATAVERSE-WAR-FILENAME WEB-INF/ejb-jar.xml
+    * jar uvf $DATAVERSE-WAR-FILENAME WEB-INF/ejb-jar.xml
 
-        * Deploy the war file
+    * Deploy the war file
 
 
 See also :ref:`saved-search` in the API Guide.

--- a/doc/sphinx-guides/source/admin/timers.rst
+++ b/doc/sphinx-guides/source/admin/timers.rst
@@ -83,11 +83,11 @@ This job is automatically scheduled to run once a week at 12:30AM local time on 
 
           * edit the parameters in the <schedule> section of the WEB-INF/ejb-jar.xml to suit your preferred schedule
 
-    * Insert the edited WEB-INF/ejb-jar.xml into the dataverse war file
+  * Insert the edited WEB-INF/ejb-jar.xml into the dataverse war file
 
     * jar uvf $DATAVERSE-WAR-FILENAME WEB-INF/ejb-jar.xml
 
-    * Deploy the war file
+  * Deploy the war file
 
 
 See also :ref:`saved-search` in the API Guide.

--- a/doc/sphinx-guides/source/admin/timers.rst
+++ b/doc/sphinx-guides/source/admin/timers.rst
@@ -59,13 +59,36 @@ This job is automatically scheduled to run once a week at 12:30AM local time on 
 
 * Create or edit dataverse/src/main/webapp/WEB-INF/ejb-jar.xml, following the :download:`sample file <../_static/admin/ejb-jar.xml>` provided.
 
-* Edit the parameters in the <schedule> section ejb-jar file in the WEB-INF directory to suit your preferred schedule
+* Edit the parameters in the <schedule> section of the ejb-jar file in the WEB-INF directory to suit your preferred schedule
 
   * The provided parameters in the sample file are <minute>, <hour>, and <dayOfWeek>; additional parameters are available
 
     * For a complete reference for calendar expressions that can be used to schedule Timer services see: https://docs.oracle.com/javaee/7/tutorial/ejb-basicexamples004.htm
 
 * Build and deploy the application
+
+* Alternatively, you can insert an ejb-jar.xml file into a provided dataverse war file without building the application.
+
+    * Check if there is already an ejb-jar.xml file in the war file (as I'm writing, the dataverse war file is named dataverse-4.20.war)
+
+        * jar tvf dataverse-4.20.war | grep ejb-jar.xml
+
+            * if the response includes " WEB-INF/ejb-jar.xml", you will need to extract the ejb-jar.xml file for editing
+
+                * jar xvf dataverse-4.20.war WEB-INF/ejb-jar.xml 
+
+                    * edit the extracted WEB-INF/ejb-jar.xml, following the :download:`sample file <../_static/admin/ejb-jar.xml>` provided.
+
+            * if the response is empty, create a WEB-INF directory and create en ejb-jar.xml file in it, following the :download:`sample file <../_static/admin/ejb-jar.xml>` provided.
+
+                * edit the parameters in the <schedule> section of the WEB-INF/ejb-jar.xml to suit your preferred schedule
+
+        * Insert the edited WEB-INF/ejb-jar.xml into the dataverse war file
+
+            * jar uvf dataverse-4.20.war WEB-INF/ejb-jar.xml
+
+        * Deploy the war file
+
 
 See also :ref:`saved-search` in the API Guide.
 

--- a/doc/sphinx-guides/source/admin/timers.rst
+++ b/doc/sphinx-guides/source/admin/timers.rst
@@ -69,13 +69,13 @@ This job is automatically scheduled to run once a week at 12:30AM local time on 
 
 * Alternatively, you can insert an ejb-jar.xml file into a provided dataverse war file without building the application.
 
-    * Check if there is already an ejb-jar.xml file in the war file (as I'm writing, the dataverse war file is named dataverse-4.20.war)
+    * Check if there is already an ejb-jar.xml file in the war file 
 
-        * jar tvf dataverse-4.20.war | grep ejb-jar.xml
+        * jar tvf $DATAVERSE-WAR-FILENAME | grep ejb-jar.xml
 
             * if the response includes " WEB-INF/ejb-jar.xml", you will need to extract the ejb-jar.xml file for editing
 
-                * jar xvf dataverse-4.20.war WEB-INF/ejb-jar.xml 
+                * jar xvf $DATAVERSE-WAR-FILENAME WEB-INF/ejb-jar.xml 
 
                     * edit the extracted WEB-INF/ejb-jar.xml, following the :download:`sample file <../_static/admin/ejb-jar.xml>` provided.
 
@@ -85,7 +85,7 @@ This job is automatically scheduled to run once a week at 12:30AM local time on 
 
         * Insert the edited WEB-INF/ejb-jar.xml into the dataverse war file
 
-            * jar uvf dataverse-4.20.war WEB-INF/ejb-jar.xml
+            * jar uvf $DATAVERSE-WAR-FILENAME WEB-INF/ejb-jar.xml
 
         * Deploy the war file
 


### PR DESCRIPTION
…nt deployment of the application if the ejb-jar file was used to modify the saved searchers timer schedule.

I updated the timer.rst file to document a procedure for inserting an edited ejb-jar.xml file into a war, rather than doing a full build of the application

**What this PR does / why we need it**:The sample file cannot be used with the wrong version number

**Which issue(s) this PR closes**:Bad version number in sample ejb-jar.xml; document procedure for updating the war file to include the ejb-jar.xml outside of a build environment

Closes #7175 

**Special notes for your reviewer**:

**Suggestions on how to test this**: You can test the procedure documented at the end of the timer.rst file. The description of this procedure starts with "Alternatively, you can insert an ejb-jar.xml ..."

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:no

**Is there a release notes update needed for this change?**:no

**Additional documentation**:
