### PR TITLE
sort compound field children by display order

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DatasetFieldCompoundValue.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetFieldCompoundValue.java
@@ -9,6 +9,7 @@ import edu.harvard.iq.dataverse.util.BundleUtil;
 import edu.harvard.iq.dataverse.util.MarkupChecker;
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -95,9 +96,10 @@ public class DatasetFieldCompoundValue implements Serializable {
     public List<DatasetField> getChildDatasetFields() {
         return childDatasetFields;
     }
-
+    
     public void setChildDatasetFields(List<DatasetField> childDatasetFields) {
         this.childDatasetFields = childDatasetFields;
+        this.childDatasetFields.sort(DatasetField.DisplayOrder);
     }
 
     @Override


### PR DESCRIPTION
**What this PR does / why we need it**: Sorts children of compound dataset fields by the specified displayOrder which orders them as intended in the metadata summary display

**Which issue(s) this PR closes**:

Closes #3685 

**Special notes for your reviewer**:  This most directly resolves the issue identified in https://groups.google.com/g/dataverse-community/c/EwtjRM4BhHM, but @jggautier has pointed out that there may be a connection to #3685. My guess for #3685 would be that the child fields are currently being sorted based on datasetfieldtype ids AND that there are duplicate datasetfieldtypes in the db affecting some datasets. If that's true, this will 'fix' those datasets (assuming the displayorder is correct for any duplicate fields), but it would probably be good to check the db to see if there are duplicates to resolve (or other issue). In either case, the change her may fix #3685 from a practical standpoint, and it will address the community issue, but there may be additional db work to resolve the underlying cause of #3685.

**Suggestions on how to test this**: To see the effect, you need datasetfieldtypes where the ids are not in the displayorder. ON a fresh install, I caused this by:
 ```
update datasetfieldtype set displayorder=10 where id=12;
 update datasetfieldtype set displayorder=11 where id=11;
```
which reverses the order of the author identifier and identifier scheme fields. 
Without this PR, the display is unchanged (identifier scheme before the identifier). With it, the identifier comes first, both in the metadata edit display and the metadata summary (e.g. "Admin, Dataverse (Dataverse.org) 1234 - ORCID:" . (Note that the '-' before 'ORCID' and the ':' after it are part of the field formatting and don't really make sense if you reverse the order from ' - ORCID: 1234' - this isn't a problem with the PR, just an artifact from this minimal test setup.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: only change is to correct the ordering of compound field children.

**Is there a release notes update needed for this change?**: No

**Additional documentation**: none
