### PR TITLE
handle getDisplayNameLang() case with no Bundle entry for a tool

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/externaltools/ExternalTool.java
+++ b/src/main/java/edu/harvard/iq/dataverse/externaltools/ExternalTool.java
@@ -1,6 +1,7 @@
 package edu.harvard.iq.dataverse.externaltools;
 
 import edu.harvard.iq.dataverse.util.BundleUtil;
+import edu.harvard.iq.dataverse.util.StringUtil;
 
 import java.io.Serializable;
 import java.util.Arrays;
@@ -357,10 +358,12 @@ public class ExternalTool implements Serializable {
         String toolName = "";
         if (this.toolName != null) {
             toolName = "externaltools." + this.toolName + ".displayname";
-            return (BundleUtil.getStringFromBundle(toolName));
-        } else {
-            return this.getDisplayName();
+            toolName = (BundleUtil.getStringFromBundle(toolName));
+        } 
+        if (StringUtil.isEmpty(toolName)) {
+            toolName = this.getDisplayName();
         }
+        return toolName;
     }
 
 

--- a/src/main/java/edu/harvard/iq/dataverse/externaltools/ExternalTool.java
+++ b/src/main/java/edu/harvard/iq/dataverse/externaltools/ExternalTool.java
@@ -345,25 +345,25 @@ public class ExternalTool implements Serializable {
     }
 
     public String getDescriptionLang() {
-        String toolName = "";
+        String description = "";
         if (this.toolName != null) {
-            toolName = "externaltools." + this.toolName + ".description";
-            return (BundleUtil.getStringFromBundle(toolName));
-        } else {
-            return this.getDescription();
+            description = (BundleUtil.getStringFromBundle("externaltools." + this.toolName + ".description"));
+        } 
+        if (StringUtil.isEmpty(description)) {
+            description = this.getDescription();
         }
+        return description;
     }
 
     public String getDisplayNameLang() {
-        String toolName = "";
+        String displayName = "";
         if (this.toolName != null) {
-            toolName = "externaltools." + this.toolName + ".displayname";
-            toolName = (BundleUtil.getStringFromBundle(toolName));
+            displayName = (BundleUtil.getStringFromBundle("externaltools." + this.toolName + ".displayname"));
         } 
-        if (StringUtil.isEmpty(toolName)) {
-            toolName = this.getDisplayName();
+        if (StringUtil.isEmpty(displayName)) {
+            displayName = this.getDisplayName();
         }
-        return toolName;
+        return displayName;
     }
 
 


### PR DESCRIPTION
**What this PR does / why we need it**: Avoids a 'null' displayName if external previewers/explorers are defined with toolNames without someone also having added i18n entries for that tool in the Bundle.properties files

**Which issue(s) this PR closes**:

Closes #7477

**Special notes for your reviewer**: The mechanism to provide an i18n display name based on the toolName already exists - this PR is just avoiding a null for a case where the toolName is defined (e.g. so installs can use one set of example curl commands for registering previewers regardless of whether they set up 18n or not)

**Suggestions on how to test this**:  Register a previewer using a curl command from the README.md in the develop branch of the github.com/GlobaldDataverseCommunityConsortium/dataverse-previewers repo and verify that it's displayName in, for example, a list of available previewers is correct/not 'null'. I think you'll have to register more than one tool for a given mimetype for that. Alternately, I think if you configure a tool to be both preview, and explore types, you'll see the displayName on the Explore button.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: no

**Is there a release notes update needed for this change?**: no

**Additional documentation**:
