### PR TITLE
persist debug=true in session, toggle with query parameter #7273

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DataverseSession.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DataverseSession.java
@@ -49,6 +49,14 @@ public class DataverseSession implements Serializable{
     private static final Logger logger = Logger.getLogger(DataverseSession.class.getCanonicalName());
     
     private boolean statusDismissed = false;
+
+    /**
+     * If debug is set to true, some pages show extra debugging information.
+     *
+     * The way to set the boolean to true is to pass debug=true as a query
+     * parameter. The boolean will remain true until debug=false is passed.
+     */
+    private boolean debug;
     
     public User getUser() {
         if ( user == null ) {
@@ -82,7 +90,15 @@ public class DataverseSession implements Serializable{
     public void setStatusDismissed(boolean status) {
         statusDismissed = status; //MAD: Set to true to enable code!
     }
-    
+
+    public boolean isDebug() {
+        return debug;
+    }
+
+    public void setDebug(boolean debug) {
+        this.debug = debug;
+    }
+
     public StaticPermissionQuery on( Dataverse d ) {
             return permissionsService.userOn(user, d);
     }

--- a/src/main/java/edu/harvard/iq/dataverse/DataverseSession.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DataverseSession.java
@@ -51,7 +51,8 @@ public class DataverseSession implements Serializable{
     private boolean statusDismissed = false;
 
     /**
-     * If debug is set to true, some pages show extra debugging information.
+     * If debug is set to true, some pages show extra debugging information to
+     * superusers.
      *
      * The way to set the boolean to true is to pass debug=true as a query
      * parameter. The boolean will remain true until debug=false is passed.
@@ -92,6 +93,10 @@ public class DataverseSession implements Serializable{
     }
 
     public boolean isDebug() {
+        // Only superusers get extra debugging information.
+        if (!getUser().isSuperuser()) {
+            return false;
+        }
         return debug;
     }
 

--- a/src/main/java/edu/harvard/iq/dataverse/DataverseSession.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DataverseSession.java
@@ -54,10 +54,15 @@ public class DataverseSession implements Serializable{
      * If debug is set to true, some pages show extra debugging information to
      * superusers.
      *
-     * The way to set the boolean to true is to pass debug=true as a query
-     * parameter. The boolean will remain true until debug=false is passed.
+     * The way to set the Boolean to true is to pass debug=true as a query
+     * parameter. The Boolean will remain true (even if nothing is passed to it)
+     * until debug=false is passed.
+     *
+     * Because a boolean is false by default when it comes from a viewParam we
+     * use a Boolean instead. That way, if the debug viewParam is null, we can
+     * leave the state alone (see setDebug()).
      */
-    private boolean debug;
+    private Boolean debug;
     
     public User getUser() {
         if ( user == null ) {
@@ -92,7 +97,7 @@ public class DataverseSession implements Serializable{
         statusDismissed = status; //MAD: Set to true to enable code!
     }
 
-    public boolean isDebug() {
+    public Boolean getDebug() {
         // Only superusers get extra debugging information.
         if (!getUser().isSuperuser()) {
             return false;
@@ -100,8 +105,11 @@ public class DataverseSession implements Serializable{
         return debug;
     }
 
-    public void setDebug(boolean debug) {
-        this.debug = debug;
+    public void setDebug(Boolean debug) {
+        // Leave the debug state alone if nothing is passed.
+        if (debug != null) {
+            this.debug = debug;
+        }
     }
 
     public StaticPermissionQuery on( Dataverse d ) {

--- a/src/main/java/edu/harvard/iq/dataverse/search/SearchIncludeFragment.java
+++ b/src/main/java/edu/harvard/iq/dataverse/search/SearchIncludeFragment.java
@@ -1018,8 +1018,7 @@ public class SearchIncludeFragment implements java.io.Serializable {
     }
 
     public Boolean getDebug() {
-        return (session.isDebug() && session.getUser().isSuperuser())
-                || settingsWrapper.isTrueForKey(":Debug", false);
+        return session.isDebug();
     }
 
     public void setDebug(Boolean debug) {

--- a/src/main/java/edu/harvard/iq/dataverse/search/SearchIncludeFragment.java
+++ b/src/main/java/edu/harvard/iq/dataverse/search/SearchIncludeFragment.java
@@ -130,7 +130,7 @@ public class SearchIncludeFragment implements java.io.Serializable {
     Map<String, String> staticSolrFieldFriendlyNamesBySolrField = new HashMap<>();
     private boolean solrIsDown = false;
     private Map<String, Integer> numberOfFacets = new HashMap<>();
-    private boolean debug = false;
+    private Boolean debug;
 //    private boolean showUnpublished;
     List<String> filterQueriesDebug = new ArrayList<>();
 //    private Map<String, String> friendlyName = new HashMap<>();
@@ -1017,13 +1017,15 @@ public class SearchIncludeFragment implements java.io.Serializable {
         this.rootDv = rootDv;
     }
 
-    public boolean isDebug() {
-        return (debug && session.getUser().isSuperuser())
+    public Boolean getDebug() {
+        return (session.isDebug() && session.getUser().isSuperuser())
                 || settingsWrapper.isTrueForKey(":Debug", false);
     }
 
-    public void setDebug(boolean debug) {
-        this.debug = debug;
+    public void setDebug(Boolean debug) {
+        if (debug != null) {
+            session.setDebug(debug);
+        }
     }
 
     public List<String> getFilterQueriesDebug() {

--- a/src/main/java/edu/harvard/iq/dataverse/search/SearchIncludeFragment.java
+++ b/src/main/java/edu/harvard/iq/dataverse/search/SearchIncludeFragment.java
@@ -130,7 +130,6 @@ public class SearchIncludeFragment implements java.io.Serializable {
     Map<String, String> staticSolrFieldFriendlyNamesBySolrField = new HashMap<>();
     private boolean solrIsDown = false;
     private Map<String, Integer> numberOfFacets = new HashMap<>();
-    private Boolean debug;
 //    private boolean showUnpublished;
     List<String> filterQueriesDebug = new ArrayList<>();
 //    private Map<String, String> friendlyName = new HashMap<>();
@@ -1015,16 +1014,6 @@ public class SearchIncludeFragment implements java.io.Serializable {
 
     public void setRootDv(boolean rootDv) {
         this.rootDv = rootDv;
-    }
-
-    public Boolean getDebug() {
-        return session.isDebug();
-    }
-
-    public void setDebug(Boolean debug) {
-        if (debug != null) {
-            session.setDebug(debug);
-        }
     }
 
     public List<String> getFilterQueriesDebug() {

--- a/src/main/webapp/dataverse.xhtml
+++ b/src/main/webapp/dataverse.xhtml
@@ -44,7 +44,7 @@
                     <f:viewParam name="sort" value="#{SearchIncludeFragment.sortField}"/>
                     <f:viewParam name="order" value="#{SearchIncludeFragment.sortOrder}"/>
                     <f:viewParam name="page" value="#{SearchIncludeFragment.page}"/>
-                    <f:viewParam name="debug" value="#{SearchIncludeFragment.debug}"/>
+                    <f:viewParam name="debug" value="#{dataverseSession.debug}"/>
                     <f:viewParam name="adjustFacetName" value="#{SearchIncludeFragment.adjustFacetName}"/>
                     <f:viewParam name="adjustFacetNumber" value="#{SearchIncludeFragment.adjustFacetNumber}"/>
                     <f:viewAction action="#{SearchIncludeFragment.search()}" />

--- a/src/main/webapp/search-include-fragment.xhtml
+++ b/src/main/webapp/search-include-fragment.xhtml
@@ -232,7 +232,7 @@
         </div>
         <div id="dv-main" class="col-sm-8 col-md-9">
             <!--DEBUG BEGIN-->
-            <div jsf:rendered="#{SearchIncludeFragment.debug}" style="background-color: lightgray">
+            <div jsf:rendered="#{dataverseSession.debug}" style="background-color: lightgray">
                 <tt>
                     <h:outputText value="mode:#{SearchIncludeFragment.mode} "/>
                     <h:outputText value="sort=#{SearchIncludeFragment.sortField}:#{SearchIncludeFragment.sortOrder}"/><br/>
@@ -448,7 +448,7 @@
             <h:dataTable id="resultsTable" styleClass="#{SearchIncludeFragment.searchResultsCount > 0 ? '' : 'resultsNone'}" value="#{SearchIncludeFragment.searchResultsList}" var="result"
                          rendered="#{SearchIncludeFragment.searchResultsList.size() > 0}">
                 <h:column>
-                    <ui:fragment rendered="#{SearchIncludeFragment.debug == true}">
+                    <ui:fragment rendered="#{dataverseSession.debug}">
                         <h:outputText value="score: #{result.score}" rendered="#{SearchIncludeFragment.mode == SearchIncludeFragment.searchModeString}"/>
                     </ui:fragment>
                     <!--DATAVERSE CARDS-->
@@ -461,7 +461,7 @@
                             <h:outputLink value="#{!SearchIncludeFragment.rootDv and !result.isInTree ? dvUrl : widgetWrapper.wrapURL(dvUrl)}" target="#{!SearchIncludeFragment.rootDv and !result.isInTree and widgetWrapper.widgetView ? '_blank' : ''}">
                                 <h:outputText value="#{result.name}" style="padding:4px 0;" rendered="#{result.nameHighlightSnippet == null}"/>
                                 <h:outputText value="#{result.nameHighlightSnippet}" style="padding:4px 0;" rendered="#{result.nameHighlightSnippet != null}" escape="false"/>
-                                <h:outputText value=" (#{result.entityId})" style="padding:4px 0;" rendered="#{SearchIncludeFragment.debug == true}"/>
+                                <h:outputText value=" (#{result.entityId})" style="padding:4px 0;" rendered="#{dataverseSession.debug}"/>
                             </h:outputLink>
                             <h:outputText value="(#{result.dataverseAffiliation})" styleClass="text-muted" style="margin-left: .5em;" rendered="#{!empty result.dataverseAffiliation and result.dataverseAffiliationHighlightSnippet == null}"/>
                             <h:outputText value="(#{result.dataverseAffiliationHighlightSnippet})" styleClass="text-muted" style="margin-left: .5em;" rendered="#{result.dataverseAffiliationHighlightSnippet != null}" escape="false"/>
@@ -519,7 +519,7 @@
                             <a href="#{!SearchIncludeFragment.rootDv and !result.isInTree ? result.datasetUrl : widgetWrapper.wrapURL(result.datasetUrl)}" target="#{(!SearchIncludeFragment.rootDv and !result.isInTree and widgetWrapper.widgetView) or result.harvested ? '_blank' : ''}">
                                 <h:outputText value="#{result.title}" style="padding:4px 0;" rendered="#{result.titleHighlightSnippet == null}"/>
                                 <h:outputText value="#{result.titleHighlightSnippet}" style="padding:4px 0;" rendered="#{result.titleHighlightSnippet != null}" escape="false"/>
-                                <h:outputText value=" (#{result.entityId})" style="padding:4px 0;" rendered="#{SearchIncludeFragment.debug == true}"/></a>
+                                <h:outputText value=" (#{result.entityId})" style="padding:4px 0;" rendered="#{dataverseSession.debug}"/></a>
 
                             <h:outputText value="#{bundle['dataset.versionUI.draft']}" styleClass="label label-primary" rendered="#{result.draftState}"/>
                             <h:outputText value="#{bundle['dataset.versionUI.inReview']}" styleClass="label label-success" rendered="#{result.inReviewState}"/>
@@ -586,7 +586,7 @@
                             <a href="#{!SearchIncludeFragment.rootDv and !result.isInTree ? (result.harvested ? result.fileDatasetUrl : result.fileUrl) : widgetWrapper.wrapURL(result.harvested ? result.fileDatasetUrl : result.fileUrl)}" target="#{(!SearchIncludeFragment.rootDv and !result.isInTree and widgetWrapper.widgetView) or result.harvested ? '_blank' : ''}">
                                 <h:outputText value="#{result.name}" style="padding:4px 0;" rendered="#{result.nameHighlightSnippet == null}"/>
                                 <h:outputText value="#{result.nameHighlightSnippet}" style="padding:4px 0;" rendered="#{result.nameHighlightSnippet != null}" escape="false"/>
-                                <h:outputText value=" (#{result.entityId})" style="padding:4px 0;" rendered="#{SearchIncludeFragment.debug == true}"/></a>
+                                <h:outputText value=" (#{result.entityId})" style="padding:4px 0;" rendered="#{dataverseSession.debug}"/></a>
                             <h:outputText value="#{bundle['dataset.versionUI.draft']}" styleClass="label label-primary" rendered="#{result.draftState}"/>
                             <h:outputText value="#{bundle['dataset.versionUI.inReview']}" styleClass="label label-success" rendered="#{result.inReviewState}"/>
                             <h:outputText value="#{bundle['dataset.versionUI.unpublished']}" styleClass="label label-warning" rendered="#{result.unpublishedState}"/>


### PR DESCRIPTION
**What this PR does / why we need it**:

Showing debug information on a page is useful but currently requires you to add debug=true as a query parameter each time you load the page. The only page this works on is the dataverse page (and this pull request doesn't change that).

This pull request allows you to add debug=true as a query parameter once and have the boolean remain true for your session.

**Which issue(s) this PR closes**:

Closes #7273

**Special notes for your reviewer**:

I didn't touch the existing logic in SearchIncludeFragment:

- debug is only true if you are a superuser
- ~~another way for debug to be true is the undocumented ":Debug" database setting.~~ 2020-10-14 update: we decided to remove this in a4582f0.

**Suggestions on how to test this**:

- Log in as a superuser.
- Go to http://localhost:8080/?debug=true (or the equivalent siteUrl) to set enable debugging for your session.
- Navigate around, observing that the extra debugging information is only available on on the dataverse page and relates to Solr (screenshot below) and is only available to superusers.
- Go to http://localhost:8080/?debug=false to disable debugging.
- ~~Play around with the undocumented ":Debug" database setting, setting it to true and false and observe that it acts the same was as the debug query parameter.~~

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

How the debugging on the dataverse page looks hasn't changed but here's what it looks like:

<img width="1206" alt="Screen Shot 2020-10-09 at 10 53 08 AM" src="https://user-images.githubusercontent.com/21006/95598385-da6f7900-0a1d-11eb-8741-42a3815c0094.png">

**Is there a release notes update needed for this change?**:

Maybe? I'm happy to add one.

**Additional documentation**:

None. I'm happy to add some. I documented the boolean within the code, at least.