### PR TITLE
use correct duration for dataset publication locks

### DIFF
--- a/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
@@ -1097,7 +1097,7 @@ public class UtilIT {
                 .post(swordConfiguration.getBaseUrlPathCurrent() + "/edit/study/" + persistentId);
         
         // Wait for the dataset to get unlocked, if/as needed:
-        sleepForLock(persistentId, "finalizePublication", apiToken, UtilIT.MAXIMUM_INGEST_LOCK_DURATION);            
+        sleepForLock(persistentId, "finalizePublication", apiToken, UtilIT.MAXIMUM_PUBLISH_LOCK_DURATION);
         return publishResponse;
     }
 
@@ -1117,7 +1117,7 @@ public class UtilIT {
         Response publishResponse = requestSpecification.post("/api/datasets/" + idInPath + "/actions/:publish?type=" + majorOrMinor + optionalQueryParam);
         
         // Wait for the dataset to get unlocked, if/as needed:
-        sleepForLock(idOrPersistentId, "finalizePublication", apiToken, UtilIT.MAXIMUM_INGEST_LOCK_DURATION);            
+        sleepForLock(idOrPersistentId, "finalizePublication", apiToken, UtilIT.MAXIMUM_PUBLISH_LOCK_DURATION);
         
         return publishResponse;
     }
@@ -1133,7 +1133,7 @@ public class UtilIT {
                 .get("/api/datasets/:persistentId/actions/:publish?type=" + majorOrMinor + "&persistentId=" + persistentId);
         
         // Wait for the dataset to get unlocked, if/as needed:
-        sleepForLock(persistentId, "finalizePublication", apiToken, UtilIT.MAXIMUM_INGEST_LOCK_DURATION);            
+        sleepForLock(persistentId, "finalizePublication", apiToken, UtilIT.MAXIMUM_PUBLISH_LOCK_DURATION);
         
         return publishResponse;
     }


### PR DESCRIPTION
**What this PR does / why we need it**:

In the test suite, when we added sleeps for locks we specified a duration for ingest (3 seconds) and a duration for publish (15 seconds). Only the ingest duration was used. This pull request switches the publish operations to use the duration for publish. I only noticed this because when testing the creation of a dataset with 200 versions, the number of seconds to publish quickly exceeded the lower ingest limit.

**Which issue(s) this PR closes**:

Closes # (none)

**Special notes for your reviewer**:

None. Just test code.

**Suggestions on how to test this**:

Let the test suite run on Jenkins.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No.

**Is there a release notes update needed for this change?**:

No.

**Additional documentation**:

None.