### PR TITLE
#7834 adding jaxb-api library for the coveralls Maven plugin configur…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -773,6 +773,13 @@
                 <groupId>org.eluder.coveralls</groupId>
                 <artifactId>coveralls-maven-plugin</artifactId>
                 <version>4.0.0</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>javax.xml.bind</groupId>
+                        <artifactId>jaxb-api</artifactId>
+                        <version>2.3.1</version>
+                    </dependency>
+                </dependencies>
             </plugin>
             <plugin>
                 <!-- https://stackoverflow.com/questions/46177921/how-to-run-unit-tests-in-excludedgroups-in-maven -->


### PR DESCRIPTION
…ation

**What this PR does / why we need it**: Right now the coverage report on https://coveralls.io/github/IQSS/dataverse is not working, because Java 11 does not come with particular XML processing class. This PR adds a library to the coveralls Maven plugin configuration to fix this problem. 

**Which issue(s) this PR closes**:

Closes #7834

**Special notes for your reviewer**: It is not a general dependency, only touch the coveralls configuration, so in theory there is no side effect.

**Suggestions on how to test this**: Build project on Travis (https://travis-ci.org/github/IQSS). Check the log's `mvn jacoco:report coveralls:report` section. It is folded by default, so unfold it. Now this section contains a

```[INFO] BUILD FAILURE```

line. The PR is success if you don't find it, but

```[INFO] BUILD SUCCESS```

instead. After some minute you should also check if coveralls.io is updated at https://coveralls.io/github/IQSS/dataverse. It should reflect the the current Travis build number, commit identifier, date. Note: by default coveralls.io displays the default branch, ie. develop. If you build it in a different branch, select that in coveralls.io as well. 

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: no

**Is there a release notes update needed for this change?**: no

**Additional documentation**: no
