### PR TITLE
Workflow speed improvement

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/FinalizeDatasetPublicationCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/FinalizeDatasetPublicationCommand.java
@@ -186,7 +186,7 @@ public class FinalizeDatasetPublicationCommand extends AbstractPublishDatasetCom
         //Should this be in onSuccess()?
         ctxt.workflows().getDefaultWorkflow(TriggerType.PostPublishDataset).ifPresent(wf -> {
             try {
-                ctxt.workflows().start(wf, buildContext(ds, TriggerType.PostPublishDataset, datasetExternallyReleased));
+                ctxt.workflows().start(wf, buildContext(ds, TriggerType.PostPublishDataset, datasetExternallyReleased), false);
             } catch (CommandException ex) {
                 ctxt.datasets().removeDatasetLocks(ds, DatasetLock.Reason.Workflow);
                 logger.log(Level.SEVERE, "Error invoking post-publish workflow: " + ex.getMessage(), ex);

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/PublishDatasetCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/PublishDatasetCommand.java
@@ -96,7 +96,7 @@ public class PublishDatasetCommand extends AbstractPublishDatasetCommand<Publish
             // We start a workflow
             theDataset = ctxt.em().merge(theDataset);
             ctxt.em().flush();
-            ctxt.workflows().start(prePubWf.get(), buildContext(theDataset, TriggerType.PrePublishDataset, datasetExternallyReleased));
+            ctxt.workflows().start(prePubWf.get(), buildContext(theDataset, TriggerType.PrePublishDataset, datasetExternallyReleased), true);
             return new PublishDatasetResult(theDataset, Status.Workflow);
             
         } else{

--- a/src/main/java/edu/harvard/iq/dataverse/workflow/WorkflowServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/workflow/WorkflowServiceBean.java
@@ -99,18 +99,43 @@ public class WorkflowServiceBean {
      */
     //ToDo - should this be @Async? or just the forward() method?
     @Asynchronous
-    public void start(Workflow wf, WorkflowContext ctxt) throws CommandException {
-        
-        // Since we are calling this asynchronously anyway - sleep here 
-        // for a few seconds, just in case, to make sure the database update of 
-        // the dataset initiated by the PublishDatasetCommand has finished, 
-        // to avoid any concurrency/optimistic lock issues. 
-        try {
-            Thread.sleep(1000);
-        } catch (Exception ex) {
-            logger.warning("Failed to sleep for a second.");
+    public void start(Workflow wf, WorkflowContext ctxt, boolean findDataset) throws CommandException {
+        /*
+         * Workflows appear to start running prior to the caller's transaction
+         * completing which can result in exceptions in setting the lock below. To avoid
+         * this, there are two work-arounds - wait briefly for that transaction to end,
+         * or refresh the dataset from the db - so the lock is written based on the
+         * current db state. The latter works for pre-publication workflows (since the
+         * only changes to the Dataset in the Publish command are edits to the version
+         * number in the draft version (which aren't valid for the draft anyway)), while
+         * the former is required for post-publication workflows which may need to see
+         * the final version number, update times and other changes made in the Finalize
+         * Publication command. Not waiting saves significant time when many datasets
+         * are processed, so is prefereable when it makes sense.
+         * 
+         * This code should be reconsidered if/when the launching of pre/post
+         * publication workflows is moved to command onSuccess methods (and when
+         * onSuccess methods are guaranteed to be after the transaction completes (see
+         * #7568) or other changes are made that can guarantee the dataset in the
+         * WorkflowContext is up-to-date/usable in further transactions in the workflow.
+         * (e.g. if this method is not asynchronous)
+         * 
+         */
+
+        if (!findDataset) {
+            /*
+             * Sleep here briefly to make sure the database update from the callers
+             * transaction completes which avoids any concurrency/optimistic lock issues.
+             * Note: 1 second appears long enough, but shorter delays may work
+             */
+            try {
+                Thread.sleep(1000);
+            } catch (Exception ex) {
+                logger.warning("Failed to sleep for a second.");
+            }
         }
-        ctxt = refresh(ctxt, retrieveRequestedSettings( wf.getRequiredSettings()), getCurrentApiToken(ctxt.getRequest().getAuthenticatedUser()));
+        //Refresh will only em.find the dataset if findDataset is true. (otherwise the dataset is em.merged)
+        ctxt = refresh(ctxt, retrieveRequestedSettings( wf.getRequiredSettings()), getCurrentApiToken(ctxt.getRequest().getAuthenticatedUser()), findDataset);
         lockDataset(ctxt, new DatasetLock(DatasetLock.Reason.Workflow, ctxt.getRequest().getAuthenticatedUser()));
         forward(wf, ctxt);
     }
@@ -466,18 +491,39 @@ public class WorkflowServiceBean {
     private WorkflowContext refresh( WorkflowContext ctxt ) {
     	return refresh(ctxt, ctxt.getSettings(), ctxt.getApiToken());
     }
-    
-    private WorkflowContext refresh( WorkflowContext ctxt, Map<String, Object> settings, ApiToken apiToken ) {
-    	/* An earlier version of this class used em.find() to 'refresh' the Dataset in the context. 
-    	 * For a PostPublication workflow, this had the consequence of hiding/removing changes to the Dataset 
-    	 * made in the FinalizeDatasetPublicationCommand (i.e. the fact that the draft version is now released and
-    	 * has a version number). It is not clear to me if the em.merge below is needed or if it handles the case of 
-    	 * resumed workflows. (The overall method is needed to allow the context to be updated in the start() method with the
-    	 * settings and APItoken retrieved by the WorkflowServiceBean) - JM - 9/18.
-    	 */
-        WorkflowContext newCtxt =new WorkflowContext( ctxt.getRequest(), 
-                em.merge(ctxt.getDataset()), ctxt.getNextVersionNumber(), 
-                ctxt.getNextMinorVersionNumber(), ctxt.getType(), settings, apiToken, ctxt.getDatasetExternallyReleased(), ctxt.getInvocationId(), ctxt.getLockId());
+
+    private WorkflowContext refresh(WorkflowContext ctxt, Map<String, Object> settings, ApiToken apiToken) {
+        return refresh(ctxt, settings, apiToken, false);
+    }
+
+    private WorkflowContext refresh(WorkflowContext ctxt, Map<String, Object> settings, ApiToken apiToken,
+            boolean findDataset) {
+        /*
+         * An earlier version of this class used em.find() to 'refresh' the Dataset in
+         * the context. For a PostPublication workflow, this had the consequence of
+         * hiding/removing changes to the Dataset made in the
+         * FinalizeDatasetPublicationCommand (i.e. the fact that the draft version is
+         * now released and has a version number). It is not clear to me if the em.merge
+         * below is needed or if it handles the case of resumed workflows. (The overall
+         * method is needed to allow the context to be updated in the start() method
+         * with the settings and APItoken retrieved by the WorkflowServiceBean) - JM -
+         * 9/18.
+         */
+        /*
+         * Introduced the findDataset boolean to optionally revert above change.
+         * Refreshing the Dataset just before trying to set the workflow lock greatly
+         * reduces the number of OptimisticLockExceptions. JvM 2/21
+         */
+        WorkflowContext newCtxt;
+        if (findDataset) {
+            newCtxt = new WorkflowContext(ctxt.getRequest(), datasets.find(ctxt.getDataset().getId()),
+                    ctxt.getNextVersionNumber(), ctxt.getNextMinorVersionNumber(), ctxt.getType(), settings, apiToken,
+                    ctxt.getDatasetExternallyReleased(), ctxt.getInvocationId(), ctxt.getLockId());
+        } else {
+            newCtxt = new WorkflowContext(ctxt.getRequest(), em.merge(ctxt.getDataset()), ctxt.getNextVersionNumber(),
+                    ctxt.getNextMinorVersionNumber(), ctxt.getType(), settings, apiToken,
+                    ctxt.getDatasetExternallyReleased(), ctxt.getInvocationId(), ctxt.getLockId());
+        }
         return newCtxt;
     }
 


### PR DESCRIPTION
**What this PR does / why we need it**: Removes a delay in launching prepublication workflows

**Which issue(s) this PR closes**:

Closes #7681

**Special notes for your reviewer**: small PR to incorporate a DANS performance improvement

**Suggestions on how to test this**: pre and post pub workflows should still work. Could run a workflow with the log step for prepublication. Setting up the local file archiver for post publication would allow checking that the version of the created bag matches the version of the new publication (versus being one behind, which was an error fixed in this same section of code.)

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: no

**Is there a release notes update needed for this change?**: no

**Additional documentation**:
