### PR TITLE
restricted summary stats #7619

### DIFF
--- a/doc/release-notes/7619-restricted-summary-starts.md
+++ b/doc/release-notes/7619-restricted-summary-starts.md
@@ -1,0 +1,14 @@
+Restricted Files and DDI "dataDscr" Information (Summary Statistics, Variable Names, Variable Labels)
+
+In previous releases, DDI "dataDscr" information (summary statistics, variable names, and variable labels, sometimes known as "variable metadata") for tabular files that were ingested successfully were available even if files were restricted. This has been changed in the following ways:
+
+- At the dataset level, DDI exports no longer show "dataDscr" information for restricted files. There is only one version of this export and it is the version that's suitable for public consumption with the "dataDscr" information hidden for restricted files.
+- Similarly, at the dataset level, the DDI HTML Codebook no longer shows "dataDscr" information for restricted files. 
+- At the file level, "dataDscr" information is no longer publicly available for restricted files. In practice, it was only possible to get this publicly via API (the download/access button was hidden).
+- At the file level, "dataDscr" (variable metadata) information can still be downloaded for restricted files if you have access to download the file.
+
+After upgrading, you should re-export to replace cached DDI exports with restricted summary stats with DDI exports fit for public consumption:
+
+    curl http://localhost:8080/api/admin/metadata/reExportAll
+
+For details on this operation, see https://guides.dataverse.org/en/5.4/admin/metadataexport.html

--- a/doc/sphinx-guides/source/user/dataset-management.rst
+++ b/doc/sphinx-guides/source/user/dataset-management.rst
@@ -179,8 +179,6 @@ Additional download options available for tabular data (found in the same drop-d
 - Data File Citation (currently in either RIS, EndNote XML, or BibTeX format); 
 - All of the above, as a zipped bundle. 
 
-See also :ref:`restricted-tabular-files`.
-
 Astronomy (FITS)
 ----------------
 
@@ -213,19 +211,6 @@ Restricted Files
 When you restrict a file it cannot be downloaded unless permission has been granted.
 
 See also :ref:`terms-of-access` and :ref:`permissions`.
-
-.. _restricted-tabular-files:
-
-Restricted Tabular Files
-------------------------
-
-Restricted tabular files are treated differently than other file types in that the following information is exposed when the files are published:
-
-- The name of columns (variables).
-- The "label" (description) of columns.
-- Summary statistics (max, min, mean, etc.) of columns.
-
-This information can been seen from the file landing page if you click "Export Metada" and then "DDI". Depending on your installation, the information above may also be available from :doc:`/admin/external-tools`.
 
 Edit Files
 ==========

--- a/src/main/java/edu/harvard/iq/dataverse/api/errorhandlers/WebApplicationExceptionHandler.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/errorhandlers/WebApplicationExceptionHandler.java
@@ -47,7 +47,7 @@ public class WebApplicationExceptionHandler implements ExceptionMapper<WebApplic
                 if ( (ex.getMessage()+"").toLowerCase().startsWith("tabular data required")) {
                     jrb.message(BundleUtil.getStringFromBundle("access.api.exception.metadata.not.available.for.nontabular.file"));
                 } else if ((ex.getMessage() + "").toLowerCase().startsWith("no permission to download file")) {
-                    jrb.message("You do not have permission to download this file.");
+                    jrb.message(BundleUtil.getStringFromBundle("access.api.exception.metadata.restricted.no.permission"));
                 } else {
                     jrb.message("Bad Request. The API request cannot be completed with the parameters supplied. Please check your code for typos, or consult our API guide at http://guides.dataverse.org.");
                     jrb.request(request);

--- a/src/main/java/edu/harvard/iq/dataverse/api/errorhandlers/WebApplicationExceptionHandler.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/errorhandlers/WebApplicationExceptionHandler.java
@@ -43,8 +43,11 @@ public class WebApplicationExceptionHandler implements ExceptionMapper<WebApplic
         switch (ex.getResponse().getStatus()) {
             // BadRequest
             case 400:
+                // It's strange to have these "startsWith" conditionals here. They both come from Access.java.
                 if ( (ex.getMessage()+"").toLowerCase().startsWith("tabular data required")) {
                     jrb.message(BundleUtil.getStringFromBundle("access.api.exception.metadata.not.available.for.nontabular.file"));
+                } else if ((ex.getMessage() + "").toLowerCase().startsWith("no permission to download file")) {
+                    jrb.message("You do not have permission to download this file.");
                 } else {
                     jrb.message("Bad Request. The API request cannot be completed with the parameters supplied. Please check your code for typos, or consult our API guide at http://guides.dataverse.org.");
                     jrb.request(request);

--- a/src/main/java/edu/harvard/iq/dataverse/export/ddi/DdiExportUtil.java
+++ b/src/main/java/edu/harvard/iq/dataverse/export/ddi/DdiExportUtil.java
@@ -1388,6 +1388,17 @@ public class DdiExportUtil {
         for (FileMetadata fileMetadata : datasetVersion.getFileMetadatas()) {
             DataFile dataFile = fileMetadata.getDataFile();
 
+            /**
+             * Previously (in Dataverse 5.3 and below) the dataDscr section was
+             * included for restricted files but that meant that summary
+             * statistics were exposed. (To get at these statistics, API users
+             * should instead use the "Data Variable Metadata Access" endpoint.)
+             * These days we return early to avoid this exposure.
+             */
+            if (dataFile.isRestricted()) {
+                return;
+            }
+
             if (dataFile != null && dataFile.isTabularData()) {
                 if (!tabularData) {
                     xmlw.writeStartElement("dataDscr");

--- a/src/main/java/propertyFiles/Bundle.properties
+++ b/src/main/java/propertyFiles/Bundle.properties
@@ -2354,6 +2354,7 @@ access.api.requestList.fileNotFound=Could not find datafile with id {0}.
 access.api.requestList.noKey=You must provide a key to get list of access requests for a file. 
 access.api.requestList.noRequestsFound=There are no access requests for this file {0}.
 access.api.exception.metadata.not.available.for.nontabular.file=This type of metadata is only available for tabular files.
+access.api.exception.metadata.restricted.no.permission=You do not have permission to download this file.
 access.api.exception.version.not.found=Could not find requested dataset version.
 
 #permission

--- a/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
@@ -834,6 +834,22 @@ public class UtilIT {
                 .get("/api/access/datafile/" + idInPath + "/metadata" + optionalFormatInPath + "?key=" + apiToken + optionalQueryParam);
     }
 
+    static Response getFileMetadata(String fileIdOrPersistentId, String optionalFormat) {
+        String idInPath = fileIdOrPersistentId; // Assume it's a number.
+        String optionalQueryParam = ""; // If idOrPersistentId is a number we'll just put it in the path.
+        if (!NumberUtils.isNumber(fileIdOrPersistentId)) {
+            idInPath = ":persistentId";
+            optionalQueryParam = "?persistentId=" + fileIdOrPersistentId;
+        }
+        String optionalFormatInPath = "";
+        if (optionalFormat != null) {
+            optionalFormatInPath = "/" + optionalFormat;
+        }
+        return given()
+                .urlEncodingEnabled(false)
+                .get("/api/access/datafile/" + idInPath + "/metadata" + optionalFormatInPath + optionalQueryParam);
+    }
+
     static Response testIngest(String fileName, String fileType) {
         return given()
                 .get("/api/ingest/test/file?fileName=" + fileName + "&fileType=" + fileType);
@@ -1634,11 +1650,19 @@ public class UtilIT {
 //        }
 //        return requestSpecification.delete("/api/files/" + idInPath + "/prov-freeform" + optionalQueryParam);
 //    }
+    static Response exportDataset(String datasetPersistentId, String exporter) {
+        return exportDataset(datasetPersistentId, exporter, null);
+    }
 
     static Response exportDataset(String datasetPersistentId, String exporter, String apiToken) {
 //        http://localhost:8080/api/datasets/export?exporter=dataverse_json&persistentId=doi%3A10.5072/FK2/W6WIMQ
-        return given()
-                .header(API_TOKEN_HTTP_HEADER, apiToken)
+        RequestSpecification requestSpecification = given();
+        if (apiToken != null) {
+            requestSpecification = given()
+                    .header(UtilIT.API_TOKEN_HTTP_HEADER, apiToken);
+        }
+        return requestSpecification
+                //                .header(API_TOKEN_HTTP_HEADER, apiToken)
                 //                .get("/api/datasets/:persistentId/export" + "?persistentId=" + datasetPersistentId + "&exporter=" + exporter);
                 .get("/api/datasets/export" + "?persistentId=" + datasetPersistentId + "&exporter=" + exporter);
     }


### PR DESCRIPTION
**What this PR does / why we need it**:

In the future we want to offer differentially private summary statistics for restricted data which means that restricted data should not present full summary statistics (and related information). This pull request corrects this.

**Which issue(s) this PR closes**:

Closes #7619

**Special notes for your reviewer**:

Not particularly. See the release note and the code. I'm weirded out by the existing BadRequestException error handling in Access.java and WebApplicationExceptionHandler.java. I just accepted the pattern of putting a string in the former and the real message in the latter.

**Suggestions on how to test this**:

Please see the release note, especially:

- At the dataset level, DDI exports no longer show "dataDscr" information for restricted files. There is only one version of this export and it is the version that's suitable for public consumption with the "dataDscr" information hidden for restricted files.
- Similarly, at the dataset level, the DDI HTML Codebook no longer shows "dataDscr" information for restricted files. 
- At the file level, "dataDscr" information is no longer publicly available for restricted files. In practice, it was only possible to get this publicly via API (the download/access button was hidden).
- At the file level, "dataDscr" (variable metadata) information can still be downloaded for restricted files if you have access to download the file.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

The DDI HTML Codebook will no longer show for restricted files summary statistics, names of variables, or descriptions of variables. Instead, you will only see the count of rows and columns, type of file, and the UNF like this:

<img width="505" alt="Screen Shot 2021-02-26 at 10 56 36 AM" src="https://user-images.githubusercontent.com/21006/109329594-c68bae80-7828-11eb-9ec8-a0234aa17f34.png">

**Is there a release notes update needed for this change?**:

Yes, included.

**Additional documentation**:

Documentation was actually removed because we used to warn people (pull request #6620) about summary statistics being publicly available for restricted data. Now we don't need to.