### PR TITLE
#7097 move dv indexing to on success in Finalize Dataset Publication Command

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/FinalizeDatasetPublicationCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/FinalizeDatasetPublicationCommand.java
@@ -32,6 +32,7 @@ import edu.harvard.iq.dataverse.GlobalIdServiceBean;
 import edu.harvard.iq.dataverse.batch.util.LoggingUtil;
 import edu.harvard.iq.dataverse.engine.command.Command;
 import edu.harvard.iq.dataverse.util.FileUtil;
+import java.util.ArrayList;
 import java.util.concurrent.Future;
 import org.apache.solr.client.solrj.SolrServerException;
 
@@ -51,6 +52,8 @@ public class FinalizeDatasetPublicationCommand extends AbstractPublishDatasetCom
      * mirror field from {@link PublishDatasetCommand} of same name
      */
     final boolean datasetExternallyReleased;
+    
+    List<Dataverse> dataversesToIndex = new ArrayList<>();
     
     public static final String FILE_VALIDATION_ERROR = "FILE VALIDATION ERROR";
     
@@ -224,6 +227,20 @@ public class FinalizeDatasetPublicationCommand extends AbstractPublishDatasetCom
             LoggingUtil.writeOnSuccessFailureLog(this, failureLogText,  dataset);
             retVal = false;
         }
+        
+        //re-indexing dataverses that have additional subjects
+        if (!dataversesToIndex.isEmpty()){
+            for (Dataverse dv : dataversesToIndex) {
+                try {
+                    Future<String> indexString = ctxt.index().indexDataverse(dv);
+                } catch (IOException | SolrServerException e) {
+                    String failureLogText = "Post-publication indexing failed. You can kick off a re-index of this dataverse with: \r\n curl http://localhost:8080/api/admin/index/dataverses/" + dv.getId().toString();
+                    failureLogText += "\r\n" + e.getLocalizedMessage();
+                    LoggingUtil.writeOnSuccessFailureLog(this, failureLogText, dataset);
+                    retVal = false;
+                } 
+            }
+        }
 
         exportMetadata(dataset, ctxt.settings());
                 
@@ -255,13 +272,13 @@ public class FinalizeDatasetPublicationCommand extends AbstractPublishDatasetCom
      * add the dataset subjects to all parent dataverses.
      */
     private void updateParentDataversesSubjectsField(Dataset savedDataset, CommandContext ctxt) throws  SolrServerException, IOException {
+        
         for (DatasetField dsf : savedDataset.getLatestVersion().getDatasetFields()) {
             if (dsf.getDatasetFieldType().getName().equals(DatasetFieldConstant.subject)) {
                 Dataverse dv = savedDataset.getOwner();
                 while (dv != null) {
                     boolean newSubjectsAdded = false;
-                    for (ControlledVocabularyValue cvv : dsf.getControlledVocabularyValues()) {
-                    
+                    for (ControlledVocabularyValue cvv : dsf.getControlledVocabularyValues()) {                   
                         if (!dv.getDataverseSubjects().contains(cvv)) {
                             logger.fine("dv "+dv.getAlias()+" does not have subject "+cvv.getStrValue());
                             newSubjectsAdded = true;
@@ -271,10 +288,11 @@ public class FinalizeDatasetPublicationCommand extends AbstractPublishDatasetCom
                         }
                     }
                     if (newSubjectsAdded) {
-                        logger.fine("new dataverse subjects added - saving and reindexing");
+                        logger.fine("new dataverse subjects added - saving and reindexing in OnSuccess");
                         Dataverse dvWithSubjectJustAdded = ctxt.em().merge(dv);
                         ctxt.em().flush();
-                        ctxt.index().indexDataverse(dvWithSubjectJustAdded); // need to reindex to capture the new subjects
+                        //adding dv to list of those we need to re-index for new subjects
+                        dataversesToIndex.add(dvWithSubjectJustAdded);                       
                     } else {
                         logger.fine("no new subjects added to the dataverse; skipping reindexing");
                     }


### PR DESCRIPTION
**What this PR does / why we need it**:
As it is currently written it's possible for the Finalize Dataset Publication Command to fail in such a way that the dataverse owners have been reindexed fond subjects while the transaction to save those subjects fails. Moving the re-index to OnSuccess will prevent that from happening.

**Which issue(s) this PR closes**:

Closes #7097 in FinalizeDatasetPublicationCommand move reindex dv to OnSuccess

**Special notes for your reviewer**:

**Suggestions on how to test this**:

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**: