### PR TITLE
emphasize need to have dot (graphviz) installed #7225

### DIFF
--- a/doc/sphinx-guides/source/developers/documentation.rst
+++ b/doc/sphinx-guides/source/developers/documentation.rst
@@ -64,6 +64,8 @@ Unless you already have it, install pip (https://pip.pypa.io/en/latest/installin
 
 run ``pip install sphinx`` in a terminal
 
+Building the guides requires the ``dot`` executable from GraphViz and you can find documentation on GraphViz below.
+
 This is all you need. You should now be able to build HTML/pdf documentation from git sources locally.
 
 Using Sphinx
@@ -119,8 +121,7 @@ In some parts of the documentation, graphs are rendered as images via Sphinx Gra
 This requires `GraphViz <http://graphviz.org/>`_ installed and either ``dot`` on the path or
 `adding options to the make call <https://groups.google.com/forum/#!topic/sphinx-users/yXgNey_0M3I>`_.
 
-This has been tested and works on Mac, Linux, and Windows. If you have not properly configured GraphViz, then the worst thing that might happen is a warning and missing images in your local documentation build.
-
+This has been tested and works on Mac, Linux, and Windows.
 
 Versions
 --------


### PR DESCRIPTION
**What this PR does / why we need it**:

Contributors trying to help with documentation may be confused by this cryptic warning (which we treat as fatal as of pull request #7093):

```
Warning, treated as error:
WARNING: dot command 'dot' cannot be run (needed for graphviz output), check the graphviz_dot setting

make: *** [html] Error 1
```

**Which issue(s) this PR closes**:

Closes #7225

**Special notes for your reviewer**:

The whole "Writing Documentation" page could use a re-write but I just made a couple small edits.

**Suggestions on how to test this**:

Try setting up a new machine to build the guides.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No.

**Is there a release notes update needed for this change?**:

No.

**Additional documentation**:

None.