### PR TITLE
#6972 allow pdf download if "original" is selected.

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/api/Access.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Access.java
@@ -331,6 +331,14 @@ public class Access extends AbstractApiBean {
             // So we need to identify when a service is being called and then let checkIfServiceSupportedAndSetConverter see if the required one exists
             if (key.equals("imageThumb") || key.equals("format") || key.equals("variables") || key.equals("noVarHeader")) {
                 serviceRequested = true;
+                //In the dataset file table context a user is allowed to select original as the format
+                //for download
+                // if the dataset has tabular files - it should not be applied to instances 
+                // where the file selected is not tabular see #6972
+                if("format".equals(key) && "original".equals(value) && !df.isTabularData()) {
+                    serviceRequested = false;
+                    break;
+                }
                 //Only need to check if this key is associated with a service
                 if (downloadInstance.checkIfServiceSupportedAndSetConverter(key, value)) {
                     // this automatically sets the conversion parameters in


### PR DESCRIPTION
**What this PR does / why we need it**:
If a user selects "original" file format as the download option for a non-tabular file it fails.

**Which issue(s) this PR closes**:

Closes #6972 

**Special notes for your reviewer**:
Applies a test of whether a file selected to be downloaded as "original" is tabular. Similar to how it is handled for a multiple file download.

**Suggestions on how to test this**:
If there are tabular files present in a dataset the option for downloading any file as "original" will be present. The user should be able to select a single non-tabular file and successfully download it by selecting "original".

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
no
**Is there a release notes update needed for this change?**:
no
**Additional documentation**:
none