### PR TITLE
#7512 update UserNotification script

### DIFF
--- a/src/main/resources/db/migration/V5.3.0.2__7512-update-notification-types.sql
+++ b/src/main/resources/db/migration/V5.3.0.2__7512-update-notification-types.sql
@@ -1,0 +1,6 @@
+--In support of removing world map we are deleting notifications related to world map
+--and updating notifications to reflect the current enumeration of types on UserNotification
+
+delete from usernotification where type = 5 or type = 6;
+
+update usernotification set type = type - 2 where type > 6;


### PR DESCRIPTION
**What this PR does / why we need it**:
Removing World Map from the UserNotification enum type causes errors for types > 18 and mischaracterizing all types >6.

**Which issue(s) this PR closes**:

Closes #7512 

**Special notes for your reviewer**:
just a simple sql script to delete notifications related to world map and to renumber others.

**Suggestions on how to test this**:
verify that notifications created prior to merging 7506 are displaying as expected.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
no

**Is there a release notes update needed for this change?**:
no
**Additional documentation**:
none