### PR TITLE
5345 Make EJB timers nonpersistent

### DIFF
--- a/doc/release-notes/5345-ejb-timers.md
+++ b/doc/release-notes/5345-ejb-timers.md
@@ -1,0 +1,4 @@
+Reset the EJB timer database back to default:
+```
+<payara install path>/asadmin set configs.config.server-config.ejb-container.ejb-timer-service.timer-datasource=jdbc/__TimerPool
+```

--- a/doc/sphinx-guides/source/_static/util/clear_timer.sh
+++ b/doc/sphinx-guides/source/_static/util/clear_timer.sh
@@ -1,9 +1,8 @@
 #!/bin/sh
 
-# EBJ timers sometimes cause problems; utility to clear generated directories and database rows
+# EBJ timers sometimes cause problems; utility to clear generated directories
 
-# assumes this script is being run as root, and that the postgres user had passwordless 
-# access to the database (local sockets, or appropriate environmental variables).
+# assumes this script is being run as root
 
 # will restart Payara if it's stopped; comment out the `start-domain` command at the end
 # if you'd like to avoid that.
@@ -14,19 +13,11 @@ PAYARA_DIR=/usr/local/payara5
 # directory within Payara (defaults)
 DV_DIR=${PAYARA_DIR}/glassfish/domains/domain1
 
-# name of dataverse database
-DV_DB=dvndb
-
-# OS user for the database
-DB_USER=postgres
-
 # stop the domain (generates a warning if app server is stopped)
 ${PAYARA_DIR}/bin/asadmin stop-domain
 
 rm -rf ${PAYARA_DIR}/${DV_DIR}/generated/
 rm -rf ${PAYARA_DIR}/${DV_DIR}/osgi-cache/felix
-
-sudo -u ${DB_USER} psql ${DV_DB} -c 'delete from "EJB__TIMER__TBL"';
 
 # restart the domain (also generates a warning if app server is stopped)
 ${PAYARA_DIR}/bin/asadmin start-domain

--- a/doc/sphinx-guides/source/admin/timers.rst
+++ b/doc/sphinx-guides/source/admin/timers.rst
@@ -22,9 +22,7 @@ The following JVM option instructs the application to act as the dedicated timer
 
 ``-Ddataverse.timerServer=true``
 
-**IMPORTANT:** Note that this option is automatically set by the Dataverse installer script. That means that when **configuring a multi-server cluster**, it will be the responsibility of the installer to remove the option from the :fixedwidthplain:`domain.xml` of every node except the one intended to be the timer server. We also recommend that the following entry in the :fixedwidthplain:`domain.xml`: ``<ejb-timer-service timer-datasource="jdbc/VDCNetDS">`` is changed back to ``<ejb-timer-service>`` on all the non-timer server nodes. Similarly, this option is automatically set by the installer script. Changing it back to the default setting on a server that doesn't need to run the timer will prevent a potential race condition, where multiple servers try to get a lock on the timer database. 
-
-**Note** that for the timer to work, the version of the PostgreSQL JDBC driver your instance is using must match the version of your PostgreSQL database. See the :ref:`timer-not-working` section of Troubleshooting in the Admin Guide.
+**IMPORTANT:** Note that this option is automatically set by the Dataverse installer script. That means that when **configuring a multi-server cluster**, it will be the responsibility of the installer to remove the option from the :fixedwidthplain:`domain.xml` of every node except the one intended to be the timer server.
 
 Harvesting Timers 
 -----------------
@@ -44,7 +42,7 @@ This timer runs a daily job that tries to export all the local, published datase
 
 This daily job will also update all the harvestable OAI sets configured on your server, adding new and/or newly published datasets or marking deaccessioned datasets as "deleted" in the corresponding sets as needed. 
 
-This job is automatically scheduled to run at 2AM local time every night. If really necessary, it is possible (for an advanced user) to change that time by directly editing the EJB timer application table in the database.  
+This job is automatically scheduled to run at 2AM local time every night.
 
 .. _saved-search-timer:
 

--- a/doc/sphinx-guides/source/admin/troubleshooting.rst
+++ b/doc/sphinx-guides/source/admin/troubleshooting.rst
@@ -98,14 +98,12 @@ We don't know what's causing this issue, but here's a known workaround:
 
 - Stop Payara; 
 
-- Remove the ``generated`` and ``osgi-cache`` directories; 
-
-- Delete all the rows from the ``EJB__TIMER__TBL`` table in the database;
+- Remove the ``generated`` and ``osgi-cache`` directories;
 
 - Start Payara
 
 The shell script below performs the steps above. 
-Note that it may or may not work on your system, so it is provided as an example only, downloadable :download:`here </_static/util/clear_timer.sh>`. Aside from the configuration values that need to be changed to reflect your environment (the Payara directory, name of the database, etc.) the script relies on the database being configured in a certain way for access. (See the comments in the script for more information)
+Note that it may or may not work on your system, so it is provided as an example only, downloadable :download:`here </_static/util/clear_timer.sh>`. The configuration values to reflect your environment (the Payara directory) might need to be changed. (See the comments in the script for more information)
 
 .. literalinclude:: ../_static/util/clear_timer.sh
 
@@ -114,7 +112,7 @@ Note that it may or may not work on your system, so it is provided as an example
 Timer Not Working
 -----------------
 
-Dataverse relies on EJB timers to perform scheduled tasks: harvesting from remote servers, updating the local OAI sets and running metadata exports. (See :doc:`timers` for details.) If these scheduled jobs are not running on your server, this may be the result of the incompatibility between the version of PostgreSQL database you are using, and PostgreSQL JDBC driver in use by your instance of Payara. The symptoms:
+Dataverse relies on EJB timers to perform scheduled tasks: harvesting from remote servers, updating the local OAI sets and running metadata exports. (See :doc:`timers` for details.) If these scheduled jobs are not running on your server, you might experience the following symptoms:
 
 If you are seeing the following in your server.log...
 
@@ -127,9 +125,9 @@ followed by an Exception stack trace with these lines in it:
 :fixedwidthplain:`Exception Description: Could not deserialize object from byte array` ...
 
 
-... it most likely means that it is the JDBC driver incompatibility that's preventing the timer from working correctly. 
-Make sure you install the correct version of the driver. For example, if you are running the version 9.3 of PostgreSQL, make sure you have the driver postgresql-9.3-1104.jdbc4.jar in your :fixedwidthplain:`<PAYARA FOLDER>/glassfish/lib` directory. Go `here <https://jdbc.postgresql.org/download.html>`_
-to download the correct version of the driver. If you have an older driver in glassfish/lib, make sure to remove it, replace it with the new version and restart Payara. (You may need to remove the entire contents of :fixedwidthplain:`<PAYARA FOLDER>/glassfish/domains/domain1/generated` before you start Payara). 
+... you should reach out by opening an issue. In the good old days of running Dataverse 4 running on Glassfish 4, this
+was a hint for an unsupported JDBC driver. In Dataverse 5 this would be a new regression and it's cause would need to be
+investigated.
 
 
 Constraint Violations Issues

--- a/doc/sphinx-guides/source/admin/troubleshooting.rst
+++ b/doc/sphinx-guides/source/admin/troubleshooting.rst
@@ -103,7 +103,7 @@ We don't know what's causing this issue, but here's a known workaround:
 - Start Payara
 
 The shell script below performs the steps above. 
-Note that it may or may not work on your system, so it is provided as an example only, downloadable :download:`here </_static/util/clear_timer.sh>`. The configuration values to reflect your environment (the Payara directory) might need to be changed. (See the comments in the script for more information)
+Note that it may or may not work on your system, so it is provided as an example only, downloadable :download:`here </_static/util/clear_timer.sh>`. The configuration values might need to be changed to reflect your environment (the Payara directory). See the comments in the script for more information.
 
 .. literalinclude:: ../_static/util/clear_timer.sh
 
@@ -126,7 +126,7 @@ followed by an Exception stack trace with these lines in it:
 
 
 ... you should reach out by opening an issue. In the good old days of running Dataverse 4 running on Glassfish 4, this
-was a hint for an unsupported JDBC driver. In Dataverse 5 this would be a new regression and it's cause would need to be
+was a hint for an unsupported JDBC driver. In Dataverse 5 this would be a new regression and its cause would need to be
 investigated.
 
 

--- a/doc/sphinx-guides/source/installation/installation-main.rst
+++ b/doc/sphinx-guides/source/installation/installation-main.rst
@@ -208,8 +208,7 @@ Fresh Reinstall
 Early on when you're installing Dataverse, you may think, "I just want to blow away what I've installed and start over." That's fine. You don't have to uninstall the various components like Payara, PostgreSQL and Solr, but you should be conscious of how to clear out their data. For Payara, a common helpful process is to:
 
 - Stop Payara; 
-- Remove the ``generated`` and ``osgi-cache`` directories; 
-- Delete all the rows from the ``EJB__TIMER__TBL`` table in the database;
+- Remove the ``generated`` and ``osgi-cache`` directories;
 - Start Payara
 
 Drop database

--- a/scripts/installer/as-setup.sh
+++ b/scripts/installer/as-setup.sh
@@ -162,11 +162,6 @@ function final_setup(){
         # Create data sources
         ./asadmin $ASADMIN_OPTS create-jdbc-resource --connectionpoolid dvnDbPool jdbc/VDCNetDS
 
-        ###
-        # Set up the data source for the timers
-
-        ./asadmin $ASADMIN_OPTS set configs.config.server-config.ejb-container.ejb-timer-service.timer-datasource=jdbc/VDCNetDS
-
         ./asadmin $ASADMIN_OPTS create-jvm-options "\-Djavax.xml.parsers.SAXParserFactory=com.sun.org.apache.xerces.internal.jaxp.SAXParserFactoryImpl"
 
 	### 

--- a/src/main/java/edu/harvard/iq/dataverse/search/savedsearch/SavedSearchServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/search/savedsearch/SavedSearchServiceBean.java
@@ -129,7 +129,7 @@ public class SavedSearchServiceBean {
     }
     
     
-    @Schedule(dayOfWeek="0", hour="0",minute="30")
+    @Schedule(dayOfWeek="0", hour="0", minute="30", persistent = false)
     public void makeLinksForAllSavedSearchesTimer() {
         if (systemConfig.isTimerServer()) {
             logger.info("Linking saved searches");

--- a/src/main/java/edu/harvard/iq/dataverse/timer/DataverseTimerServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/timer/DataverseTimerServiceBean.java
@@ -7,10 +7,7 @@ package edu.harvard.iq.dataverse.timer;
 
 import edu.harvard.iq.dataverse.DatasetServiceBean;
 import edu.harvard.iq.dataverse.Dataverse;
-import edu.harvard.iq.dataverse.DataverseServiceBean;
 import edu.harvard.iq.dataverse.authorization.AuthenticationServiceBean;
-import edu.harvard.iq.dataverse.authorization.providers.builtin.BuiltinUser;
-import edu.harvard.iq.dataverse.authorization.providers.builtin.BuiltinUserServiceBean;
 import edu.harvard.iq.dataverse.authorization.users.AuthenticatedUser;
 import edu.harvard.iq.dataverse.engine.command.DataverseRequest;
 import edu.harvard.iq.dataverse.harvest.client.HarvestingClient;
@@ -33,13 +30,10 @@ import javax.annotation.Resource;
 import javax.ejb.EJB;
 import javax.ejb.Singleton;
 import javax.ejb.Startup;
-import javax.ejb.Stateless;
 import javax.ejb.Timeout;
 import javax.ejb.Timer;
 import javax.ejb.TransactionAttribute;
 import javax.ejb.TransactionAttributeType;
-import javax.persistence.EntityManager;
-import javax.persistence.PersistenceContext;
 import javax.servlet.http.HttpServletRequest;
 
 
@@ -56,15 +50,13 @@ import javax.servlet.http.HttpServletRequest;
 @Singleton
 @Startup
 public class DataverseTimerServiceBean implements Serializable {
+    
+    private static final Logger logger = Logger.getLogger("edu.harvard.iq.dataverse.timer.DataverseTimerServiceBean");
+    
     @Resource
     javax.ejb.TimerService timerService;
-    @PersistenceContext(unitName = "VDCNet-ejbPU")
-    private EntityManager em;
-    private static final Logger logger = Logger.getLogger("edu.harvard.iq.dataverse.timer.DataverseTimerServiceBean");
     @EJB
     HarvesterServiceBean harvesterService;
-    @EJB
-    DataverseServiceBean dataverseService;
     @EJB
     HarvestingClientServiceBean harvestingClientService;
     @EJB 

--- a/src/main/java/edu/harvard/iq/dataverse/timer/DataverseTimerServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/timer/DataverseTimerServiceBean.java
@@ -32,6 +32,7 @@ import javax.ejb.Singleton;
 import javax.ejb.Startup;
 import javax.ejb.Timeout;
 import javax.ejb.Timer;
+import javax.ejb.TimerConfig;
 import javax.ejb.TransactionAttribute;
 import javax.ejb.TransactionAttributeType;
 import javax.servlet.http.HttpServletRequest;
@@ -97,7 +98,7 @@ public class DataverseTimerServiceBean implements Serializable {
         } catch (UnknownHostException ex) {
             Logger.getLogger(DataverseTimerServiceBean.class.getName()).log(Level.SEVERE, null, ex);
         }
-        timerService.createTimer(initialExpiration, intervalDuration, info);
+        timerService.createIntervalTimer(initialExpiration, intervalDuration, new TimerConfig(info, false));
     }
 
     /**


### PR DESCRIPTION
**What this PR does / why we need it**:
As discussed in #5345, #7048, on IRC, Slack and Zoom plus [this Google doc](https://docs.google.com/document/d/1MU8Qo7EYmy75LaiwabzdID-Co3QriEe0i-YxV98hnSA/edit), we need to make the EJB timers non-persistent for enabling application-level database connection definitions.

**Which issue(s) this PR closes**:

Closes #5345

**Special notes for your reviewer**:
- It might me an idea to add a Flyway migration dropping the unused EJB timer table from the DB.

**Suggestions on how to test this**:
- Remember to reconfigure the EJB timer database (see release note)
- Check if timers still work.
- Check if timers still work on multi-instance installation without conflicting runs.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
Nope.

**Is there a release notes update needed for this change?**:
Yeah, a small one about removing the EJB timer database configuration setting on the app server. :battery: included.

**Additional documentation**:
This is a quick and dirty solution, not very sophisticated for future enhancements. At some point in the future, we need to come back to the ideas of the Google Doc.