### PR TITLE
Update dataset-create-new-all-default-fields.json

### DIFF
--- a/scripts/api/data/dataset-create-new-all-default-fields.json
+++ b/scripts/api/data/dataset-create-new-all-default-fields.json
@@ -181,7 +181,7 @@
                   "typeName": "dsDescriptionValue",
                   "multiple": false,
                   "typeClass": "primitive",
-                  "value": "DescriptionText 1"
+                  "value": "DescriptionText1"
                 },
                 "dsDescriptionDate": {
                   "typeName": "dsDescriptionDate",
@@ -265,6 +265,53 @@
             ]
           },
           {
+            "typeName": "topicClassification",
+            "multiple": true,
+            "typeClass": "compound",
+            "value": [
+              {
+                "topicClassValue": {
+                  "typeName": "topicClassValue",
+                  "multiple": false,
+                  "typeClass": "primitive",
+                  "value": "Topic Classification Term1"
+                },
+                "topicClassVocab": {
+                  "typeName": "topicClassVocab",
+                  "multiple": false,
+                  "typeClass": "primitive",
+                  "value": "Topic Classification Vocab1"
+                },
+                "topicClassVocabURI": {
+                  "typeName": "topicClassVocabURI",
+                  "multiple": false,
+                  "typeClass": "primitive",
+                  "value": "https://TopicClassificationURL1.com"
+                }
+              },
+              {
+                "topicClassValue": {
+                  "typeName": "topicClassValue",
+                  "multiple": false,
+                  "typeClass": "primitive",
+                  "value": "Topic Classification Term2"
+                },
+                "topicClassVocab": {
+                  "typeName": "topicClassVocab",
+                  "multiple": false,
+                  "typeClass": "primitive",
+                  "value": "Topic Classification Vocab2"
+                },
+                "topicClassVocabURI": {
+                  "typeName": "topicClassVocabURI",
+                  "multiple": false,
+                  "typeClass": "primitive",
+                  "value": "https://TopicClassificationURL2.com"
+                }
+              }
+            ]
+          },
+          {
             "typeName": "publication",
             "multiple": true,
             "typeClass": "compound",
@@ -328,6 +375,15 @@
             "multiple": false,
             "typeClass": "primitive",
             "value": "Notes1"
+          },
+          {
+            "typeName": "language",
+            "multiple": true,
+            "typeClass": "controlledVocabulary",
+            "value": [
+              "Abkhaz",
+              "Afar"
+            ]
           },
           {
             "typeName": "producer",


### PR DESCRIPTION
**What this PR does / why we need it**: The create-a-dataset-in-a-dataverse endpoint in the API guides includes an example JSON file, "dataset-create-new-all-default-fields.json", that should contain all of the fields in Dataverse's standard metadatablocks.

**Which issue(s) this PR closes**:

Closes #6671 

**Special notes for your reviewer**: 

**Suggestions on how to test this**:
- Use the [create-a-dataset-in-a-dataverse endpoint in the API guides](http://guides.dataverse.org/en/4.19/api/native-api.html#create-a-dataset-in-a-dataverse) to create a dataset using the updated JSON file.
- Check that the metadata for the created dataset includes values for the topic classification and language fields.
- Don't use Demo Dataverse to test - if you do, the API call will fail because some of the metadatablocks loaded on Demo Dataverse are missing controlled vocabulary values that are present in the updated JSON file (GitHub issue incoming)

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: No

**Is there a release notes update needed for this change?**: No

**Additional documentation**: I don't think anything else in the API Guide needs to change for this PR