### PR TITLE
emphasize differences with SWORD auth (vs. native) #7441

### DIFF
--- a/doc/sphinx-guides/source/api/auth.rst
+++ b/doc/sphinx-guides/source/api/auth.rst
@@ -21,6 +21,8 @@ Anyone who has your API Token can add and delete data as you so you should treat
 Passing Your API Token as an HTTP Header (Preferred) or a Query Parameter
 -------------------------------------------------------------------------
 
+Note: The SWORD API uses a different way of passing the API token. Please see :ref:`sword-auth` for details.
+
 See :ref:`curl-examples-and-environment-variables` if you are unfamiliar with the use of ``export`` below.
 
 There are two ways to pass your API token to Dataverse APIs. The preferred method is to send the token in the ``X-Dataverse-key`` HTTP header, as in the following curl example.

--- a/doc/sphinx-guides/source/api/sword.rst
+++ b/doc/sphinx-guides/source/api/sword.rst
@@ -23,6 +23,25 @@ As a profile of AtomPub, XML is used throughout SWORD. As of Dataverse 4.0 datas
 
 .. _SWORDv2 specification: http://swordapp.github.io/SWORDv2-Profile/SWORDProfile.html
 
+.. _sword-auth:
+
+Authentication for SWORD
+------------------------
+
+The :doc:`/api/auth` section describes how to pass API tokens for the "native" API (as a header or query parameter) but SWORD uses a different mechanism known as HTTP Basic Authentication (`RFC 7617`_).
+
+HTTP Basic Authentication commonly makes use of both a username and a password but the SWORD API uses only a username that is populated with the user's API token. The password should be blank or empty.
+
+Clients such as ``curl`` expect both a username and a password separated by a colon. With ``curl``, the way to indicate that the password should be blank or empty is to include the colon at the end of the username (the API token) like this:
+
+``curl -u 54b143b5-d001-4254-afc0-a1c0f6a5b5a7:``
+
+All the curl examples below take this form but instead of showing an API token like above, a Bash environment variable called ``$API_TOKEN`` is shown instead like this:
+
+``curl -u $API_TOKEN:``
+
+.. _RFC 7617: https://tools.ietf.org/html/rfc7617
+
 .. _incompatible:
 
 Backward incompatible changes
@@ -45,7 +64,7 @@ Differences in Dataverse 4 from DVN 3.x lead to a few minor backward incompatibl
 New features as of v1.1
 -----------------------
 
-- Dataverse 4 supports API tokens and requires them to be used for APIs instead of a username and password. In the ``curl`` examples below, you will see ``curl -u $API_TOKEN:`` showing that you should send your API token as the username and nothing as the password. For example, ``curl -u 54b143b5-d001-4254-afc0-a1c0f6a5b5a7:``.
+- Dataverse 4+ supports API tokens and requires them to be used for APIs instead of a username and password. In the ``curl`` examples below, you will see ``curl -u $API_TOKEN:`` showing that you should send your API token as the username and nothing as the password. For example, ``curl -u 54b143b5-d001-4254-afc0-a1c0f6a5b5a7:``. See also :ref:`sword-auth`.
 
 - SWORD operations no longer require "admin" permission. In order to use any SWORD operation in DVN 3.x, you had to be an "admin" on a dataverse (the container for your dataset) and similar rules were applied in Dataverse 4.4 and earlier (the ``EditDataverse`` permission was required). The SWORD API has now been fully integrated with the Dataverse 4 permission model such that any action you have permission to perform in the GUI or "native" API you are able to perform via SWORD. This means that even a user with a "Contributor" role can operate on datasets via SWORD. Note that users with the "Contributor" role do not have the ``PublishDataset`` permission and will not be able publish their datasets via any mechanism, GUI or API.
 


### PR DESCRIPTION
**What this PR does / why we need it**:

There has been confusion over how SWORD auth works, especially if you're used to the native API.

**Which issue(s) this PR closes**:

Closes #7441

**Special notes for your reviewer**:

In the Google thread @joenio said, "I think would be nice to update the Dataverse API doc with some examples of using SWORD API by code (can be examples in javascript as I sent in last message or python, or other language). Specially to be clear about the authentication differences between native api and sword api." But then later in the issue he didn't ask for code examples. It's easier and more language neutral to just document APIs with curl so that's what I'm sticking with. Plus, this was estimated as a small.

**Suggestions on how to test this**:

Nothing to test unless you want to try a curl example on that page. SWORD is exercised regularly from the API test suite and this is just a doc change.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No.

**Is there a release notes update needed for this change?**:

No.

**Additional documentation**:

None.