### PR TITLE
Iqss/7309 s3 resource leaks

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/dataaccess/S3AccessIO.java
+++ b/src/main/java/edu/harvard/iq/dataverse/dataaccess/S3AccessIO.java
@@ -578,20 +578,20 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
     
     //Helper method for supporting saving streams with unknown length to S3
     //We save those streams to a file and then upload the file
-    private File createTempFile(Path path, InputStream inputStream) throws IOException {
+	private File createTempFile(Path path, InputStream inputStream) throws IOException {
 
-        File targetFile = new File(path.toUri()); //File needs a name
-		try (OutputStream outStream = new FileOutputStream(targetFile);) {
+        File targetFile = new File(path.toUri()); // File needs a name
+        try (OutputStream outStream = new FileOutputStream(targetFile);) {
 
-			byte[] buffer = new byte[8 * 1024];
-			int bytesRead;
-			while ((bytesRead = inputStream.read(buffer)) != -1) {
-				outStream.write(buffer, 0, bytesRead);
-			}
+            byte[] buffer = new byte[8 * 1024];
+            int bytesRead;
+            while ((bytesRead = inputStream.read(buffer)) != -1) {
+                outStream.write(buffer, 0, bytesRead);
+            }
 
-		} finally {
-			IOUtils.closeQuietly(inputStream);
-		}
+        } finally {
+            IOUtils.closeQuietly(inputStream);
+        }
         return targetFile;
     } 
     

--- a/src/main/java/edu/harvard/iq/dataverse/dataaccess/S3AccessIO.java
+++ b/src/main/java/edu/harvard/iq/dataverse/dataaccess/S3AccessIO.java
@@ -581,15 +581,17 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
     private File createTempFile(Path path, InputStream inputStream) throws IOException {
 
         File targetFile = new File(path.toUri()); //File needs a name
-        OutputStream outStream = new FileOutputStream(targetFile);
+		try (OutputStream outStream = new FileOutputStream(targetFile);) {
 
-        byte[] buffer = new byte[8 * 1024];
-        int bytesRead;
-        while ((bytesRead = inputStream.read(buffer)) != -1) {
-            outStream.write(buffer, 0, bytesRead);
-        }
-        IOUtils.closeQuietly(inputStream);
-        IOUtils.closeQuietly(outStream);
+			byte[] buffer = new byte[8 * 1024];
+			int bytesRead;
+			while ((bytesRead = inputStream.read(buffer)) != -1) {
+				outStream.write(buffer, 0, bytesRead);
+			}
+
+		} finally {
+			IOUtils.closeQuietly(inputStream);
+		}
         return targetFile;
     } 
     

--- a/src/main/java/edu/harvard/iq/dataverse/dataaccess/StoredOriginalFile.java
+++ b/src/main/java/edu/harvard/iq/dataverse/dataaccess/StoredOriginalFile.java
@@ -26,6 +26,8 @@ import java.nio.channels.Channel;
 import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
 import java.util.logging.Logger;
+
+import org.apache.tika.io.IOUtils;
 /**
  *
  * @author Leonid Andreev
@@ -56,17 +58,18 @@ public class StoredOriginalFile {
 
         long storedOriginalSize; 
         InputStreamIO inputStreamIO;
-        
+        Channel storedOriginalChannel = null;
         try {
             storageIO.open();
-            Channel storedOriginalChannel = storageIO.openAuxChannel(SAVED_ORIGINAL_FILENAME_EXTENSION);
+            storedOriginalChannel = storageIO.openAuxChannel(SAVED_ORIGINAL_FILENAME_EXTENSION);
             storedOriginalSize = dataFile.getDataTable().getOriginalFileSize() != null ? 
                     dataFile.getDataTable().getOriginalFileSize() : 
                     storageIO.getAuxObjectSize(SAVED_ORIGINAL_FILENAME_EXTENSION);
             inputStreamIO = new InputStreamIO(Channels.newInputStream((ReadableByteChannel) storedOriginalChannel), storedOriginalSize);
             logger.fine("Opened stored original file as Aux "+SAVED_ORIGINAL_FILENAME_EXTENSION);
         } catch (IOException ioEx) {
-            // The original file not saved, or could not be opened.
+        	IOUtils.closeQuietly(storedOriginalChannel);
+        	// The original file not saved, or could not be opened.
             logger.fine("Failed to open stored original file as Aux "+SAVED_ORIGINAL_FILENAME_EXTENSION+"!");
             return null;
         }

--- a/src/main/java/edu/harvard/iq/dataverse/dataset/DatasetUtil.java
+++ b/src/main/java/edu/harvard/iq/dataverse/dataset/DatasetUtil.java
@@ -273,7 +273,7 @@ public class DatasetUtil {
         try {
             tmpFile = FileUtil.inputStreamToFile(inputStream);
         } catch (IOException ex) {
-            logger.severe(ex.getMessage());
+        	logger.severe(ex.getMessage());
         }
 
         StorageIO<Dataset> dataAccess = null;
@@ -298,11 +298,13 @@ public class DatasetUtil {
         try {
             fullSizeImage = ImageIO.read(tmpFile);
         } catch (IOException ex) {
+        	IOUtils.closeQuietly(inputStream);
             logger.severe(ex.getMessage());
             return null;
         }
         if (fullSizeImage == null) {
             logger.fine("fullSizeImage was null!");
+            IOUtils.closeQuietly(inputStream);
             return null;
         }
         int width = fullSizeImage.getWidth();
@@ -311,6 +313,7 @@ public class DatasetUtil {
         try {
             src = new FileInputStream(tmpFile).getChannel();
         } catch (FileNotFoundException ex) {
+        	IOUtils.closeQuietly(inputStream);
             logger.severe(ex.getMessage());
             return null;
         }
@@ -318,6 +321,7 @@ public class DatasetUtil {
         try {
             dest = new FileOutputStream(tmpFile).getChannel();
         } catch (FileNotFoundException ex) {
+        	IOUtils.closeQuietly(inputStream);
             logger.severe(ex.getMessage());
             return null;
         }
@@ -329,10 +333,13 @@ public class DatasetUtil {
         }
         File tmpFileForResize = null;
         try {
+        	//The stream was used around line 274 above, so this creates an empty file (OK since all it is used for is getting a path, but not reusing it here would make it easier to close it above.)
             tmpFileForResize = FileUtil.inputStreamToFile(inputStream);
         } catch (IOException ex) {
             logger.severe(ex.getMessage());
             return null;
+        } finally {
+        	IOUtils.closeQuietly(inputStream);
         }
         // We'll try to pre-generate the rescaled versions in both the 
         // DEFAULT_DATASET_LOGO (currently 140) and DEFAULT_CARDIMAGE_SIZE (48)

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/RedetectFileTypeCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/RedetectFileTypeCommand.java
@@ -53,11 +53,11 @@ public class RedetectFileTypeCommand extends AbstractCommand<DataFile> {
             } else {
                 // Need to create a temporary local file: 
 
-                ReadableByteChannel targetFileChannel = (ReadableByteChannel) storageIO.getReadChannel();
                 tempFile = File.createTempFile("tempFileTypeCheck", ".tmp");
-                FileChannel tempFileChannel = new FileOutputStream(tempFile).getChannel();
-                tempFileChannel.transferFrom(targetFileChannel, 0, storageIO.getSize());
-
+                try (ReadableByteChannel targetFileChannel = (ReadableByteChannel) storageIO.getReadChannel();
+                		FileChannel tempFileChannel = new FileOutputStream(tempFile).getChannel();) {
+                    tempFileChannel.transferFrom(targetFileChannel, 0, storageIO.getSize());
+                }
                 localFile = tempFile;
             }
 

--- a/src/main/java/edu/harvard/iq/dataverse/ingest/tabulardata/impl/plugins/dta/DTAFileReaderSpi.java
+++ b/src/main/java/edu/harvard/iq/dataverse/ingest/tabulardata/impl/plugins/dta/DTAFileReaderSpi.java
@@ -131,6 +131,7 @@ public class DTAFileReaderSpi extends TabularDataFileReaderSpi{
 
     @Override
     public boolean canDecodeInput(BufferedInputStream stream) throws IOException {
+    	//who closes this stream?
         if (stream ==null){
             throw new IllegalArgumentException("stream == null!");
         }
@@ -185,21 +186,21 @@ public class DTAFileReaderSpi extends TabularDataFileReaderSpi{
             throw new IIOException("cannot read the input file");
         }
 
-        // set-up a FileChannel instance for a given file object
-        FileChannel srcChannel = new FileInputStream(file).getChannel();
-
-        // create a read-only MappedByteBuffer
-        MappedByteBuffer buff = srcChannel.map(FileChannel.MapMode.READ_ONLY, 0, DTA_HEADER_SIZE);
-
-        //printHexDump(buff, "hex dump of the byte-buffer");
-
-        buff.rewind();
-
-        dbgLog.fine("applying the dta test\n");
-
         byte[] hdr4 = new byte[4];
-        buff.get(hdr4, 0, 4);
+        // set-up a FileChannel instance for a given file object
+		try (FileChannel srcChannel = new FileInputStream(file).getChannel();) {
 
+			// create a read-only MappedByteBuffer
+			MappedByteBuffer buff = srcChannel.map(FileChannel.MapMode.READ_ONLY, 0, DTA_HEADER_SIZE);
+
+			// printHexDump(buff, "hex dump of the byte-buffer");
+
+			buff.rewind();
+
+			dbgLog.fine("applying the dta test\n");
+
+			buff.get(hdr4, 0, 4);
+		}
        dbgLog.fine("hex dump: 1st 4bytes =>" +
                 new String(Hex.encodeHex(hdr4)) + "<-");
 


### PR DESCRIPTION
**What this PR does / why we need it**:  Closes more streams/channels that may hold S3 http connections open and exhaust the aws s3 client's pool.

**Which issue(s) this PR closes**:

Closes #7309 

**Special notes for your reviewer**:
Tried to use the new try-with-resources format where that looked simple and just used Apache's IOUtils.closeQuietly() for others (it just closes if the object isn't null and eats any exception). If I understand correctly, using try-with-resources will still throw any exception (unless you add a catch) so I think the only effect is to assure the streams/channels are closed.

One place where this PR isn't complete is in the tabulardata/impl/plugins classes. There are other classes there that do the same thing as DTAFileReaderSpi in creating a stream that doesn't look like it gets closed, and in having methods that have a stream param. In this latter case, I didn't find where these methods were getting called, so I didn't want to just close the streams in case that was already handled by the caller (or the stream is reused, etc.). So - some discussion about what could/should happen there would help.

**Suggestions on how to test this**: If we can reliably exhaust the pool by setting a low value and using some of the functionality affected by this PR (e.g. thumbnails created for pdfs), then applying this PR should stop that problem. 
Testing should also cover making sure that things still work, e.g. that I haven't accidentally closed streams/channels before they're used. 

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: No.

**Is there a release notes update needed for this change?**:

**Additional documentation**:
