### PR TITLE
Fix for the json LD export error in the dataset page

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DataFileServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DataFileServiceBean.java
@@ -578,7 +578,7 @@ public class DataFileServiceBean implements java.io.Serializable {
         
         int i = 0; 
         
-        List<Object[]> dataTableResults = em.createNativeQuery("SELECT t0.ID, t0.DATAFILE_ID, t0.UNF, t0.CASEQUANTITY, t0.VARQUANTITY, t0.ORIGINALFILEFORMAT, t0.ORIGINALFILESIZE FROM dataTable t0, dataFile t1, dvObject t2 WHERE ((t0.DATAFILE_ID = t1.ID) AND (t1.ID = t2.ID) AND (t2.OWNER_ID = " + owner.getId() + ")) ORDER BY t0.ID").getResultList();
+        List<Object[]> dataTableResults = em.createNativeQuery("SELECT t0.ID, t0.DATAFILE_ID, t0.UNF, t0.CASEQUANTITY, t0.VARQUANTITY, t0.ORIGINALFILEFORMAT, t0.ORIGINALFILESIZE, t0.ORIGINALFILENAME FROM dataTable t0, dataFile t1, dvObject t2 WHERE ((t0.DATAFILE_ID = t1.ID) AND (t1.ID = t2.ID) AND (t2.OWNER_ID = " + owner.getId() + ")) ORDER BY t0.ID").getResultList();
         
         for (Object[] result : dataTableResults) {
             DataTable dataTable = new DataTable(); 
@@ -595,6 +595,8 @@ public class DataFileServiceBean implements java.io.Serializable {
             dataTable.setOriginalFileFormat((String)result[5]);
             
             dataTable.setOriginalFileSize((Long)result[6]);
+            
+            dataTable.setOriginalFileName((String)result[7]);
             
             dataTables.add(dataTable);
             datatableMap.put(fileId, i++);
@@ -856,8 +858,10 @@ public class DataFileServiceBean implements java.io.Serializable {
 
             fileMetadata.setDatasetVersion(version);
             
-            //fileMetadata.setDataFile(dataset.getFiles().get(file_list_id));
+            // Link the FileMetadata object to the DataFile:
             fileMetadata.setDataFile(dataFiles.get(file_list_id));
+            // ... and the DataFile back to the FileMetadata:
+            fileMetadata.getDataFile().getFileMetadatas().add(fileMetadata);
             
             String description = (String) result[2]; 
             


### PR DESCRIPTION
**What this PR does / why we need it**:
A fix for the optimized/hacky method that quickly populates all the DataFiles in a Dataset with custom queries.  This addresses the json LD export issue found in #7310.

(I'm going to open a general issue for adding a section to the dev. guide - a checklist for anytime we modify certain entities. For example, custom queries in this method may need to be modified again if we add any more fields to the datafile-level entities. For most other entities, the json export and import methods may need to be modified. There may be more such places?)

**Which issue(s) this PR closes**:

Closes #7310

**Special notes for your reviewer**:

**Suggestions on how to test this**:

See the issue on how to reproduce. 
The error was thrown specifically when retrieving the original name of an ingested tabular file. So a super prudent way to test this would be with both a file ingested since 5.0 (for which the original filename is saved in the database), and for a file ingested earlier. In a new database the latter can be emulated by a direct db update: 
`UPDATE datatable SET originalfilename=NULL WHERE datafile_id=...;`.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
