### PR TITLE
fix delete bug by renaming edit delete confirmation widgetvar

### DIFF
--- a/src/main/webapp/editFilesFragment.xhtml
+++ b/src/main/webapp/editFilesFragment.xhtml
@@ -579,15 +579,15 @@
             </button>
         </div>
     </p:dialog>
-    <p:dialog id="deleteFileConfirmDialog" styleClass="smallPopUp" header="#{bundle['file.deleteFileDialog.header']}" widgetVar="deleteFileConfirmation" modal="true">
+    <p:dialog id="deleteFileConfirmDialog" styleClass="smallPopUp" header="#{bundle['file.deleteFileDialog.header']}" widgetVar="editDeleteFileConfirmation" modal="true">
         <p class="text-warning"><span class="glyphicon glyphicon-warning-sign"/> #{bundle['file.deleteFileDialog.tip']}</p>
         <ui:fragment rendered="#{EditDatafilesPage.dataset.released}">
             <p class="text-warning"><span class="glyphicon glyphicon-warning-sign"/> #{bundle['file.deleteFileDialog.failed.tip']}</p>
         </ui:fragment>
         <div class="button-block">
-            <p:commandButton styleClass="btn btn-default" value="#{bundle.continue}" onclick="PF('deleteFileConfirmation').hide()" oncomplete="window.scrollTo(0, 0);deleteFinished();bind_bsui_components();"
+            <p:commandButton styleClass="btn btn-default" value="#{bundle.continue}" onclick="PF('editDeleteFileConfirmation').hide()" oncomplete="window.scrollTo(0, 0);deleteFinished();bind_bsui_components();"
                              update=":#{p:resolveClientId('datasetForm:filesTable', view)},:messagePanel,:#{p:resolveClientId('datasetForm:fileUpload', view)},uploadMessage" action="#{EditDatafilesPage.deleteFiles()}"/>
-            <button class="btn btn-link" onclick="PF('deleteFileConfirmation').hide();bind_bsui_components();" type="button">                              
+            <button class="btn btn-link" onclick="PF('editDeleteFileConfirmation').hide();bind_bsui_components();" type="button">                              
                 #{bundle.cancel}
             </button>
         </div>
@@ -947,7 +947,7 @@
         function checkFilesSelected() {
             var count = PF('filesTable').getSelectedRowsCount();
             if (count > 0) {
-                PF('deleteFileConfirmation').show();
+                PF('editDeleteFileConfirmation').show();
             } else {
                 PF('selectFilesForDeleteFragment').show();              
             }


### PR DESCRIPTION
**What this PR does / why we need it**:
fixes the delete issue found in #7450 

**Which issue(s) this PR closes**:

Closes #7450

**Special notes for your reviewer**:
changed the widgetvar of the delete confirmation popup in the edit fragment; if / when this gets consolidated into kebabs, will need more work, but this is a quick change to fix the bug

**Suggestions on how to test this**:
Just make sure the scenario works.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
No.

**Is there a release notes update needed for this change?**:
No.

**Additional documentation**:
