### PR TITLE
Change h4 to h3 on login page

### DIFF
--- a/src/main/webapp/loginpage.xhtml
+++ b/src/main/webapp/loginpage.xhtml
@@ -202,7 +202,7 @@
                             </div>
 
                             <div id="otherProviders" jsf:rendered="#{LoginPage.listAuthenticationProviders().size() > 1}">
-                                <h4>#{bundle['auth.providers.title']}</h4>
+                                <h3>#{bundle['auth.providers.title']}</h3>
                                 <h:form>
                                     <ui:repeat value="#{LoginPage.listAuthenticationProviders()}" var="provider">
                                         <p:commandLink rendered="#{provider.id != LoginPage.authProvider.id}" styleClass="btn btn-default" actionListener="#{LoginPage.setAuthProviderById(provider.id)}" update="login-container">


### PR DESCRIPTION
**What this PR does / why we need it**:

Changes the level 4 heading on the login page to a level 3 heading so heading levels aren't being skipped and are properly nested. "Log In" is a level 2 heading.

**Which issue(s) this PR closes**:

N/A

**Special notes for your reviewer**:

N/A

**Suggestions on how to test this**:

Open the "login" page

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

This will introduce a small change with the "Other options" text on the login page, as it will be larger with the default styling being used.

Current version:

![Screen Shot 2021-01-28 at 9 10 35 AM](https://user-images.githubusercontent.com/6903515/106150691-95489180-6149-11eb-9d2a-9b2276390b1c.png)

Updated version:

![Screen Shot 2021-01-28 at 9 09 43 AM](https://user-images.githubusercontent.com/6903515/106150700-97aaeb80-6149-11eb-8239-94102485e9d7.png)

**Is there a release notes update needed for this change?**:

No

**Additional documentation**:

https://www.w3.org/WAI/WCAG21/Techniques/general/G141.html