### PR TITLE
bump jquery to 3.5.1 to fix sphinx search

### DIFF
--- a/doc/sphinx-guides/source/conf.py
+++ b/doc/sphinx-guides/source/conf.py
@@ -225,7 +225,7 @@ html_title = 'Dataverse.org'
 html_static_path = ['_static']
 
 html_js_files = [
-    'js/jquery-3.4.1.min.js',
+    'js/jquery-3.5.1.min.js',
 ]
 
 # Add any extra paths that contain custom files (such as robots.txt or


### PR DESCRIPTION
**What this PR does / why we need it**: this, along with updating sphinx to 3.2.1 on gdcc-jenkins01, seems to fix guide search

**Which issue(s) this PR closes**:

Closes #7228

**Special notes for your reviewer**: none

**Suggestions on how to test this**: testable in jenkins workspace or branch space on guides.dataverse

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: no

**Is there a release notes update needed for this change?**: no

**Additional documentation**: none
