### PR TITLE
#7536 update .travis.yml to openjdk11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
 jdk:
-  - openjdk8
+  - openjdk11
 script: mvn -DcompilerArgument=-Xlint:unchecked test -P all-unit-tests
 after_success: mvn jacoco:report coveralls:report 


### PR DESCRIPTION
**What this PR does / why we need it**: Travis builds are currently failing due to the switch to Java 11.

**Which issue(s) this PR closes**:

Closes #7536

**Special notes for your reviewer**: none

**Suggestions on how to test this**: watch for Travis output

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: no

**Is there a release notes update needed for this change?**: no

**Additional documentation**: none
