### PR TITLE
Fixed extra returns copied with api token on account pg [ref #7601]

### DIFF
--- a/src/main/webapp/dataverseuser.xhtml
+++ b/src/main/webapp/dataverseuser.xhtml
@@ -521,7 +521,7 @@
                                 //]]>
                             </script>
                             <div class="btn-toolbar" role="toolbar">
-                                <button class="btn btn-default btn-copy" data-clipboard-action="copy" data-clipboard-target="#apiToken code" type="button" jsf:rendered="#{ApiTokenPage.checkForApiToken() and !ApiTokenPage.tokenIsExpired()}">
+                                <button class="btn btn-default btn-copy" data-clipboard-action="copy" data-clipboard-text="#{ApiTokenPage.apiToken}" type="button" jsf:rendered="#{ApiTokenPage.checkForApiToken() and !ApiTokenPage.tokenIsExpired()}">
                                     #{bundle['copyClipboard']}
                                 </button>
                                 <button class="btn btn-default" jsf:action="#{ApiTokenPage.generate()}">

--- a/src/main/webapp/resources/js/dv_rebind_bootstrap_ui.js
+++ b/src/main/webapp/resources/js/dv_rebind_bootstrap_ui.js
@@ -202,7 +202,7 @@ function clickCopyClipboard(){
 
         // check which selector was clicked
         // swap icon for success ok
-        if ($(e.trigger).hasClass('btn-copy')) {
+        if ($(e.trigger).hasClass('glyphicon')) {
             $(e.trigger).removeClass('glyphicon-copy').addClass('glyphicon-ok text-success');
             // then swap icon back to clipboard
             // https://stackoverflow.com/a/54270499
@@ -211,9 +211,9 @@ function clickCopyClipboard(){
             }, 2000);
         }
         else {
-            $(e.trigger).next('.btn-copy').removeClass('glyphicon-copy').addClass('glyphicon-ok text-success');
+            $(e.trigger).next('.btn-copy.glyphicon').removeClass('glyphicon-copy').addClass('glyphicon-ok text-success');
             setTimeout(()=> {
-                $(e.trigger).next('.btn-copy').removeClass('glyphicon-ok text-success').addClass('glyphicon-copy')
+                $(e.trigger).next('.btn-copy.glyphicon').removeClass('glyphicon-ok text-success').addClass('glyphicon-copy')
             }, 2000);
         }
     });


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes odd bug in Firefox where extra returns were added before and after the api token when copied to the clipboard. Also fixes the copy function success from trying to add an "OK" success icon to the copy button.

**Which issue(s) this PR closes**:

Closes # N/A

Related to #6039 Copy buttons for API Token and Private URL 

**Special notes for your reviewer**:

To resolve this, rather have the plugin get the token from the `code` element on the pg, I am passing the token directly to the clipboard with a data attribute `data-clipboard-text="#{ApiTokenPage.apiToken}"` on the copy button.

**Suggestions on how to test this**:

Make sure you're only getting the single string of the api token from your clipboard, with no additional returns before or aftere. Phil was using the terminal commandline to prove this. Something pasting in a WYSIWYG that formats the text will not show you these odd invisible returns.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
