### PR TITLE
Catch abnormal EC2 exit and fail build

### DIFF
--- a/tests/jenkins/ec2/Jenkinsfile
+++ b/tests/jenkins/ec2/Jenkinsfile
@@ -41,6 +41,13 @@ pipeline {
 	  sourcePattern: 'src/main/java',
 	  exclusionPattern: 'src/test*']
 	)
+        script {
+          if (fileExists('./ansible_complete')) {
+            sh '/bin/rm ./ansible_complete'
+          } else {
+            error('Ansible run terminated abnormally, failing build.')
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
**What this PR does / why we need it**: AWS sometimes dies "connection closed by remote host", which doesn't trigger an exit failure so the Jenkins run continues. This checks for a semaphore created in EC2 after the Ansible run, and fails the build if not found.

**Which issue(s) this PR closes**:

Closes #7268

**Special notes for your reviewer**: none

**Suggestions on how to test this**: submit a PR, kill EC2 instance in mid-run

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: no

**Is there a release notes update needed for this change?**: no

**Additional documentation**: none
