### PR TITLE
Added js+css to get the checksum to display in Bootstrap tooltips

### DIFF
--- a/src/main/webapp/file-info-fragment.xhtml
+++ b/src/main/webapp/file-info-fragment.xhtml
@@ -71,24 +71,32 @@
                 </div>
                 <!-- CHECKSUM -->
                 <div class="checksum-block" jsf:rendered="#{!fileMetadata.dataFile.tabularData and !(empty fileMetadata.dataFile.checksumValue)}">
-                    <span class="sr-only #{!editDatafilesPage ? 'checksum-truncate' : ''}" style="margin-right:3px;"
+                    <span class="sr-only #{!editDatafilesPage ? 'checksum-truncate checksum-tooltip' : ''}" style="margin-right:3px;"
+                                  data-toggle="tooltip" data-placement="top" data-html="true"
                                   data-clipboard-action="copy"
                                   data-clipboard-text="#{fileMetadata.dataFile.checksumValue}"
-                                  title="#{bundle['file.metaData.checksum.copy']} #{fileMetadata.dataFile.checksumValue}">#{fileMetadata.dataFile.checksumType}: #{fileMetadata.dataFile.checksumValue}</span>
-                    <span class="glyphicon glyphicon-copy btn-copy" data-clipboard-action="copy"
-                                  data-clipboard-text="#{fileMetadata.dataFile.checksumValue}" title="#{bundle['file.metaData.checksum.copy']} #{fileMetadata.dataFile.checksumValue}"></span>
+                                  title="#{bundle['file.metaData.checksum.copy']}&lt;br/&gt;#{fileMetadata.dataFile.checksumValue}">#{fileMetadata.dataFile.checksumType}: #{fileMetadata.dataFile.checksumValue}</span>
+                    <span class="glyphicon glyphicon-copy btn-copy checksum-tooltip" 
+                                  data-toggle="tooltip" data-placement="top" data-html="true"
+                                  data-clipboard-action="copy"
+                                  data-clipboard-text="#{fileMetadata.dataFile.checksumValue}" 
+                                  title="#{bundle['file.metaData.checksum.copy']}&lt;br/&gt;#{fileMetadata.dataFile.checksumValue}"></span>
                 </div>
                 <!-- TABULAR VARIABLES, OBSERVATIONS + UNF -->
                 <div class="unf-block" jsf:rendered="#{fileMetadata.dataFile.tabularData}">
                     <h:outputText id="fileNumVars" value="#{fileMetadata.dataFile.dataTable.varQuantity} #{bundle['file.metaData.dataFile.dataTab.variables']}, "/>
                     <h:outputText id="fileNumObs" value="#{fileMetadata.dataFile.dataTable.caseQuantity} #{bundle['file.metaData.dataFile.dataTab.observations']} "/>
-                    <span jsf:id="fileUNF" class="sr-only #{!editDatafilesPage ? 'checksum-truncate' : ''}" style="margin-right:3px;"
+                    <span jsf:id="fileUNF" class="sr-only #{!editDatafilesPage ? 'checksum-truncate checksum-tooltip' : ''}" style="margin-right:3px;"
                                   jsf:rendered="#{!(empty fileMetadata.dataFile.unf)}"
+                                  data-toggle="tooltip" data-placement="top" data-html="true"
                                   data-clipboard-action="copy"
                                   data-clipboard-text="#{fileMetadata.dataFile.unf}"
-                                  title="#{bundle['file.metaData.checksum.copy']} #{fileMetadata.dataFile.unf}">#{fileMetadata.dataFile.unf}</span>
-                    <span class="glyphicon glyphicon-copy btn-copy" jsf:rendered="#{!(empty fileMetadata.dataFile.unf)}" data-clipboard-action="copy"
-                                  data-clipboard-text="#{fileMetadata.dataFile.unf}" title="#{bundle['file.metaData.checksum.copy']} #{fileMetadata.dataFile.unf}"></span>
+                                  title="#{bundle['file.metaData.checksum.copy']}&lt;br/&gt;#{fileMetadata.dataFile.unf}">#{fileMetadata.dataFile.unf}</span>
+                    <span class="glyphicon glyphicon-copy btn-copy checksum-tooltip" jsf:rendered="#{!(empty fileMetadata.dataFile.unf)}" 
+                                  data-toggle="tooltip" data-placement="top" data-html="true"
+                                  data-clipboard-action="copy"
+                                  data-clipboard-text="#{fileMetadata.dataFile.unf}" 
+                                  title="#{bundle['file.metaData.checksum.copy']}&lt;br/&gt;#{fileMetadata.dataFile.unf}"></span>
                 </div>
             </div>
             <div class="fileDescription small" jsf:rendered="#{!(empty fileMetadata.description)}">

--- a/src/main/webapp/resources/js/dv_rebind_bootstrap_ui.js
+++ b/src/main/webapp/resources/js/dv_rebind_bootstrap_ui.js
@@ -186,6 +186,9 @@ function checksumTruncate(){
             }
         }
     });
+    $('span.checksum-tooltip').on('inserted.bs.tooltip', function () {
+        $("body div.tooltip-inner").css("word-break", "break-all");
+    });
 }
 
 function clickCopyClipboard(){

--- a/src/main/webapp/search-include-fragment.xhtml
+++ b/src/main/webapp/search-include-fragment.xhtml
@@ -614,25 +614,29 @@
                             <h:outputText value=" - #{SearchIncludeFragment.dataFileSizeDisplay(result.entity)}" rendered="#{!result.harvested}"/>
                             <h:outputText value=" - " rendered="#{!result.harvested and !SearchIncludeFragment.isTabular(result.entity) and !(empty result.fileChecksumValue)}"/>
                             <span class="checksum-block" jsf:rendered="#{!result.harvested and !SearchIncludeFragment.isTabular(result.entity) and !(empty result.fileChecksumValue)}">
-                                <span class="sr-only checksum-truncate" style="margin-right:3px;"
+                                <span class="sr-only checksum-truncate checksum-tooltip" style="margin-right:3px;"
+                                          data-toggle="tooltip" data-placement="top" data-html="true"
                                           data-clipboard-action="copy"
                                           data-clipboard-text="#{result.fileChecksumValue}"
-                                          title="#{bundle['file.metaData.checksum.copy']} #{result.fileChecksumValue}">#{result.fileChecksumType}: #{result.fileChecksumValue}</span>
-                                <span class="glyphicon glyphicon-copy btn-copy"
+                                          title="#{bundle['file.metaData.checksum.copy']}&lt;br/&gt;#{result.fileChecksumValue}">#{result.fileChecksumType}: #{result.fileChecksumValue}</span>
+                                <span class="glyphicon glyphicon-copy btn-copy checksum-tooltip"
+                                        data-toggle="tooltip" data-placement="top" data-html="true"
                                         data-clipboard-action="copy"
-                                        data-clipboard-text="#{result.fileChecksumValue}" title="#{bundle['file.metaData.checksum.copy']} #{result.fileChecksumValue}"></span>
+                                        data-clipboard-text="#{result.fileChecksumValue}" title="#{bundle['file.metaData.checksum.copy']}&lt;br/&gt;#{result.fileChecksumValue}"></span>
                             </span>
                             <!-- if tabular data file, display number of variables and observations, and unf -->
                             <span class="unf-block" jsf:rendered="#{!empty SearchIncludeFragment.tabularDataDisplayInfo(result.entity)}">
                                 <h:outputText value=" - #{SearchIncludeFragment.tabularDataDisplayInfo(result.entity)}"/>
                                 <h:outputText value=" - " rendered="#{!empty SearchIncludeFragment.tabularDataUnfDisplay(result.entity)}"/>
-                                <span class="sr-only checksum-truncate" style="margin-right:3px;" jsf:rendered="#{!empty SearchIncludeFragment.tabularDataUnfDisplay(result.entity)}"
+                                <span class="sr-only checksum-truncate checksum-tooltip" style="margin-right:3px;" jsf:rendered="#{!empty SearchIncludeFragment.tabularDataUnfDisplay(result.entity)}"
+                                          data-toggle="tooltip" data-placement="top" data-html="true"
                                           data-clipboard-action="copy"
                                           data-clipboard-text="#{SearchIncludeFragment.tabularDataUnfDisplay(result.entity)}"
-                                          title="#{bundle['file.metaData.checksum.copy']} #{SearchIncludeFragment.tabularDataUnfDisplay(result.entity)}">#{SearchIncludeFragment.tabularDataUnfDisplay(result.entity)}</span>
-                                <span class="glyphicon glyphicon-copy btn-copy" jsf:rendered="#{!empty SearchIncludeFragment.tabularDataUnfDisplay(result.entity)}"
+                                          title="#{bundle['file.metaData.checksum.copy']}&lt;br/&gt;#{SearchIncludeFragment.tabularDataUnfDisplay(result.entity)}">#{SearchIncludeFragment.tabularDataUnfDisplay(result.entity)}</span>
+                                <span class="glyphicon glyphicon-copy btn-copy checksum-tooltip" jsf:rendered="#{!empty SearchIncludeFragment.tabularDataUnfDisplay(result.entity)}"
+                                        data-toggle="tooltip" data-placement="top" data-html="true"
                                         data-clipboard-action="copy"
-                                        data-clipboard-text="#{SearchIncludeFragment.tabularDataUnfDisplay(result.entity)}" title="#{bundle['file.metaData.checksum.copy']} #{SearchIncludeFragment.tabularDataUnfDisplay(result.entity)}"></span>
+                                        data-clipboard-text="#{SearchIncludeFragment.tabularDataUnfDisplay(result.entity)}" title="#{bundle['file.metaData.checksum.copy']}&lt;br/&gt;#{SearchIncludeFragment.tabularDataUnfDisplay(result.entity)}"></span>
                             </span>
                         </div>
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Kevin pointed out the delayed display of the full checksum in the default browser title hover, as compared to the smooth Bootstrap tooltips commonly used in the UI. Couldn't argue that astute observation, especially when he was willing to investigate [workarounds in Stack Overflow](https://stackoverflow.com/a/64140548).

With a wee bit of extra JS and some additional massaging of the HTML, got the tooltips displaying the checksums with word-break CSS to make sure they're not breaking out of the tooltip width.

**Which issue(s) this PR closes**:

Closes # N/A

[ref #7081, #6685, #5210]

**Special notes for your reviewer**:

Enjoy.

**Suggestions on how to test this**:

You know what to do. Thanks for the help investigating solutions.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

Yes. No mockups.

**Is there a release notes update needed for this change?**:

**Additional documentation**:
