### PR TITLE
support different checksum algorithms in direct upload

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/EditDatafilesPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/EditDatafilesPage.java
@@ -1,6 +1,7 @@
 package edu.harvard.iq.dataverse;
 
 import edu.harvard.iq.dataverse.provenance.ProvPopupFragmentBean;
+import edu.harvard.iq.dataverse.DataFile.ChecksumType;
 import edu.harvard.iq.dataverse.api.AbstractApiBean;
 import edu.harvard.iq.dataverse.authorization.AuthenticationServiceBean;
 import edu.harvard.iq.dataverse.authorization.Permission;
@@ -1788,6 +1789,7 @@ public class EditDatafilesPage implements java.io.Serializable {
         if (fileReplacePageHelper.handleNativeFileUpload(inputStream,null,
                                     fileName,
                                     contentType, 
+                                    null, 
                                     null
                                 )){
             saveEnabled = true;
@@ -1848,12 +1850,13 @@ public class EditDatafilesPage implements java.io.Serializable {
     private void handleReplaceFileUpload(String fullStorageLocation, 
     		String fileName, 
     		String contentType, 
-    		String checkSum){
+    		String checkSumValue,
+    		ChecksumType checkSumType){
 
     	fileReplacePageHelper.resetReplaceFileHelper();
     	saveEnabled = false;
     	String storageIdentifier = DataAccess.getStorarageIdFromLocation(fullStorageLocation);
-    	if (fileReplacePageHelper.handleNativeFileUpload(null, storageIdentifier, fileName, contentType, checkSum)){
+    	if (fileReplacePageHelper.handleNativeFileUpload(null, storageIdentifier, fileName, contentType, checkSumValue, checkSumType)){
     		saveEnabled = true;
 
     		/**
@@ -1985,9 +1988,12 @@ public class EditDatafilesPage implements java.io.Serializable {
         String fullStorageIdentifier = paramMap.get("fullStorageIdentifier");
         String fileName = paramMap.get("fileName");
         String contentType = paramMap.get("contentType");
-        String checksumType = paramMap.get("checksumType");
+        String checksumTypeString = paramMap.get("checksumType");
         String checksumValue = paramMap.get("checksumValue");
-        
+        ChecksumType checksumType = null;
+        if (!checksumTypeString.isBlank()) {
+            checksumType = ChecksumType.fromString(checksumTypeString);
+        }
         int lastColon = fullStorageIdentifier.lastIndexOf(':');
         String storageLocation= fullStorageIdentifier.substring(0,lastColon) + "/" + dataset.getAuthorityForFileStorage() + "/" + dataset.getIdentifierForFileStorage() + "/" + fullStorageIdentifier.substring(lastColon+1);
     	if (uploadInProgress.isFalse()) {
@@ -2009,12 +2015,6 @@ public class EditDatafilesPage implements java.io.Serializable {
 				contentType = FileUtil.MIME_TYPE_UNDETERMINED_DEFAULT;
 			}
 			
-			if(DataFile.ChecksumType.fromString(checksumType) != DataFile.ChecksumType.MD5 ) {
-				String warningMessage = "Non-MD5 checksums not yet supported in external uploads";
-				localWarningMessage = warningMessage;
-				//ToDo - methods like handleReplaceFileUpload and classes like OptionalFileParams will need to track the algorithm in addition to the value to enable this
-			}
-			
     		/* ----------------------------
                 Check file size
                 - Max size NOT specified in db: default is unlimited
@@ -2029,7 +2029,7 @@ public class EditDatafilesPage implements java.io.Serializable {
     			// Is this a FileReplaceOperation?  If so, then diverge!
     			// -----------------------------------------------------------
     			if (this.isFileReplaceOperation()){
-    				this.handleReplaceFileUpload(storageLocation, fileName, contentType, checksumValue);
+    				this.handleReplaceFileUpload(storageLocation, fileName, contentType, checksumValue, checksumType);
     				this.setFileMetadataSelectedForTagsPopup(fileReplacePageHelper.getNewFileMetadatasBeforeSave().get(0));
     				return;
     			}
@@ -2047,7 +2047,7 @@ public class EditDatafilesPage implements java.io.Serializable {
     				//datafiles = ingestService.createDataFiles(workingVersion, dropBoxStream, fileName, "application/octet-stream");
 
 
-    				datafiles = FileUtil.createDataFiles(workingVersion, null, fileName, contentType, fullStorageIdentifier, checksumValue, systemConfig);
+    				datafiles = FileUtil.createDataFiles(workingVersion, null, fileName, contentType, fullStorageIdentifier, checksumValue, checksumType, systemConfig);
     			} catch (IOException ex) {
     				logger.log(Level.SEVERE, "Error during ingest of file {0}", new Object[]{fileName});
     			}

--- a/src/main/java/edu/harvard/iq/dataverse/datasetutility/AddReplaceFileHelper.java
+++ b/src/main/java/edu/harvard/iq/dataverse/datasetutility/AddReplaceFileHelper.java
@@ -6,6 +6,7 @@
 package edu.harvard.iq.dataverse.datasetutility;
 
 import edu.harvard.iq.dataverse.DataFile;
+import edu.harvard.iq.dataverse.DataFile.ChecksumType;
 import edu.harvard.iq.dataverse.DataFileServiceBean;
 import edu.harvard.iq.dataverse.Dataset;
 import edu.harvard.iq.dataverse.DatasetServiceBean;
@@ -117,11 +118,12 @@ public class AddReplaceFileHelper{
     // -----------------------------------
     private Dataset dataset;                    // constructor (for add, not replace)
     private DataverseRequest dvRequest;         // constructor
-    private InputStream newFileInputStream;     // step 20
-    private String newFileName;                 // step 20
-    private String newFileContentType;          // step 20
-    private String newStorageIdentifier;        // step 20
-    private String newCheckSum;        // step 20
+    private InputStream newFileInputStream;     // step 30
+    private String newFileName;                 // step 30
+    private String newFileContentType;          // step 30
+    private String newStorageIdentifier;        // step 30
+    private String newCheckSum;                 // step 30
+    private ChecksumType newCheckSumType;       //step 30
     
     // -- Optional  
     private DataFile fileToReplace;             // step 25
@@ -552,6 +554,7 @@ public class AddReplaceFileHelper{
         if(optionalFileParams != null) {
         	if(optionalFileParams.hasCheckSum()) {
         		newCheckSum = optionalFileParams.getCheckSum();
+        		newCheckSumType = optionalFileParams.getCheckSumType();
         	}
         }
 
@@ -1131,6 +1134,7 @@ public class AddReplaceFileHelper{
                     this.newFileContentType,
                     this.newStorageIdentifier,
                     this.newCheckSum,
+                    this.newCheckSumType,
                     this.systemConfig);
 
         } catch (IOException ex) {

--- a/src/main/java/edu/harvard/iq/dataverse/datasetutility/FileReplacePageHelper.java
+++ b/src/main/java/edu/harvard/iq/dataverse/datasetutility/FileReplacePageHelper.java
@@ -6,6 +6,7 @@
 package edu.harvard.iq.dataverse.datasetutility;
 
 import edu.harvard.iq.dataverse.DataFile;
+import edu.harvard.iq.dataverse.DataFile.ChecksumType;
 import edu.harvard.iq.dataverse.Dataset;
 import edu.harvard.iq.dataverse.FileMetadata;
 import java.io.InputStream;
@@ -93,7 +94,7 @@ public class FileReplacePageHelper {
      * @param checkSum 
      * @param event 
      */
-    public boolean handleNativeFileUpload(InputStream inputStream, String fullStorageId, String fileName, String fileContentType, String checkSum) {
+    public boolean handleNativeFileUpload(InputStream inputStream, String fullStorageId, String fileName, String fileContentType, String checkSumValue, ChecksumType checkSumType) {
                 
         phase1Success = false;
         
@@ -110,14 +111,14 @@ public class FileReplacePageHelper {
         }
         
         OptionalFileParams ofp = null;
-        if(checkSum != null) {
-        	try {
-				ofp = new OptionalFileParams(null);
-			} catch (DataFileTagException e) {
-				//Shouldn't happen with null input
-				e.printStackTrace();
-			}
-        	ofp.setCheckSum(checkSum);
+        if(checkSumValue != null) {
+            try {
+                ofp = new OptionalFileParams(null);
+            } catch (DataFileTagException e) {
+                // Shouldn't happen with null input
+                e.printStackTrace();
+            }
+            ofp.setCheckSum(checkSumValue, checkSumType);
         }
         // Run 1st phase of replace
         //

--- a/src/main/java/edu/harvard/iq/dataverse/datasetutility/OptionalFileParams.java
+++ b/src/main/java/edu/harvard/iq/dataverse/datasetutility/OptionalFileParams.java
@@ -10,7 +10,9 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonSyntaxException;
 import com.google.gson.internal.LinkedTreeMap;
 import com.google.gson.reflect.TypeToken;
+
 import edu.harvard.iq.dataverse.DataFile;
+import edu.harvard.iq.dataverse.DataFile.ChecksumType;
 import edu.harvard.iq.dataverse.DataFileTag;
 import edu.harvard.iq.dataverse.FileMetadata;
 import edu.harvard.iq.dataverse.api.Util;
@@ -68,8 +70,12 @@ public class OptionalFileParams {
     public static final String FILE_NAME_ATTR_NAME = "fileName";
     private String mimeType;
     public static final String MIME_TYPE_ATTR_NAME = "mimeType";
-    private String checkSum;
-    public static final String CHECKSUM_ATTR_NAME = "md5Hash";
+    private String checkSumValue;
+    private ChecksumType checkSumType;
+    public static final String LEGACY_CHECKSUM_ATTR_NAME = "md5Hash";
+    public static final String CHECKSUM_OBJECT_NAME = "checksum";
+    public static final String CHECKSUM_OBJECT_TYPE = "@type";
+    public static final String CHECKSUM_OBJECT_VALUE = "@value";
 
      
     public OptionalFileParams(String jsonData) throws DataFileTagException{
@@ -218,16 +224,20 @@ public class OptionalFileParams {
 	}
 
 	public void setCheckSum(String checkSum) {
-		this.checkSum = checkSum;
+		this.checkSumValue = checkSum;
 	}
 	
 	public boolean hasCheckSum() {
-		return ((checkSum!=null)&&(!checkSum.isEmpty()));
+		return ((checkSumValue!=null)&&(!checkSumValue.isEmpty()));
 	}
 
 	public String getCheckSum() {
-		return checkSum;
+		return checkSumValue;
 	}
+	
+    public ChecksumType getCheckSumType() {
+        return checkSumType;
+    }
 
     /**
      *  Set tags
@@ -350,11 +360,21 @@ public class OptionalFileParams {
         }
         
         // -------------------------------
-        // get checkSum as string
+        // get md5 checkSum as string
         // -------------------------------
-        if ((jsonObj.has(CHECKSUM_ATTR_NAME)) && (!jsonObj.get(CHECKSUM_ATTR_NAME).isJsonNull())){
+        if ((jsonObj.has(LEGACY_CHECKSUM_ATTR_NAME)) && (!jsonObj.get(LEGACY_CHECKSUM_ATTR_NAME).isJsonNull())){
 
-            this.checkSum = jsonObj.get(CHECKSUM_ATTR_NAME).getAsString();
+            this.checkSumValue = jsonObj.get(LEGACY_CHECKSUM_ATTR_NAME).getAsString();
+            this.checkSumType= ChecksumType.MD5;
+        }
+        // -------------------------------
+        // get checkSum type and value
+        // -------------------------------
+        else if ((jsonObj.has(CHECKSUM_OBJECT_NAME)) && (!jsonObj.get(CHECKSUM_OBJECT_NAME).isJsonNull())){
+
+            this.checkSumValue = ((JsonObject) jsonObj.get(CHECKSUM_OBJECT_NAME)).get(CHECKSUM_OBJECT_VALUE).getAsString();
+            this.checkSumType = ChecksumType.fromString(((JsonObject) jsonObj.get(CHECKSUM_OBJECT_NAME)).get(CHECKSUM_OBJECT_TYPE).getAsString());
+
         }
         
         // -------------------------------

--- a/src/main/java/edu/harvard/iq/dataverse/datasetutility/OptionalFileParams.java
+++ b/src/main/java/edu/harvard/iq/dataverse/datasetutility/OptionalFileParams.java
@@ -223,8 +223,9 @@ public class OptionalFileParams {
 		return mimeType;
 	}
 
-	public void setCheckSum(String checkSum) {
+	public void setCheckSum(String checkSum, ChecksumType type) {
 		this.checkSumValue = checkSum;
+		this.checkSumType = type;
 	}
 	
 	public boolean hasCheckSum() {

--- a/src/main/java/edu/harvard/iq/dataverse/util/FileUtil.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/FileUtil.java
@@ -732,6 +732,11 @@ public class FileUtil implements java.io.Serializable  {
     public static List<DataFile> createDataFiles(DatasetVersion version, InputStream inputStream, String fileName, String suppliedContentType, String newStorageIdentifier, String newCheckSum, ChecksumType newCheckSumType, SystemConfig systemConfig) throws IOException {
         List<DataFile> datafiles = new ArrayList<>();
 
+        //When there is no checksum/checksumtype being sent (normal upload, needs to be calculated), set the type to the current default
+        if(newCheckSumType == null) {
+            newCheckSumType = systemConfig.getFileFixityChecksumAlgorithm();
+        }
+
         String warningMessage = null;
 
         // save the file, in the temporary location for now: 

--- a/src/main/java/edu/harvard/iq/dataverse/util/FileUtil.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/FileUtil.java
@@ -719,7 +719,17 @@ public class FileUtil implements java.io.Serializable  {
         return "";
     }
     
-    public static List<DataFile> createDataFiles(DatasetVersion version, InputStream inputStream, String fileName, String suppliedContentType, String newStorageIdentifier, String newCheckSum, SystemConfig systemConfig) throws IOException {
+    public static List<DataFile> createDataFiles(DatasetVersion version, InputStream inputStream,
+            String fileName, String suppliedContentType, String newStorageIdentifier, String newCheckSum,
+            SystemConfig systemConfig)  throws IOException {
+        ChecksumType checkSumType = DataFile.ChecksumType.MD5;
+        if (newStorageIdentifier == null) {
+            checkSumType = systemConfig.getFileFixityChecksumAlgorithm();
+        }
+        return createDataFiles(version, inputStream, fileName, suppliedContentType, newStorageIdentifier, newCheckSum, checkSumType, systemConfig);
+    }
+    
+    public static List<DataFile> createDataFiles(DatasetVersion version, InputStream inputStream, String fileName, String suppliedContentType, String newStorageIdentifier, String newCheckSum, ChecksumType newCheckSumType, SystemConfig systemConfig) throws IOException {
         List<DataFile> datafiles = new ArrayList<>();
 
         String warningMessage = null;
@@ -1106,12 +1116,9 @@ public class FileUtil implements java.io.Serializable  {
         if (tempFile != null) {
             newFile = tempFile.toFile();
         }
-        ChecksumType checkSumType = DataFile.ChecksumType.MD5;
-        if (newStorageIdentifier == null) {
-            checkSumType = systemConfig.getFileFixityChecksumAlgorithm();
-        }
+        
 
-        DataFile datafile = createSingleDataFile(version, newFile, newStorageIdentifier, fileName, finalType, checkSumType, newCheckSum);
+        DataFile datafile = createSingleDataFile(version, newFile, newStorageIdentifier, fileName, finalType, newCheckSumType, newCheckSum);
         File f = null;
         if (tempFile != null) {
             f = tempFile.toFile();


### PR DESCRIPTION
**What this PR does / why we need it**: Allows different algorithms to be used for checksums/fixity in the s3 direct upload API, mirroring the underlying support for different algorithms in the Dataverse software.

**Which issue(s) this PR closes**:

Closes #7600

**Special notes for your reviewer**: 

**Suggestions on how to test this**: documentation in #7596 - should verify that direct upload via the UI still works (backwards compatibility). Could ask DANS to confirm that it works with other algorithms. Alternately, the minimal scenario would be to add a file in S3 with the same path as other files and then call this API with a value from some other algorithm (could use online tools to compute the hash). Following through the whole s3 direct upload process as described in #7596 would also work.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: no

**Is there a release notes update needed for this change?**:

**Additional documentation**:
