### PR TITLE
#7775 remove unwanted lines

### DIFF
--- a/scripts/dev/dev-rebuild.sh
+++ b/scripts/dev/dev-rebuild.sh
@@ -52,9 +52,6 @@ cd scripts/api
 ./setup-all.sh --insecure -p=admin1 | tee /tmp/setup-all.sh.out
 cd ../..
 
-echo "Loading SQL reference data..."
-psql -U $DB_USER $DB_NAME -f scripts/database/reference_data.sql
-
 echo "Creating SQL sequence..."
 psql -U $DB_USER $DB_NAME -f doc/sphinx-guides/source/_static/util/createsequence.sql
 


### PR DESCRIPTION
**What this PR does / why we need it**: It removes an unwanted command from the dev install script. The command refers to an SQL script which has been already deleted from the repository. 

**Which issue(s) this PR closes**: #7775 

Closes #7775

**Special notes for your reviewer**: The referred SQL script has been deleted because it has been integrated as a Flyway migration script (see #7355).

**Suggestions on how to test this**: Run this script.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: no

**Is there a release notes update needed for this change?**: no

**Additional documentation**: no
