### PR TITLE
support download of UTF-8 filenames #7188

### DIFF
--- a/doc/release-notes/7188-utf-8-filenames.md
+++ b/doc/release-notes/7188-utf-8-filenames.md
@@ -1,6 +1,8 @@
 ## Notes for Tool Developers and Integrators
 
-### Spaces in File Names
+### UTF-8 Characters and Spaces in File Names
+
+UTF-8 characters in filenames are now preserved when downloaded.
 
 Dataverse Installations will no longer replace spaces in file names of downloaded files with the + character. If your tool or integration has any special handling around this, you may need to make further adjustments to maintain backwards compatibility while also supporting Dataverse installations on 5.4+.
 

--- a/doc/release-notes/7188-utf-8-filenames.md
+++ b/doc/release-notes/7188-utf-8-filenames.md
@@ -1,0 +1,7 @@
+## Notes for Tool Developers and Integrators
+
+### Spaces in File Names
+
+Dataverse Installations will no longer replace spaces in file names of downloaded files with the + character. If your tool or integration has any special handling around this, you may need to make further adjustments to maintain backwards compatibility while also supporting Dataverse installations on 5.4+.
+
+Note that this follows a change from 5.1 that only corrected this for installations running with S3 storage. This makes the behavior consistent across installations running all types of file storage.

--- a/src/main/java/edu/harvard/iq/dataverse/api/DownloadInstanceWriter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/DownloadInstanceWriter.java
@@ -302,9 +302,11 @@ public class DownloadInstanceWriter implements MessageBodyWriter<DownloadInstanc
                     
                     // Provide both the "Content-disposition" and "Content-Type" headers,
                     // to satisfy the widest selection of browsers out there. 
-                    
-                    httpHeaders.add("Content-disposition", "attachment; filename=\"" + URLEncoder.encode(fileName, "UTF-8") + "\"");
-                    httpHeaders.add("Content-Type", mimeType + "; name=\"" + URLEncoder.encode(fileName, "UTF-8") + "\"");
+                    // Encode the filename as UTF-8, then deal with spaces. "encode" changes
+                    // a space to + so we change it back to a space (%20).
+                    String finalFileName = URLEncoder.encode(fileName, "UTF-8").replaceAll("\\+", "%20");
+                    httpHeaders.add("Content-disposition", "attachment; filename=\"" + finalFileName + "\"");
+                    httpHeaders.add("Content-Type", mimeType + "; name=\"" + finalFileName + "\"");
                     
                     long contentSize; 
                     boolean useChunkedTransfer = false; 

--- a/src/main/java/edu/harvard/iq/dataverse/api/DownloadInstanceWriter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/DownloadInstanceWriter.java
@@ -33,6 +33,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
@@ -302,8 +303,8 @@ public class DownloadInstanceWriter implements MessageBodyWriter<DownloadInstanc
                     // Provide both the "Content-disposition" and "Content-Type" headers,
                     // to satisfy the widest selection of browsers out there. 
                     
-                    httpHeaders.add("Content-disposition", "attachment; filename=\"" + fileName + "\"");
-                    httpHeaders.add("Content-Type", mimeType + "; name=\"" + fileName + "\"");
+                    httpHeaders.add("Content-disposition", "attachment; filename=\"" + URLEncoder.encode(fileName, "UTF-8") + "\"");
+                    httpHeaders.add("Content-Type", mimeType + "; name=\"" + URLEncoder.encode(fileName, "UTF-8") + "\"");
                     
                     long contentSize; 
                     boolean useChunkedTransfer = false; 

--- a/src/test/java/edu/harvard/iq/dataverse/api/DownloadFilesIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/DownloadFilesIT.java
@@ -371,7 +371,7 @@ public class DownloadFilesIT {
     }
 
     /**
-     * Download a file with a UTF-8 filename.
+     * Download a file with a UTF-8 filename with a space.
      */
     @Test
     public void downloadFilenameUtf8() throws IOException {
@@ -398,14 +398,14 @@ public class DownloadFilesIT {
         Integer datasetId = UtilIT.getDatasetIdFromResponse(createDataset);
         String datasetPid = UtilIT.getDatasetPersistentIdFromResponse(createDataset);
 
-        // Put a filename with an en-dash (READ–ME.md) into a zip file.
+        // Put a filename with an en-dash ("MY READ–ME.md") into a zip file.
         StringBuilder sb = new StringBuilder();
         sb.append("This is my README.");
         Path pathtoTempDir = Paths.get(Files.createTempDirectory(null).toString());
         String pathToZipFile = pathtoTempDir + File.separator + "test.zip";
         File f = new File(pathToZipFile);
         ZipOutputStream out = new ZipOutputStream(new FileOutputStream(f));
-        ZipEntry e = new ZipEntry("READ–ME.md");
+        ZipEntry e = new ZipEntry("MY READ–ME.md");
         out.putNextEntry(e);
         byte[] data = sb.toString().getBytes();
         out.write(data, 0, data.length);
@@ -433,11 +433,11 @@ public class DownloadFilesIT {
         downloadFile.then().assertThat()
                 .statusCode(OK.getStatusCode());
         Headers headers = downloadFile.getHeaders();
-        // In READ–ME.md the en-dash ("–") is "%E2%80%93" (e2 80 93 in hex).
-        Assert.assertEquals("attachment; filename=\"READ%E2%80%93ME.md\"", headers.getValue("Content-disposition"));
-        Assert.assertEquals("text/markdown; name=\"READ%E2%80%93ME.md\";charset=UTF-8", headers.getValue("Content-Type"));
+        // In "MY READ–ME.md" below the space is %20 and the en-dash ("–") is "%E2%80%93" (e2 80 93 in hex).
+        Assert.assertEquals("attachment; filename=\"MY%20READ%E2%80%93ME.md\"", headers.getValue("Content-disposition"));
+        Assert.assertEquals("text/markdown; name=\"MY%20READ%E2%80%93ME.md\";charset=UTF-8", headers.getValue("Content-Type"));
 
-        // Download all files as a zip and assert READ–ME.md has an en-dash.
+        // Download all files as a zip and assert "MY READ–ME.md" has an en-dash.
         Response downloadFiles = UtilIT.downloadFiles(datasetPid, apiToken);
         downloadFiles.then().assertThat()
                 .statusCode(OK.getStatusCode());
@@ -445,8 +445,8 @@ public class DownloadFilesIT {
         HashSet<String> filenamesFound = gatherFilenames(downloadFiles.getBody().asInputStream());
 
         // Note that a MANIFEST.TXT file is added.
-        // READ–ME.md (with an en-dash) is correctly extracted from the downloaded zip
-        HashSet<String> expectedFiles = new HashSet<>(Arrays.asList("MANIFEST.TXT", "READ–ME.md"));
+        // "MY READ–ME.md" (with an en-dash) is correctly extracted from the downloaded zip
+        HashSet<String> expectedFiles = new HashSet<>(Arrays.asList("MANIFEST.TXT", "MY READ–ME.md"));
         Assert.assertEquals(expectedFiles, filenamesFound);
     }
 

--- a/src/test/java/edu/harvard/iq/dataverse/api/DownloadFilesIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/DownloadFilesIT.java
@@ -2,8 +2,10 @@ package edu.harvard.iq.dataverse.api;
 
 import com.jayway.restassured.RestAssured;
 import com.jayway.restassured.path.json.JsonPath;
+import com.jayway.restassured.response.Headers;
 import com.jayway.restassured.response.Response;
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
@@ -13,6 +15,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
+import java.util.zip.ZipOutputStream;
 import static javax.ws.rs.core.Response.Status.CREATED;
 import static javax.ws.rs.core.Response.Status.FORBIDDEN;
 import static javax.ws.rs.core.Response.Status.OK;
@@ -365,6 +368,86 @@ public class DownloadFilesIT {
 
         // By passing format=original we get the original version, Stata (.dta) in this case.
         Assert.assertEquals(new HashSet<>(Arrays.asList("50by1000.dta", "MANIFEST.TXT")), gatherFilenames(downloadFiles2.getBody().asInputStream()));
+    }
+
+    /**
+     * Download a file with a UTF-8 filename.
+     */
+    @Test
+    public void downloadFilenameUtf8() throws IOException {
+
+        Response createUser = UtilIT.createRandomUser();
+        createUser.prettyPrint();
+        createUser.then().assertThat()
+                .statusCode(OK.getStatusCode());
+        String username = UtilIT.getUsernameFromResponse(createUser);
+        String apiToken = UtilIT.getApiTokenFromResponse(createUser);
+
+        Response createDataverseResponse = UtilIT.createRandomDataverse(apiToken);
+        createDataverseResponse.prettyPrint();
+        createDataverseResponse.then().assertThat()
+                .statusCode(CREATED.getStatusCode());
+
+        String dataverseAlias = UtilIT.getAliasFromResponse(createDataverseResponse);
+
+        Response createDataset = UtilIT.createRandomDatasetViaNativeApi(dataverseAlias, apiToken);
+        createDataset.prettyPrint();
+        createDataset.then().assertThat()
+                .statusCode(CREATED.getStatusCode());
+
+        Integer datasetId = UtilIT.getDatasetIdFromResponse(createDataset);
+        String datasetPid = UtilIT.getDatasetPersistentIdFromResponse(createDataset);
+
+        // Put a filename with an en-dash (READ–ME.md) into a zip file.
+        StringBuilder sb = new StringBuilder();
+        sb.append("This is my README.");
+        Path pathtoTempDir = Paths.get(Files.createTempDirectory(null).toString());
+        String pathToZipFile = pathtoTempDir + File.separator + "test.zip";
+        File f = new File(pathToZipFile);
+        ZipOutputStream out = new ZipOutputStream(new FileOutputStream(f));
+        ZipEntry e = new ZipEntry("READ–ME.md");
+        out.putNextEntry(e);
+        byte[] data = sb.toString().getBytes();
+        out.write(data, 0, data.length);
+        out.closeEntry();
+        out.close();
+
+        // We upload via SWORD (as a zip) because the native API gives this error:
+        // "Constraint violation found in FileMetadata. File Name cannot contain any
+        // of the following characters: / : * ? " < > | ; # . The invalid value is "READ?ME.md"."
+        // This error probably has something to do with the way REST Assured sends the filename
+        // to the native API. The en-dash is turned into question mark, which is disallowed.
+        Response uploadViaSword = UtilIT.uploadZipFileViaSword(datasetPid, pathToZipFile, apiToken);
+        uploadViaSword.prettyPrint();
+        uploadViaSword.then().assertThat()
+                .statusCode(CREATED.getStatusCode());
+
+        Response getDatasetJson = UtilIT.nativeGet(datasetId, apiToken);
+        getDatasetJson.then().assertThat()
+                .statusCode(OK.getStatusCode());
+
+        int fileId = JsonPath.from(getDatasetJson.getBody().asString()).getInt("data.latestVersion.files[0].dataFile.id");
+
+        // Download the file individually and assert READ–ME.md has an en-dash.
+        Response downloadFile = UtilIT.downloadFile(new Integer(fileId), apiToken);
+        downloadFile.then().assertThat()
+                .statusCode(OK.getStatusCode());
+        Headers headers = downloadFile.getHeaders();
+        // In READ–ME.md the en-dash ("–") is "%E2%80%93" (e2 80 93 in hex).
+        Assert.assertEquals("attachment; filename=\"READ%E2%80%93ME.md\"", headers.getValue("Content-disposition"));
+        Assert.assertEquals("text/markdown; name=\"READ%E2%80%93ME.md\";charset=UTF-8", headers.getValue("Content-Type"));
+
+        // Download all files as a zip and assert READ–ME.md has an en-dash.
+        Response downloadFiles = UtilIT.downloadFiles(datasetPid, apiToken);
+        downloadFiles.then().assertThat()
+                .statusCode(OK.getStatusCode());
+
+        HashSet<String> filenamesFound = gatherFilenames(downloadFiles.getBody().asInputStream());
+
+        // Note that a MANIFEST.TXT file is added.
+        // READ–ME.md (with an en-dash) is correctly extracted from the downloaded zip
+        HashSet<String> expectedFiles = new HashSet<>(Arrays.asList("MANIFEST.TXT", "READ–ME.md"));
+        Assert.assertEquals(expectedFiles, filenamesFound);
     }
 
     private HashSet<String> gatherFilenames(InputStream inputStream) throws IOException {


### PR DESCRIPTION
**What this PR does / why we need it**:

If you upload a file to Dataverse with a filename that has UTF-8 characters, they get munged on the download. For example, an en-dash ("-") is replaced by a space. "READ–ME.md" become "READ ME.md".

**Which issue(s) this PR closes**:

Closes #7188

**Special notes for your reviewer**:

None.

**Suggestions on how to test this**:

- Upload a file with UTF-8 characters such as READ–ME.md and Save Changes.
- Download the file and make sure the name is the same.
- Try files with spaces in them too.

Emojis seem to work too! 🎉 🎉 🎉 

<img width="737" alt="Screen Shot 2021-01-07 at 4 06 00 PM" src="https://user-images.githubusercontent.com/21006/103944863-48e9d300-5102-11eb-83a9-9cab2fe59955.png">


**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No.

**Is there a release notes update needed for this change?**:

I didn't add one but I'd be happy to.

**Additional documentation**:

None. My guess is that people assume this already works. I don't think we declare support for UTF-8 filenames anywhere. To be honest, I'm surprised it works as well as it does but I guess it is 2021. We're living in the future. 😎 