### PR TITLE
update curl examples to support external zip service

### DIFF
--- a/doc/sphinx-guides/source/api/dataaccess.rst
+++ b/doc/sphinx-guides/source/api/dataaccess.rst
@@ -40,7 +40,7 @@ A curl example using a DOI (no version):
   export SERVER_URL=https://demo.dataverse.org
   export PERSISTENT_ID=doi:10.70122/FK2/N2XGBJ
 
-  curl -O -J -H "X-Dataverse-key:$API_TOKEN" $SERVER_URL/api/access/dataset/:persistentId/?persistentId=$PERSISTENT_ID
+  curl -L -O -J -H "X-Dataverse-key:$API_TOKEN" $SERVER_URL/api/access/dataset/:persistentId/?persistentId=$PERSISTENT_ID
 
 The fully expanded example above (without environment variables) looks like this:
 

--- a/doc/sphinx-guides/source/api/dataaccess.rst
+++ b/doc/sphinx-guides/source/api/dataaccess.rst
@@ -46,7 +46,7 @@ The fully expanded example above (without environment variables) looks like this
 
 .. code-block:: bash
 
-  curl -O -J -H X-Dataverse-key:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx https://demo.dataverse.org/api/access/dataset/:persistentId/?persistentId=doi:10.70122/FK2/N2XGBJ
+  curl -L -O -J -H X-Dataverse-key:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx https://demo.dataverse.org/api/access/dataset/:persistentId/?persistentId=doi:10.70122/FK2/N2XGBJ
 
 Download By Dataset By Version
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
**What this PR does / why we need it**:

A user reported not being able to download datasets using the API. For Harvard Dataverse (and other installations running external zip service) we need to add the -L option. It won't hurt for installations that aren't running the external zip service. Details in the issue, thanks dv-tech dwellers for the help. 

**Which issue(s) this PR closes**:

Closes #7413 

**Special notes for your reviewer**:

None

**Suggestions on how to test this**:

I tested it on Harvard Dataverse and it worked

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No change

**Is there a release notes update needed for this change?**:

No

**Additional documentation**:
