### PR TITLE
correct dataciterestapiurlstrings, add mdcbaseurlstring deletion example

### DIFF
--- a/doc/release-notes/5.0-release-notes.md
+++ b/doc/release-notes/5.0-release-notes.md
@@ -302,13 +302,15 @@ Add the below JVM options beneath the -Ddataverse settings:
 
 For production environments:
 
-   `/usr/local/payara5/bin/asadmin create-jvm-options "\-Ddoi.dataciterestapiurlstring=https://api.datacite.org"`
+   `/usr/local/payara5/bin/asadmin create-jvm-options "\-Ddoi.dataciterestapiurlstring=https\://api.datacite.org"`
    
 For test environments: 
 
-   `/usr/local/payara5/bin/asadmin create-jvm-options "\-Ddoi.dataciterestapiurlstring=https://api.test.datacite.org"`
+   `/usr/local/payara5/bin/asadmin create-jvm-options "\-Ddoi.dataciterestapiurlstring=https\://api.test.datacite.org"`
 
-The JVM option `doi.mdcbaseurlstring` should be deleted if it was previously set.
+The JVM option `doi.mdcbaseurlstring` should be deleted if it was previously set, for example:
+
+   `/usr/local/payara5/bin/asadmin delete-jvm-options "\-Ddoi.mdcbaseurlstring=https\://api.test.datacite.org"`
      
 4. (Recommended for installations using DataCite) Pre-register DOIs
 


### PR DESCRIPTION
**What this PR does / why we need it**: current instructions fail

```
$  /usr/local/payara5/bin/asadmin create-jvm-options "\-Ddoi.dataciterestapiurlstring=https://api.test.datacite.org"
remote failure: JVM option //api.test.datacite.org is invalid because it does not start with a '-'

Command create-jvm-options failed.
```

**Which issue(s) this PR closes**:

Closes #7215

**Special notes for your reviewer**: none

**Suggestions on how to test this**: copy-paste commands

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: no

**Is there a release notes update needed for this change?**: yes

**Additional documentation**: none
