### PR TITLE
7423 jms config

### DIFF
--- a/doc/release-notes/7423-jms-move-to-code.md
+++ b/doc/release-notes/7423-jms-move-to-code.md
@@ -1,0 +1,13 @@
+# Java Message System Configuration
+
+The ingest part of Dataverse uses the Java Message System to create ingest tasks in a queue.
+That queue had been configured from command line or domain.xml before. This has now changed to being done
+in code.
+
+In the unlikely case you might want to change any of these settings, feel free to change and recompile or raise an issue.
+See `IngestQueueProducer` for more details.
+
+If you want to clean up your existing installation, you can delete the old, unused queue like this:
+```shell
+asadmin delete-connector-connection-pool --cascade=true jms/IngestQueueConnectionFactoryPool
+```

--- a/scripts/installer/as-setup.sh
+++ b/scripts/installer/as-setup.sh
@@ -122,26 +122,6 @@ function preliminary_setup()
   # bump the http-listener timeout from 900 to 3600
   ./asadmin $ASADMIN_OPTS set server-config.network-config.protocols.protocol.http-listener-1.http.request-timeout-seconds="${GLASSFISH_REQUEST_TIMEOUT}"
 
-  ./asadmin $ASADMIN_OPTS delete-connector-connection-pool --cascade=true jms/__defaultConnectionFactory-Connection-Pool 
-
-  # no need to explicitly delete the connector resource for the connection pool deleted in the step 
-  # above - the cascade delete takes care of it.
-  #./asadmin $ASADMIN_OPTS delete-connector-resource jms/__defaultConnectionFactory-Connection-Pool
-
-  # http://docs.oracle.com/cd/E19798-01/821-1751/gioce/index.html
-  ./asadmin $ASADMIN_OPTS create-connector-connection-pool --steadypoolsize 1 --maxpoolsize 250 --poolresize 2 --maxwait 60000 --raname jmsra --connectiondefinition javax.jms.QueueConnectionFactory jms/IngestQueueConnectionFactoryPool
-
-  # http://docs.oracle.com/cd/E18930_01/html/821-2416/abllx.html#giogt
-  ./asadmin $ASADMIN_OPTS create-connector-resource --poolname jms/IngestQueueConnectionFactoryPool --description "ingest connector resource" jms/IngestQueueConnectionFactory
-
-  # http://docs.oracle.com/cd/E18930_01/html/821-2416/ablmc.html#giolr
-  ./asadmin $ASADMIN_OPTS create-admin-object --restype javax.jms.Queue --raname jmsra --description "sample administered object" --property Name=DataverseIngest jms/DataverseIngest
-
-  # no need to explicitly create the resource reference for the connection factory created above -
-  # the "create-connector-resource" creates the reference automatically.
-  #./asadmin $ASADMIN_OPTS create-resource-ref --target Cluster1 jms/IngestQueueConnectionFactory
-
-
   # so we can front with apache httpd ( ProxyPass / ajp://localhost:8009/ )
   ./asadmin $ASADMIN_OPTS create-network-listener --protocol http-listener-1 --listenerport 8009 --jkenabled true jk-connector
 }

--- a/src/main/java/edu/harvard/iq/dataverse/ingest/IngestMessageBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/ingest/IngestMessageBean.java
@@ -45,7 +45,13 @@ import javax.jms.ObjectMessage;
  * 
  * @author Leonid Andreev 
  */
-@MessageDriven(mappedName = "jms/DataverseIngest", activationConfig =  {@ActivationConfigProperty(propertyName = "acknowledgeMode", propertyValue = "Auto-acknowledge"), @ActivationConfigProperty(propertyName = "destinationType", propertyValue = "javax.jms.Queue")})
+@MessageDriven(
+    mappedName = "java:app/jms/queue/ingest",
+    activationConfig =  {
+        @ActivationConfigProperty(propertyName = "acknowledgeMode", propertyValue = "Auto-acknowledge"),
+        @ActivationConfigProperty(propertyName = "destinationType", propertyValue = "javax.jms.Queue")
+    }
+)
 public class IngestMessageBean implements MessageListener {
     private static final Logger logger = Logger.getLogger(IngestMessageBean.class.getCanonicalName());
     @EJB DatasetServiceBean datasetService;

--- a/src/main/java/edu/harvard/iq/dataverse/ingest/IngestQueueProducer.java
+++ b/src/main/java/edu/harvard/iq/dataverse/ingest/IngestQueueProducer.java
@@ -1,0 +1,50 @@
+package edu.harvard.iq.dataverse.ingest;
+
+import javax.annotation.Resource;
+// https://www.baeldung.com/jee-cdi-vs-ejb-singleton
+import javax.inject.Singleton;
+import javax.enterprise.inject.Produces;
+import javax.jms.JMSConnectionFactoryDefinition;
+import javax.jms.JMSDestinationDefinition;
+import javax.jms.Queue;
+import javax.jms.QueueConnectionFactory;
+
+@JMSConnectionFactoryDefinition(
+    description = "Dataverse Ingest Queue Factory",
+    name = "java:app/jms/factory/ingest",
+    resourceAdapter = "jmsra",
+    interfaceName = "javax.jms.QueueConnectionFactory",
+    maxPoolSize = 250,
+    minPoolSize = 1,
+    properties = {
+        "org.glassfish.connector-connection-pool.max-wait-time-in-millis=60000",
+        "org.glassfish.connector-connection-pool.pool-resize-quantity=2"
+    }
+)
+@JMSDestinationDefinition(
+    description = "Dataverse Ingest Queue",
+    name = "java:app/jms/queue/ingest",
+    resourceAdapter = "jmsra",
+    interfaceName="javax.jms.Queue",
+    destinationName = "DataverseIngest"
+)
+@Singleton
+public class IngestQueueProducer {
+    
+    @Resource(lookup="java:app/jms/queue/ingest")
+    Queue ingestQueue;
+    
+    @Resource(lookup="java:app/jms/factory/ingest")
+    QueueConnectionFactory ingestQueueFactory;
+    
+    @Produces
+    public Queue getIngestQueue() {
+        return ingestQueue;
+    }
+    
+    @Produces
+    public QueueConnectionFactory getIngestQueueFactory() {
+        return ingestQueueFactory;
+    }
+    
+}

--- a/src/main/java/edu/harvard/iq/dataverse/ingest/IngestServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/ingest/IngestServiceBean.java
@@ -136,9 +136,9 @@ public class IngestServiceBean {
     @EJB
     SystemConfig systemConfig;
 
-    @Resource(mappedName = "jms/DataverseIngest")
+    @Resource(name = "java:app/jms/queue/ingest")
     Queue queue;
-    @Resource(mappedName = "jms/IngestQueueConnectionFactory")
+    @Resource(name = "java:app/jms/factory/ingest")
     QueueConnectionFactory factory;
     
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR enables removing the configuration of the Java Messaging System Queue used for ingest from the installer and deploying it from inside the app instead. This greatly reduces the amount of bash glue necessary in containers.

**Which issue(s) this PR closes**:

Closes #7423 

**Special notes for your reviewer**:
The release notes are missing. It's debateable wheter we want people to delete existing queue etc, as those are simply unused, doing no harm to anyone.

**Suggestions on how to test this**:
Just deploy and try ingest. 

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
Nope.

**Is there a release notes update needed for this change?**:
Not yet.

**Additional documentation**:
None.