### PR TITLE
Fix btn text word wrap, other responsive layout improvements [ref #7326]

### DIFF
--- a/src/main/java/propertyFiles/Bundle.properties
+++ b/src/main/java/propertyFiles/Bundle.properties
@@ -1982,7 +1982,7 @@ citationFrame.banner.countdownMessage.seconds=seconds
 dataset.access.accessHeader=Restrict Files and Add Dataset Terms of Access
 dataset.access.description=Restricting limits access to published files. You can add or edit Terms of Access for the dataset, and allow people to Request Access to restricted files.
 
-#dataserFieldForEditFragment.xhtml
+#datasetFieldForEditFragment.xhtml
 dataset.AddReplication=Add "Replication Data for" to Title
 dataset.replicationDataFor=Replication Data for:
 

--- a/src/main/webapp/dashboard-users.xhtml
+++ b/src/main/webapp/dashboard-users.xhtml
@@ -34,8 +34,8 @@
                                 <p:watermark for="searchFiles" value="#{bundle['dashboard.list_users.searchTerm.watermark']}"/>
                                 <p:remoteCommand name="submitsearch" action="#{DashboardUsersPage.runUserSearch()}" process="@this @widgetVar(inputSearchTerm)" update="@form" partialSubmit="true"/>
                                 <span class="input-group-btn">
-                                    <p:commandLink styleClass="btn btn-default" action="#{DashboardUsersPage.runUserSearch()}" process="@this @widgetVar(inputSearchTerm)" update="@form" partialSubmit="true">
-                                        <span class="glyphicon glyphicon-search"></span> #{bundle['dataverse.search.btn.find']}
+                                    <p:commandLink title="#{bundle['dataverse.search.btn.find']}" styleClass="btn btn-default" action="#{DashboardUsersPage.runUserSearch()}" process="@this @widgetVar(inputSearchTerm)" update="@form" partialSubmit="true">
+                                        <span class="glyphicon glyphicon-search no-text"/>
                                     </p:commandLink>
                                 </span>
                             </div>

--- a/src/main/webapp/dashboard-users.xhtml
+++ b/src/main/webapp/dashboard-users.xhtml
@@ -34,7 +34,7 @@
                                 <p:watermark for="searchFiles" value="#{bundle['dashboard.list_users.searchTerm.watermark']}"/>
                                 <p:remoteCommand name="submitsearch" action="#{DashboardUsersPage.runUserSearch()}" process="@this @widgetVar(inputSearchTerm)" update="@form" partialSubmit="true"/>
                                 <span class="input-group-btn">
-                                    <p:commandLink title="#{bundle['dataverse.search.btn.find']}" styleClass="btn btn-default" action="#{DashboardUsersPage.runUserSearch()}" process="@this @widgetVar(inputSearchTerm)" update="@form" partialSubmit="true">
+                                    <p:commandLink title="#{bundle['dataverse.search.btn.find']}" styleClass="btn btn-default bootstrap-button-tooltip" action="#{DashboardUsersPage.runUserSearch()}" process="@this @widgetVar(inputSearchTerm)" update="@form" partialSubmit="true">
                                         <span class="glyphicon glyphicon-search no-text"/>
                                     </p:commandLink>
                                 </span>

--- a/src/main/webapp/dataset-citation.xhtml
+++ b/src/main/webapp/dataset-citation.xhtml
@@ -26,7 +26,7 @@
                 <span class="glyphicon glyphicon-question-sign text-primary" jsf:rendered="#{DatasetPage.workingVersion.deaccessioned}" 
                       data-toggle="tooltip" data-placement="top" data-original-title="#{bundle['dataset.cite.title.deassessioned']}"/>
             </div>
-            <div class="pull-left row col-sm-8 padding-none">
+            <div class="pull-left row col-sm-9 padding-none">
                 <div class="col-sm-3 col-md-4 col-lg-3 btn-group margin-bottom citation-download" jsf:rendered="#{!DatasetPage.workingVersion.deaccessioned}">
                     <button type="button" class="btn btn-link dropdown-toggle padding-none downloadCitation" data-toggle="dropdown">
                         #{bundle['dataset.cite.downloadBtn']} <span class="caret"></span>

--- a/src/main/webapp/dataset.xhtml
+++ b/src/main/webapp/dataset.xhtml
@@ -425,7 +425,7 @@
                                         <!-- END: ActionButtonBlock -->
                                     </div>
 
-                                    <div class="col-xs-12 col-sm-12 col-md-4 col-lg-3 pull-right margin-bottom" 
+                                    <div style="clear:right;" class="col-xs-12 col-sm-12 col-md-4 col-lg-3 pull-right margin-bottom" 
                                          jsf:rendered="#{!(settingsWrapper.rsyncDownload or DatasetPage.workingVersion.deaccessioned)}">
                                         <!-- Metrics -->
                                         <div id="metrics-block">

--- a/src/main/webapp/dataverse_header.xhtml
+++ b/src/main/webapp/dataverse_header.xhtml
@@ -59,8 +59,8 @@
                                     <div class="input-group">
                                         <input id="navbarsearch" type="text" class="form-control" size="28" value="" placeholder="#{bundle['header.search.title']}" aria-labelledby="searchNavLabel"/>
                                         <span class="input-group-btn">
-                                            <button type="submit" class="btn btn-default" onclick="window.location='/dataverse/#{dataverseServiceBean.findRootDataverse().alias}&#63;q=' + document.getElementById('navbarsearch').value;return false;">
-                                                <span class="glyphicon glyphicon-search"/> #{bundle.find}
+                                            <button type="submit" title="#{bundle.find}" class="btn btn-default" onclick="window.location='/dataverse/#{dataverseServiceBean.findRootDataverse().alias}&#63;q=' + document.getElementById('navbarsearch').value;return false;">
+                                                <span class="glyphicon glyphicon-search no-text"/>
                                             </button>
                                         </span>
                                     </div>

--- a/src/main/webapp/dataverse_header.xhtml
+++ b/src/main/webapp/dataverse_header.xhtml
@@ -59,7 +59,7 @@
                                     <div class="input-group">
                                         <input id="navbarsearch" type="text" class="form-control" size="28" value="" placeholder="#{bundle['header.search.title']}" aria-labelledby="searchNavLabel"/>
                                         <span class="input-group-btn">
-                                            <button type="submit" title="#{bundle.find}" class="btn btn-default" onclick="window.location='/dataverse/#{dataverseServiceBean.findRootDataverse().alias}&#63;q=' + document.getElementById('navbarsearch').value;return false;">
+                                            <button type="submit" title="#{bundle.find}" class="btn btn-default bootstrap-button-tooltip" onclick="window.location='/dataverse/#{dataverseServiceBean.findRootDataverse().alias}&#63;q=' + document.getElementById('navbarsearch').value;return false;">
                                                 <span class="glyphicon glyphicon-search no-text"/>
                                             </button>
                                         </span>

--- a/src/main/webapp/file.xhtml
+++ b/src/main/webapp/file.xhtml
@@ -94,7 +94,7 @@
                                                 <span class="glyphicon glyphicon-question-sign text-primary" jsf:rendered="#{FilePage.fileMetadata.datasetVersion.dataset.released and FilePage.fileMetadata.datasetVersion.draft}" 
                                                       data-toggle="tooltip" data-placement="top" data-original-title="#{bundle['dataset.cite.title.draft']}"/>
                                             </div>
-                                            <div class="pull-left row col-sm-8 padding-none">
+                                            <div class="pull-left row col-sm-9 padding-none">
                                                 <div class="col-sm-3 col-md-4 col-lg-3 btn-group margin-bottom citation-download" jsf:rendered="#{!FilePage.fileMetadata.datasetVersion.deaccessioned}">
                                                     <button type="button" class="btn btn-link dropdown-toggle padding-none downloadCitation" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                                                          #{bundle['file.cite.file.downloadBtn']} <span class="caret"></span>
@@ -140,7 +140,7 @@
                                                 <span class="glyphicon glyphicon-question-sign text-primary" jsf:rendered="#{FilePage.fileMetadata.datasetVersion.deaccessioned}" 
                                                       data-toggle="tooltip" data-placement="top" data-original-title="#{bundle['dataset.cite.title.deassessioned']}"/>
                                             </div>
-                                            <div class="pull-left row col-sm-8 padding-none">
+                                            <div class="pull-left row col-sm-9 padding-none">
                                                 <div class="col-sm-3 col-md-4 col-lg-3 btn-group margin-bottom citation-download" jsf:rendered="#{!FilePage.fileMetadata.datasetVersion.deaccessioned}">
                                                     <button type="button" class="btn btn-link dropdown-toggle padding-none downloadCitation" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                                                         #{bundle['dataset.cite.downloadBtn']} <span class="caret"></span>
@@ -260,7 +260,7 @@
                                     <!-- END: ActionButtonBlock -->
                                 </div>
 
-                                <div class="col-xs-12 col-sm-12 col-md-4 col-lg-3 pull-right margin-bottom" 
+                                <div style="clear:right;" class="col-xs-12 col-sm-12 col-md-4 col-lg-3 pull-right margin-bottom" 
                                      jsf:rendered="#{!(widgetWrapper.widgetView or FilePage.fileMetadata.dataFile.filePackage or FilePage.fileMetadata.datasetVersion.deaccessioned)}">
                                     <!-- Metrics -->
                                     <div id="metrics-block">

--- a/src/main/webapp/filesFragment.xhtml
+++ b/src/main/webapp/filesFragment.xhtml
@@ -112,8 +112,8 @@
                         <p:remoteCommand name="submitsearch" action="#{DatasetPage.updateFileSearch()}" process="@this @widgetVar(inputSearchTerm)" update="@form" partialSubmit="true"/>
 
                         <span class="input-group-btn">
-                            <p:commandLink styleClass="btn btn-default" action="#{DatasetPage.updateFileSearch()}" process="@this @widgetVar(inputSearchTerm)" update="@form" partialSubmit="true">
-                                <span class="glyphicon glyphicon-search"></span> #{bundle['dataverse.search.btn.find']}
+                            <p:commandLink title="#{bundle['dataverse.search.btn.find']}" styleClass="btn btn-default" action="#{DatasetPage.updateFileSearch()}" process="@this @widgetVar(inputSearchTerm)" update="@form" partialSubmit="true">
+                                <span class="glyphicon glyphicon-search no-text"/>
                             </p:commandLink>
                         </span>
                     </div>

--- a/src/main/webapp/filesFragment.xhtml
+++ b/src/main/webapp/filesFragment.xhtml
@@ -112,7 +112,7 @@
                         <p:remoteCommand name="submitsearch" action="#{DatasetPage.updateFileSearch()}" process="@this @widgetVar(inputSearchTerm)" update="@form" partialSubmit="true"/>
 
                         <span class="input-group-btn">
-                            <p:commandLink title="#{bundle['dataverse.search.btn.find']}" styleClass="btn btn-default" action="#{DatasetPage.updateFileSearch()}" process="@this @widgetVar(inputSearchTerm)" update="@form" partialSubmit="true">
+                            <p:commandLink title="#{bundle['dataverse.search.btn.find']}" styleClass="btn btn-default bootstrap-button-tooltip" action="#{DatasetPage.updateFileSearch()}" process="@this @widgetVar(inputSearchTerm)" update="@form" partialSubmit="true">
                                 <span class="glyphicon glyphicon-search no-text"/>
                             </p:commandLink>
                         </span>

--- a/src/main/webapp/resources/css/structure.css
+++ b/src/main/webapp/resources/css/structure.css
@@ -925,6 +925,8 @@ span.ui-autocomplete input.ui-autocomplete-input {width:100%;}
 .ui-autocomplete input {padding:6px 12px; margin:0;}
 
 /* Overwrite Bootstrap */
+.btn, .input-group-btn {white-space: normal !important;}
+
 @media print {
     a[href]:after {
       content: none;

--- a/src/main/webapp/search-include-fragment.xhtml
+++ b/src/main/webapp/search-include-fragment.xhtml
@@ -21,9 +21,9 @@
                         <p:watermark for="searchBasic" value="#{dataverseRedirectPage == 'dataverseuser.xhtml' ? bundle['account.search.input.watermark'] : bundle['dataverse.search.input.watermark']}"/>
 
                         <span class="input-group-btn">
-                            <p:commandLink id="searchbutton" styleClass="btn btn-default" 
+                            <p:commandLink id="searchbutton" title="#{bundle['dataverse.search.btn.find']}" styleClass="btn btn-default" 
                                            action="#{SearchIncludeFragment.searchRedirect(dataverseRedirectPage, DataversePage.dataverse)}">
-                                <span class="glyphicon glyphicon-search"/> #{bundle['dataverse.search.btn.find']}
+                                <span class="glyphicon glyphicon-search no-text"/>
                             </p:commandLink>
                         </span>
 

--- a/src/main/webapp/search-include-fragment.xhtml
+++ b/src/main/webapp/search-include-fragment.xhtml
@@ -21,7 +21,7 @@
                         <p:watermark for="searchBasic" value="#{dataverseRedirectPage == 'dataverseuser.xhtml' ? bundle['account.search.input.watermark'] : bundle['dataverse.search.input.watermark']}"/>
 
                         <span class="input-group-btn">
-                            <p:commandLink id="searchbutton" title="#{bundle['dataverse.search.btn.find']}" styleClass="btn btn-default" 
+                            <p:commandLink id="searchbutton" title="#{bundle['dataverse.search.btn.find']}" styleClass="btn btn-default bootstrap-button-tooltip" 
                                            action="#{SearchIncludeFragment.searchRedirect(dataverseRedirectPage, DataversePage.dataverse)}">
                                 <span class="glyphicon glyphicon-search no-text"/>
                             </p:commandLink>


### PR DESCRIPTION
**What this PR does / why we need it**:

Overwrite CSS from Bootstrap 3 stylesheet that causes long button text overflow to be hidden by the width of the containing button. Specifically this issue can be best scene in the action buttons on the top of the dataset and file pgs, when the language display is set to French, when the button text "Modalités d'accès à l'ensemble de données" needs to break to another line to display fully inside in the button container.

As a result of this CSS overwrite added to our stylesheet, we also had to remove the "Find" button text label from various input-btn-group components that included a magnifying glass glyphicon, because the text label inexplicably wrapped to another line under the glyphicon. This was resolved by removing the text label and moving it to the button title attribute, so that it displays on hover. This change to the search components can be found in the dataverse header, manage users dashboard pg, dataverse pg and dataset pg.

**Which issue(s) this PR closes**:

Closes #7326 Dataset page - button and citations display issues in different languages 

**Special notes for your reviewer**:

Happy to discuss any changes found in the code that are not clearly outlined above. If more detail is needed to better explain anything, I can add that as well.

**Suggestions on how to test this**:

Requires an installation configured with the French language bundle. View pages in multiple browser window sizes (Pro-tip: Safari provides a Responsive Design Mode under the Develop OS menu option.)

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No mockups for these UI clean up changes.

**Is there a release notes update needed for this change?**:

N/A

**Additional documentation**:

N/A
