### PR TITLE
Removed extra link from Feature Dataverse carousel [ref #7476]

### DIFF
--- a/src/main/webapp/dataverse.xhtml
+++ b/src/main/webapp/dataverse.xhtml
@@ -580,17 +580,13 @@
                                     </div>
                                     <div id="featuredDataversesList" class="owl-carousel owl-theme">
                                         <ui:repeat value="#{DataversePage.carouselFeaturedDataverses}" var="dv" varStatus="status">
-                                            <div class="item">
-                                                <div style="vertical-align:middle;">
-                                                    <c:set var="dvFeatUrl" value="/dataverse/#{dv.alias}"/>
-                                                    <a href="#{widgetWrapper.wrapURL(dvFeatUrl)}" title="#{dv.name}">
-                                                        <img src="/logos/#{dv.logoOwnerId}/#{dv.dataverseTheme.logo}" alt="#{of:format1(bundle['alt.logo'], dv.name)}" jsf:rendered="#{!empty dv.dataverseTheme.logo}"/>
-                                                        <span class="icon-dataverse" jsf:rendered="#{empty dv.dataverseTheme.logo}"></span>
-                                                    </a>
-                                                    <a href="#{widgetWrapper.wrapURL(dvFeatUrl)}" title="#{dv.name}">
-                                                        <h:outputText value="#{dv.name}"/>
-                                                    </a>
-                                                </div>
+                                            <div class="item" style="vertical-align:middle;">
+                                                <c:set var="dvFeatUrl" value="/dataverse/#{dv.alias}"/>
+                                                <a href="#{widgetWrapper.wrapURL(dvFeatUrl)}">
+                                                    <img src="/logos/#{dv.logoOwnerId}/#{dv.dataverseTheme.logo}" alt="#{of:format1(bundle['alt.logo'], dv.name)}" jsf:rendered="#{!empty dv.dataverseTheme.logo}"/>
+                                                    <span class="icon-dataverse" jsf:rendered="#{empty dv.dataverseTheme.logo}"></span>
+                                                    <h:outputText styleClass="show" value="#{dv.name}"/>
+                                                </a>
                                             </div>
                                         </ui:repeat>
                                     </div>


### PR DESCRIPTION
**What this PR does / why we need it**:

Improves UX for users who visit Dataverse using a screenreader. Removes extra link inside Featured Dataverse carousel, so there's only one link for screenreaders to read in each carousel item, rather than two duplicate links.

**Which issue(s) this PR closes**:

Closes #7476 Accessibility - carousel images and text links duplications for screenreader users 

**Special notes for your reviewer**:

**Suggestions on how to test this**:

Quick tutorial on [how to use Mac OS's VoiceOver app as a screenreader in Safari](https://webaim.org/articles/voiceover/).

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
