### PR TITLE
default guides BaseUrl to https

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/SettingsWrapper.java
+++ b/src/main/java/edu/harvard/iq/dataverse/SettingsWrapper.java
@@ -125,7 +125,7 @@ public class SettingsWrapper implements java.io.Serializable {
         if (true)
 
             if (guidesBaseUrl == null) {
-            String saneDefault = "http://guides.dataverse.org";
+            String saneDefault = "https://guides.dataverse.org";
         
             guidesBaseUrl = getValueForKey(SettingsServiceBean.Key.GuidesBaseUrl);
             if (guidesBaseUrl == null) {

--- a/src/main/java/edu/harvard/iq/dataverse/util/SystemConfig.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/SystemConfig.java
@@ -366,7 +366,7 @@ public class SystemConfig {
     }
 
     public String getGuidesBaseUrl() {
-        String saneDefault = "http://guides.dataverse.org";
+        String saneDefault = "https://guides.dataverse.org";
         String guidesBaseUrl = settingsService.getValueForKey(SettingsServiceBean.Key.GuidesBaseUrl, saneDefault);
         return guidesBaseUrl + "/" + getGuidesLanguage();
     }


### PR DESCRIPTION
**What this PR does / why we need it**: e-mail message sent containing links to http://guides.dataverse.org are receiving a higher spam score and are being flagged as such. This PR updates the SystemConfig.java and SettingsWrapper.java saneDefault values to use https. There are many other hard-coded references to specific pages on the guides, but those should be picked up by the redirect: `RewriteRule ^ https://%{SERVER_NAME}%{REQUEST_URI} [END,NE,R=permanent]`

**Which issue(s) this PR closes**:

Closes #7327

**Special notes for your reviewer**: none

**Suggestions on how to test this**: build branch, click "User Guide" on homepage. Since most everything appears to use settingsWrapper.guidesBaseUrl I'm assuming this should update the URL used in outgoing e-mail messages as well.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: no

**Is there a release notes update needed for this change?**: no

**Additional documentation**: none
