### PR TITLE
Fix intermittent Bag generation failure

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/util/bagit/BagGenerator.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/bagit/BagGenerator.java
@@ -93,7 +93,6 @@ public class BagGenerator {
     private int timeout = 60;
     private RequestConfig config = RequestConfig.custom().setConnectTimeout(timeout * 1000)
             .setConnectionRequestTimeout(timeout * 1000).setSocketTimeout(timeout * 1000).build();
-    private static HttpClientContext localContext = HttpClientContext.create();
     protected CloseableHttpClient client;
     private PoolingHttpClientConnectionManager cm = null;
 
@@ -986,7 +985,8 @@ public class BagGenerator {
                         HttpGet getMap = createNewGetRequest(new URI(uri), null);
                         logger.finest("Retrieving " + tries + ": " + uri);
                         CloseableHttpResponse response;
-                        response = client.execute(getMap, localContext);
+                        //Note - if we ever need to pass an HttpClientContext, we need a new one per thread.
+                        response = client.execute(getMap);
                         if (response.getStatusLine().getStatusCode() == 200) {
                             logger.finest("Retrieved: " + uri);
                             return response.getEntity().getContent();


### PR DESCRIPTION
**What this PR does / why we need it**: Fixes an issue in Bag generation related to parallel zipping of the Datafiles in a dataset. 

**Which issue(s) this PR closes**:

Closes #7731 

**Special notes for your reviewer**: In addition to QDR seeing this issue, TDL has reported some problem with the batch generation of Bags (in #7494) which could be from this issue (still trying to get details).

**Suggestions on how to test this**: Since this is an intermittent problem, it may be hard to fully test. SO - regression testing - just to assure that Bags created with this PR are the same as those without is probably enough. (If any bag generation failures are seen, this PR should have fewer (and hopefully none - let me know if any are seen)). The standard setup for creating Bags applies, e.g. setting up a file system archiver and either setting up a post publish workflow or calling the archiving api to create Bags.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:no

**Is there a release notes update needed for this change?**: no

**Additional documentation**:
