### PR TITLE
Removed inline calls to js function, added it to rebind function

### DIFF
--- a/src/main/webapp/dashboard-datamove.xhtml
+++ b/src/main/webapp/dashboard-datamove.xhtml
@@ -61,9 +61,6 @@
                                             <p:ajax process="@this" event="itemSelect" />
                                             <p:ajax process="@this" event="itemUnselect" />
                                         </p:autoComplete>
-                                        <script>
-                                            handle_dropdown_popup_scroll();
-                                        </script>
                                         <p:message for="sourceDatasetMenu"/>
                                     </div>
                                 </div>
@@ -105,9 +102,6 @@
                                             <p:ajax process="@this" event="itemSelect" />
                                             <p:ajax process="@this" event="itemUnselect" />
                                         </p:autoComplete>
-                                        <script>
-                                            handle_dropdown_popup_scroll();
-                                        </script>
                                         <p:message for="destinationDataverseMenu"/>
                                     </div>
                                 </div>             

--- a/src/main/webapp/explicitGroup-new-dialog.xhtml
+++ b/src/main/webapp/explicitGroup-new-dialog.xhtml
@@ -79,7 +79,6 @@
                             <p:ajax process="@this" event="itemSelect" />
                             <p:ajax process="@this" event="itemUnselect" />
                         </p:autoComplete>
-                        <!-- tried handle_dropdown_popup_scroll() fix here, conflicts -->
                     </div>
                 </div>
             </div>

--- a/src/main/webapp/harvestclients.xhtml
+++ b/src/main/webapp/harvestclients.xhtml
@@ -274,9 +274,6 @@
                                             <p:ajax process="@this" event="itemSelect" />
                                             <p:ajax process="@this" event="itemUnselect" />
                                         </p:autoComplete>
-                                        <script>
-                                            handle_dropdown_popup_scroll();
-                                        </script>
                                         <p:message for="destinationDataverseMenu"/>
                                     </div>
                                 </div>

--- a/src/main/webapp/manage-groups.xhtml
+++ b/src/main/webapp/manage-groups.xhtml
@@ -134,9 +134,6 @@
                                         <p:ajax process="@this" event="itemSelect" />
                                         <p:ajax process="@this" event="itemUnselect" />
                                     </p:autoComplete>
-                                    <script>
-                                        handle_dropdown_popup_scroll();
-                                    </script>
                                     <!-- <p:message for="roleAssigneeName" display="text"/> -->
                                 </div>
                             </div>

--- a/src/main/webapp/provenance-popups-fragment.xhtml
+++ b/src/main/webapp/provenance-popups-fragment.xhtml
@@ -94,9 +94,7 @@
                             forceSelection="true" 
                             converter="provEntityFileDataConverter"
                             styleClass="DropdownPopup" panelStyleClass="DropdownPopupPanel"
-                            onkeypress="if (event.keyCode == 13) {
-                                return false;
-                            }">
+                            onkeypress="if (event.keyCode == 13) {return false;}">
                             <p:column headerText="#{bundle['file.editProvenanceDialog.bundleEntity.nameHeader']}">
                                 <h:outputText value="#{provEntityFileData.fileName}" />
                             </p:column>
@@ -107,9 +105,6 @@
                                 <h:outputText value="#{provEntityFileData.entityName}" />
                             </p:column>
                         </p:autoComplete>
-                        <script>
-                            handle_dropdown_popup_scroll();
-                        </script>
                         <p:message for="provJsonNameDropdown" display="text"/>
                     </div>
                 </div>

--- a/src/main/webapp/resources/js/dv_rebind_bootstrap_ui.js
+++ b/src/main/webapp/resources/js/dv_rebind_bootstrap_ui.js
@@ -41,6 +41,9 @@ function bind_bsui_components(){
     // clipboard.js click to copy
     clickCopyClipboard();
     
+    // Scrolling autoComplete dropdown in popups
+    handle_dropdown_popup_scroll();
+    
     // Dialog Listener For Calling handleResizeDialog
     PrimeFaces.widget.Dialog.prototype.postShow = function() {
         var dialog_id = this.jq.attr('id').split(/[:]+/).pop();

--- a/src/main/webapp/roles-assign.xhtml
+++ b/src/main/webapp/roles-assign.xhtml
@@ -40,9 +40,6 @@
                             <p:ajax process="@this" event="itemSelect" />
                             <p:ajax process="@this" event="itemUnselect" />
                         </p:autoComplete>
-                        <script>
-                            handle_dropdown_popup_scroll();
-                        </script>
                         <p:message for="userGroupNameAssign" display="text"/>
                     </div>
                 </div>


### PR DESCRIPTION
**What this PR does / why we need it**:

Resolves ReferenceError in console when `handle_dropdown_popup_scroll()` function is called to fix a scrolling bug with the autoComplete component dropdown menu, when it is inside a popup.

The function call has been moved to the `bind_bsui_components()` function which is properly called when the document is ready. The reason we were seeing the ReferenceError is because the inline function call added under the autoComplete was being called before the javascript with the function is loaded by the page.

**Which issue(s) this PR closes**:

Closes #5653 handle_dropdown_popup_scroll is not defined on `permissions-manage.xhtml`

**Special notes for your reviewer**:

**Suggestions on how to test this**:

Might need to hold SHIFT and reload the page a few times to clear the browser cache and get a fresh copy of the dv_rebind_bootstrap_ui.js file from the server with the new code fix.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
