### PR TITLE
Fixed publish btn dropdown display [ref #7183]

### DIFF
--- a/src/main/webapp/dataset.xhtml
+++ b/src/main/webapp/dataset.xhtml
@@ -251,7 +251,7 @@
                                                 <!-- Publish BTN -->
                                                 <h:outputLink value="#" disabled="#{DatasetPage.lockedFromPublishing}">
                                                     <c:if test="#{!(showSubmitForReviewLink or showReturnToAuthorLink)}">
-                                                        <f:passThroughAttribute name="class" value="btn btn-default btn-access btn-publish dropdown-toggle #{DatasetPage.lockedFromPublishing ? 'disabled' : ''}"/>
+                                                        <f:passThroughAttribute name="class" value="btn btn-default btn-access btn-publish #{DatasetPage.lockedFromPublishing ? 'disabled' : ''}"/>
                                                         <f:passThroughAttribute name="onclick" value="$(this).parent().find( 'li > a' ).trigger( 'click' );"/>
                                                     </c:if>
                                                     <c:if test="#{showSubmitForReviewLink or showReturnToAuthorLink}">


### PR DESCRIPTION
**What this PR does / why we need it**:

Extra `dropdown-toggle` style class snuck into the single-click version of the Publish btn, which triggered the display of the dropdown menu under the button when clicked.

**Which issue(s) this PR closes**:

Closes #7183 Extraneous Publish Option on Release Candidate 

**Special notes for your reviewer**:

See screenshot in original issue for how the single-click version of the Publish btn should NOT look.

**Suggestions on how to test this**:

When you click the Publish btn on a dataset with no Submit For Review set up, you should NOT see the dropdown menu displayed, as the screenshot in the original issue shows. If you see a dropdown carrot icon in the button for a dataset WITH the Submit For Review workflow set up, then you should see the dropdown menu, showing the Publish or Return To Author options.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

It fixes a UI bug, returning the page to intended functionality, this is not a change in design.

**Is there a release notes update needed for this change?**:

No.

**Additional documentation**:

N/A
