### PR TITLE
Security18 hibernate validator vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -294,9 +294,9 @@
             <version>1.7</version> <!-- Or 1.8-SNAPSHOT -->
         </dependency>
         <dependency>
-            <groupId>org.hibernate</groupId>
+            <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
-            <version>6.1.5.Final</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.glassfish</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -296,7 +296,12 @@
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-validator</artifactId>
-            <version>5.0.3.Final</version>
+            <version>6.1.5.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>javax.el</artifactId>
+            <version>3.0.1-b11</version>
         </dependency>
         <dependency>
             <groupId>commons-lang</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -296,7 +296,7 @@
         <dependency>
             <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
-            <scope>provided</scope>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.glassfish</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -296,13 +296,12 @@
         <dependency>
             <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
-            <scope>compile</scope>
         </dependency>
-        <dependency>
+<!--       <dependency>
             <groupId>org.glassfish</groupId>
             <artifactId>jakarta.el</artifactId>
             <scope>provided</scope>
-        </dependency>
+        </dependency> -->
         <dependency>
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -297,11 +297,11 @@
             <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
         </dependency>
-<!--       <dependency>
+      <dependency>
             <groupId>org.glassfish</groupId>
             <artifactId>jakarta.el</artifactId>
             <scope>provided</scope>
-        </dependency> -->
+        </dependency>
         <dependency>
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -300,8 +300,8 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish</groupId>
-            <artifactId>javax.el</artifactId>
-            <version>3.0.1-b11</version>
+            <artifactId>jakarta.el</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>commons-lang</groupId>

--- a/src/test/java/edu/harvard/iq/dataverse/URLValidatorTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/URLValidatorTest.java
@@ -7,6 +7,10 @@ import javax.validation.ConstraintValidatorContext;
 
 import org.hibernate.validator.internal.engine.constraintvalidation.ConstraintValidatorContextImpl;
 import org.hibernate.validator.internal.engine.path.PathImpl;
+//import org.hibernate.validator.internal.engine.time.DefaultTimeProvider;
+import javax.validation.Validation;
+import javax.validation.ValidatorFactory;
+import javax.validation.ClockProvider;
 import org.junit.Test;
 
 /**
@@ -14,6 +18,9 @@ import org.junit.Test;
  * @author skraffmi
  */
 public class URLValidatorTest {
+    //static DefaultTimeProvider timeProvider = DefaultTimeProvider.getInstance();
+    ValidatorFactory vFac = Validation.buildDefaultValidatorFactory();
+    
 
     @Test
     public void testIsURLValid() {
@@ -35,7 +42,7 @@ public class URLValidatorTest {
     @Test
     public void testIsValidWithContextAndValidURL() {
         String value = "https://twitter.com/";
-        ConstraintValidatorContext context = new ConstraintValidatorContextImpl(null, PathImpl.createPathFromString(""), null);
+        ConstraintValidatorContext context = new ConstraintValidatorContextImpl(vFac.getClockProvider(), PathImpl.createPathFromString(""),null, null);
 
         assertEquals(true, new URLValidator().isValid(value, context));
     }
@@ -43,7 +50,7 @@ public class URLValidatorTest {
     @Test
     public void testIsValidWithContextButInvalidURL() {
         String value = "cnn.com";
-        ConstraintValidatorContext context = new ConstraintValidatorContextImpl(null, PathImpl.createPathFromString(""), null);
+        ConstraintValidatorContext context = new ConstraintValidatorContextImpl(vFac.getClockProvider(), PathImpl.createPathFromString(""),null, null);
 
         assertEquals(false, new URLValidator().isValid(value, context));
     }

--- a/src/test/java/edu/harvard/iq/dataverse/URLValidatorTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/URLValidatorTest.java
@@ -7,10 +7,8 @@ import javax.validation.ConstraintValidatorContext;
 
 import org.hibernate.validator.internal.engine.constraintvalidation.ConstraintValidatorContextImpl;
 import org.hibernate.validator.internal.engine.path.PathImpl;
-//import org.hibernate.validator.internal.engine.time.DefaultTimeProvider;
 import javax.validation.Validation;
 import javax.validation.ValidatorFactory;
-import javax.validation.ClockProvider;
 import org.junit.Test;
 
 /**
@@ -19,7 +17,7 @@ import org.junit.Test;
  */
 public class URLValidatorTest {
     //static DefaultTimeProvider timeProvider = DefaultTimeProvider.getInstance();
-    ValidatorFactory vFac = Validation.buildDefaultValidatorFactory();
+    ValidatorFactory validatorFactory = Validation.buildDefaultValidatorFactory();
     
 
     @Test
@@ -42,7 +40,7 @@ public class URLValidatorTest {
     @Test
     public void testIsValidWithContextAndValidURL() {
         String value = "https://twitter.com/";
-        ConstraintValidatorContext context = new ConstraintValidatorContextImpl(vFac.getClockProvider(), PathImpl.createPathFromString(""),null, null);
+        ConstraintValidatorContext context = new ConstraintValidatorContextImpl(validatorFactory.getClockProvider(), PathImpl.createPathFromString(""),null, null);
 
         assertEquals(true, new URLValidator().isValid(value, context));
     }
@@ -50,7 +48,7 @@ public class URLValidatorTest {
     @Test
     public void testIsValidWithContextButInvalidURL() {
         String value = "cnn.com";
-        ConstraintValidatorContext context = new ConstraintValidatorContextImpl(vFac.getClockProvider(), PathImpl.createPathFromString(""),null, null);
+        ConstraintValidatorContext context = new ConstraintValidatorContextImpl(validatorFactory.getClockProvider(), PathImpl.createPathFromString(""),null, null);
 
         assertEquals(false, new URLValidator().isValid(value, context));
     }

--- a/src/test/java/edu/harvard/iq/dataverse/URLValidatorTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/URLValidatorTest.java
@@ -16,7 +16,6 @@ import org.junit.Test;
  * @author skraffmi
  */
 public class URLValidatorTest {
-    //static DefaultTimeProvider timeProvider = DefaultTimeProvider.getInstance();
     ValidatorFactory validatorFactory = Validation.buildDefaultValidatorFactory();
     
 


### PR DESCRIPTION
**What this PR does / why we need it**:an attacker to escalate permissions and access private values and create invalid instances - see CVE-2017-7536. It is reported to be fixed in versions 5.2.5.Final and greater

**Which issue(s) this PR closes**:Investigate and Address Possible Vulnerability in org.hibernate:hibernate-validator #18

Closes  #IQSS/dataverse-security#18

**Special notes for your reviewer**:

**Suggestions on how to test this**:The library upgrade is reported to be sufficient to eliminate the security vulnerability. However, it required code changes due to changes in the api and a dependency change due to a change in the initialization behavior of the library
The issue you were seeing earlier may have been due to a specified library conflicting with provide library in Payara. I had thought this was addressed due to a comment by Oliver, but somehow that change may not have gotten into the pull request. I believe it is up to date now and the hibernate validator pom entry references the Payara provided version. org.hibernate.validator.internal.util.CollectionHelper is provided by Payara

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:no

**Is there a release notes update needed for this change?**:no

**Additional documentation**:
