### PR TITLE
add basic Sphinx-build GitHub Action and accompanying status badge

### DIFF
--- a/.github/workflows/guides_build_sphinx.yml
+++ b/.github/workflows/guides_build_sphinx.yml
@@ -1,0 +1,12 @@
+name: "Guides Build Status"
+on: 
+- pull_request
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ammaraskar/sphinx-action@master
+      with:
+        docs-folder: "doc/sphinx-guides/source/"

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Dataverse is a trademark of President and Fellows of Harvard College and is regi
 [![API Test Coverage](https://img.shields.io/jenkins/coverage/jacoco?jobUrl=https%3A%2F%2Fjenkins.dataverse.org%2Fjob%2FIQSS-dataverse-develop&label=API%20Test%20Coverage)](https://jenkins.dataverse.org/job/IQSS-dataverse-develop/ws/target/coverage-it/index.html)
 [![Unit Test Status](https://img.shields.io/travis/IQSS/dataverse?label=Unit%20Test%20Status)](https://travis-ci.org/IQSS/dataverse)
 [![Unit Test Coverage](https://img.shields.io/coveralls/github/IQSS/dataverse?label=Unit%20Test%20Coverage)](https://coveralls.io/github/IQSS/dataverse?branch=develop)
+[![Guides Build Status](https://github.com/IQSS/dataverse/actions/workflows/guides_build_sphinx.yml/badge.svg)](https://github.com/IQSS/dataverse/actions/workflows/guides_build_sphinx.yml)
 
 [dataverse.org]: https://dataverse.org
 [demo.dataverse.org]: https://demo.dataverse.org


### PR DESCRIPTION
**What this PR does / why we need it**: now that Sphinx is upgraded we can enable a basic, and currently free, GitHub Action to build the guides triggered by any pull request affecting `doc/sphinx-guides/source/`. This is a first step to allow for Sphinx syntax linting, but further experimentation could push HTML builds to gdcc.io or possibly guides.dataverse.org.

**Which issue(s) this PR closes**:

Closes #7837

**Special notes for your reviewer**: none

**Suggestions on how to test this**: once merged, should run automatically on the next PR against `doc/sphinx-guides/source/`

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: no

**Is there a release notes update needed for this change?**: no

**Additional documentation**: none
