### PR TITLE
ignore maven/ subdirectory created by docker-aio scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,10 @@ conf/docker-aio/dv/deps/
 conf/docker-aio/dv/install/dvinstall.zip
 # or copy of test data
 conf/docker-aio/testdata/
+
+# docker-aio creates maven/ which reports 86 new files. ignore this wd.
+maven/
+
 scripts/installer/default.config
 *.pem
 


### PR DESCRIPTION
**What this PR does / why we need it**: quiesce noisy maven/ subdirectory in `git status`

**Which issue(s) this PR closes**:

Closes #7735

**Special notes for your reviewer**: none

**Suggestions on how to test this**: run docker-aio scripts, then `git status`

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: no

**Is there a release notes update needed for this change?**: no

**Additional documentation**: none
