### PR TITLE
fix failing test for deactivate by id #7629

### DIFF
--- a/src/test/java/edu/harvard/iq/dataverse/api/DeactivateUsersIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/DeactivateUsersIT.java
@@ -141,14 +141,12 @@ public class DeactivateUsersIT {
 
     @Test
     public void testDeactivateUserById() {
-
+        
         Response createUser = UtilIT.createRandomUser();
         createUser.prettyPrint();
         createUser.then().assertThat().statusCode(OK.getStatusCode());
-        String username = UtilIT.getUsernameFromResponse(createUser);
+        
         Long userId = JsonPath.from(createUser.body().asString()).getLong("data.authenticatedUser.id");
-        String apiToken = UtilIT.getApiTokenFromResponse(createUser);
-
         Response deactivateUser = UtilIT.deactivateUser(userId);
         deactivateUser.prettyPrint();
         deactivateUser.then().assertThat().statusCode(OK.getStatusCode());

--- a/src/test/java/edu/harvard/iq/dataverse/api/DeactivateUsersIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/DeactivateUsersIT.java
@@ -142,19 +142,11 @@ public class DeactivateUsersIT {
     @Test
     public void testDeactivateUserById() {
 
-        Response createSuperuser = UtilIT.createRandomUser();
-        createSuperuser.then().assertThat().statusCode(OK.getStatusCode());
-        String superuserUsername = UtilIT.getUsernameFromResponse(createSuperuser);
-        String superuserApiToken = UtilIT.getApiTokenFromResponse(createSuperuser);
-        Response toggleSuperuser = UtilIT.makeSuperUser(superuserUsername);
-        toggleSuperuser.then().assertThat()
-                .statusCode(OK.getStatusCode());
-
         Response createUser = UtilIT.createRandomUser();
         createUser.prettyPrint();
         createUser.then().assertThat().statusCode(OK.getStatusCode());
         String username = UtilIT.getUsernameFromResponse(createUser);
-        Long userId = JsonPath.from(createUser.body().asString()).getLong("data.user.id");
+        Long userId = JsonPath.from(createUser.body().asString()).getLong("data.authenticatedUser.id");
         String apiToken = UtilIT.getApiTokenFromResponse(createUser);
 
         Response deactivateUser = UtilIT.deactivateUser(userId);


### PR DESCRIPTION
**What this PR does / why we need it**:

Tests are failing.

Use the id from authenticateduser rather than builtinuser.

Also remove superuser, no longer needed.

**Which issue(s) this PR closes**:

None but fixes a test introduced in pull request #7629

**Special notes for your reviewer**:

None.

**Suggestions on how to test this**:

Run the test suite.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No.

**Is there a release notes update needed for this change?**:

No.

**Additional documentation**:

None.