### PR TITLE
7684 - fix class import for HTTPException in DeletePidCommand

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/DeletePidCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/DeletePidCommand.java
@@ -13,11 +13,11 @@ import edu.harvard.iq.dataverse.engine.command.exception.IllegalCommandException
 import edu.harvard.iq.dataverse.engine.command.exception.PermissionException;
 import edu.harvard.iq.dataverse.settings.SettingsServiceBean;
 import edu.harvard.iq.dataverse.util.BundleUtil;
+import org.apache.commons.httpclient.HttpException;
+
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.logging.Logger;
-
-import javax.xml.ws.http.HTTPException;
 
 /**
  * No required permissions because we check for superuser status.
@@ -51,8 +51,8 @@ public class DeletePidCommand extends AbstractVoidCommand {
             dataset.setGlobalIdCreateTime(null);
             dataset.setIdentifierRegistered(false);
             ctxt.datasets().merge(dataset);
-        } catch (HTTPException hex) {
-        	String message = BundleUtil.getStringFromBundle("pids.deletePid.failureExpected", Arrays.asList(dataset.getGlobalId().asString(), Integer.toString(hex.getStatusCode())));
+        } catch (HttpException hex) {
+        	String message = BundleUtil.getStringFromBundle("pids.deletePid.failureExpected", Arrays.asList(dataset.getGlobalId().asString(), Integer.toString(hex.getReasonCode())));
             logger.info(message);
             throw new IllegalCommandException(message, this);
         } catch (Exception ex) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixing a small wrong import of a class, most likely happened by accident.

**Which issue(s) this PR closes**:

Closes #7684

**Special notes for your reviewer**:
None

**Suggestions on how to test this**:
Seems hard to force a HTTPException by DataCite. This might be tested with some more advanced stuff like response mocking.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
Nope

**Is there a release notes update needed for this change?**:
Nope

**Additional documentation**:
