### PR TITLE
Fixed guides scrolling horizontal layout bug

### DIFF
--- a/doc/sphinx-guides/source/admin/mail-groups.rst
+++ b/doc/sphinx-guides/source/admin/mail-groups.rst
@@ -33,11 +33,9 @@ To list just that Mail Domain Group, you can include the alias in the curl comma
 Creating a Mail Domain Group
 ----------------------------
 
-Mail Domain Groups can be created with a simple JSON file:
+Mail Domain Groups can be created with a simple JSON file such as domainGroup1.json:
 
 .. code-block:: json
-   :caption: domainGroup1.json
-   :name: domainGroup1.json
 
     {
       "name": "Users from @example.org",

--- a/doc/sphinx-guides/source/admin/mail-groups.rst
+++ b/doc/sphinx-guides/source/admin/mail-groups.rst
@@ -58,7 +58,7 @@ To load it into your Dataverse installation, either use a ``POST`` or ``PUT`` re
 Updating a Mail Domain Group
 ----------------------------
 
-Editing a group is done by replacing it. Grab your group definition like the :ref:`above example <domainGroup1.json>`,
+Editing a group is done by replacing it. Grab your group definition like the domainGroup1.json example above,
 change it as you like and ``PUT`` it into your installation:
 
 ``curl -X PUT -H 'Content-type: application/json' http://localhost:8080/api/admin/groups/domain/domainGroup1 --upload-file domainGroup1.json``

--- a/doc/sphinx-guides/source/installation/oidc.rst
+++ b/doc/sphinx-guides/source/installation/oidc.rst
@@ -60,19 +60,18 @@ Finding the issuer URL is best done by searching for terms like "discovery" in t
 The discovery document is always located at ``<issuer url>/.well-known/openid-configuration`` (standardized).
 To be sure, you can always lookup the ``issuer`` value inside the live JSON-based discovery document.
 
-Please create a file like this, replacing every ``<...>`` with your values:
+Please create a my-oidc-provider.json file like this, replacing every ``<...>`` with your values:
 
 .. code-block:: json
-   :caption: my-oidc-provider.json
 
-   {
-     "id":"<a unique id>",
-     "factoryAlias":"oidc",
-     "title":"<a title - shown in UI>",
-     "subtitle":"<a subtitle - currently unused in UI>",
-     "factoryData":"type: oidc | issuer: <issuer url> | clientId: <client id> | clientSecret: <client secret>",
-     "enabled":true
-   }
+    {
+        "id":"<a unique id>",
+        "factoryAlias":"oidc",
+        "title":"<a title - shown in UI>",
+        "subtitle":"<a subtitle - currently unused in UI>",
+        "factoryData":"type: oidc | issuer: <issuer url> | clientId: <client id> | clientSecret: <client secret>",
+        "enabled":true
+    }
 
 Now load the configuration into Dataverse using the same API as with :doc:`oauth2`:
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes ``:caption::`` option from code-block in two pages to fix a horizontal scrolling over sidenav layout bug. Moved caption to context text so users can still reference it.

**Which issue(s) this PR closes**:

Closes *#3577 Documentation: When content is wide enough to require horizontal scroll, content scrolls but left nav outline does not.*

**Special notes for your reviewer**:

**Suggestions on how to test this**:

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
