### PR TITLE
document default zip upload files limit, provide curl example

### DIFF
--- a/doc/sphinx-guides/source/installation/config.rst
+++ b/doc/sphinx-guides/source/installation/config.rst
@@ -1650,7 +1650,7 @@ For example, if you want your installation of Dataverse to not attempt to ingest
 :ZipUploadFilesLimit
 ++++++++++++++++++++
 
-Limit the number of files in a zip that Dataverse will accept. In the absence of this setting, Dataverse defaults to 1,000 files per zipfile.
+Limit the number of files in a zip that Dataverse will accept. In the absence of this setting, Dataverse defaults to a limit of 1,000 files per zipfile.
 
 ``curl -X PUT -d 2048 http://localhost:8080/api/admin/settings/:ZipUploadFilesLimit``
 

--- a/doc/sphinx-guides/source/installation/config.rst
+++ b/doc/sphinx-guides/source/installation/config.rst
@@ -1650,7 +1650,9 @@ For example, if you want your installation of Dataverse to not attempt to ingest
 :ZipUploadFilesLimit
 ++++++++++++++++++++
 
-Limit the number of files in a zip that Dataverse will accept.
+Limit the number of files in a zip that Dataverse will accept. In the absence of this setting, Dataverse defaults to 1,000 files per zipfile.
+
+``curl -X PUT -d 2048 http://localhost:8080/api/admin/settings/:ZipUploadFilesLimit``
 
 :SolrHostColonPort
 ++++++++++++++++++


### PR DESCRIPTION
**What this PR does / why we need it**: the ZipUploadFilesLimit setting defaults to 1,000 but this isn't documented in the configuration guide.

**Which issue(s) this PR closes**:

Closes #7442 

**Special notes for your reviewer**: none

**Suggestions on how to test this**: just a doc change

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: no

**Is there a release notes update needed for this change?**: no

**Additional documentation**: none
