### PR TITLE
Removed extra servlet pointing to HomepageServlet

### DIFF
--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -97,10 +97,6 @@
         <servlet-class>edu.harvard.iq.dataverse.CitationServlet</servlet-class>
     </servlet>
     <servlet>
-        <servlet-name>Homepage Servlet</servlet-name>
-        <servlet-class>edu.harvard.iq.dataverse.HomepageServlet</servlet-class>
-    </servlet>
-    <servlet>
         <servlet-name>HomepageServlet</servlet-name>
         <servlet-class>edu.harvard.iq.dataverse.HomepageServlet</servlet-class>
     </servlet>


### PR DESCRIPTION
**What this PR does / why we need it**:

Remove extra servlet pointing to HomepageServlet from web.xml that was discovered when troubleshooting a deployment localhost custom hmpg issue (that ultimately was just a browser cache issue 🤦 ).

```
    <servlet>
        <servlet-name>Homepage Servlet</servlet-name>
        <servlet-class>edu.harvard.iq.dataverse.HomepageServlet</servlet-class>
    </servlet>
    <servlet>
        <servlet-name>HomepageServlet</servlet-name>
        <servlet-class>edu.harvard.iq.dataverse.HomepageServlet</servlet-class>
    </servlet>
    <servlet-mapping>
        <servlet-name>HomepageServlet</servlet-name>
        <url-pattern>/Homepage</url-pattern>
    </servlet-mapping>
 ```

**Which issue(s) this PR closes**:

N/A

**Special notes for your reviewer**:

**Suggestions on how to test this**:

Apparently this changes nothing, and only cleans up the code. Please see @scolapasta and @landreev for further historical details in troubleshooting the homepage config settings on my localhost.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
