### PR TITLE
Configuring file stores (storage drivers) for individual datasets

### DIFF
--- a/doc/sphinx-guides/source/admin/dataverses-datasets.rst
+++ b/doc/sphinx-guides/source/admin/dataverses-datasets.rst
@@ -59,6 +59,8 @@ The available drivers can be listed with::
 
     curl -H "X-Dataverse-key: $API_TOKEN" http://$SERVER/api/admin/dataverse/storageDrivers
     
+(Individual datasets can be configured to use specific file stores as well. See the "Datasets" section below.)
+
 
 Datasets
 --------
@@ -129,4 +131,24 @@ Diagnose Constraint Violations Issues in Datasets
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 To identify invalid data values in specific datasets (if, for example, an attempt to edit a dataset results in a ConstraintViolationException in the server log), or to check all the datasets in the Dataverse for constraint violations, see :ref:`Dataset Validation <dataset-validation-api>` in the :doc:`/api/native-api` section of the User Guide.
+
+Configure a Dataset to store all new files in a specific file store
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Configure a dataset to use a specific file store (this API can only be used by a superuser) ::
+ 
+    curl -H "X-Dataverse-key: $API_TOKEN" -X PUT -d $storageDriverLabel http://$SERVER/api/datasets/$dataset-id/storageDriver
+    
+The current driver can be seen using::
+
+    curl http://$SERVER/api/datasets/$dataset-id/storageDriver
+
+It can be reset to the default store as follows (only a superuser can do this) ::
+
+    curl -H "X-Dataverse-key: $API_TOKEN" -X DELETE http://$SERVER/api/datasets/$dataset-id/storageDriver
+    
+The available drivers can be listed with::
+
+    curl -H "X-Dataverse-key: $API_TOKEN" http://$SERVER/api/admin/dataverse/storageDrivers
+    
 

--- a/doc/sphinx-guides/source/api/native-api.rst
+++ b/doc/sphinx-guides/source/api/native-api.rst
@@ -1654,6 +1654,11 @@ The fully expanded example above (without environment variables) looks like this
   
 Calling the destroy endpoint is permanent and irreversible. It will remove the dataset and its datafiles, then re-index the parent dataverse in Solr. This endpoint requires the API token of a superuser.
 
+Configure a Dataset to Use a Specific File Store
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``/api/datasets/$dataset-id/storageDriver`` can be used to check, configure or reset the designated file store (storage driver) for a dataset. Please see the :doc:`/admin/dataverses-datasets` section of the guide for more information on this API.
+
 Files
 -----
 

--- a/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
@@ -1879,7 +1879,7 @@ public class DatasetPage implements java.io.Serializable {
                 //retrieveDatasetVersionResponse = datasetVersionService.retrieveDatasetVersionByVersionId(versionId);
 
             }
-            this.maxFileUploadSizeInBytes = systemConfig.getMaxFileUploadSizeForStore(dataset.getOwner().getEffectiveStorageDriverId());
+            this.maxFileUploadSizeInBytes = systemConfig.getMaxFileUploadSizeForStore(dataset.getEffectiveStorageDriverId());
 
 
             if (retrieveDatasetVersionResponse == null) {

--- a/src/main/java/edu/harvard/iq/dataverse/Dataverse.java
+++ b/src/main/java/edu/harvard/iq/dataverse/Dataverse.java
@@ -151,7 +151,7 @@ public class Dataverse extends DvObjectContainer {
 
     private String affiliation;
     
-    private String storageDriver=null;
+    ///private String storageDriver=null;
 
 	// Note: We can't have "Remove" here, as there are role assignments that refer
     //       to this role. So, adding it would mean violating a forign key contstraint.
@@ -761,32 +761,4 @@ public class Dataverse extends DvObjectContainer {
         }
         return false;
     }
-
-	public String getEffectiveStorageDriverId() {
-		String id = storageDriver;
-		if(StringUtils.isBlank(id)) {
-			if(this.getOwner() != null) {
-				id = this.getOwner().getEffectiveStorageDriverId(); 
-			} else {
-				id= DataAccess.DEFAULT_STORAGE_DRIVER_IDENTIFIER;
-			}
-		}
-		return id;
-	}
-	
-	
-	public String getStorageDriverId() {
-		if(storageDriver==null) {
-			return DataAccess.UNDEFINED_STORAGE_DRIVER_IDENTIFIER;
-		}
-		return storageDriver;
-	}
-
-	public void setStorageDriverId(String storageDriver) {
-		if(storageDriver!=null&&storageDriver.equals(DataAccess.UNDEFINED_STORAGE_DRIVER_IDENTIFIER)) {
-			this.storageDriver=null;
-		} else {
-		  this.storageDriver = storageDriver;
-		}
-	}
 }

--- a/src/main/java/edu/harvard/iq/dataverse/DvObjectContainer.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DvObjectContainer.java
@@ -1,6 +1,8 @@
 package edu.harvard.iq.dataverse;
 
+import edu.harvard.iq.dataverse.dataaccess.DataAccess;
 import javax.persistence.MappedSuperclass;
+import org.apache.commons.lang.StringUtils;
 
 /**
  * A {@link DvObject} that can contain other {@link DvObject}s.
@@ -26,4 +28,32 @@ public abstract class DvObjectContainer extends DvObject {
         return isPermissionRoot() || (getOwner() == null);
     }
 
+    private String storageDriver=null;
+    
+    public String getEffectiveStorageDriverId() {
+        String id = storageDriver;
+        if (StringUtils.isBlank(id)) {
+            if (this.getOwner() != null) {
+                id = this.getOwner().getEffectiveStorageDriverId();
+            } else {
+                id = DataAccess.DEFAULT_STORAGE_DRIVER_IDENTIFIER;
+            }
+        }
+        return id;
+    }
+    
+    public String getStorageDriverId() {
+        if (storageDriver == null) {
+            return DataAccess.UNDEFINED_STORAGE_DRIVER_IDENTIFIER;
+        }
+        return storageDriver;
+    }
+
+    public void setStorageDriverId(String storageDriver) {
+        if (storageDriver != null && storageDriver.equals(DataAccess.UNDEFINED_STORAGE_DRIVER_IDENTIFIER)) {
+            this.storageDriver = null;
+        } else {
+            this.storageDriver = storageDriver;
+        }
+    }
 }

--- a/src/main/java/edu/harvard/iq/dataverse/EditDatafilesPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/EditDatafilesPage.java
@@ -444,7 +444,7 @@ public class EditDatafilesPage implements java.io.Serializable {
         uploadedFiles = uploadedFilesList;
         selectedFiles = selectedFileMetadatasList;
         
-        this.maxFileUploadSizeInBytes = systemConfig.getMaxFileUploadSizeForStore(dataset.getOwner().getEffectiveStorageDriverId());
+        this.maxFileUploadSizeInBytes = systemConfig.getMaxFileUploadSizeForStore(dataset.getEffectiveStorageDriverId());
         this.multipleUploadFilesLimit = systemConfig.getMultipleUploadFilesLimit();
         
         logger.fine("done");
@@ -481,7 +481,7 @@ public class EditDatafilesPage implements java.io.Serializable {
         
 
 
-        this.maxFileUploadSizeInBytes = systemConfig.getMaxFileUploadSizeForStore(dataset.getOwner().getEffectiveStorageDriverId());
+        this.maxFileUploadSizeInBytes = systemConfig.getMaxFileUploadSizeForStore(dataset.getEffectiveStorageDriverId());
         this.multipleUploadFilesLimit = systemConfig.getMultipleUploadFilesLimit();
                        
         workingVersion = dataset.getEditVersion();

--- a/src/main/java/edu/harvard/iq/dataverse/api/Datasets.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Datasets.java
@@ -156,6 +156,7 @@ import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
 import org.glassfish.jersey.media.multipart.FormDataParam;
 
 import com.amazonaws.services.s3.model.PartETag;
+import java.util.Map.Entry;
 
 @Path("datasets")
 public class Datasets extends AbstractApiBean {
@@ -2204,6 +2205,57 @@ public Response completeMPUpload(String partETagBody, @QueryParam("globalid") St
             return wr.getResponse();
         }
     }
+    
+    @GET
+    @Path("{identifier}/filestore")
+    public Response getFileStore(@PathParam("identifier") String dvIdtf,
+            @Context UriInfo uriInfo, @Context HttpHeaders headers) throws WrappedResponse { 
+        
+        Dataset dataset = findDatasetOrDie(dvIdtf);
+            
+        return response(req -> ok(dataset.getEffectiveStorageDriverId()));
+    }
+    
+    @PUT
+    @Path("{identifier}/filestore")
+    public Response setFileStore(@PathParam("identifier") String dvIdtf,
+            @PathParam("storeId") String fileStoreId,
+            @Context UriInfo uriInfo, @Context HttpHeaders headers) throws WrappedResponse {
+        
+        // Superuser-only:
+        AuthenticatedUser user = findAuthenticatedUserOrDie();
+        if (!user.isSuperuser()) {
+            return error(Response.Status.FORBIDDEN, "Superusers only.");
+    	}
+        
+        Dataset dataset = findDatasetOrDie(dvIdtf);
+        
+        // We don't want to allow setting this to a store id that does not exist: 
+        for (Entry<String, String> store: DataAccess.getStorageDriverLabels().entrySet()) {
+            if(store.getKey().equals(fileStoreId)) {
+    		dataset.setStorageDriverId(store.getValue());
+                    return ok("Storage set to: " + store.getKey() + "/" + store.getValue());
+    		}
+    	}
+    	return error(Response.Status.BAD_REQUEST,
+            "No Storage Driver found for : " + fileStoreId);
+    }
+    
+    @DELETE
+    @Path("{identifier}/filestore")
+    public Response resetFileStore(@PathParam("identifier") String dvIdtf,
+            @Context UriInfo uriInfo, @Context HttpHeaders headers) throws WrappedResponse {
+    
+        // Superuser-only:
+        AuthenticatedUser user = findAuthenticatedUserOrDie();
+        if (!user.isSuperuser()) {
+            return error(Response.Status.FORBIDDEN, "Superusers only.");
+    	}
+        
+        Dataset dataset = findDatasetOrDie(dvIdtf);
 
+        dataset.setStorageDriverId(null);
+    	return ok("Storage reset to default: " + DataAccess.DEFAULT_STORAGE_DRIVER_IDENTIFIER);
+    }
 }
 

--- a/src/main/java/edu/harvard/iq/dataverse/api/Datasets.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Datasets.java
@@ -2211,7 +2211,13 @@ public Response completeMPUpload(String partETagBody, @QueryParam("globalid") St
     public Response getFileStore(@PathParam("identifier") String dvIdtf,
             @Context UriInfo uriInfo, @Context HttpHeaders headers) throws WrappedResponse { 
         
-        Dataset dataset = findDatasetOrDie(dvIdtf);
+        Dataset dataset; 
+        
+        try {
+            dataset = findDatasetOrDie(dvIdtf);
+        } catch (WrappedResponse ex) {
+            return error(Response.Status.NOT_FOUND, "No such dataset");
+        }
             
         return response(req -> ok(dataset.getEffectiveStorageDriverId()));
     }

--- a/src/main/java/edu/harvard/iq/dataverse/api/Datasets.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Datasets.java
@@ -2207,7 +2207,7 @@ public Response completeMPUpload(String partETagBody, @QueryParam("globalid") St
     }
     
     @GET
-    @Path("{identifier}/filestore")
+    @Path("{identifier}/storageDriver")
     public Response getFileStore(@PathParam("identifier") String dvIdtf,
             @Context UriInfo uriInfo, @Context HttpHeaders headers) throws WrappedResponse { 
         
@@ -2217,9 +2217,9 @@ public Response completeMPUpload(String partETagBody, @QueryParam("globalid") St
     }
     
     @PUT
-    @Path("{identifier}/filestore")
+    @Path("{identifier}/storageDriver")
     public Response setFileStore(@PathParam("identifier") String dvIdtf,
-            @PathParam("storeId") String fileStoreId,
+            @PathParam("label") String storageDriverLabel,
             @Context UriInfo uriInfo, @Context HttpHeaders headers) throws WrappedResponse {
         
         // Superuser-only:
@@ -2232,17 +2232,17 @@ public Response completeMPUpload(String partETagBody, @QueryParam("globalid") St
         
         // We don't want to allow setting this to a store id that does not exist: 
         for (Entry<String, String> store: DataAccess.getStorageDriverLabels().entrySet()) {
-            if(store.getKey().equals(fileStoreId)) {
+            if(store.getKey().equals(storageDriverLabel)) {
     		dataset.setStorageDriverId(store.getValue());
                     return ok("Storage set to: " + store.getKey() + "/" + store.getValue());
     		}
     	}
     	return error(Response.Status.BAD_REQUEST,
-            "No Storage Driver found for : " + fileStoreId);
+            "No Storage Driver found for : " + storageDriverLabel);
     }
     
     @DELETE
-    @Path("{identifier}/filestore")
+    @Path("{identifier}/storageDriver")
     public Response resetFileStore(@PathParam("identifier") String dvIdtf,
             @Context UriInfo uriInfo, @Context HttpHeaders headers) throws WrappedResponse {
     

--- a/src/main/java/edu/harvard/iq/dataverse/dataaccess/DataAccess.java
+++ b/src/main/java/edu/harvard/iq/dataverse/dataaccess/DataAccess.java
@@ -20,6 +20,7 @@
 
 package edu.harvard.iq.dataverse.dataaccess;
 
+import edu.harvard.iq.dataverse.Dataset;
 import edu.harvard.iq.dataverse.DvObject;
 import java.io.IOException;
 import java.util.HashMap;
@@ -147,7 +148,11 @@ public class DataAccess {
             throw new IOException("getDataAccessObject: null or invalid datafile.");
         }
                 
-        return createNewStorageIO(dvObject, storageTag, dvObject.getDataverseContext().getEffectiveStorageDriverId());
+        if (dvObject instanceof Dataset) {
+            return createNewStorageIO(dvObject, storageTag, ((Dataset)dvObject).getEffectiveStorageDriverId());
+        } 
+        // it's a DataFile:
+        return createNewStorageIO(dvObject, storageTag, dvObject.getOwner().getEffectiveStorageDriverId());
     }
 
     public static <T extends DvObject> StorageIO<T> createNewStorageIO(T dvObject, String storageTag, String storageDriverId) throws IOException {

--- a/src/main/java/edu/harvard/iq/dataverse/dataset/DatasetUtil.java
+++ b/src/main/java/edu/harvard/iq/dataverse/dataset/DatasetUtil.java
@@ -447,7 +447,7 @@ public class DatasetUtil {
         // instead of testing for the 's3" store,
         //This method is used by both the dataset and edit files page so one change here
         //will fix both
-       return dataset.getDataverseContext().getEffectiveStorageDriverId().equals("s3");
+       return dataset.getEffectiveStorageDriverId().equals("s3");
     }
     
     /**

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/AbstractCreateDatasetCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/AbstractCreateDatasetCommand.java
@@ -96,7 +96,7 @@ public abstract class AbstractCreateDatasetCommand extends AbstractDatasetComman
             theDataset.setAuthority(ctxt.settings().getValueForKey(SettingsServiceBean.Key.Authority, nonNullDefaultIfKeyNotFound));
         }
         if (theDataset.getStorageIdentifier() == null) {
-        	String driverId = theDataset.getDataverseContext().getEffectiveStorageDriverId();
+        	String driverId = theDataset.getEffectiveStorageDriverId();
         	theDataset.setStorageIdentifier(driverId  + "://" + theDataset.getAuthorityForFileStorage() + "/" + theDataset.getIdentifierForFileStorage());
         }
         if (theDataset.getIdentifier()==null) {

--- a/src/main/java/edu/harvard/iq/dataverse/util/FileUtil.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/FileUtil.java
@@ -721,7 +721,7 @@ public class FileUtil implements java.io.Serializable  {
         // save the file, in the temporary location for now: 
         Path tempFile = null; 
         
-        Long fileSizeLimit = systemConfig.getMaxFileUploadSizeForStore(version.getDataset().getOwner().getEffectiveStorageDriverId());
+        Long fileSizeLimit = systemConfig.getMaxFileUploadSizeForStore(version.getDataset().getEffectiveStorageDriverId());
         String finalType = null; 
 		if (newStorageIdentifier == null) {
 			if (getFilesTempDirectory() != null) {
@@ -1331,7 +1331,7 @@ public class FileUtil implements java.io.Serializable  {
     }
     
     public static void generateS3PackageStorageIdentifier(DataFile dataFile) {
-    	String driverId = dataFile.getDataverseContext().getEffectiveStorageDriverId();
+    	String driverId = dataFile.getOwner().getEffectiveStorageDriverId();
 		
         String bucketName = System.getProperty("dataverse.files." + driverId + ".bucket-name");
         String storageId = driverId + "://" + bucketName + ":" + dataFile.getFileMetadata().getLabel();

--- a/src/main/java/edu/harvard/iq/dataverse/util/FileUtil.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/FileUtil.java
@@ -1666,7 +1666,7 @@ public class FileUtil implements java.io.Serializable  {
     }
     
     public static S3AccessIO getS3AccessForDirectUpload(Dataset dataset) {
-    	String driverId = dataset.getDataverseContext().getEffectiveStorageDriverId();
+    	String driverId = dataset.getEffectiveStorageDriverId();
     	boolean directEnabled = Boolean.getBoolean("dataverse.files." + driverId + ".upload-redirect");
     	//Should only be requested when it is allowed, but we'll log a warning otherwise
     	if(!directEnabled) {

--- a/src/main/java/edu/harvard/iq/dataverse/util/SystemConfig.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/SystemConfig.java
@@ -4,6 +4,7 @@ import com.ocpsoft.pretty.PrettyContext;
 import edu.harvard.iq.dataverse.DataFile;
 import edu.harvard.iq.dataverse.Dataset;
 import edu.harvard.iq.dataverse.DataverseServiceBean;
+import edu.harvard.iq.dataverse.DvObjectContainer;
 import edu.harvard.iq.dataverse.authorization.AuthenticationServiceBean;
 import edu.harvard.iq.dataverse.authorization.providers.builtin.BuiltinAuthenticationProvider;
 import edu.harvard.iq.dataverse.authorization.providers.oauth2.AbstractOAuth2AuthenticationProvider;
@@ -1052,8 +1053,8 @@ public class SystemConfig {
         return settingsService.isTrueForKey(SettingsServiceBean.Key.FileValidationOnPublishEnabled, safeDefaultIfKeyNotFound);
     }
 
-	public boolean directUploadEnabled(Dataset dataset) {
-    	return Boolean.getBoolean("dataverse.files." + dataset.getDataverseContext().getEffectiveStorageDriverId() + ".upload-redirect");
+	public boolean directUploadEnabled(DvObjectContainer container) {
+    	return Boolean.getBoolean("dataverse.files." + container.getEffectiveStorageDriverId() + ".upload-redirect");
 	}
 	
 	public String getDataCiteRestApiUrlString() {

--- a/src/main/resources/db/migration/V5.0.0.1__6872-assign-storage-drivers-to-datasets.sql
+++ b/src/main/resources/db/migration/V5.0.0.1__6872-assign-storage-drivers-to-datasets.sql
@@ -1,0 +1,1 @@
+ALTER TABLE dataset ADD COLUMN  IF NOT EXISTS storagedriver VARCHAR(255);


### PR DESCRIPTION
**What this PR does / why we need it**:
Even though the title of the issue specifically mentions "direct S3 upload", the PR adds something more general - an ability to designate a file store for a specific dataset. The file store in question does not have to be S3. But enabling direct S3 upload is the main use case behind this PR. For example, if we want to enable  direct upload for a specific dataset in prod., without opening it for everybody, we will achieve it by 
1. Creating another S3-type store, pointing to the same storage bucket (for ex., "s3direct")
2. Enable direct upload on the above. 
3. Configure "s3direct" to be the designated storage driver for the dataset in question, using the API added in this PR: 
`curl -H "X-Dataverse-key: XXX" -X PUT -d s3direct http://localhost:8080/api/datasets/NNNN/storageDriver`

The words "API based" in the issue title refer to the fact that a file store can be configured for a dataset via API only; i.e. there's no GUI for that (like we have for dataverses). But once a direct upload-enabled store has been assigned to a dataset, the uploads will work both via the dataset page, or the API (using the DVUploader utility); just like when it's enabled dataverse-wide. 

**Which issue(s) this PR closes**:

Closes #6872

**Special notes for your reviewer**:

**Suggestions on how to test this**:

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
