### PR TITLE
Compare against mimetype of orig file in replace (if ingested)

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/datasetutility/AddReplaceFileHelper.java
+++ b/src/main/java/edu/harvard/iq/dataverse/datasetutility/AddReplaceFileHelper.java
@@ -1318,9 +1318,11 @@ public class AddReplaceFileHelper{
             
             // Has the content type of the file changed?
             //
-            if (!finalFileList.get(0).getContentType().equalsIgnoreCase(fileToReplace.getContentType())){
-            
-                List<String> errParams = Arrays.asList(fileToReplace.getFriendlyType(),
+            String origType = fileToReplace.getOriginalFileFormat() != null ? fileToReplace.getOriginalFileFormat() : fileToReplace.getContentType();
+            if (!finalFileList.get(0).getContentType().equalsIgnoreCase(origType)) {
+                String friendlyType = fileToReplace.getOriginalFormatLabel() != null ? fileToReplace.getOriginalFormatLabel() : fileToReplace.getFriendlyType();
+                
+                List<String> errParams = Arrays.asList(friendlyType,
                                                 finalFileList.get(0).getFriendlyType());
                 
                 String contentTypeErr = BundleUtil.getStringFromBundle("file.addreplace.error.replace.new_file_has_different_content_type", 

--- a/src/main/java/edu/harvard/iq/dataverse/datasetutility/AddReplaceFileHelper.java
+++ b/src/main/java/edu/harvard/iq/dataverse/datasetutility/AddReplaceFileHelper.java
@@ -1318,8 +1318,8 @@ public class AddReplaceFileHelper{
             
             // Has the content type of the file changed?
             //
-            String origType = fileToReplace.getOriginalFileFormat() != null ? fileToReplace.getOriginalFileFormat() : fileToReplace.getContentType();
-            if (!finalFileList.get(0).getContentType().equalsIgnoreCase(origType)) {
+            String fileType = fileToReplace.getOriginalFileFormat() != null ? fileToReplace.getOriginalFileFormat() : fileToReplace.getContentType();
+            if (!finalFileList.get(0).getContentType().equalsIgnoreCase(fileType)) {
                 String friendlyType = fileToReplace.getOriginalFormatLabel() != null ? fileToReplace.getOriginalFormatLabel() : fileToReplace.getFriendlyType();
                 
                 List<String> errParams = Arrays.asList(friendlyType,


### PR DESCRIPTION
**What this PR does / why we need it**: Updates the replace command to compare the mimetype of the replacement file with the mimetype of the original file (if it exists because of ingest) rather than the type of the generated tabular file.

**Which issue(s) this PR closes**:

Closes #7817

**Special notes for your reviewer**:

**Suggestions on how to test this**: Try to replace an ingested file without using the 'force' parameter (UI or API) and it should work if the original and replacement file are the same type (e.g. csv or .xlsx). Other file types (text, pdf, gif, ...) shouldn't be affected.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**: 
