### PR TITLE
db_password_alias changed to dataverse.db.password #7418 #7422

### DIFF
--- a/doc/sphinx-guides/source/installation/advanced.rst
+++ b/doc/sphinx-guides/source/installation/advanced.rst
@@ -17,7 +17,7 @@ You should be conscious of the following when running multiple app servers.
 - When a sitemap is created by an app server it is written to the filesystem of just that app server. By default the sitemap is written to the directory ``/usr/local/payara5/glassfish/domains/domain1/docroot/sitemap``.
 - If Make Data Count is used, its raw logs must be copied from each app server to single instance of Counter Processor. See also :ref:`:MDCLogPath` section in the Configuration section of this guide and the :doc:`/admin/make-data-count` section of the Admin Guide.
 - Dataset draft version logging occurs separately on each app server. See :ref:`edit-draft-versions-logging` section in Monitoring of the Admin Guide for details.
-- Password aliases (``db_password_alias``, etc.) are stored per app server.
+- Password aliases (``dataverse.db.password``, etc.) are stored per app server.
 
 Detecting Which App Server a User Is On
 +++++++++++++++++++++++++++++++++++++++

--- a/doc/sphinx-guides/source/installation/installation-main.rst
+++ b/doc/sphinx-guides/source/installation/installation-main.rst
@@ -74,9 +74,9 @@ All the Payara configuration tasks performed by the installer are isolated in th
 
 While Postgres can accomodate usernames and database names containing hyphens, it is strongly recommended to use only alphanumeric characters.
 
-**IMPORTANT:** As a security measure, the ``as-setup.sh`` script stores passwords as "aliases" rather than plaintext. If you change your database password, for example, you will need to update the alias with ``asadmin update-password-alias db_password_alias``, for example. Here is a list of the password aliases that are set by the installation process and entered into Payara's ``domain.xml`` file:
+**IMPORTANT:** As a security measure, the ``as-setup.sh`` script stores passwords as "aliases" rather than plaintext. If you change your database password, for example, you will need to update the alias with ``asadmin update-password-alias dataverse.db.password``, for example. Here is a list of the password aliases that are set by the installation process and entered into Payara's ``domain.xml`` file:
 
-- ``db_password_alias``
+- ``dataverse.db.password``
 - ``doi_password_alias``
 - ``rserve_password_alias``
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Pull request #7422 didn't include a doc change having to do with db_password_alias being renamed to dataverse.db.password.

**Which issue(s) this PR closes**:

None but is part of the issue that the original pull request closed: #7418

**Special notes for your reviewer**:

None.

**Suggestions on how to test this**:

Just a doc change.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No.

**Is there a release notes update needed for this change?**:

I don't think so. The upgrade instructions from the previous pull request explain about deleting the old alias.

**Additional documentation**:

None.