### PR TITLE
only call retrieveFileAccessRequesters for restricted files #7841

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DataFileServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DataFileServiceBean.java
@@ -774,7 +774,13 @@ public class DataFileServiceBean implements java.io.Serializable {
                     dataFile.addTag(tag);
                 }
             }            
-            dataFile.setFileAccessRequesters(retrieveFileAccessRequesters(dataFile));              
+            if (dataFile.isRestricted()) {
+                // retrieveFileAccessRequesters is expensive. Only call it for restricted files.
+                dataFile.setFileAccessRequesters(retrieveFileAccessRequesters(dataFile));
+            } else {
+                // Ok to set to empty array because file is not restricted.
+                dataFile.setFileAccessRequesters(new ArrayList<>());
+            }
             dataFiles.add(dataFile);
             filesMap.put(dataFile.getId(), i++);
         }


### PR DESCRIPTION
**What this PR does / why we need it**:

Reduces the number of queries for a dataset with 200 versions and 15 public files for each version from 5206 to 2204. (The reduction of 3000 is 200 x 15.)

**Which issue(s) this PR closes**:

Closes #7841

**Special notes for your reviewer**:

None.

**Suggestions on how to test this**:

Compare query counts (the pull request vs develop) for datasets with many versions.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No.

**Is there a release notes update needed for this change?**:

No. I assume there will be a mention of performance in general.

**Additional documentation**:

Here's the "after" report of query counts. The "before" can be found in #7841.

```
Parsed and counted the queries. Total number:
2204

Queries, counted and sorted: 

 201 SELECT ID, UNF, ARCHIVALCOPYLOCATION, ARCHIVENOTE, ARCHIVETIME, CREATETIME, DEACCESSIONLINK, LASTUPDATETIME, MINORVERSIONNUMBER, RELEASETIME, VERSION, VERSIONNOTE, VERSIONNUMBER, VERSIONSTATE, DATASET_ID, termsOfUseAndAccess_id FROM DATASETVERSION
 200 select t0.filecategories_id, t0.filemetadatas_id from filemetadata_datafilecategory t0, filemetadata t1
 200 select id, datafile_id, DESCRIPTION, LABEL, RESTRICTED, DIRECTORYLABEL, prov_freeform from FileMetadata
 200 SELECT ID, CREATETIME, NAME, USAGECOUNT, DATAVERSE_ID, termsOfUseAndAccess_id FROM TEMPLATE
 200 SELECT ID, AVAILABILITYSTATUS, CITATIONREQUIREMENTS, CONDITIONS, CONFIDENTIALITYDECLARATION, CONTACTFORACCESS, DATAACCESSPLACE, DEPOSITORREQUIREMENTS, DISCLAIMER, FILEACCESSREQUEST, LICENSE, ORIGINALARCHIVE, RESTRICTIONS, SIZEOFCOLLECTION, SPECIALPERMISSIONS, STUDYCOMPLETION, TERMSOFACCESS, TERMSOFUSE FROM TERMSOFUSEANDACCESS
 178 SELECT ID, AUTHENTICATIONPROVIDERID, PERSISTENTUSERID, AUTHENTICATEDUSER_ID FROM AUTHENTICATEDUSERLOOKUP
 178 SELECT ID, AFFILIATION, CREATEDTIME, DEACTIVATED, DEACTIVATEDTIME, EMAIL, EMAILCONFIRMED, FIRSTNAME, LASTAPIUSETIME, LASTLOGINTIME, LASTNAME, POSITION, SUPERUSER, USERIDENTIFIER FROM AUTHENTICATEDUSER
 131 SELECT ID, ALIAS, DESCRIPTION, NAME, PERMISSIONBITS, OWNER_ID FROM DATAVERSEROLE
 122 SELECT t0.ID, t0.DTYPE, t0.AUTHORITY, t0.CREATEDATE, t0.GLOBALIDCREATETIME, t0.IDENTIFIER, t0.IDENTIFIERREGISTERED, t0.INDEXTIME, t0.MODIFICATIONTIME, t0.PERMISSIONINDEXTIME, t0.PERMISSIONMODIFICATIONTIME, t0.PREVIEWIMAGEAVAILABLE, t0.PROTOCOL, t0.PUBLICATIONDATE, t0.STORAGEIDENTIFIER, t0.CREATOR_ID, t0.OWNER_ID, t0.RELEASEUSER_ID, t1.ID, t1.AFFILIATION, t1.ALIAS, t1.DATAVERSETYPE, t1.description, t1.FACETROOT, t1.GUESTBOOKROOT, t1.METADATABLOCKROOT, t1.NAME, t1.PERMISSIONROOT, t1.STORAGEDRIVER, t1.TEMPLATEROOT, t1.THEMEROOT, t1.DEFAULTCONTRIBUTORROLE_ID, t1.DEFAULTTEMPLATE_ID FROM DVOBJECT t0, DATAVERSE t1
 122 SELECT ID, BACKGROUNDCOLOR, LINKCOLOR, LINKURL, LOGO, LOGOALIGNMENT, LOGOBACKGROUNDCOLOR, LOGOFOOTER, LOGOFOOTERALIGNMENT, LOGOFOOTERBACKGROUNDCOLOR, LOGOFORMAT, TAGLINE, TEXTCOLOR, dataverse_id FROM DATAVERSETHEME
 108 SELECT ID, CONTENT, LANG, NAME FROM SETTING
 100 SELECT DISTINCT DTYPE FROM DVOBJECT
  42 SELECT t0.ID, t0.DTYPE, t0.AUTHORITY, t0.CREATEDATE, t0.GLOBALIDCREATETIME, t0.IDENTIFIER, t0.IDENTIFIERREGISTERED, t0.INDEXTIME, t0.MODIFICATIONTIME, t0.PERMISSIONINDEXTIME, t0.PERMISSIONMODIFICATIONTIME, t0.PREVIEWIMAGEAVAILABLE, t0.PROTOCOL, t0.PUBLICATIONDATE, t0.STORAGEIDENTIFIER, t0.CREATOR_ID, t0.OWNER_ID, t0.RELEASEUSER_ID, t1.ID, t1.FILEACCESSREQUEST, t1.HARVESTIDENTIFIER, t1.LASTEXPORTTIME, t1.STORAGEDRIVER, t1.USEGENERICTHUMBNAIL, t1.citationDateDatasetFieldType_id, t1.harvestingClient_id, t1.guestbook_id, t1.thumbnailfile_id FROM DVOBJECT t0, DATASET t1
  35 SELECT t0.ID, t0.DESCRIPTION, t0.DISPLAYNAME, t0.GROUPALIAS, t0.GROUPALIASINOWNER, t0.OWNER_ID FROM EXPLICITGROUP t0, ExplicitGroup_CONTAINEDROLEASSIGNEES t1
  35 SELECT ID, ASSIGNEEIDENTIFIER, PRIVATEURLTOKEN, DEFINITIONPOINT_ID, ROLE_ID FROM ROLEASSIGNMENT
  20 SELECT t0.ID, t0.DTYPE, t0.AUTHORITY, t0.CREATEDATE, t0.GLOBALIDCREATETIME, t0.IDENTIFIER, t0.IDENTIFIERREGISTERED, t0.INDEXTIME, t0.MODIFICATIONTIME, t0.PERMISSIONINDEXTIME, t0.PERMISSIONMODIFICATIONTIME, t0.PREVIEWIMAGEAVAILABLE, t0.PROTOCOL, t0.PUBLICATIONDATE, t0.STORAGEIDENTIFIER, t0.CREATOR_ID, t0.OWNER_ID, t0.RELEASEUSER_ID, t1.ID, t1.CHECKSUMTYPE, t1.CHECKSUMVALUE, t1.CONTENTTYPE, t1.FILESIZE, t1.INGESTSTATUS, t1.PREVIOUSDATAFILEID, t1.prov_entityname, t1.RESTRICTED, t1.ROOTDATAFILEID FROM DVOBJECT t0, DATAFILE t1
  20 SELECT ID, CONTROLCARD, FORCETYPECHECK, LABELSFILE, TEXTENCODING, datafile_id FROM INGESTREQUEST
  20 SELECT ID, CASEQUANTITY, ORIGINALFILEFORMAT, ORIGINALFILENAME, ORIGINALFILESIZE, ORIGINALFORMATVERSION, RECORDSPERCASE, UNF, VARQUANTITY, DATAFILE_ID FROM DATATABLE
  19 SELECT ID, ADVANCEDSEARCHFIELDTYPE, ALLOWCONTROLLEDVOCABULARY, ALLOWMULTIPLES, description, DISPLAYFORMAT, DISPLAYONCREATE, DISPLAYORDER, FACETABLE, FIELDTYPE, name, REQUIRED, title, uri, VALIDATIONFORMAT, WATERMARK, METADATABLOCK_ID, PARENTDATASETFIELDTYPE_ID FROM DATASETFIELDTYPE
  11 select count(o.id) from GuestbookResponse  o 
  10 SELECT ID, CITEDBYURL, DATASET_ID FROM DATASETEXTERNALCITATIONS
  10 SELECT ID, CHECKSUM, CONTENTTYPE, FILESIZE, FORMATTAG, FORMATVERSION, ISPUBLIC, ORIGIN, TYPE, DATAFILE_ID FROM AUXILIARYFILE
   7 SELECT ID, DISPLAYORDER, value, DATASETFIELD_ID FROM DATASETFIELDVALUE
   4 SELECT t1.ID, t1.CONTENTTYPE, t1.DESCRIPTION, t1.DISPLAYNAME, t1.SCOPE, t1.TOOLNAME, t1.TOOLPARAMETERS, t1.TOOLURL FROM EXTERNALTOOLTYPE t0, EXTERNALTOOL t1
   4 SELECT ID, DATASETFIELDTYPE_ID, DATASETVERSION_ID, PARENTDATASETFIELDCOMPOUNDVALUE_ID, TEMPLATE_ID FROM DATASETFIELD
   3 SELECT df.id FROM datafile df, filemetadata fm, datasetversion dv, dvobject o
   3 SELECT ID, DISPLAYORDER, PARENTDATASETFIELD_ID FROM DATASETFIELDCOMPOUNDVALUE
   2 SELECT ID, INFO, REASON, STARTTIME, DATASET_ID, USER_ID FROM DATASETLOCK
   2 SELECT ID, INCLUDE, REQUIRED, datasetfieldtype_id, dataverse_id FROM DataverseFieldTypeInputLevel
   2 SELECT DISTINCT t0.ID, t0.DTYPE, t0.DESCRIPTION, t0.DISPLAYNAME, t0.PERSISTEDGROUPALIAS FROM IPV4RANGE t1 LEFT OUTER JOIN PERSISTEDGLOBALGROUP t0 ON (t0.ID = t1.OWNER_ID)
   1 SELECT t1.ID, t1.DISPLAYORDER, t1.IDENTIFIER, t1.STRVALUE, t1.DATASETFIELDTYPE_ID FROM DATASETFIELD_CONTROLLEDVOCABULARYVALUE t0, CONTROLLEDVOCABULARYVALUE t1
   1 SELECT t1.ID, t1.DISPLAYNAME, t1.NAME, t1.namespaceuri, t1.owner_id FROM DATAVERSE_METADATABLOCK t0, METADATABLOCK t1
   1 SELECT t1.ID, t1.ADVANCEDSEARCHFIELDTYPE, t1.ALLOWCONTROLLEDVOCABULARY, t1.ALLOWMULTIPLES, t1.description, t1.DISPLAYFORMAT, t1.DISPLAYONCREATE, t1.DISPLAYORDER, t1.FACETABLE, t1.FIELDTYPE, t1.name, t1.REQUIRED, t1.title, t1.uri, t1.VALIDATIONFORMAT, t1.WATERMARK, t1.METADATABLOCK_ID, t1.PARENTDATASETFIELDTYPE_ID FROM dataverse_citationDatasetFieldTypes t0, DATASETFIELDTYPE t1
   1 SELECT t0.ID, t0.DATAFILE_ID, t0.UNF, t0.CASEQUANTITY, t0.VARQUANTITY, t0.ORIGINALFILEFORMAT, t0.ORIGINALFILESIZE, t0.ORIGINALFILENAME FROM dataTable t0, dataFile t1, dvObject t2
   1 SELECT t0.ID, t0.CREATEDATE, t0.INDEXTIME, t0.MODIFICATIONTIME, t0.PERMISSIONINDEXTIME, t0.PERMISSIONMODIFICATIONTIME, t0.PUBLICATIONDATE, t0.CREATOR_ID, t0.RELEASEUSER_ID, t1.CONTENTTYPE, t0.STORAGEIDENTIFIER, t1.FILESIZE, t1.INGESTSTATUS, t1.CHECKSUMVALUE, t1.RESTRICTED, t1.CHECKSUMTYPE, t1.PREVIOUSDATAFILEID, t1.ROOTDATAFILEID, t0.PROTOCOL, t0.AUTHORITY, t0.IDENTIFIER FROM DVOBJECT t0, DATAFILE t1
   1 SELECT t0.DATAFILE_ID, t0.TYPE FROM DataFileTag t0, dvObject t1
   1 SELECT id FROM fileMetadata
   1 SELECT ID, NAME, DATASET_ID FROM DATAFILECATEGORY
   1 SELECT ID, DISPLAYNAME, NAME, namespaceuri, owner_id FROM METADATABLOCK
   1 SELECT ID, CREATETIME, EMAILREQUIRED, ENABLED, INSTITUTIONREQUIRED, NAME, NAMEREQUIRED, POSITIONREQUIRED, DATAVERSE_ID FROM GUESTBOOK
   1 SELECT ID, CREATED, MESSAGE, TOBESHOWN, TYPE, AUTHENTICATEDUSER_ID, DATASETVERSION_ID FROM WORKFLOWCOMMENT
   1 SELECT ID, AUTHORITY, GLOBALIDCREATETIME, IDENTIFIER, IDENTIFIERREGISTERED, PROTOCOL, STORAGELOCATIONDESIGNATOR, DVOBJECT_ID FROM ALTERNATIVEPERSISTENTIDENTIFIER
   1 SELECT ID, ACTIVE, DISMISSIBLEBYUSER FROM BANNERMESSAGE
   1 INSERT INTO ACTIONLOGRECORD (ID, ACTIONRESULT, ACTIONSUBTYPE, ACTIONTYPE, ENDTIME, INFO, STARTTIME, USERIDENTIFIER) VALUES ('2145672a-ae75-4743-a11c-e7d992102932', 'OK', 'edu.harvard.iq.dataverse.engine.command.impl.GetLatestPublishedDatasetVersionCommand', 'Command', '2021-05-03 14:57:06.808', ':[211 Darwin''s Finches] ', '2021-05-03 14:57:06.807', ':guest')
   1 INSERT INTO ACTIONLOGRECORD (ID, ACTIONRESULT, ACTIONSUBTYPE, ACTIONTYPE, ENDTIME, INFO, STARTTIME, USERIDENTIFIER) VALUES ('03b01b7f-3d6a-446e-9e23-062772370d78', 'PermissionError', 'edu.harvard.iq.dataverse.engine.command.impl.GetPrivateUrlCommand', 'Command', '2021-05-03 14:57:06.837', ':[211 Darwin''s Finches]  Can''t execute command edu.harvard.iq.dataverse.engine.command.impl.GetPrivateUrlCommand@461c505d, because request [DataverseRequest user:[GuestUser :guest]@127.0.0.1] is missing permissions [ManageDatasetPermissions] on Object Darwin''s Finches', '2021-05-03 14:57:06.835', ':guest')
```