### PR TITLE
add .rst trigger/filter, correct over-zealous docs-folder path

### DIFF
--- a/.github/workflows/guides_build_sphinx.yml
+++ b/.github/workflows/guides_build_sphinx.yml
@@ -1,6 +1,8 @@
 name: "Guides Build Status"
 on: 
-- pull_request
+  pull_request:
+    paths:
+      - 'doc/sphinx-guides/**/*.rst'
 
 jobs:
   docs:
@@ -9,4 +11,4 @@ jobs:
     - uses: actions/checkout@v2
     - uses: ammaraskar/sphinx-action@master
       with:
-        docs-folder: "doc/sphinx-guides/source/"
+        docs-folder: "doc/sphinx-guides/"


### PR DESCRIPTION
**What this PR does / why we need it**: Don's first PR was no good

**Which issue(s) this PR closes**:

Closes #7839

**Special notes for your reviewer**: none

**Suggestions on how to test this**: after merge, should run automatically on next change to an `.rst` file beneath `docs/sphinx-guides/`

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: no

**Is there a release notes update needed for this change?**: no

**Additional documentation**: none
