### PR TITLE
6672-Fix Workflow Resume

### DIFF
--- a/doc/sphinx-guides/source/developers/workflows.rst
+++ b/doc/sphinx-guides/source/developers/workflows.rst
@@ -16,7 +16,7 @@ Workflow steps are created using *step providers*. Dataverse ships with an inter
 
 Steps can be internal (say, writing some data to the log) or external. External steps involve Dataverse sending a request to an external system, and waiting for the system to reply. The wait period is arbitrary, and so allows the external system unbounded operation time. This is useful, e.g., for steps that require human intervension, such as manual approval of a dataset publication.
 
-The external system reports the step result back to dataverse, by sending a HTTP ``POST`` command to ``api/workflows/{invocation-id}``. The body of the request is passed to the paused step for further processing.
+The external system reports the step result back to dataverse, by sending a HTTP ``POST`` command to ``api/workflows/{invocation-id}`` with Content-Type: text/plain. The body of the request is passed to the paused step for further processing.
 
 If a step in a workflow fails, Dataverse make an effort to roll back all the steps that preceded it. Some actions, such as writing to the log, cannot be rolled back. If such an action has a public external effect (e.g. send an EMail to a mailing list) it is advisable to put it in the post-release workflow.
 
@@ -60,7 +60,7 @@ A step that writes data about the current workflow invocation to the instance lo
 pause
 +++++
 
-A step that pauses the workflow. The workflow is paused until a POST request is sent to ``/api/workflows/{invocation-id}``.
+A step that pauses the workflow. The workflow is paused until a POST request is sent to ``/api/workflows/{invocation-id}``. Sending 'fail' in the POST body (Content-type:text/plain) will trigger a failure and workflow rollback. All other responses are considered as successes. 
 
 .. code:: json
 
@@ -74,6 +74,7 @@ http/sr
 +++++++
 
 A step that sends a HTTP request to an external system, and then waits for a response. The response has to match a regular expression specified in the step parameters. The url, content type, and message body can use data from the workflow context, using a simple markup language. This step has specific parameters for rollback.
+The workflow is restarted when the external system replies with a POST request  to ``/api/workflows/{invocation-id}``. Responses starting with "OK" (Content-type:text/plain) are considered successes. Other responses will be considered failures and trigger workflow rollback.
 
 .. code:: json
 

--- a/src/main/java/edu/harvard/iq/dataverse/workflow/WorkflowContext.java
+++ b/src/main/java/edu/harvard/iq/dataverse/workflow/WorkflowContext.java
@@ -40,9 +40,13 @@ public class WorkflowContext {
                 aDataset.getLatestVersion().getMinorVersionNumber(),
                 aTriggerType, null, null, datasetExternallyReleased);
     }
-    
     public WorkflowContext(DataverseRequest request, Dataset dataset, long nextVersionNumber, 
-                            long nextMinorVersionNumber, TriggerType type, Map<String, Object> settings, ApiToken apiToken, boolean datasetExternallyReleased) {
+            long nextMinorVersionNumber, TriggerType type, Map<String, Object> settings, ApiToken apiToken, boolean datasetExternallyReleased) {
+        this(request, dataset, nextVersionNumber,nextMinorVersionNumber, type, settings, apiToken, datasetExternallyReleased, null);
+    }
+
+    public WorkflowContext(DataverseRequest request, Dataset dataset, long nextVersionNumber, 
+                            long nextMinorVersionNumber, TriggerType type, Map<String, Object> settings, ApiToken apiToken, boolean datasetExternallyReleased, String invocationId) {
         this.request = request;
         this.dataset = dataset;
         this.nextVersionNumber = nextVersionNumber;
@@ -51,6 +55,9 @@ public class WorkflowContext {
         this.settings = settings;
         this.apiToken = apiToken;
         this.datasetExternallyReleased = datasetExternallyReleased;
+        if(invocationId!=null) {
+            setInvocationId(invocationId);
+        }
     }
 
     public Dataset getDataset() {

--- a/src/main/java/edu/harvard/iq/dataverse/workflow/WorkflowServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/workflow/WorkflowServiceBean.java
@@ -429,9 +429,12 @@ public class WorkflowServiceBean {
     	 * resumed workflows. (The overall method is needed to allow the context to be updated in the start() method with the
     	 * settings and APItoken retrieved by the WorkflowServiceBean) - JM - 9/18.
     	 */
-        return new WorkflowContext( ctxt.getRequest(), 
-                       em.merge(ctxt.getDataset()), ctxt.getNextVersionNumber(), 
-                       ctxt.getNextMinorVersionNumber(), ctxt.getType(), settings, apiToken, ctxt.getDatasetExternallyReleased());
+        String id = ctxt.getInvocationId();
+        WorkflowContext newCtxt =new WorkflowContext( ctxt.getRequest(), 
+                em.merge(ctxt.getDataset()), ctxt.getNextVersionNumber(), 
+                ctxt.getNextMinorVersionNumber(), ctxt.getType(), settings, apiToken, ctxt.getDatasetExternallyReleased());
+        newCtxt.setInvocationId(id);
+        return newCtxt;
     }
 
 }

--- a/src/main/java/edu/harvard/iq/dataverse/workflow/WorkflowServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/workflow/WorkflowServiceBean.java
@@ -429,11 +429,9 @@ public class WorkflowServiceBean {
     	 * resumed workflows. (The overall method is needed to allow the context to be updated in the start() method with the
     	 * settings and APItoken retrieved by the WorkflowServiceBean) - JM - 9/18.
     	 */
-        String id = ctxt.getInvocationId();
         WorkflowContext newCtxt =new WorkflowContext( ctxt.getRequest(), 
                 em.merge(ctxt.getDataset()), ctxt.getNextVersionNumber(), 
-                ctxt.getNextMinorVersionNumber(), ctxt.getType(), settings, apiToken, ctxt.getDatasetExternallyReleased());
-        newCtxt.setInvocationId(id);
+                ctxt.getNextMinorVersionNumber(), ctxt.getType(), settings, apiToken, ctxt.getDatasetExternallyReleased(), ctxt.getInvocationId());
         return newCtxt;
     }
 


### PR DESCRIPTION
**What this PR does / why we need it**: This fixes a bug introduced in 2018 :-) that resulted in different workflow Ids being recorded in the db and log (and presumably sent the an external client with the https/r workflow step), making it 'hard' to resume the workflow and, for prepublish workflows to then finalize publication. (Things worked if you could get the correct invocationid from the database).

**Which issue(s) this PR closes**:

Closes #6672 

**Special notes for your reviewer**:

**Suggestions on how to test this**: Set up and running a workflow including the pause step. You should then be able to post a success/fail message and have it work. All per Guides instruction. Note that one can test the combo of this and #7519 by setting this up a pre-publication workflow. This fix will allow you to unpause the workflow and #7519 will assure that publication is not finalized until after you do.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: no

**Is there a release notes update needed for this change?**:  

**Additional documentation**:
