### PR TITLE
document addition of ETag header setting in 5.1.1 release notes

### DIFF
--- a/doc/release-notes/5.1.1-release-notes.md
+++ b/doc/release-notes/5.1.1-release-notes.md
@@ -27,6 +27,10 @@ Larger installations may want to increase the number of open S3 connections allo
 `./asadmin create-jvm-options "-Ddataverse.files.<id>.connection-pool-size=4096"`
 (where `<id>` is the identifier of your S3 file store (likely `"s3"`). The JVM Options section of the [Configuration Guide](http://guides.dataverse.org/en/5.1.1/installation/config/) has more information.
 
+### New S3 Bucket CORS setting for Direct Upload/Download
+
+When using S3 storage with direct upload and/or download enabled, one must now expose the ETag header as documented in the [updated cors.json example](https://guides.dataverse.org/en/latest/developers/big-data-support.html?highlight=etag#s3-direct-upload-and-download).
+
 ## Complete List of Changes
 
 For the complete list of code changes in this release, see the [5.1.1 Milestone](https://github.com/IQSS/dataverse/milestone/91?closed=1) in Github.


### PR DESCRIPTION
**What this PR does / why we need it**: The 5.1.1 release notes don't include the addition of the ETag header. Without it, installation admins may discover this setting the hard way.

**Which issue(s) this PR closes**:

Closes #7364

**Special notes for your reviewer**: none

**Suggestions on how to test this**: click link

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: no

**Is there a release notes update needed for this change?**: yes

**Additional documentation**: none
