### PR TITLE
Fix for the folders in zipper

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/FileDownloadServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/FileDownloadServiceBean.java
@@ -20,6 +20,7 @@ import edu.harvard.iq.dataverse.privateurl.PrivateUrl;
 import edu.harvard.iq.dataverse.privateurl.PrivateUrlServiceBean;
 import edu.harvard.iq.dataverse.settings.SettingsServiceBean;
 import edu.harvard.iq.dataverse.util.FileUtil;
+import edu.harvard.iq.dataverse.util.StringUtil;
 import java.io.IOException;
 import java.sql.Timestamp;
 import java.util.ArrayList;
@@ -562,6 +563,10 @@ public class FileDownloadServiceBean implements java.io.Serializable {
             } else {
                 fileName = dataFile.getFileMetadata().getLabel();
             }
+        }
+        
+        if (StringUtil.nonEmpty(dataFile.getFileMetadata().getDirectoryLabel())) {
+            fileName = dataFile.getFileMetadata().getDirectoryLabel() + "/" + fileName;
         }
                 
         if (location != null && fileName != null) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Dataverse was not passing the names of the folders to the zipper utility. 

**Which issue(s) this PR closes**:

Closes #7255

**Special notes for your reviewer**:

**Suggestions on how to test this**:

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
