### PR TITLE
Added installer setup-all log to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ oauth-credentials.md
 
 /src/main/webapp/oauth2/newAccount.html
 scripts/api/setup-all.sh*
+scripts/api/setup-all.43167.log
 
 # ctags generated tag file
 tags

--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,7 @@ oauth-credentials.md
 
 /src/main/webapp/oauth2/newAccount.html
 scripts/api/setup-all.sh*
-scripts/api/setup-all.43167.log
+scripts/api/setup-all.*.log
 
 # ctags generated tag file
 tags


### PR DESCRIPTION
**What this PR does / why we need it**:

Discovered the new installer created a new `scripts/api/setup-all.43167.log` file that GitHub worries about it being untracked, so I added it to the gitignore file.

**Which issue(s) this PR closes**:

Closes #

**Special notes for your reviewer**:

Removes this log file from your untracked files.

```
...$ git status
On branch develop
Your branch is up to date with 'origin/develop'.

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   src/main/webapp/WEB-INF/web.xml

Untracked files:
  (use "git add <file>..." to include in what will be committed)
	scripts/api/setup-all.43167.log

no changes added to commit (use "git add" and/or "git commit -a")
```

**Suggestions on how to test this**:

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
