### PR TITLE
IQSS/7517-fix-prepublication-workflow

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/PublishDatasetCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/PublishDatasetCommand.java
@@ -213,7 +213,11 @@ public class PublishDatasetCommand extends AbstractPublishDatasetCommand<Publish
 
         if (dataset != null) {
             logger.fine("From onSuccess, calling FinalizeDatasetPublicationCommand for dataset " + dataset.getGlobalId().asString());
-            ctxt.datasets().callFinalizePublishCommandAsynchronously(dataset.getId(), ctxt, request, datasetExternallyReleased);
+            Optional<Workflow> prePubWf = ctxt.workflows().getDefaultWorkflow(TriggerType.PrePublishDataset);
+            //A pre-publication workflow will call this when it completes
+            if (! prePubWf.isPresent() ) {
+                ctxt.datasets().callFinalizePublishCommandAsynchronously(dataset.getId(), ctxt, request, datasetExternallyReleased);
+            }
             return true;
         }
         

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/PublishDatasetCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/PublishDatasetCommand.java
@@ -212,12 +212,12 @@ public class PublishDatasetCommand extends AbstractPublishDatasetCommand<Publish
         }
 
         if (dataset != null) {
-            logger.fine("From onSuccess, calling FinalizeDatasetPublicationCommand for dataset " + dataset.getGlobalId().asString());
             Optional<Workflow> prePubWf = ctxt.workflows().getDefaultWorkflow(TriggerType.PrePublishDataset);
-            //A pre-publication workflow will call this when it completes
+            //A pre-publication workflow will call FinalizeDatasetPublicationCommand itself when it completes
             if (! prePubWf.isPresent() ) {
+                logger.fine("From onSuccess, calling FinalizeDatasetPublicationCommand for dataset " + dataset.getGlobalId().asString());
                 ctxt.datasets().callFinalizePublishCommandAsynchronously(dataset.getId(), ctxt, request, datasetExternallyReleased);
-            }
+            } 
             return true;
         }
         

--- a/src/main/java/edu/harvard/iq/dataverse/workflow/WorkflowServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/workflow/WorkflowServiceBean.java
@@ -429,9 +429,12 @@ public class WorkflowServiceBean {
     	 * resumed workflows. (The overall method is needed to allow the context to be updated in the start() method with the
     	 * settings and APItoken retrieved by the WorkflowServiceBean) - JM - 9/18.
     	 */
-        return new WorkflowContext( ctxt.getRequest(), 
-                       em.merge(ctxt.getDataset()), ctxt.getNextVersionNumber(), 
-                       ctxt.getNextMinorVersionNumber(), ctxt.getType(), settings, apiToken, ctxt.getDatasetExternallyReleased());
+        String id = ctxt.getInvocationId();
+        WorkflowContext newCtxt =new WorkflowContext( ctxt.getRequest(), 
+                em.merge(ctxt.getDataset()), ctxt.getNextVersionNumber(), 
+                ctxt.getNextMinorVersionNumber(), ctxt.getType(), settings, apiToken, ctxt.getDatasetExternallyReleased());
+        newCtxt.setInvocationId(id);
+        return newCtxt;
     }
 
 }


### PR DESCRIPTION
**What this PR does / why we need it**: In earlier code, the call to FinalizeDatasetPublicationCommand was only called from the PublishDatasetCommand when there was no pre-publication workflow. In the workflow case, FinalizeDatasetPublicationCommand is called when the workflow completes. When the call to Finalize publication was moved to the onsuccess method, it ended up executing even when there is a pre-pub workflow which means a) it is called twice, and b) it is potentially executing in parallel with the workflow (async ones at least).

**Which issue(s) this PR closes**:

Closes #7517

**Special notes for your reviewer**:

**Suggestions on how to test this**: 
DANS will be testing. A relatively simple test would be to configure a workflow with the 'pause' step as a pre-publication workflow and to verify that the dataset is not published until after the command to unpause is sent. (Should also verify that doing this workflow without the PR ends up publishing the dataset even without un-pausing the worklflow.)

Note: from the conversation below, there is currently an issue with the 'pause' step being worked on separately. While it is not necessary to test with it, it does simplify testing a bit, so we suggest waiting until that is merged to test this PR.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: none

**Is there a release notes update needed for this change?**:

**Additional documentation**:
