### PR TITLE
Escape description for use in datacite xml (file and datacite api call)

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DOIDataCiteRegisterService.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DOIDataCiteRegisterService.java
@@ -5,7 +5,6 @@
  */
 package edu.harvard.iq.dataverse;
 
-import edu.harvard.iq.dataverse.AbstractGlobalIdServiceBean.GlobalIdMetadataTemplate;
 import edu.harvard.iq.dataverse.branding.BrandingUtil;
 
 import java.io.ByteArrayOutputStream;
@@ -21,7 +20,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.ejb.EJB;
 import javax.ejb.Stateless;
-import javax.inject.Inject;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import javax.persistence.TypedQuery;
@@ -176,7 +174,8 @@ public class DOIDataCiteRegisterService {
         metadataTemplate.setCreators(Util.getListFromStr(metadata.get("datacite.creator")));
         metadataTemplate.setAuthors(dataset.getLatestVersion().getDatasetAuthors());
         if (dvObject.isInstanceofDataset()) {
-            String description = dataset.getLatestVersion().getDescriptionPlainText();
+            //While getDescriptionPlainText strips < and > from HTML, it leaves '&' (at least so we need to xml escape as well
+            String description = StringEscapeUtils.escapeXml(dataset.getLatestVersion().getDescriptionPlainText());
             if (description.isEmpty() || description.equals(DatasetField.NA_VALUE)) {
                 description = AbstractGlobalIdServiceBean.UNAVAILABLE;
             }


### PR DESCRIPTION
**What this PR does / why we need it**: Adds escaping appropriate for include text in an xml doc to the description metadata in the DataCite metadata export/the same xml metadata as sent to the DataCite server via API during publication.

**Which issue(s) this PR closes**:

Closes #3328

**Special notes for your reviewer**: If I recall, some fields like title are escaped when created so additional escaping at this stage isn't needed. I haven't checked the status of all the other fields that get included (creator, publisher, contributor) where, if they aren't being escaped now, special chars could still cause an issue. That said, the description field seems like a key one to cover where most of the practical examples of special chars being used have shown up, so I think this is a useful step, although it won't stop problems from special chars in other fields if they indeed aren't already handled.

**Suggestions on how to test this**: The best test would be to have a test server configured with a test DataCite account and verify that a description with & < > * etc. fails before the PR and works afterwards. However, as noted in the issue, demo.dataverse.org seems to allow publication without this even though it appears to use the DataCite test server now.

A simpler test would be to just verify by inspection that the datacite metadata export file is valid xml, either by using a browser than can display xml (and not seeing an error like the one shown in the issue) or doing a view page source and seeing that characters such as & are escaped in the source (i.e. as &amp; in this case).

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: no

**Is there a release notes update needed for this change?**: could note the fix

**Additional documentation**:
