### PR TITLE
IQSS/7687-Curate command updates

### DIFF
--- a/doc/release-notes/7687-curate-command.md
+++ b/doc/release-notes/7687-curate-command.md
@@ -1,0 +1,9 @@
+## Notes for Dataverse Installation Administrators
+
+### DB Cleanup for Superusers Releasing without Version Updates
+
+In datasets where a superuser has run the Curate command and the update included a change to the fileaccessrequest flag, those changes would not be reflected appropriately in the published version. This should be a rare occurrence.
+
+Instead of an automated solution, we recommend inspecting the affected datasets and correcting the fileaccessrequest flag as appropriate. You can identify the affected datasets this via a query, which is available in the folder here:
+
+https://github.com/IQSS/dataverse/raw/develop/scripts/issues/7687/

--- a/scripts/issues/7687/file_access_flag_update_bug.txt
+++ b/scripts/issues/7687/file_access_flag_update_bug.txt
@@ -1,0 +1,11 @@
+-- this query will identify datasets where a superuser has run the Curate command and the update included a change to the fileaccessrequest flag, resulting in the file access request updates not being reflected in the published version
+
+select da.id, dv.id, ta.id, da.fileaccessrequest, ta.fileaccessrequest, dv.releasetime 
+from datasetversion dv, termsofuseandaccess ta, dataset da 
+where dv.dataset_id=da.id 
+and dv.termsofuseandaccess_id=ta.id 
+and ta.fileaccessrequest != da.fileaccessrequest 
+and dv.versionstate='RELEASED' 
+and dv.releasetime in (select max(releasetime) 
+from datasetversion 
+where dataset_id=da.id);

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/CuratePublishedDatasetVersionCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/CuratePublishedDatasetVersionCommand.java
@@ -61,7 +61,7 @@ public class CuratePublishedDatasetVersionCommand extends AbstractDatasetCommand
         // final DatasetVersion editVersion = getDataset().getEditVersion();
         tidyUpFields(updateVersion);
 
-        // Merge the new version into out JPA context
+        // Merge the new version into our JPA context
         ctxt.em().merge(updateVersion);
 
 
@@ -71,7 +71,8 @@ public class CuratePublishedDatasetVersionCommand extends AbstractDatasetCommand
         updateVersion.setTermsOfUseAndAccess(newTerms);
         //Put old terms on version that will be deleted....
         getDataset().getEditVersion().setTermsOfUseAndAccess(oldTerms);
-        
+        //Also set the fileaccessrequest boolean on the dataset to match the new terms
+        getDataset().setFileAccessRequest(updateVersion.getTermsOfUseAndAccess().isFileAccessRequest());
         List<WorkflowComment> newComments = getDataset().getEditVersion().getWorkflowComments();
         if (newComments!=null && newComments.size() >0) {
             for(WorkflowComment wfc: newComments) {
@@ -162,7 +163,7 @@ public class CuratePublishedDatasetVersionCommand extends AbstractDatasetCommand
         // Update modification time on the published version and the dataset
         updateVersion.setLastUpdateTime(getTimestamp());
         tempDataset.setModificationTime(getTimestamp());
-
+        ctxt.em().merge(updateVersion);
         Dataset savedDataset = ctxt.em().merge(tempDataset);
 
         // Flush before calling DeleteDatasetVersion which calls


### PR DESCRIPTION
**What this PR does / why we need it**: Fixes a bug where the Curate (update an existing published dataset) command, usable by superadmins, didn't correctly update the file access request allowed flag if it was changed in the update. The PR also include a couple other fixes updates - at QDR, file name updates were being dropped, noticed after the equivalent of #7337 was merged. Also changing the permission annotation (see issue discussion).

**Which issue(s) this PR closes**:

Closes #7687

**Special notes for your reviewer**:  The file access request issue was just discovered and I've verified the fix at QDR. The change to add a merge of the datasetversion makes sense, but I'm just catching up from last year on that and my notes indicate that I thought some change related to #7337 could be involved, but it's possible that the problem affects develop.
W.r.t. addressing legacy db issues - I hope use is fairly rare and that if there were any name issues, those would have been caught/reported. The file access flag was more subtle, so easier to miss. As I noted in the issue, I'm not sure a flyway script makes sense but I could add a release note (that could either point to the query I listed that would help find instances and/or just point out that you can just do the update again to fix any affected datasets). Let me know what makes the most sense.

**Suggestions on how to test this**: Change the file request access flag in the Terms panel and update a file name, then use the Curate command and verify that Terms panel shows the flag update and/or that a restricted file acts as specified by the flag (requesting access is/isn't allowed), and make sure the file name changed.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: no

**Is there a release notes update needed for this change?**: Some note along the lines of 'Bugs were found in the functionality allowing superadmins to update a published dataset version (without creating a new version) involving the Terms setting on whether to allow file access requests and with file name changes.  If you have used this functionality, issue #7687 provides details and includes an sql query that will help in identifying any affected dataset.'

**Additional documentation**:
