### PR TITLE
correct run-test-suite.sh syntax

### DIFF
--- a/conf/docker-aio/run-test-suite.sh
+++ b/conf/docker-aio/run-test-suite.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # This is the canonical list of which "IT" tests are expected to pass.
 
 dvurl=$1
@@ -8,4 +8,4 @@ fi
 
 # Please note the "dataverse.test.baseurl" is set to run for "all-in-one" Docker environment.
 # TODO: Rather than hard-coding the list of "IT" classes here, add a profile to pom.xml.
-source maven/maven.sh mvn test -Dtest=DataversesIT,DatasetsIT,SwordIT,AdminIT,BuiltinUsersIT,UsersIT,UtilIT,ConfirmEmailIT,FileMetadataIT,FilesIT,SearchIT,InReviewWorkflowIT,HarvestingServerIT,MoveIT,MakeDataCountApiIT,FileTypeDetectionIT,EditDDIIT,ExternalToolsIT,AccessIT,DuplicateFilesIT,DownloadFilesIT,LinkIT -Ddataverse.test.baseurl=$dvurl
+source maven/maven.sh && mvn test -Dtest=DataversesIT,DatasetsIT,SwordIT,AdminIT,BuiltinUsersIT,UsersIT,UtilIT,ConfirmEmailIT,FileMetadataIT,FilesIT,SearchIT,InReviewWorkflowIT,HarvestingServerIT,MoveIT,MakeDataCountApiIT,FileTypeDetectionIT,EditDDIIT,ExternalToolsIT,AccessIT,DuplicateFilesIT,DownloadFilesIT,LinkIT -Ddataverse.test.baseurl=$dvurl


### PR DESCRIPTION
**What this PR does / why we need it**: Corrects run-test-suite.sh syntax

**Which issue(s) this PR closes**:

Closes #7541

**Special notes for your reviewer**: changes are to specify custom maven version (maven packaged in RHEL/CentOS are tied to OpenJDK 1.8)

**Suggestions on how to test this**: run the script

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: no

**Is there a release notes update needed for this change?**: no

**Additional documentation**: none
