### PR TITLE
bump Apache Tika to 1.24.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -573,7 +573,7 @@
         <dependency>
             <groupId>org.apache.tika</groupId>
             <artifactId>tika-parsers</artifactId>
-            <version>1.22</version>
+            <version>1.24.1</version>
         </dependency>
         <!-- Named Entity Recognition -->
         <dependency>


### PR DESCRIPTION
**What this PR does / why we need it**: The Apache Tika version in pom.xml is vulnerable to CVE-2020-1950 and CVE-2020-1951

**Which issue(s) this PR closes**:

Closes #21 aka https://github.com/IQSS/dataverse-security/issues/21

**Special notes for your reviewer**: none

**Suggestions on how to test this**: I ran this through unit and integration tests, how better to test?

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: no

**Is there a release notes update needed for this change?**: no

**Additional documentation**: none
