### PR TITLE
proposed reorganization of query docs and release notes for 7398

### DIFF
--- a/scripts/issues/7398/delete_dld.txt
+++ b/scripts/issues/7398/delete_dld.txt
@@ -1,0 +1,21 @@
+-- these queries will delete linked objects identified using the query in dld_for_deletion
+
+begin;
+
+delete from datasetlinkingdataverse where id in (
+select dld.id
+from datasetlinkingdataverse dld, dvobject dvo, dataverselinkingdataverse dvld
+where dld.dataset_id = dvo.id
+and dld.linkingdataverse_id = dvld.linkingdataverse_id
+and dvo.owner_id = dvld.dataverse_id
+);
+
+delete from dataverselinkingdataverse where id in (
+select dld.id
+from dataverselinkingdataverse dld, dvobject dvo, dataverselinkingdataverse dvld
+where dld.dataverse_id = dvo.id
+and dld.linkingdataverse_id = dvld.linkingdataverse_id
+and dvo.owner_id = dvld.dataverse_id
+);
+
+commit;

--- a/scripts/issues/7398/delete_ss.txt
+++ b/scripts/issues/7398/delete_ss.txt
@@ -1,0 +1,18 @@
+-- these queries will delete the saved searches identified using the ss_for_deletion query
+
+begin;
+
+create temporary table delete_ss on commit drop as (
+Select ss.id
+from savedsearch ss, savedsearchfilterquery ssfq, dataverselinkingdataverse dld
+where ss.id = ssfq.savedsearch_id
+and ss.definitionpoint_id = dld.linkingdataverse_id
+and dld.dataverse_id = rtrim(reverse(split_part(reverse(ssfq.filterquery),'/',1)),'"')::integer
+and ss.query='*'
+and ssfq.filterquery like 'subtreePaths%'
+);
+
+delete from savedsearchfilterquery where savedsearch_id in (select id from delete_ss);
+delete from savedsearch where id in (select id from delete_ss);
+
+commit;

--- a/scripts/issues/7398/dld_for_deletion.txt
+++ b/scripts/issues/7398/dld_for_deletion.txt
@@ -1,0 +1,17 @@
+-- this query will show you the linked objects that will get deleted
+
+select dld.dataset_id, dvo.owner_id, dld.linkingdataverse_id, 
+dvld.dataverse_id, dvld.linkingdataverse_id  
+from datasetlinkingdataverse dld, dvobject dvo, dataverselinkingdataverse dvld
+where dld.dataset_id = dvo.id
+and dld.linkingdataverse_id = dvld.linkingdataverse_id
+and dvo.owner_id = dvld.dataverse_id
+order by dld.linkingdataverse_id;
+
+select dld.dataverse_id, dvo.owner_id, dld.linkingdataverse_id, 
+dvld.dataverse_id, dvld.linkingdataverse_id  
+from dataverselinkingdataverse dld, dvobject dvo, dataverselinkingdataverse dvld
+where dld.dataverse_id = dvo.id
+and dld.linkingdataverse_id = dvld.linkingdataverse_id
+and dvo.owner_id = dvld.dataverse_id
+order by dld.linkingdataverse_id;

--- a/scripts/issues/7398/ss_for_deletion.txt
+++ b/scripts/issues/7398/ss_for_deletion.txt
@@ -1,0 +1,10 @@
+-- this query will show you the saved searches that will get deleted
+
+select ss.id, ss.definitionpoint_id, dld.dataverse_id, ssfq.filterquery
+from savedsearch ss, savedsearchfilterquery ssfq, dataverselinkingdataverse dld
+where ss.id = ssfq.savedsearch_id
+and ss.definitionpoint_id = dld.linkingdataverse_id
+and dld.dataverse_id = rtrim(reverse(split_part(reverse(ssfq.filterquery),'/',1)),'"')::integer
+and ss.query='*'
+and ssfq.filterquery like 'subtreePaths%'
+order by ss.definitionpoint_id;


### PR DESCRIPTION
**What this PR does / why we need it**:

@scolapasta asked for some input formatting and organizing the release notes. I put the non-controversial stuff in https://github.com/IQSS/dataverse/pull/7510/commits/29186f7be8b27ae7dc8ee758909f917b5f105c76 but decided to follow on with this PR for the larger changes.

**Which issue(s) this PR closes**:

N/A

**Special notes for your reviewer**:

Nothing special.

**Suggestions on how to test this**:

N/A

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

N/A

**Is there a release notes update needed for this change?**:

👀 

**Additional documentation**:

N/A