### PR TITLE
properly report error from editVersionMetadata

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/api/Datasets.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Datasets.java
@@ -805,11 +805,16 @@ public class Datasets extends AbstractApiBean {
     
     @PUT
     @Path("{id}/editMetadata")
-    public Response editVersionMetadata(String jsonBody, @PathParam("id") String id, @QueryParam("replace") Boolean replace) throws WrappedResponse{
+    public Response editVersionMetadata(String jsonBody, @PathParam("id") String id, @QueryParam("replace") Boolean replace) {
 
         Boolean replaceData = replace != null;
-
-        DataverseRequest req = createDataverseRequest(findUserOrDie());
+        DataverseRequest req = null;
+        try {
+         req = createDataverseRequest(findUserOrDie());
+        } catch (WrappedResponse ex) {
+            logger.log(Level.SEVERE, "Edit metdata error: " + ex.getMessage(), ex);
+            return ex.getResponse();
+        }
 
         return processDatasetUpdate(jsonBody, id, req, replaceData);
     }


### PR DESCRIPTION
**What this PR does / why we need it**: This PR unwraps a WrappedResponse to make the call properly return a useful error/proper status code if/when the user can't be found (e.g. an invalid apikey)

**Which issue(s) this PR closes**:

Closes #

**Special notes for your reviewer**: This issue appears to be one of a few related ones where API calls throw WrappedResponse. That doesn't work. There is a pattern where AbstractAPIBean handles the unwrapping (see [createPrivateUrl()](https://github.com/IQSS/dataverse/blob/3600a0e3498f767473e5e473a67956661c029c70/src/main/java/edu/harvard/iq/dataverse/api/Datasets.java#L1217-L1223) for example, but some calls through the WrappedResponse without using it, and those are broken. The PR fixes one of those. If that's the way to fix others, I can scan for the rest, but if there's an alternate approach, it would be good to define it before doing the rest. Due to this, I haven't added #7588 in the Closes section above yet.

**Suggestions on how to test this**: Send a bad api key to the /editMetadata method.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: no

**Is there a release notes update needed for this change?**:

**Additional documentation**:
