### PR TITLE
Remove negative z-index, add position:relative to content block to fix footer overlap bug [ref #7558]

### DIFF
--- a/src/main/webapp/resources/css/structure.css
+++ b/src/main/webapp/resources/css/structure.css
@@ -14,8 +14,6 @@ body .ui-widget {font-size: inherit;}
 .ui-widget-content a:hover, .ui-widget-content a:focus {color: #23527C;}
 
 /* -------- TEMPLATE -------- */
-/* STICKY FOOTER VS DROPDOWN MENU POSITION + Z-INDEX */
-/*#content {position:relative;}*/
 .panelgridHeaderTable {width:100%;}
 .panelgridHeaderTable .ui-widget-content, .panelgridHeaderTable .ui-widget-content > td {border:0; background:none;}
 .panelgridHeaderTable .ui-widget-content > td:last-child table {margin-left:auto;}

--- a/src/main/webapp/resources/css/structure.css
+++ b/src/main/webapp/resources/css/structure.css
@@ -14,8 +14,8 @@ body .ui-widget {font-size: inherit;}
 .ui-widget-content a:hover, .ui-widget-content a:focus {color: #23527C;}
 
 /* -------- TEMPLATE -------- */
-/* TODO FIX DROPDOWN MENU LAYERED UNDER FOOTER */
-#content {padding-bottom:0px;}
+/* STICKY FOOTER VS DROPDOWN MENU POSITION + Z-INDEX */
+#content {position:relative; z-index:50;}
 .panelgridHeaderTable {width:100%;}
 .panelgridHeaderTable .ui-widget-content, .panelgridHeaderTable .ui-widget-content > td {border:0; background:none;}
 .panelgridHeaderTable .ui-widget-content > td:last-child table {margin-left:auto;}
@@ -63,7 +63,7 @@ body .ui-widget {font-size: inherit;}
 #status-alert {margin-top:0; margin-bottom:0;}
 #status-alert div.alert {border:0; box-shadow:none;}
 
-#footer {position:absolute; z-index:-1; bottom:0; width:100%; height:60px; padding-bottom:100px; color:#808080;}
+#footer {position:absolute; bottom:0; width:100%; height:60px; padding-bottom:100px; color:#808080;}
 #footer.widget-view {position:fixed; left:0; bottom:0; margin:0; padding:4px 0 0 0; min-height:44px; height:auto; background:#fff;}
 #footer .poweredbylogo {text-align:right;}
 #footer .poweredbylogo span {font-size:.85em;margin-right:.3em;}

--- a/src/main/webapp/resources/css/structure.css
+++ b/src/main/webapp/resources/css/structure.css
@@ -15,27 +15,15 @@ body .ui-widget {font-size: inherit;}
 
 /* -------- TEMPLATE -------- */
 /* STICKY FOOTER VS DROPDOWN MENU POSITION + Z-INDEX */
-#content {position:relative; z-index:50;}
+/*#content {position:relative;}*/
 .panelgridHeaderTable {width:100%;}
 .panelgridHeaderTable .ui-widget-content, .panelgridHeaderTable .ui-widget-content > td {border:0; background:none;}
 .panelgridHeaderTable .ui-widget-content > td:last-child table {margin-left:auto;}
 
-.bg-dataverse, bg-brand {background:#C55B28;}
-.bg-dataset {background:#337AB7;}
-.bg-file {background:#777777;}
-.bg-muted {background:#f5f5f5;}
-.text-dataverse, .text-brand {color:#C55B28;}
-.text-dataset {color:#31708F;}
-.text-file {color:#777777;}
-
-#navbarFixed {margin-bottom:0;}
-.navbar-fixed-top, .navbar-fixed-bottom {
-    z-index: 930;
-}
+#navbarFixed.navbar-fixed-top {margin-bottom:0; z-index:9999;}
 #navbarFixed .navbar-brand {color:#C55B28; padding-left:32px;}
 #navbarFixed .navbar-brand.custom-logo {height:auto; padding:0;}
 #navbarFixed .icon-dataverse {color:#C55B28; font-size:28px; margin: -4px 0 0 -27px; position: absolute;}
-
 #navbarFixed .dropdown.accountName a:focus {outline: -webkit-focus-ring-color 5px auto;}
 #navbarFixed form.navbar-form.navbar-form-link {margin:0; padding:0;}
 #navbarFixed form.navbar-form-link a.ui-commandlink, #navbarFixed ul.navbar-nav li.dropdown span.dropdown-toggle {display:block; padding:15px; color: #777;}
@@ -70,39 +58,7 @@ body .ui-widget {font-size: inherit;}
 #footer .version {vertical-align:bottom;white-space:nowrap;}
 #footer.widget-view .widgetBrandMsg {line-height:42px;}
 
-.panelLayoutBlock, .panelLayoutTitleBlock, .panelLayoutButtonBlock {border:0;}
-.panelLayoutBlock .ui-panelgrid.panelgridLayoutTable .ui-widget-content, .panelLayoutBlock .ui-panelgrid.panelgridLayoutTable .ui-widget-content > td {border:0;}
 .form-group table.noBorders tr.ui-widget-content, .form-group table.noBorders td {border:0; padding-left:0;}
-
-.panelgridLayoutTable, .panelgridFormTable {width:100%;}
-.panelgridFormTable > tbody > tr.ui-widget-content > td:first-child {width:20%;}
-.panelgridFormTable.ui-panelgrid td table.ui-picklist td {border: 0; padding:0;}
-.panelgridFormTable.ui-panelgrid td table.ui-picklist td ul.ui-widget-content.ui-corner-all {border:1px solid #DDDDDD; border-radius: 4px;}
-
-.panelLayoutButtonBlock button {/*margin-right:2em;*/}
-
-.panelLayoutBlock > .ui-widget-content {border-bottom:1px solid #DDDDDD;}
-.panelLayoutBlock.ui-panel.padding-none > .ui-widget-content.ui-panel-content {padding:0;}
-
-.panelLayoutBlock.breadcrumbNavBlock > .ui-widget-content {border-bottom:0;}
-.panelLayoutTitleBlock > .ui-widget-content {border:0;}
-
-.panelLayoutBlock .ui-panelgrid.panelgridLayoutTable .ui-widget-content .ui-panelgrid {margin-bottom: 1em;}
-.panelLayoutBlock .ui-panelgrid.panelgridLayoutTable .ui-widget-content .ui-panelgrid .ui-widget-content .ui-panelgrid {margin-bottom: 0}
-.panelLayoutBlock .ui-panelgrid.panelgridLayoutTable .ui-widget-content .ui-panelgrid .ui-widget-content .ui-panelgrid td:first-child {padding-left:0;}
-
-.btn span.glyphicon {margin-right:.3em;}
-.btn.btn-link.bootstrap-button-tooltip span.glyphicon {margin:0;} /* OR JUST USE NO-TEXT... */
-.btn.btn-link.bootstrap-button-tooltip span.caret {margin-left:6px;}
-.btn span.glyphicon.no-text {margin:0;}
-.btn-group .btn span.glyphicon.no-text {margin-left:10px;margin-right:10px;}
-.col-manage-action .btn-group .btn span.glyphicon.no-text {margin:0;}
-.icon-inline-action {margin-left:.3em;}
-.icon-inline-action:first-of-type {margin-left:1em;}
-
-.btn-group .text-button {display:inline-block;padding:6px;}
-
-.text-icon-inline {font-size:1.3em;line-height:1.1em;margin-right:4px;}
 
 #messagePanel div.messagePanel {margin-top:1em;}
 .messagePanel .glyphicon {font-size: 1.5em; vertical-align: bottom;}
@@ -128,6 +84,14 @@ td.col-select-width, th.col-select-width {width:36px;}
 #ajaxStatusPanel_start {width:31px;height:31px;position:fixed;right:50%;bottom:50%;z-index:111111;}
 #ajaxStatusPanel_complete {position:absolute;top:-9999px;left:-9999px;}
 
+.bg-dataverse, bg-brand {background:#C55B28;}
+.bg-dataset {background:#337AB7;}
+.bg-file {background:#777777;}
+.bg-muted {background:#f5f5f5;}
+.text-dataverse, .text-brand {color:#C55B28;}
+.text-dataset {color:#31708F;}
+.text-file {color:#777777;}
+
 .italic {font-style: italic;}
 .margin-top {margin-top:1em;}
 .margin-top-half {margin-top:.5em;}
@@ -148,6 +112,16 @@ table.selectManyCheckboxBlock label {font-weight:normal;}
 
 hr {border-color: #ddd;}
 
+.btn span.glyphicon {margin-right:.3em;}
+.btn.btn-link.bootstrap-button-tooltip span.glyphicon {margin:0;} /* OR JUST USE NO-TEXT... */
+.btn.btn-link.bootstrap-button-tooltip span.caret {margin-left:6px;}
+.btn span.glyphicon.no-text {margin:0;}
+.btn-group .btn span.glyphicon.no-text {margin-left:10px;margin-right:10px;}
+.col-manage-action .btn-group .btn span.glyphicon.no-text {margin:0;}
+.icon-inline-action {margin-left:.3em;}
+.icon-inline-action:first-of-type {margin-left:1em;}
+.btn-group .text-button {display:inline-block;padding:6px;}
+.text-icon-inline {font-size:1.3em;line-height:1.1em;margin-right:4px;}
 span.glyphicon[data-toggle='tooltip'] {cursor: default;}
 span.glyphicon-question-sign.tooltip-icon {color: #99bcdb !important;}
 span.glyphicon-question-sign.tooltip-icon:hover {color: #337AB7 !important;}
@@ -261,17 +235,11 @@ body.widget-view #dataverse-header-block {padding-top:0px;}
 #breadcrumbNavBlock .breadcrumbActive {font-weight:bold;}
 #breadcrumbNavBlock a[id^='breadcrumbLnkTree'] {cursor: pointer; cursor: hand;}
 #breadcrumbNavBlock a[id^='breadcrumbLnkTree'] span.glyphicon-chevron-down {vertical-align:middle;padding-bottom:2px;}
-
 #breadcrumbNavBlock > .ui-panel-content {overflow:hidden;}
-        
 #breadcrumbNavBlock.panelLayoutBlock > .ui-widget-content {border-bottom: 0;}
-
 #breadcrumbNavBlock .breadcrumbCarrot {float:left; margin:0 .4em; color:#B3B3B3;}
-
 #breadcrumbNavBlock div.dropdown-menu {padding-right:.5em; min-width:280px;}
-
 #breadcrumbNavBlock .ui-tree {width: auto;}
-
 #breadcrumbNavBlock div.ui-tree.ui-widget-content {border:0;}
 #breadcrumbNavBlock div.ui-tree.ui-widget-content span.ui-treenode-content span.ui-icon.ui-tree-toggler {background-size: auto 284px; height:20px; width:20px;}
 #breadcrumbNavBlock div.ui-tree.ui-widget-content span.ui-treenode-content span.ui-icon.ui-tree-toggler.ui-icon-triangle-1-s {background-position: -72px -16px;}
@@ -511,9 +479,7 @@ form[id$='facetType'] > div.clearfix:last-child {margin-bottom:0;}
 form[id$='facetType'] > div.clearfix .facetTypeChBox {display:block; float:left;}
 form[id$='facetType'] > div.clearfix .facetTypeChBox > div.ui-chkbox {padding-top:2px;padding-right:4px;}
 form[id$='facetType'] > div.clearfix a.facetTypeLink {display:block; float:left; text-decoration:none;}
-
 form[id$='facetType'] > div.clearfix a.facetTypeLink span {padding:4px 0px;}
-
 form[id$='facetCategoryForm'] {margin-top:1em;}
 div[id$='facetCategoryList'] ul, div[id$='facetCategoryList'] li, div[id$='facetCategoryList'] div {margin:0; padding:0; list-style: none; border:0;}
 div[id$='facetCategoryList'] > div > ul > li {border-bottom:1px solid #DDD; margin-bottom:.5em;}
@@ -522,7 +488,6 @@ div[id$='facetCategoryList'] div li div {padding:4px 0px;}
 div[id$='facetCategoryList'] div li div.ui-datalist-empty-message {padding:4px 0px; font-style:italic; color:#AAA;}
 div[id$='facetCategoryList'] div.ui-datalist, div[id$='facetCategoryList'] div.ui-datalist div.ui-datalist-content {padding-top:0;}
 .facetCategoryName {font-weight:bold;}
-
 .facetCategoryName, .facetLink {
 -ms-word-break: break-all;
 
@@ -572,7 +537,7 @@ div.ui-dialog.smallPopUp {max-width:600px;}
 div.ui-dialog.largePopUp {min-width:60%; max-width:80%; max-height:80%; overflow-y:scroll;}
 div.ui-dialog .ui-datatable-scrollable table {table-layout: auto !important;}
 div.ui-dialog .ui-datatable-scrollable table colgroup col {max-width:1000px;}
-
+.ui-dialog.ui-widget.ui-widget-content {min-width:600px;}
 div.ui-dialog div.highlight {
     background-color: #f7f7f9;
     border: 1px solid #e1e1e8;
@@ -582,8 +547,6 @@ div.ui-dialog div.highlight {
 }
 .ui-dialog.dialog-submenu, .ui-dialog.dialog-submenu .ui-dialog-content, .ui-dialog.dialog-submenu .form-inline, .ui-dialog.dialog-submenu .form-group {overflow:visible !important;}
 .ui-dialog.dialog-submenu .ui-menu-list.ui-menu-child {z-index: 9999 !important; width: auto; min-width: 12.5em;}
-
-.ui-dialog.ui-widget.ui-widget-content {min-width:600px;}
 
 /* -------- SUBTABS -------- */
 div.popupSubTabParent > div.ui-tabs-panels > div.ui-tabs-panel.ui-widget-content {padding-left:0; padding-right:0;}
@@ -742,15 +705,10 @@ div[id$="filesHeaderCount"] {padding:6px 12px;}
 div[id$="filesHeaderCount"] span.highlightBold {display:block; padding:0; line-height:1.65;}
 div[id$="filesTable"] .ui-selection-column {width:20px !important;}
 div[id$="filesTable"] .col-file-metadata {padding-left:0; padding-right:0; border-left:0; border-right:0; text-align:left; font-weight:normal;}
-
-/*div[id$="filesTable"] .col-file-thumb {padding:4px 10px; width:84px;}*/
 div[id$="filesTable"] .col-file-thumb div.thumbnail-block {position:relative;width:64px;height:64px;margin:0 auto;}
 div[id$="filesTable"] .col-file-thumb div.thumbnail-block span.file-thumbnail-icon {font-size:62px;line-height:1.05;}
 div[id$="filesTable"] .col-file-thumb div.thumbnail-block span.file-thumbnail-preview-img {display:block;}
 div[id$="filesTable"] .col-file-thumb div.thumbnail-block div.file-icon-restricted-block {display:block;position:absolute;bottom:-4px;right:-1px;}
-/*div[id$="filesTable"] .file-metadata-block {-webkit-flex: 1 100%;
-	-moz-flex: 1 100%;
-	-ms-flex: 1 100%; flex: 1 100%;}*/
 div[id$="filesTable"] div.file-tags-block {padding-bottom:2px;}
 div[id$="filesTable"] div.file-tags-block a.ui-commandlink {font-size:12px;}
 div[id$="filesTable"] div.file-tags-block span.label {display:inline-block;}
@@ -837,8 +795,6 @@ div[id$="filesTable"] .ui-paginator .ui-paginator-pages .ui-state-active {
 /* FILES TREE */
 div[id$="filesTree"] span.ui-treenode-label span[class^='icon'] {margin-left: -2px;}
 
-/* span.ingest-warning {font-size:2em !important; line-height:1; vertical-align: middle;} */
-
 /* DOWNLOAD POPUP */
 div.panel-body.read-terms{max-height:220px; overflow-y:scroll; width:100%; background-color:#eeeeee;}
 
@@ -848,11 +804,9 @@ div.panel-body.read-terms{max-height:220px; overflow-y:scroll; width:100%; backg
 
 /* VERSIONS */
 div[id$="versionsTable"] th.col-select-width * {display:none;}
-
 #version-details-block > div {width:35%; padding:4px 10px; border: 1px solid #DDDDDD;}
 #version-details-block > div:first-of-type {width:30%; border:0;}
 #version-details-block > div:last-of-type {border-left-width:0;}
-
 div.dvnDifferanceTable > div.ui-datatable-tablewrapper > table > thead {display:none;}
 div.dvnDifferanceTable > div.ui-datatable-tablewrapper > table, div.dvnDifferanceTable > div.ui-datatable-tablewrapper > table > tbody {border:0;}
 div.dvnDifferanceTable > div.ui-datatable-tablewrapper > table > tbody > tr:first-child, div.dvnDifferanceTable > div.ui-datatable-tablewrapper > table > tbody > tr:first-child > td {border-top-width:0;}
@@ -861,22 +815,14 @@ div.dvnDifferanceTable > div.ui-datatable-tablewrapper > table > tbody > tr, div
 div.dvnDifferanceTable > div.ui-datatable-tablewrapper > table > tbody > tr, div.dvnDifferanceTable > div.ui-datatable-tablewrapper > table > tbody > tr > td:last-child {border-right-width:0;}
 div.dvnDifferanceTable div.ui-datatable-tablewrapper table td.versionValue {width:30%;}
 div.dvnDifferanceTable div.ui-datatable-tablewrapper table td.versionDetails {width:35%;}
-
 div.dvnDifferanceTable .diffDetailBlock {display:block;}
 
-/* MANAGE TABLE + DROPDOWN BUTTON */
-div.manageTable.ui-datatable div.ui-datatable-tablewrapper, div.manageTable.ui-datatable td.col-manage-action {overflow:visible;}
-div[id$="filesTable"].ui-datatable thead th.col-file-action, div[id$="filesTable"].ui-datatable tbody td.col-file-action {overflow:visible !important;}
+/* DATATABLE + DROPDOWN BUTTON + OVERFLOW VISIBLE */
 thead.ui-datatable-scrollable-theadclone {display:none}
-
-/* DATATABE + OVERFLOW VISIBLE */
-.ui-datatable thead th, .ui-datatable tbody td, .ui-datatable tfoot td, .ui-datatable tfoot th {overflow:visible;}
+.ui-datatable thead th, .ui-datatable tbody td, .ui-datatable tfoot td, .ui-datatable tfoot th {overflow:visible !important;}
 
 /* FILE */
-#file-preview-icon-block > #border-block {/*border:1px solid #DDD;border-radius:4px; padding: 10px;*/}
-#file-preview-icon-block > #border-block > #preview-square {/*position: relative; overflow:hidden; padding-bottom:100%;*/}
-#file-preview-icon-block > #border-block > #preview-square > span.text-muted {font-size:6.5em; line-height:1 !important; /*text-align: center; position: absolute; width: 100%; height: 100%; margin:0;*/}
-#file-preview-icon-block > #border-block > #preview-square > img.img-responsive {/*position: absolute; max-width: 100%; max-height: 100%; top: 50%; left: 50%; transform: translateX(-50%) translateY(-50%);*/}
+#file-preview-icon-block > #border-block > #preview-square > span.text-muted {font-size:6.5em; line-height:1 !important;}
 @media(min-width:768px){
     #file-preview-icon-block > #border-block > #preview-square > span.text-muted {
         font-size: 9.5em;
@@ -905,10 +851,11 @@ thead.ui-datatable-scrollable-theadclone {display:none}
 div.ui-dialog.ui-widget-content {z-index:100001 !important;}
 
 /* POPUP DROPDOWN MENUS + TOOLTIPS + BLOCK UI */
-div.ui-selectcheckboxmenu-panel, div.ui-selectonemenu-panel, div.ui-autocomplete-panel,
-.ui-selectonemenu-list, .ui-selectcheckboxmenu-list, div.tooltip, div.popover {z-index:100002 !important;}
+.ui-selectcheckboxmenu-panel, .ui-selectonemenu-panel, .ui-autocomplete-panel,
+.ui-selectonemenu-list, .ui-selectcheckboxmenu-list, .tooltip, .popover {z-index:100002 !important;}
 
 /* Overwrite Primefaces */
+.ui-tabs.ui-widget.ui-widget-content {position:relative; z-index:999;}
 .ui-tabs.ui-widget-content .ui-tabs-nav li.ui-tabs-selected a {color: #555555;}
 button.btn-default.ui-button-text-only .ui-button-text {padding:0; font-size:14px;}
 button.btn-default span.ui-button-text {line-height:inherit !important;}
@@ -922,12 +869,8 @@ div.ui-widget-overlay {background:#ccc; opacity:.6;}
 .ui-button.btn-link:hover, .ui-button.btn-link:focus {color: #23527c; text-decoration: underline !important; background-color: transparent;}
 .ui-button.btn-link[disabled]:hover, fieldset[disabled] .ui-button.btn-link:hover, .ui-button.btn-link[disabled]:focus, fieldset[disabled] .ui-button.btn-link:focus {color: #777;text-decoration: none;}
 .ui-widget-header .form-group {font-weight:normal;}
-/* .ui-messages-info-detail, .ui-messages-warn-detail, .ui-messages-error-detail, .ui-messages-fatal-detail, .ui-message-info-detail, .ui-message-warn-detail, .ui-message-error-detail, .ui-message-fatal-detail {
-    margin-left: 0px;
-} */
+
 .ui-state-disabled, .ui-widget-content .ui-state-disabled, .ui-widget-header .ui-state-disabled {background: #e0e0e0; border-color: #ccc; opacity: 0.65;}
-/* .ui-autocomplete-input-token input, .ui-autocomplete-input-token {width:100%;} */
-.ui-autocomplete-panel {z-index:100002 !important;}
 div.ui-autocomplete {width:100%;}
 div.ui-autocomplete > ul, div.ui-autocomplete > ul > li > input {width:100%;} /* FIX WIDTH FOR AUTOCOMPLETE WITHOUT P:FRAGMENT */
 span.ui-autocomplete {width:100%;} /* FIX WIDTH FOR AUTOCOMPLETE IN P:FRAGMENT */


### PR DESCRIPTION
**What this PR does / why we need it**:

In Firefox, the sticky footer of the app was overlapping dropdown menus in the dataset pg files table, specifically the Access File options for a tabular file.

**Which issue(s) this PR closes**:

Closes #7558 Footer - Links not clickable in Firefox

**Special notes for your reviewer**:

CSS and z-index are hard.

**Suggestions on how to test this**:

Make sure it's all good in Firefox, but double check other browsers too. Should be able to click privacy, accessibility and Dataverse Projects. Make sure that the tabular file download options listed in dropdown menu under Access File icon btns are not hidden under the layer that contains the footer.

Make sure the layering of other elements in the app are all kosher, like navbar dropdown menus, popups + background overlays, autocomplete dropdown menus, etc.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

Fixes a UI bug. Should look the same.

<img width="1146" alt="Screen Shot 2021-02-05 at 1 55 42 PM" src="https://user-images.githubusercontent.com/687227/107076780-e562cc00-67b9-11eb-90c6-e8ac71a1de3b.png">

**Is there a release notes update needed for this change?**:

Nope.

**Additional documentation**:
