### PR TITLE
#7205 fix dataset page load

### DIFF
--- a/doc/release-notes/7205-orig-file-size.md
+++ b/doc/release-notes/7205-orig-file-size.md
@@ -1,0 +1,11 @@
+## Notes to Admins
+
+Beginning in Dataverse Software 4.10, the size of the saved original file (for an ingested tabular datafile) was stored in the database. For files added before this change, we provide an API that retrieves and permanently stores the sizes for any already existing saved originals. See [Datafile Integrity API](https://guides.dataverse.org/en/5.4/api/native-api.html#datafile-integrity) for more information.
+
+This was documented as a step in previous release notes, but we are noting it in these release notes to give it more visibility.
+
+## Upgrade Instructions
+
+X./ Retroactively store original file size
+
+Use the [Datafile Integrity API](https://guides.dataverse.org/en/5.4/api/native-api.html#datafile-integrity) to ensure that the sizes of all original files are stored in the database.

--- a/src/main/java/edu/harvard/iq/dataverse/dataset/DatasetUtil.java
+++ b/src/main/java/edu/harvard/iq/dataverse/dataset/DatasetUtil.java
@@ -469,8 +469,8 @@ public class DatasetUtil {
         long bytes = 0l;
         for (FileMetadata fileMetadata : dsv.getFileMetadatas()) {
             DataFile dataFile = fileMetadata.getDataFile();
-            if (original && dataFile.isTabularData()) {
-                bytes += dataFile.getOriginalFileSize();
+            if (original && dataFile.isTabularData()) {                
+                bytes += dataFile.getOriginalFileSize() == null ? 0 : dataFile.getOriginalFileSize();
             } else {
                 bytes += dataFile.getFilesize();
             }

--- a/src/main/webapp/dataset.xhtml
+++ b/src/main/webapp/dataset.xhtml
@@ -158,7 +158,7 @@
                                                                 </p:commandLink>
                                                             </li>
                                                             <!-- DOWNLOAD ORIGINAL BUTTON (TABULAR FILES PRESENT) -->
-                                                            <li jsf:rendered="#{DatasetPage.versionHasTabular}">
+                                                            <li jsf:rendered="#{DatasetPage.versionHasTabular and DatasetPage.sizeOfDatasetOrig != '0 B' }">
                                                                 <p:commandLink update="@form" actionListener="#{DatasetPage.validateAllFilesForDownloadOriginal()}" styleClass="btn-download">
                                                                     #{bundle.downloadOriginal}
                                                                     <h:outputFormat value="#{bundle['dataset.accessBtn.download.size']}">


### PR DESCRIPTION
**What this PR does / why we need it**:
The Dataset Page fails to load when a tabular file has an original file size of null. A one line change assigns a value of zero to the size when it is null so that the page will load properly

**Which issue(s) this PR closes**:

Closes #7205

**Special notes for your reviewer**:
This also suppresses the download original at the dataset level if the full size of the original files is zero (none have an original file size.)


**Suggestions on how to test this**:
Null out the original file size of a tabular file and verify that its dataset page will load.
update datatable set originalfilesize = null where datafile_id = ??;

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
no
**Is there a release notes update needed for this change?**:
Not really unless we want to remind installations to run the fixmissingoriginalsizes api

**Additional documentation**: