### PR TITLE
Add render logic around edit file popup fragment #7427

### DIFF
--- a/src/main/webapp/dataset.xhtml
+++ b/src/main/webapp/dataset.xhtml
@@ -828,15 +828,16 @@
                     </div>
                     <!-- END: Create/Save Dataset Button Panel BTM editMode -->
                     <p:blockUI block="datasetForm" widgetVar="blockDatasetForm"/>
-                    <!-- POPUPS -->                    
-                    <ui:include src="file-edit-popup-fragment.xhtml">
-                        <ui:param name="datasetVersion" value="#{DatasetPage.workingVersion}"/>   
-                        <ui:param name="fileMetadataForAction" value="#{DatasetPage.fileMetadataForAction}"/>                        
-                        <ui:param name="bean" value="#{DatasetPage}"/>                        
-                        <ui:param name="restrictFileAction" value="restrictFiles"/>
-                        <ui:param name="deleteFileAction" value="deleteFiles"/> 
-                    </ui:include>                  
-
+                    <!-- POPUPS -->
+                    <ui:fragment rendered="#{DatasetPage.editMode == 'CREATE' or empty DatasetPage.editMode }">                    
+                        <ui:include src="file-edit-popup-fragment.xhtml">
+                              <ui:param name="datasetVersion" value="#{DatasetPage.workingVersion}"/>   
+                              <ui:param name="fileMetadataForAction" value="#{DatasetPage.fileMetadataForAction}"/>                        
+                              <ui:param name="bean" value="#{DatasetPage}"/>                        
+                              <ui:param name="restrictFileAction" value="restrictFiles"/>
+                              <ui:param name="deleteFileAction" value="deleteFiles"/> 
+                        </ui:include>                  
+                    </ui:fragment>
                     <p:dialog id="shareDialog" header="#{bundle['dataset.share.datasetShare']}" widgetVar="shareDialog" modal="true" rendered="#{!DatasetPage.workingVersion.deaccessioned}">
                         <p class="help-block">#{bundle['dataset.share.datasetShare.tip']}</p>
                         <div id="sharrre-widget" data-url="#{DatasetPage.dataverseSiteUrl}/dataset.xhtml?persistentId=#{dataset.globalId}" data-text="#{bundle['dataset.share.datasetShare.shareText']}"></div>


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes an issue where you couldn't edit terms of access or enable request access

**Which issue(s) this PR closes**:

Closes #7427

**Special notes for your reviewer**:
added render logic around edit file popup fragment (only needed when no edit mode; left create asthat was the older logic and will likely be needed there when the logic of the edit files in brought into the fold)

**Suggestions on how to test this**:
confirm editing terms of access and enabling request access work (from the popup and from the tab)

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
no, bug fix.

**Is there a release notes update needed for this change?**:
no

**Additional documentation**:
