### PR TITLE
improve docs on setting up a new dev environment

### DIFF
--- a/doc/sphinx-guides/source/developers/dev-environment.rst
+++ b/doc/sphinx-guides/source/developers/dev-environment.rst
@@ -27,7 +27,7 @@ Install Java
 
 Dataverse requires Java 8.
 
-On Mac, we recommend Oracle's version of the JDK, which can be downloaded from http://www.oracle.com/technetwork/java/javase/downloads/index.html
+We suggest downloading OpenJDK from https://adoptopenjdk.net
 
 On Linux, you are welcome to use the OpenJDK available from package managers.
 

--- a/doc/sphinx-guides/source/developers/dev-environment.rst
+++ b/doc/sphinx-guides/source/developers/dev-environment.rst
@@ -53,15 +53,14 @@ Fork https://github.com/IQSS/dataverse and then clone your fork like this:
 Build the Dataverse War File
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To build the Dataverse war file using versions of Netbeans newer than 8.2 requires some setup because Jakarta EE support is not enabled by default. An alternative is to build the war file with Maven, which is explained below.
+If you installed Netbeans, follow these steps:
 
-Launch Netbeans and click "File" and then "Open Project". Navigate to where you put the Dataverse code and double-click "dataverse" to open the project.
+- Launch Netbeans and click "File" and then "Open Project". Navigate to where you put the Dataverse code and double-click "dataverse" to open the project.
+- If you see "resolve project problems," go ahead and let Netbeans try to resolve them. This will probably including downloading dependencies, which can take a while.
+- Allow Netbeans to install nb-javac (required for Java 8 and below).
+- Select "dataverse" under Projects and click "Run" in the menu and then "Build Project (dataverse)". Check back for "BUILD SUCCESS" at the end.
 
-If you are using Netbeans 8.2, Jakarta EE support should "just work" but if you are using a newer version of Netbeans, you will see "dataverse (broken)". If you see "broken", click "Tools", "Plugins", and "Installed". Check the box next to "Java Web and EE" and click "Activate". Let Netbeans install all the dependencies. You will observe that the green "Active" checkmark does not appear next to "Java Web and EE". Restart Netbeans.
-
-In Netbeans, select "dataverse" under Projects and click "Run" in the menu and then "Build Project (dataverse)". The first time you build the war file, it will take a few minutes while dependencies are downloaded from Maven Central. Feel free to move on to other steps but check back for "BUILD SUCCESS" at the end.
-
-If you installed Maven instead of Netbeans, run ``mvn package``.
+If you installed Maven instead of Netbeans, run ``mvn package``. Check for "BUILD SUCCESS" at the end.
 
 NOTE: Do you use a locale different than ``en_US.UTF-8`` on your development machine? Are you in a different timezone
 than Harvard (Eastern Time)? You might experience issues while running tests that were written with these settings

--- a/doc/sphinx-guides/source/developers/dev-environment.rst
+++ b/doc/sphinx-guides/source/developers/dev-environment.rst
@@ -91,19 +91,6 @@ To install Payara, run the following commands:
 
 ``sudo chown -R $USER /usr/local/payara5``
 
-Test Payara Startup Time on Mac
-+++++++++++++++++++++++++++++++
-
-``cd /usr/local/payara5/glassfish/bin``
-
-``./asadmin start-domain``
-
-``grep "startup time" /usr/local/payara5/glassfish/domains/domain1/logs/server.log``
-
-If you are seeing startup times in the 30 second range (31,584ms for "Felix" for example) please be aware that startup time can be greatly reduced (to less than 1.5 seconds in our testing) if you make a small edit to your ``/etc/hosts`` file as described at https://stackoverflow.com/questions/39636792/jvm-takes-a-long-time-to-resolve-ip-address-for-localhost/39698914#39698914 and https://thoeni.io/post/macos-sierra-java/
-
-Look for a line that says ``127.0.0.1 localhost`` and add a space followed by the output of ``hostname`` which should be something like ``foobar.local`` depending on the name of your Mac. For example, the line would say ``127.0.0.1 localhost foobar.local`` if your Mac's name is "foobar".
-
 Install PostgreSQL
 ~~~~~~~~~~~~~~~~~~
 

--- a/doc/sphinx-guides/source/developers/dev-environment.rst
+++ b/doc/sphinx-guides/source/developers/dev-environment.rst
@@ -162,7 +162,19 @@ Navigate to the directory where you cloned the Dataverse git repo change directo
 
 ``cd scripts/installer``
 
-Follow the instructions in :download:`README_python.txt <../../../../scripts/installer/README_python.txt>` which can be found in the directory above.
+Create a Python virtual environment, activate it, then install dependencies:
+
+``python3 -m venv venv``
+
+``source venv/bin/activate``
+
+``pip install psycopg2-binary``
+
+The installer will try to connect to the SMTP server you tell it to use. If you don't have a mail server handy you can run ``nc -l 25`` in another terminal and choose "localhost" (the default) to get past this check.
+
+Finally, run the installer (see also :download:`README_python.txt <../../../../scripts/installer/README_python.txt>` if necessary):
+
+``python3 install.py``
 
 Verify Dataverse is Running
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/sphinx-guides/source/developers/dev-environment.rst
+++ b/doc/sphinx-guides/source/developers/dev-environment.rst
@@ -85,9 +85,9 @@ To install Payara, run the following commands:
 
 ``cd /usr/local``
 
-``sudo curl -O -L https://search.maven.org/remotecontent?filepath=fish/payara/distributions/payara/5.201/payara-5.201.zip``
+``sudo curl -O -L https://github.com/payara/Payara/releases/download/payara-server-5.2020.2/payara-5.2020.2.zip``
 
-``sudo unzip payara-5.201.zip``
+``sudo unzip payara-5.2020.2.zip``
 
 ``sudo chown -R $USER /usr/local/payara5``
 

--- a/doc/sphinx-guides/source/developers/dev-environment.rst
+++ b/doc/sphinx-guides/source/developers/dev-environment.rst
@@ -96,7 +96,7 @@ Install PostgreSQL
 
 PostgreSQL 9.6 is recommended to match the version in the Installation Guide.
 
-On Mac, go to https://www.postgresql.org/download/macosx/ and choose "Interactive installer by EnterpriseDB" option. We've tested version 9.6.9. When prompted to set a password for the "database superuser (postgres)" just enter "password".
+On Mac, go to https://www.postgresql.org/download/macosx/ and choose "Interactive installer by EDB" option. We've tested version 9.6.19. When prompted to set a password for the "database superuser (postgres)" just enter "password".
 
 After installation is complete, make a backup of the ``pg_hba.conf`` file like this:
 
@@ -106,11 +106,11 @@ Then edit ``pg_hba.conf`` with an editor such as vi:
 
 ``sudo vi /Library/PostgreSQL/9.6/data/pg_hba.conf``
 
-In the "METHOD" column, change all instances of "md5" to "trust".
+In the "METHOD" column, change all instances of "md5" to "trust". This will make it so PostgreSQL doesn't require a password.
 
 In the Finder, click "Applications" then "PostgreSQL 9.6" and launch the "Reload Configuration" app. Click "OK" after you see "server signaled".
 
-Next, launch the "pgAdmin" application from the same folder. Under "Browser", expand "Servers" and double click "PostgreSQL 9.6". When you are prompted for a password, leave it blank and click "OK". If you have successfully edited "pg_hba.conf", you can get in without a password.
+Next, to confirm the edit worked, launch the "pgAdmin" application from the same folder. Under "Browser", expand "Servers" and double click "PostgreSQL 9.6". When you are prompted for a password, leave it blank and click "OK". If you have successfully edited "pg_hba.conf", you can get in without a password.
 
 On Linux, you should just install PostgreSQL from your package manager without worrying about the version as long as it's 9.x. Find ``pg_hba.conf`` and set the authentication method to "trust" and restart PostgreSQL.
 

--- a/doc/sphinx-guides/source/developers/tips.rst
+++ b/doc/sphinx-guides/source/developers/tips.rst
@@ -12,7 +12,7 @@ Iterating on Code and Redeploying
 
 When you followed the steps in the :doc:`dev-environment` section, the war file was deployed to Payara by the Dataverse installation script. That's fine but once you're ready to make a change to the code you will need to get comfortable with undeploying and redeploying code (a war file) to Payara.
 
-It's certainly possible to manage deployment and undeployment of the war file via the command line using the ``asadmin`` command that ships with Payara (that's what the Dataverse installation script uses and the steps are documented below), but we recommend getting set up with and IDE such as Netbeans to manage deployment for you.
+It's certainly possible to manage deployment and undeployment of the war file via the command line using the ``asadmin`` command that ships with Payara (that's what the Dataverse installation script uses and the steps are documented below), but we recommend getting set up with an IDE such as Netbeans to manage deployment for you.
 
 Undeploy the war File from the Dataverse Installation Script
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
**What this PR does / why we need it**:

I got a new laptop and ran into various issue setting up a Dataverse dev environment:

- confusion over which distribution of Java to install #7234
- wrong version of Payara (updated in pull request #7036)
- using pip before running the installer and having lots to read in the README
- specifically, when running the installer, not having an SMTP server #7236

One of our strategic goals is "increase contributions from the open-source development community" and I hope this pull request helps.

The summary is:

- Switch from Oracle JDK to OpenJDK.
- Bring version of Payara inline with version in Installation Guide.
- Avoid need to read long installer README and provide shorter instructions inline.
- Suggest a workaround (netcat running on port 25) instead of requiring new developers to install a mail/SMTP server.
- Various cleanup.

**Which issue(s) this PR closes**:

- Closes #7241 issues setting up a dev environment
- Closes #7234 confusion over how to install Java 8 from Oracle for potential Dataverse developers
- Closes #7236 When setting up a dev environment, I don't want to be blocked by not having a mail server

**Special notes for your reviewer**:

I left comments in the commits. Here's a dump of them:

commit 91b835edac53a1b255fd6f8d641d1ace6aa01924 (HEAD -> 7241-dev-env, origin/7241-dev-env)
Author: Philip Durbin <philip_durbin@harvard.edu>
Date:   Fri Aug 28 12:37:09 2020 -0400

    put install.py instructions inline, add venv #7241
    
    The README_python.txt is long and a lot to digest. I still link
    to this text file for reference but I simplified the instructions
    to put all the commands I used inline.
    
    I also introduced venv which is what I think Python developers
    should be using in 2020.

commit 45a85ac5e3afcd7ce5330efa1ff6c46aec2fb2c0
Author: Philip Durbin <philip_durbin@harvard.edu>
Date:   Fri Aug 28 12:32:30 2020 -0400

    bump version of postgres (within 9.6), clarify docs #7241
    
    We got a question about all the pgAdmin stuff. What it's for, what's
    going on. It wasn't clear that we're simply using this tool to check
    if the "trust" change worked (which simplifies the installation later).
    Perhaps in the future we could switch to a test with `psql` but an
    advantage of mentioning pgAdmin early is to let the new developer know
    that this tool exists.

commit 95bfbf193d6750796a803941c8708c9519abb072
Author: Philip Durbin <philip_durbin@harvard.edu>
Date:   Fri Aug 28 12:27:40 2020 -0400

    remove section on Glassfish/Payara startup time #7241
    
    I had added in in pull request #5438 but I'm not sure we need it.
    I didn't seem to need it this time.

commit 4fc67ea3a7c047d90cc1ac359819ed6144393017
Author: Philip Durbin <philip_durbin@harvard.edu>
Date:   Fri Aug 28 12:22:56 2020 -0400

    match version of Payara used in Installation Guide #7241
    
    The Installation Guide was updated in pull request #7036 for #7017.

commit 6402322be835cf28ac14166738ab3026b710c30c
Author: Philip Durbin <philip_durbin@harvard.edu>
Date:   Fri Aug 28 12:10:59 2020 -0400

    simply Netbeans steps for version 12 #7241

commit 791437ca662ce26add61e61c3972ce7dd62d17dd
Author: Philip Durbin <philip_durbin@harvard.edu>
Date:   Fri Aug 28 12:07:53 2020 -0400

    recommend OpenJDK instead of Oracle JDK #7234 #7241



**Suggestions on how to test this**:

Have a another developer run through these instructions, on Mac.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No.

**Is there a release notes update needed for this change?**:

No.

**Additional documentation**:

None.