### PR TITLE
Iqss/7223 don't change name when replacing file

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
@@ -3619,7 +3619,7 @@ public class DatasetPage implements java.io.Serializable {
                     // have been created in the dataset. 
                     dataset = datasetService.find(dataset.getId());
                     
-                    List<DataFile> filesAdded = ingestService.saveAndAddFilesToDataset(dataset.getEditVersion(), newFiles);
+                    List<DataFile> filesAdded = ingestService.saveAndAddFilesToDataset(dataset.getEditVersion(), newFiles, false);
                     newFiles.clear();
                     
                     // and another update command: 

--- a/src/main/java/edu/harvard/iq/dataverse/EditDatafilesPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/EditDatafilesPage.java
@@ -1128,7 +1128,7 @@ public class EditDatafilesPage implements java.io.Serializable {
             }
                                 
             // Try to save the NEW files permanently: 
-            List<DataFile> filesAdded = ingestService.saveAndAddFilesToDataset(workingVersion, newFiles);
+            List<DataFile> filesAdded = ingestService.saveAndAddFilesToDataset(workingVersion, newFiles, false);
             
             // reset the working list of fileMetadatas, as to only include the ones
             // that have been added to the version successfully: 

--- a/src/main/java/edu/harvard/iq/dataverse/api/datadeposit/MediaResourceManagerImpl.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/datadeposit/MediaResourceManagerImpl.java
@@ -335,7 +335,7 @@ public class MediaResourceManagerImpl implements MediaResourceManager {
                     throw new SwordError(UriRegistry.ERROR_BAD_REQUEST, "Unable to add file(s) to dataset: " + violation.getMessage() + " The invalid value was \"" + violation.getInvalidValue() + "\".");
                 } else {
 
-                    ingestService.saveAndAddFilesToDataset(editVersion, dataFiles);
+                    ingestService.saveAndAddFilesToDataset(editVersion, dataFiles, false);
 
                 }
             } else {

--- a/src/main/java/edu/harvard/iq/dataverse/datasetutility/AddReplaceFileHelper.java
+++ b/src/main/java/edu/harvard/iq/dataverse/datasetutility/AddReplaceFileHelper.java
@@ -1501,7 +1501,7 @@ public class AddReplaceFileHelper{
         }
         
         int nFiles = finalFileList.size();
-        finalFileList = ingestService.saveAndAddFilesToDataset(workingVersion, finalFileList);
+        finalFileList = ingestService.saveAndAddFilesToDataset(workingVersion, finalFileList, isFileReplaceOperation());
 
         if (nFiles != finalFileList.size()) {
             if (nFiles == 1) {

--- a/src/main/java/edu/harvard/iq/dataverse/ingest/IngestServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/ingest/IngestServiceBean.java
@@ -153,7 +153,7 @@ public class IngestServiceBean {
     // DataFileCategory objects, if any were already assigned to the files). 
     // It must be called before we attempt to permanently save the files in 
     // the database by calling the Save command on the dataset and/or version. 
-	public List<DataFile> saveAndAddFilesToDataset(DatasetVersion version, List<DataFile> newFiles) {
+	public List<DataFile> saveAndAddFilesToDataset(DatasetVersion version, List<DataFile> newFiles, boolean isReplaceOperation) {
 		List<DataFile> ret = new ArrayList<>();
 
 		if (newFiles != null && newFiles.size() > 0) {
@@ -162,9 +162,10 @@ public class IngestServiceBean {
 			// we tried to make the file names unique on upload, but then
 			// the user may have edited them on the "add files" page, and
 			// renamed FOOBAR-1.txt back to FOOBAR.txt...
-
-			IngestUtil.checkForDuplicateFileNamesFinal(version, newFiles);
-
+		    //Don't change the name if we're replacing a file - (the original hasn't yet been deleted but will be in a later step)
+            if(!isReplaceOperation) {
+			  IngestUtil.checkForDuplicateFileNamesFinal(version, newFiles);
+            }
 			Dataset dataset = version.getDataset();
 
 			for (DataFile dataFile : newFiles) {


### PR DESCRIPTION
**What this PR does / why we need it**: When doing a file replace operation, it disables the duplicate filename check that would otherwise append a '_1' to the file name.

**Which issue(s) this PR closes**:

Closes #7223 

**Special notes for your reviewer**:

**Suggestions on how to test this**: can do a replace file in the UI and/or API, with or without the 'force' option that allows you to change the mimetype, and the replacement should result in the file having the same name (note - in the UI, I was uploading a file with a different name and then changing it to match the name of the file being replaced in the UI.)

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: No

**Is there a release notes update needed for this change?**: No

**Additional documentation**: none
