### PR TITLE
5050 Parse all dc identifier elements and allow identifiers that don'…

### DIFF
--- a/doc/release-notes/5.0-release-notes.md
+++ b/doc/release-notes/5.0-release-notes.md
@@ -302,13 +302,15 @@ Add the below JVM options beneath the -Ddataverse settings:
 
 For production environments:
 
-   `/usr/local/payara5/bin/asadmin create-jvm-options "\-Ddoi.dataciterestapiurlstring=https://api.datacite.org"`
+   `/usr/local/payara5/bin/asadmin create-jvm-options "\-Ddoi.dataciterestapiurlstring=https\://api.datacite.org"`
    
 For test environments: 
 
-   `/usr/local/payara5/bin/asadmin create-jvm-options "\-Ddoi.dataciterestapiurlstring=https://api.test.datacite.org"`
+   `/usr/local/payara5/bin/asadmin create-jvm-options "\-Ddoi.dataciterestapiurlstring=https\://api.test.datacite.org"`
 
-The JVM option `doi.mdcbaseurlstring` should be deleted if it was previously set.
+The JVM option `doi.mdcbaseurlstring` should be deleted if it was previously set, for example:
+
+   `/usr/local/payara5/bin/asadmin delete-jvm-options "\-Ddoi.mdcbaseurlstring=https\://api.test.datacite.org"`
      
 4. (Recommended for installations using DataCite) Pre-register DOIs
 

--- a/doc/release-notes/7184-spaces-in-filenames.md
+++ b/doc/release-notes/7184-spaces-in-filenames.md
@@ -1,0 +1,7 @@
+## Notes for Tool Developers and Integrators
+
+### Filenames
+
+Dataverse Installations using S3 storage will no longer replace spaces in file names with the + character. If your tool or integration has any special handling around this character change, you can remove it.
+
+(review this note if this is in the same release as the fix for #7188)

--- a/pom.xml
+++ b/pom.xml
@@ -294,9 +294,13 @@
             <version>1.7</version> <!-- Or 1.8-SNAPSHOT -->
         </dependency>
         <dependency>
-            <groupId>org.hibernate</groupId>
+            <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
-            <version>5.0.3.Final</version>
+        </dependency>
+      <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>jakarta.el</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>commons-lang</groupId>

--- a/src/main/java/edu/harvard/iq/dataverse/api/imports/ImportGenericServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/imports/ImportGenericServiceBean.java
@@ -375,6 +375,7 @@ public class ImportGenericServiceBean {
             if ("citation".equals(key)) {
                 for (FieldDTO fieldDTO : value.getFields()) {
                     if (DatasetFieldConstant.otherId.equals(fieldDTO.getTypeName())) {
+                        String otherId = "";
                         for (HashSet<FieldDTO> foo : fieldDTO.getMultipleCompound()) {
                             for (FieldDTO next : foo) {
                                 if (DatasetFieldConstant.otherIdValue.equals(next.getTypeName())) {

--- a/src/main/java/edu/harvard/iq/dataverse/api/imports/ImportGenericServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/imports/ImportGenericServiceBean.java
@@ -375,7 +375,6 @@ public class ImportGenericServiceBean {
             if ("citation".equals(key)) {
                 for (FieldDTO fieldDTO : value.getFields()) {
                     if (DatasetFieldConstant.otherId.equals(fieldDTO.getTypeName())) {
-                        String otherId = "";
                         for (HashSet<FieldDTO> foo : fieldDTO.getMultipleCompound()) {
                             for (FieldDTO next : foo) {
                                 if (DatasetFieldConstant.otherIdValue.equals(next.getTypeName())) {

--- a/src/main/java/edu/harvard/iq/dataverse/api/imports/ImportGenericServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/imports/ImportGenericServiceBean.java
@@ -40,6 +40,8 @@ import javax.persistence.EntityManager;
 import javax.persistence.NoResultException;
 import javax.persistence.PersistenceContext;
 import javax.xml.stream.XMLInputFactory;
+import net.handle.hdllib.HandleException;
+import net.handle.hdllib.HandleResolver;
 
 
 /**
@@ -393,8 +395,12 @@ public class ImportGenericServiceBean {
             }
             // But identifiers without hdl or doi like "10.6084/m9.figshare.12725075.v1" are also allowed
             for (String otherId : otherIds) {
-                if (otherId.startsWith("10.") && otherId.contains("/")) {
+                try {
+                    HandleResolver hr = new HandleResolver();
+                    hr.resolveHandle(otherId);
                     return GlobalId.HDL_PROTOCOL + ":" + otherId;
+                } catch (HandleException e) {
+                    logger.fine("Not a valid handle: " + e.toString());
                 }
             }
         }

--- a/src/main/java/edu/harvard/iq/dataverse/api/imports/ImportGenericServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/imports/ImportGenericServiceBean.java
@@ -389,7 +389,7 @@ public class ImportGenericServiceBean {
         if (!otherIds.isEmpty()) {
             // We prefer doi or hdl identifiers like "doi:10.7910/DVN/1HE30F"
             for (String otherId : otherIds) {
-                if (otherId.contains(GlobalId.DOI_PROTOCOL) || otherId.contains(GlobalId.HDL_PROTOCOL)) {
+                if (otherId.toLowerCase().contains(GlobalId.DOI_PROTOCOL) || otherId.toLowerCase().contains(GlobalId.HDL_PROTOCOL)) {
                     return otherId;
                 }
             }

--- a/src/main/java/edu/harvard/iq/dataverse/api/imports/ImportGenericServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/imports/ImportGenericServiceBean.java
@@ -389,7 +389,6 @@ public class ImportGenericServiceBean {
         if (!otherIds.isEmpty()) {
             // We prefer doi or hdl identifiers like "doi:10.7910/DVN/1HE30F"
             for (String otherId : otherIds) {
-                otherId = otherId.toLowerCase();
                 if (otherId.startsWith(GlobalId.DOI_PROTOCOL) || otherId.startsWith(GlobalId.HDL_PROTOCOL) || otherId.startsWith(GlobalId.DOI_RESOLVER_URL) || otherId.startsWith(GlobalId.HDL_RESOLVER_URL)) {
                     return otherId;
                 }

--- a/src/main/java/edu/harvard/iq/dataverse/api/imports/ImportGenericServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/imports/ImportGenericServiceBean.java
@@ -389,7 +389,8 @@ public class ImportGenericServiceBean {
         if (!otherIds.isEmpty()) {
             // We prefer doi or hdl identifiers like "doi:10.7910/DVN/1HE30F"
             for (String otherId : otherIds) {
-                if (otherId.toLowerCase().contains(GlobalId.DOI_PROTOCOL) || otherId.toLowerCase().contains(GlobalId.HDL_PROTOCOL)) {
+                otherId = otherId.toLowerCase();
+                if (otherId.startsWith(GlobalId.DOI_PROTOCOL) || otherId.startsWith(GlobalId.HDL_PROTOCOL) || otherId.startsWith(GlobalId.DOI_RESOLVER_URL) || otherId.startsWith(GlobalId.HDL_RESOLVER_URL)) {
                     return otherId;
                 }
             }

--- a/src/main/java/edu/harvard/iq/dataverse/dataaccess/S3AccessIO.java
+++ b/src/main/java/edu/harvard/iq/dataverse/dataaccess/S3AccessIO.java
@@ -838,7 +838,8 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
             // Most browsers are happy with just "filename="+URLEncoder.encode(this.getDataFile().getDisplayName(), "UTF-8") 
             // in the header. But Firefox appears to require that "UTF8" is 
             // specified explicitly, as below:
-            responseHeaders.setContentDisposition("attachment; filename*=UTF-8''"+URLEncoder.encode(this.getDataFile().getDisplayName(), "UTF-8"));
+            responseHeaders.setContentDisposition("attachment; filename*=UTF-8''" + URLEncoder.encode(this.getDataFile().getDisplayName(), "UTF-8")
+                    .replaceAll("\\+", "%20"));
             // - without it, download will work, but Firefox will leave the special
             // characters in the file name encoded. For example, the file name 
             // will look like "1976%E2%80%932016.txt" instead of "1976–2016.txt", 

--- a/src/test/java/edu/harvard/iq/dataverse/URLValidatorTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/URLValidatorTest.java
@@ -7,6 +7,8 @@ import javax.validation.ConstraintValidatorContext;
 
 import org.hibernate.validator.internal.engine.constraintvalidation.ConstraintValidatorContextImpl;
 import org.hibernate.validator.internal.engine.path.PathImpl;
+import javax.validation.Validation;
+import javax.validation.ValidatorFactory;
 import org.junit.Test;
 
 /**
@@ -14,6 +16,8 @@ import org.junit.Test;
  * @author skraffmi
  */
 public class URLValidatorTest {
+    ValidatorFactory validatorFactory = Validation.buildDefaultValidatorFactory();
+    
 
     @Test
     public void testIsURLValid() {
@@ -35,7 +39,7 @@ public class URLValidatorTest {
     @Test
     public void testIsValidWithContextAndValidURL() {
         String value = "https://twitter.com/";
-        ConstraintValidatorContext context = new ConstraintValidatorContextImpl(null, PathImpl.createPathFromString(""), null);
+        ConstraintValidatorContext context = new ConstraintValidatorContextImpl(validatorFactory.getClockProvider(), PathImpl.createPathFromString(""),null, null);
 
         assertEquals(true, new URLValidator().isValid(value, context));
     }
@@ -43,7 +47,7 @@ public class URLValidatorTest {
     @Test
     public void testIsValidWithContextButInvalidURL() {
         String value = "cnn.com";
-        ConstraintValidatorContext context = new ConstraintValidatorContextImpl(null, PathImpl.createPathFromString(""), null);
+        ConstraintValidatorContext context = new ConstraintValidatorContextImpl(validatorFactory.getClockProvider(), PathImpl.createPathFromString(""),null, null);
 
         assertEquals(false, new URLValidator().isValid(value, context));
     }

--- a/src/test/java/edu/harvard/iq/dataverse/dataaccess/S3AccessIOTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/dataaccess/S3AccessIOTest.java
@@ -89,7 +89,7 @@ public class S3AccessIOTest {
     }
     
     @Test
-    void keyNullstorageIdNull_getMainFileKey() throws IOException {
+    void keyNullstorageIdInvalid_getMainFileKey() throws IOException {
         // given
         dataFile.setStorageIdentifier("invalid://abcd");
         // when & then


### PR DESCRIPTION
…t have "doi" or "hdl" in them.

**What this PR does / why we need it**: Allows dataverse to harvest more datasets

**Which issue(s) this PR closes**: 5050

Closes #5050 

**Special notes for your reviewer**: Small change, big impact!

**Suggestions on how to test this**: Harvest the server https://api.figshare.com/v2/oai with prefix oai_dc and set portal_895. Without the fix they would all fail but now they're all harvested.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: No

**Is there a release notes update needed for this change?**: Yes

**Additional documentation**:
