### PR TITLE
Security17 guava update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -294,9 +294,9 @@
             <version>1.7</version> <!-- Or 1.8-SNAPSHOT -->
         </dependency>
         <dependency>
-            <groupId>org.hibernate</groupId>
+            <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
-            <version>6.1.5.Final</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.glassfish</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -296,7 +296,12 @@
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-validator</artifactId>
-            <version>5.0.3.Final</version>
+            <version>6.1.5.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>javax.el</artifactId>
+            <version>3.0.1-b11</version>
         </dependency>
         <dependency>
             <groupId>commons-lang</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -264,7 +264,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>16.0.1</version>
+            <version>29.0-jre</version>
             <type>jar</type>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -300,8 +300,8 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish</groupId>
-            <artifactId>javax.el</artifactId>
-            <version>3.0.1-b11</version>
+            <artifactId>jakarta.el</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>commons-lang</groupId>

--- a/src/test/java/edu/harvard/iq/dataverse/URLValidatorTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/URLValidatorTest.java
@@ -7,6 +7,10 @@ import javax.validation.ConstraintValidatorContext;
 
 import org.hibernate.validator.internal.engine.constraintvalidation.ConstraintValidatorContextImpl;
 import org.hibernate.validator.internal.engine.path.PathImpl;
+//import org.hibernate.validator.internal.engine.time.DefaultTimeProvider;
+import javax.validation.Validation;
+import javax.validation.ValidatorFactory;
+import javax.validation.ClockProvider;
 import org.junit.Test;
 
 /**
@@ -14,6 +18,9 @@ import org.junit.Test;
  * @author skraffmi
  */
 public class URLValidatorTest {
+    //static DefaultTimeProvider timeProvider = DefaultTimeProvider.getInstance();
+    ValidatorFactory vFac = Validation.buildDefaultValidatorFactory();
+    
 
     @Test
     public void testIsURLValid() {
@@ -35,7 +42,7 @@ public class URLValidatorTest {
     @Test
     public void testIsValidWithContextAndValidURL() {
         String value = "https://twitter.com/";
-        ConstraintValidatorContext context = new ConstraintValidatorContextImpl(null, PathImpl.createPathFromString(""), null);
+        ConstraintValidatorContext context = new ConstraintValidatorContextImpl(vFac.getClockProvider(), PathImpl.createPathFromString(""),null, null);
 
         assertEquals(true, new URLValidator().isValid(value, context));
     }
@@ -43,7 +50,7 @@ public class URLValidatorTest {
     @Test
     public void testIsValidWithContextButInvalidURL() {
         String value = "cnn.com";
-        ConstraintValidatorContext context = new ConstraintValidatorContextImpl(null, PathImpl.createPathFromString(""), null);
+        ConstraintValidatorContext context = new ConstraintValidatorContextImpl(vFac.getClockProvider(), PathImpl.createPathFromString(""),null, null);
 
         assertEquals(false, new URLValidator().isValid(value, context));
     }

--- a/src/test/java/edu/harvard/iq/dataverse/URLValidatorTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/URLValidatorTest.java
@@ -7,10 +7,8 @@ import javax.validation.ConstraintValidatorContext;
 
 import org.hibernate.validator.internal.engine.constraintvalidation.ConstraintValidatorContextImpl;
 import org.hibernate.validator.internal.engine.path.PathImpl;
-//import org.hibernate.validator.internal.engine.time.DefaultTimeProvider;
 import javax.validation.Validation;
 import javax.validation.ValidatorFactory;
-import javax.validation.ClockProvider;
 import org.junit.Test;
 
 /**
@@ -19,7 +17,7 @@ import org.junit.Test;
  */
 public class URLValidatorTest {
     //static DefaultTimeProvider timeProvider = DefaultTimeProvider.getInstance();
-    ValidatorFactory vFac = Validation.buildDefaultValidatorFactory();
+    ValidatorFactory validatorFactory = Validation.buildDefaultValidatorFactory();
     
 
     @Test
@@ -42,7 +40,7 @@ public class URLValidatorTest {
     @Test
     public void testIsValidWithContextAndValidURL() {
         String value = "https://twitter.com/";
-        ConstraintValidatorContext context = new ConstraintValidatorContextImpl(vFac.getClockProvider(), PathImpl.createPathFromString(""),null, null);
+        ConstraintValidatorContext context = new ConstraintValidatorContextImpl(validatorFactory.getClockProvider(), PathImpl.createPathFromString(""),null, null);
 
         assertEquals(true, new URLValidator().isValid(value, context));
     }
@@ -50,7 +48,7 @@ public class URLValidatorTest {
     @Test
     public void testIsValidWithContextButInvalidURL() {
         String value = "cnn.com";
-        ConstraintValidatorContext context = new ConstraintValidatorContextImpl(vFac.getClockProvider(), PathImpl.createPathFromString(""),null, null);
+        ConstraintValidatorContext context = new ConstraintValidatorContextImpl(validatorFactory.getClockProvider(), PathImpl.createPathFromString(""),null, null);
 
         assertEquals(false, new URLValidator().isValid(value, context));
     }

--- a/src/test/java/edu/harvard/iq/dataverse/URLValidatorTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/URLValidatorTest.java
@@ -16,7 +16,6 @@ import org.junit.Test;
  * @author skraffmi
  */
 public class URLValidatorTest {
-    //static DefaultTimeProvider timeProvider = DefaultTimeProvider.getInstance();
     ValidatorFactory validatorFactory = Validation.buildDefaultValidatorFactory();
     
 


### PR DESCRIPTION
**What this PR does / why we need it**: There is a potential denial of service attack in current guava version due to unbounded memory allocation. This was fixed in version 24.1.1 and above (also some back-fixes)

**Which issue(s) this PR closes**:

Closes https://github.com/IQSS/dataverse-security/issues/17

**Special notes for your reviewer**:the following libraries used in dataverse depend on guava: auto-service, org.everit.json.schema, tika, search box, xoai-common.

**Suggestions on how to test this**: It is related to code which uses the above listed libraries, but it should be a plug-in fix. I went though the guava release notes (https://github.com/google/guava/releases)  between 16.0.1 and 29.0 are and there was only one potential breaking change listed. However, I checked the mvn repository pages for each library e.g. https://mvnrepository.com/artifact/org.everit.json/org.everit.json.schema/1.5.1 and 29.0-jre is listed as an update for the guava dependency on each page.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:no

**Is there a release notes update needed for this change?**:no

**Additional documentation**:
https://nvd.nist.gov/vuln/detail/CVE-2018-10237
https://github.com/advisories/GHSA-mvr2-9pj6-7w5j
