### PR TITLE
guide change, for the download API. 

### DIFF
--- a/doc/sphinx-guides/source/api/dataaccess.rst
+++ b/doc/sphinx-guides/source/api/dataaccess.rst
@@ -87,7 +87,7 @@ Basic access URI:
 
   Example: Getting the file whose DOI is *10.5072/FK2/J8SJZB* ::
 
-    GET http://$SERVER/api/access/datafile/:persistentId/?persistentId=doi:10.5072/FK2/J8SJZB
+    GET http://$SERVER/api/access/datafile/:persistentId?persistentId=doi:10.5072/FK2/J8SJZB
 
 
 Parameters:


### PR DESCRIPTION
a minor change in the data access guide - removes the trailing slash from the download-by-persistent-id API example in the guide . (#7787)

(the version with the backslash is still going to be supported! this is just to advertise/recommend the cleaner notation)

**What this PR does / why we need it**:

**Which issue(s) this PR closes**:

Closes #

**Special notes for your reviewer**:

Not really crucial... if you have any reason not to want to mess with this guide - please speak up. 


**Suggestions on how to test this**:

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
