### PR TITLE
Improved responsive layout, added word-break CSS to Assign Role popup on Manage Permissions pg

### DIFF
--- a/src/main/webapp/resources/css/structure.css
+++ b/src/main/webapp/resources/css/structure.css
@@ -645,7 +645,7 @@ div.ui-selectonemenu.form-control {padding:0px;}
 table.ui-selectoneradio {border-collapse:separate;}
 table.ui-selectoneradio td {padding:1px;}
 table.ui-selectoneradio span.ui-icon-bullet, .ui-radiobutton-box span.ui-icon-bullet {background-position: -81.3px -145.1px;}
-table.ui-selectoneradio label {font-weight: normal; margin-right:1em;}
+table.ui-selectoneradio label {font-weight: normal; margin-right:1em; word-break:break-all; /* BREAK ALL LONG STRING RESPONSIVE FIX */}
 .ui-radiobutton-box span.ui-radiobutton-icon {height: 16px; width: 16px; display: block; overflow: hidden;}
 
 div.ui-radiobutton {margin:0; vertical-align:text-bottom;}

--- a/src/main/webapp/roles-assign.xhtml
+++ b/src/main/webapp/roles-assign.xhtml
@@ -16,10 +16,10 @@
             <div class="form-horizontal">
                 <p class="help-block">#{bundle['dataverse.permissions.usersOrGroups.assignDialog.description']}</p>
                 <div class="form-group">
-                    <label for="userGroupAccessInput" class="col-sm-2 control-label">
+                    <label for="userGroupAccessInput" class="col-md-2 control-label">
                         #{bundle['dataverse.permissions.usersOrGroups.assignDialog.userOrGroup']} <span class="glyphicon glyphicon-asterisk text-danger" title="#{bundle.requiredField}"/>
                     </label>
-                    <div class="col-sm-9">
+                    <div class="col-md-9">
                         <p:autoComplete id="userGroupNameAssign" placeholder="#{bundle['dataverse.permissions.usersOrGroups.assignDialog.userOrGroup.enterName']}"
                                         multiple="true" scrollHeight="180" forceSelection="true"
                                         minQueryLength="2" queryDelay="1000"                                      
@@ -47,11 +47,11 @@
                     </div>
                 </div>
                 <div class="form-group">
-                    <label for="assignRoleRadios" class="col-sm-2 control-label">
+                    <label for="assignRoleRadios" class="col-md-2 control-label">
                         #{bundle['dataverse.permissions.usersOrGroups.tabHeader.role']} <span class="glyphicon glyphicon-asterisk text-danger" title="#{bundle.requiredField}"/>
                     </label>
-                    <div class="col-sm-10 form-group">
-                        <div class="col-sm-5">
+                    <div class="col-md-9">
+                        <div class="col-xs-6">
                             <p:fragment id="availableRoles">
                                 <p:selectOneRadio id="assignRoleRadios" layout="pageDirection"
                                                   value="#{managePermissionsPage.selectedRoleId}"
@@ -63,7 +63,7 @@
                                 <p:message for="assignRoleRadios" display="text"/>
                             </p:fragment>
                         </div>
-                        <div class="col-sm-7 bg-muted">
+                        <div class="col-xs-6 bg-muted">
                             <p:fragment id="roleDetails">
                                 <div id="assignRolePermissionLabels">
                                     <p class="help-block">#{bundle['dataverse.permissions.usersOrGroups.assignDialog.role.description']}</p>


### PR DESCRIPTION
**What this PR does / why we need it**:

When the name of the role is a longer string, the display is not correct and breaks onto a separate line below the checkbox (see attached screenshot).

![screen shot 2018-11-28 at 10 37 34 am](https://user-images.githubusercontent.com/6903515/49163032-29183c00-f2fa-11e8-8a4d-fa45bc4240c2.png)

**Which issue(s) this PR closes**:

Closes #5350 Display when assigning a role

Relates to #6578 Handle long strings in the UI

**Special notes for your reviewer**:

**Suggestions on how to test this**:

Hold SHIFT and reload browse page if you do not see the fixes right away, in order to force a reload of the stylesheet in your browser.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
