### PR TITLE
7612 - fix(ingest): No more JNDI lookup fails during deploy

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/ingest/IngestServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/ingest/IngestServiceBean.java
@@ -136,9 +136,9 @@ public class IngestServiceBean {
     @EJB
     SystemConfig systemConfig;
 
-    @Resource(name = "java:app/jms/queue/ingest")
+    @Resource(lookup = "java:app/jms/queue/ingest")
     Queue queue;
-    @Resource(name = "java:app/jms/factory/ingest")
+    @Resource(lookup = "java:app/jms/factory/ingest")
     QueueConnectionFactory factory;
     
 


### PR DESCRIPTION
**What this PR does / why we need it**:
As we produce the JMS topic and factory for Ingest in
`IngestQueueProducer` since Dataverse 5.3, error messages
about unsupported missing message-destination appeared.
This commit fixes the underlying cause by using lookup()
instead of name() for the @Resource dependency injection.

**Which issue(s) this PR closes**:

Closes #7612

**Special notes for your reviewer**:
Needs manual testing of Ingest!

**Suggestions on how to test this**:
Usual setup. Try real ingest, so the JMS part is actually used. Not sure API tests already cover that.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
None.

**Is there a release notes update needed for this change?**:
Nope.

**Additional documentation**:
None.
