### PR TITLE
7176 create dataset fix save validation

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
@@ -2012,7 +2012,11 @@ public class DatasetPage implements java.io.Serializable {
             }                        
             dataverseTemplates.addAll(dataverseService.find(ownerId).getTemplates());
             if (!dataverseService.find(ownerId).isTemplateRoot()) {
-                dataverseTemplates.addAll(dataverseService.find(ownerId).getParentTemplates());
+                for (Template templateTest: dataverseService.find(ownerId).getParentTemplates()){
+                   if(!dataverseTemplates.contains(templateTest)){
+                       dataverseTemplates.add(templateTest);
+                   }
+                }               
             }
             Collections.sort(dataverseTemplates, (Template t1, Template t2) -> t1.getName().compareToIgnoreCase(t2.getName()));
 

--- a/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
@@ -1811,7 +1811,20 @@ public class DatasetPage implements java.io.Serializable {
             init(true);
             // rebuild the bred crumbs display:
             dataverseHeaderFragment.initBreadcrumbs(dataset);
+        }       
+    }
+    
+    public boolean rsyncUploadSupported() {
+        // ToDo - rsync was written before multiple store support and currently is hardcoded to use the "s3" store. 
+        // When those restrictions are lifted/rsync can be configured per store, this test should check that setting
+        // instead of testing for the 's3" store.
+
+        /*failsafe when no new owner selected*/
+        if (dataset.getOwner() == null || dataset.getOwner().getId() == null) {
+            dataset.setOwner(ownerId != null ? dataverseService.find(ownerId) : null);
         }
+
+        return settingsWrapper.isRsyncUpload() && dataset.getDataverseContext().getEffectiveStorageDriverId().equals("s3");
     }
     
     private String init(boolean initFull) {
@@ -3494,6 +3507,7 @@ public class DatasetPage implements java.io.Serializable {
     }
      
     public String save() {
+        
         //Before dataset saved, write cached prov freeform to version
         if (systemConfig.isProvCollectionEnabled()) {
             provPopupFragmentBean.saveStageProvFreeformToLatestVersion();

--- a/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
@@ -3507,7 +3507,6 @@ public class DatasetPage implements java.io.Serializable {
     }
      
     public String save() {
-        
         //Before dataset saved, write cached prov freeform to version
         if (systemConfig.isProvCollectionEnabled()) {
             provPopupFragmentBean.saveStageProvFreeformToLatestVersion();

--- a/src/main/java/edu/harvard/iq/dataverse/EditDatafilesPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/EditDatafilesPage.java
@@ -3081,10 +3081,9 @@ public class EditDatafilesPage implements java.io.Serializable {
 
     public boolean rsyncUploadSupported() {
     	// ToDo - rsync was written before multiple store support and currently is hardcoded to use the "s3" store. 
-    	// When those restrictions are lifted/rsync can be configured per store, this test should check that setting
-    	// instead of testing for the 's3" store.
-        //NOTE - This method also exists in DatasetPage so when it is changed here it must be
-        //changed there. SEK 8/12/2020
+    	// When those restrictions are lifted/rsync can be configured per store, the test in the 
+        // Dataset Util method should be updated
+
     	return settingsWrapper.isRsyncUpload() && DatasetUtil.isAppropriateStorageDriver(dataset);
     }
     

--- a/src/main/java/edu/harvard/iq/dataverse/EditDatafilesPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/EditDatafilesPage.java
@@ -3082,6 +3082,8 @@ public class EditDatafilesPage implements java.io.Serializable {
     	// ToDo - rsync was written before multiple store support and currently is hardcoded to use the "s3" store. 
     	// When those restrictions are lifted/rsync can be configured per store, this test should check that setting
     	// instead of testing for the 's3" store.
+        //NOTE - This method also exists in DatasetPage so when it is changed here it must be
+        //changed there. SEK 8/12/2020
     	return settingsWrapper.isRsyncUpload() && dataset.getDataverseContext().getEffectiveStorageDriverId().equals("s3");
     }
     

--- a/src/main/java/edu/harvard/iq/dataverse/EditDatafilesPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/EditDatafilesPage.java
@@ -18,6 +18,7 @@ import edu.harvard.iq.dataverse.dataaccess.StorageIO;
 import edu.harvard.iq.dataverse.datacapturemodule.DataCaptureModuleUtil;
 import edu.harvard.iq.dataverse.datacapturemodule.ScriptRequestResponse;
 import edu.harvard.iq.dataverse.dataset.DatasetThumbnail;
+import edu.harvard.iq.dataverse.dataset.DatasetUtil;
 import edu.harvard.iq.dataverse.engine.command.Command;
 import edu.harvard.iq.dataverse.engine.command.exception.CommandException;
 import edu.harvard.iq.dataverse.engine.command.exception.IllegalCommandException;
@@ -3084,7 +3085,7 @@ public class EditDatafilesPage implements java.io.Serializable {
     	// instead of testing for the 's3" store.
         //NOTE - This method also exists in DatasetPage so when it is changed here it must be
         //changed there. SEK 8/12/2020
-    	return settingsWrapper.isRsyncUpload() && dataset.getDataverseContext().getEffectiveStorageDriverId().equals("s3");
+    	return settingsWrapper.isRsyncUpload() && DatasetUtil.isAppropriateStorageDriver(dataset);
     }
     
     

--- a/src/main/java/edu/harvard/iq/dataverse/dataset/DatasetUtil.java
+++ b/src/main/java/edu/harvard/iq/dataverse/dataset/DatasetUtil.java
@@ -440,7 +440,16 @@ public class DatasetUtil {
             
         return datasetFields;
     }
-
+    
+    public static boolean isAppropriateStorageDriver(Dataset dataset){
+        // ToDo - rsync was written before multiple store support and currently is hardcoded to use the "s3" store. 
+        // When those restrictions are lifted/rsync can be configured per store, this test should check that setting
+        // instead of testing for the 's3" store,
+        //This method is used by both the dataset and edit files page so one change here
+        //will fix both
+       return dataset.getDataverseContext().getEffectiveStorageDriverId().equals("s3");
+    }
+    
     /**
      * Given a dataset version, return it's size in human readable units such as
      * 42.9 MB.There is a GetDatasetStorageSizeCommand but it's overly complex

--- a/src/main/webapp/dataset.xhtml
+++ b/src/main/webapp/dataset.xhtml
@@ -593,7 +593,7 @@
                                                             emptyMessage="#{bundle['dataverse.host.autocomplete.nomatches']}"
                                                             scrollHeight="180" forceSelection="true" 
                                                             minQueryLength="1" queryDelay="1000"
-                                                            value="#{DatasetPage.dataset.owner}" 
+                                                            value="#{DatasetPage.selectedHostDataverse}" 
                                                             multiple="false"
                                                             completeMethod="#{DatasetPage.completeHostDataverseMenuList}"
                                                             required="#{param['DO_DS_LINK_VALIDATION']}" requiredMessage="#{bundle['dataverse.link.select']}"
@@ -727,6 +727,7 @@
                             <ui:include src="editFilesFragment.xhtml">
                                 <ui:param name="datasetPage" value="true"/>
                                 <ui:param name="editDatafilesPage" value="false"/>
+                                <ui:param name="rsyncSupported" value="#{DatasetPage.rsyncUploadSupported()}"/>
                                 <ui:param name="dataverse" value="#{DatasetPage.dataset.owner}"/>
                                 <ui:param name="dataset" value="#{DatasetPage.dataset}"/>
                                 <ui:param name="version" value="#{DatasetPage.workingVersion}"/>

--- a/src/main/webapp/editFilesFragment.xhtml
+++ b/src/main/webapp/editFilesFragment.xhtml
@@ -157,8 +157,7 @@
                     
                     </div>
                     
-                    <div jsf:id="rsyncPanel" jsf:rendered="#{((datasetPage and DatasetPage.rsyncUploadSupported())
-                                                             or EditDatafilesPage.rsyncUploadSupported()) and !EditDatafilesPage.fileReplaceOperation}" class="panel panel-default">
+                    <div jsf:id="rsyncPanel" jsf:rendered="#{rsyncSupported and !EditDatafilesPage.fileReplaceOperation}" class="panel panel-default">
                         <!-- NOTE: conditional logic for 'glyphicon-chevron-up' icon in rsync header if HTTP is off, but isn't scalable when a third upload mode is added -->
                         <div role="tab" id="headingRsync" data-toggle="collapse" data-target="#panelCollapseRsync" class="panel-heading text-info" aria-expanded="true" aria-controls="panelCollapseRsync">
                             #{bundle['file.fromRsync']} &#160;<span class="glyphicon #{!settingsWrapper.HTTPUpload ? 'glyphicon-chevron-up' : 'glyphicon-chevron-down'}"/>

--- a/src/main/webapp/editFilesFragment.xhtml
+++ b/src/main/webapp/editFilesFragment.xhtml
@@ -157,7 +157,8 @@
                     
                     </div>
                     
-                    <div jsf:id="rsyncPanel" jsf:rendered="#{EditDatafilesPage.rsyncUploadSupported() and !EditDatafilesPage.fileReplaceOperation}" class="panel panel-default">
+                    <div jsf:id="rsyncPanel" jsf:rendered="#{((datasetPage and DatasetPage.rsyncUploadSupported())
+                                                             or EditDatafilesPage.rsyncUploadSupported()) and !EditDatafilesPage.fileReplaceOperation}" class="panel panel-default">
                         <!-- NOTE: conditional logic for 'glyphicon-chevron-up' icon in rsync header if HTTP is off, but isn't scalable when a third upload mode is added -->
                         <div role="tab" id="headingRsync" data-toggle="collapse" data-target="#panelCollapseRsync" class="panel-heading text-info" aria-expanded="true" aria-controls="panelCollapseRsync">
                             #{bundle['file.fromRsync']} &#160;<span class="glyphicon #{!settingsWrapper.HTTPUpload ? 'glyphicon-chevron-up' : 'glyphicon-chevron-down'}"/>

--- a/src/main/webapp/editdatafiles.xhtml
+++ b/src/main/webapp/editdatafiles.xhtml
@@ -60,6 +60,7 @@
                                 <ui:param name="editDatafilesPage" value="true"/>
                                 <ui:param name="createDataset" value="false"/>
                                 <ui:param name="showFileButtonUpdate" value="true"/>
+                                <ui:param name="rsyncSupported" value="#{EditDatafilesPage.rsyncUploadSupported()}"/>
                                 <ui:param name="lockedFromEdits" value="#{EditDatafilesPage.lockedFromEdits}"/>                             
                             </ui:include>
                         </div>


### PR DESCRIPTION
**What this PR does / why we need it**: Alternate fix for Create Dataset validation issue. Relies on the rsync support test being copied to the DatasetPage bean and resetting a null dataset owner to the ownerId of the page - as is done on Save.

**Which issue(s) this PR closes**:

Closes #7176 Create Dataset Form Validation fails on Save

**Special notes for your reviewer**:

**Suggestions on how to test this**:

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
No

**Is there a release notes update needed for this change?**: None

**Additional documentation**:
None