### PR TITLE
7130-handle missing contact name

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/util/bagit/BagGenerator.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/bagit/BagGenerator.java
@@ -756,8 +756,10 @@ public class BagGenerator {
                         info.append(CRLF);
 
                     } else {
-                        info.append(((JsonObject) person).get(contactNameTerm.getLabel()).getAsString());
-                        info.append(CRLF);
+                        if(contactNameTerm != null) {
+                          info.append(((JsonObject) person).get(contactNameTerm.getLabel()).getAsString());
+                          info.append(CRLF);
+                        }
                         if ((contactEmailTerm!=null) &&((JsonObject) person).has(contactEmailTerm.getLabel())) {
                             info.append("Contact-Email: ");
                             info.append(((JsonObject) person).get(contactEmailTerm.getLabel()).getAsString());
@@ -774,9 +776,10 @@ public class BagGenerator {
 
                 } else {
                     JsonObject person = contacts.getAsJsonObject();
-
-                    info.append(person.get(contactNameTerm.getLabel()).getAsString());
-                    info.append(CRLF);
+                    if(contactNameTerm != null) {
+                      info.append(person.get(contactNameTerm.getLabel()).getAsString());
+                      info.append(CRLF);
+                    }
                     if ((contactEmailTerm!=null) && (person.has(contactEmailTerm.getLabel()))) {
                         info.append("Contact-Email: ");
                         info.append(person.get(contactEmailTerm.getLabel()).getAsString());


### PR DESCRIPTION
**What this PR does / why we need it**: This PR handles the case where a contact has an email but not a name which previously resulted in a null pointer exception.

**Which issue(s) this PR closes**:

Closes #7130 

**Special notes for your reviewer**: discussion in issue. Note this branch was merged once to close 7130 - reusing the issue and branch to handle another point that has come up.

**Suggestions on how to test this**: create a dataset with a contact that only has an email. Publish. Trigger bag creation (probably easiest to configure the file archiver and then use the API to request bag creation - per guides). Bag should be created. (@mderuijter may also be able to test?)

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: no

**Is there a release notes update needed for this change?**: no

**Additional documentation**: none
