### PR TITLE
recommend RHEL8 or derivative such as Rocky or Alma instead of …

### DIFF
--- a/doc/sphinx-guides/source/installation/advanced.rst
+++ b/doc/sphinx-guides/source/installation/advanced.rst
@@ -22,7 +22,7 @@ You should be conscious of the following when running multiple app servers.
 Detecting Which App Server a User Is On
 +++++++++++++++++++++++++++++++++++++++
 
-If you have successfully installed multiple app servers behind a load balancer you might like to know which server a user has landed on. A straightforward solution is to place a file called ``host.txt`` in a directory that is served up by Apache such as ``/var/www/html`` and then configure Apache not to proxy requests to ``/host.txt`` to the app server. Here are some example commands on RHEL/CentOS 7 that accomplish this::
+If you have successfully installed multiple app servers behind a load balancer you might like to know which server a user has landed on. A straightforward solution is to place a file called ``host.txt`` in a directory that is served up by Apache such as ``/var/www/html`` and then configure Apache not to proxy requests to ``/host.txt`` to the app server. Here are some example commands on RHEL/derivatives that accomplish this::
 
         [root@server1 ~]# vim /etc/httpd/conf.d/ssl.conf
         [root@server1 ~]# grep host.txt /etc/httpd/conf.d/ssl.conf

--- a/doc/sphinx-guides/source/installation/installation-main.rst
+++ b/doc/sphinx-guides/source/installation/installation-main.rst
@@ -14,7 +14,7 @@ Running the Dataverse Software Installer
 
 A scripted, interactive installer is provided. This script will configure your app server environment, create the database, set some required options and start the application. Some configuration tasks will still be required after you run the installer! So make sure to consult the next section. 
 
-As mentioned in the :doc:`prerequisites` section, RHEL/CentOS is the recommended Linux distribution. (The installer is also known to work on Mac OS X for setting up a development environment.)
+As mentioned in the :doc:`prerequisites` section, RHEL or a derivative such as RockyLinux or AlmaLinux is recommended. (The installer is also known to work on Mac OS X for setting up a development environment.)
 
 Generally, the installer has a better chance of succeeding if you run it against a freshly installed Payara node that still has all the default configuration settings. In any event, please make sure that it is still configured to accept http connections on port 8080 - because that's where the installer expects to find the application once it's deployed.
 

--- a/doc/sphinx-guides/source/installation/prep.rst
+++ b/doc/sphinx-guides/source/installation/prep.rst
@@ -51,7 +51,7 @@ Required Components
 
 When planning your installation you should be aware of the following components of the Dataverse Software architecture:
 
-- Linux: RHEL/CentOS is highly recommended since all development and QA happens on this distribution.
+- Linux: RHEL or derivative is highly recommended since all development and QA happens on this distribution.
 - App server: Payara is the recommended Jakarta EE application server.
 - PostgreSQL: a relational database.
 - Solr: a search engine. A Dataverse Software-specific schema is provided.

--- a/doc/sphinx-guides/source/installation/prerequisites.rst
+++ b/doc/sphinx-guides/source/installation/prerequisites.rst
@@ -14,7 +14,7 @@ After following all the steps below, you can proceed to the :doc:`installation-m
 Linux
 -----
 
-We assume you plan to run your Dataverse installation on Linux and we recommend RHEL or a derivative such as RockyLinux or AlmaLinux, which is the distribution family tested by the Dataverse Project team. Please be aware that while EL8 (RHEL/derivatives) is the recommended platform, the steps below were orginally written for EL6 and may need to be updated (please feel free to make a pull request!). A number of community members have installed Dataverse in Debian/Ubuntu.
+We assume you plan to run your Dataverse installation on Linux and we recommend RHEL or a derivative such as RockyLinux or AlmaLinux, which is the distribution family tested by the Dataverse Project team. Please be aware that while EL8 (RHEL/derivatives) is the recommended platform, the steps below were orginally written for EL6 and may need to be updated (please feel free to make a pull request!). A number of community members have installed the Dataverse Software in Debian/Ubuntu environments.
 
 Java
 ----

--- a/doc/sphinx-guides/source/installation/prerequisites.rst
+++ b/doc/sphinx-guides/source/installation/prerequisites.rst
@@ -14,7 +14,7 @@ After following all the steps below, you can proceed to the :doc:`installation-m
 Linux
 -----
 
-We assume you plan to run your Dataverse installation on Linux and we recommend RHEL/CentOS, which is the Linux distribution tested by the Dataverse Project team. Please be aware that while el8 (RHEL/CentOS 8) is the recommended platform, the steps below were orginally written for el6 and may need to be updated (please feel free to make a pull request!).
+We assume you plan to run your Dataverse installation on Linux and we recommend RHEL or a derivative such as RockyLinux or AlmaLinux, which is the distribution family tested by the Dataverse Project team. Please be aware that while EL8 (RHEL/derivatives) is the recommended platform, the steps below were orginally written for EL6 and may need to be updated (please feel free to make a pull request!). A number of community members have installed Dataverse in Debian/Ubuntu.
 
 Java
 ----
@@ -28,13 +28,13 @@ The Dataverse Software should run fine with only the Java Runtime Environment (J
 
 The Oracle JDK can be downloaded from http://www.oracle.com/technetwork/java/javase/downloads/index.html
 
-On a RHEL/CentOS, install OpenJDK (devel version) using yum::
+On a RHEL/derivative, install OpenJDK (devel version) using yum::
 
 	# sudo yum install java-11-openjdk
 
 If you have multiple versions of Java installed, Java 11 should be the default when ``java`` is invoked from the command line. You can test this by running ``java -version``.
 
-On RHEL/CentOS you can make Java 11 the default with the ``alternatives`` command, having it prompt you to select the version of Java from a list::
+On RHEL/derivative you can make Java 11 the default with the ``alternatives`` command, having it prompt you to select the version of Java from a list::
 
         # alternatives --config java
 
@@ -80,15 +80,15 @@ Launching Payara on System Boot
 
 The Dataverse Software installation script will start Payara if necessary, but you may find the following scripts helpful to launch Payara start automatically on boot. They were originally written for Glassfish but have been adjusted for Payara.
 
-- This :download:`Systemd file<../_static/installation/files/etc/systemd/payara.service>` may be serve as a reference for systems using Systemd (such as RHEL/CentOS 7 or Ubuntu 16+)
-- This :download:`init script<../_static/installation/files/etc/init.d/payara.init.service>` may be useful for RHEL/CentOS 6 or Ubuntu >= 14 if you're using a Payara service account, or
+- This :download:`Systemd file<../_static/installation/files/etc/systemd/payara.service>` may be serve as a reference for systems using Systemd (such as RHEL/derivative or Debian 10, Ubuntu 16+)
+- This :download:`init script<../_static/installation/files/etc/init.d/payara.init.service>` may be useful for RHEL/derivative or Ubuntu >= 14 if you're using a Payara service account, or
 - This :download:`Payara init script <../_static/installation/files/etc/init.d/payara.init.root>` may be helpful if you're just going to run Payara as root (not recommended).
 
 It is not necessary for Payara to be running before you execute the Dataverse Software installation script; it will start Payara for you.
 
 Please note that you must run Payara in an English locale. If you are using something like ``LANG=de_DE.UTF-8``, ingest of tabular data will fail with the message "RoundRoutines:decimal separator no in right place".
 
-Also note that Payara may utilize more than the default number of file descriptors, especially when running batch jobs such as harvesting. We have increased ours by adding ulimit -n 32768 to our Payara init script. On operating systems which use systemd such as RHEL or CentOS 7, file descriptor limits may be increased by adding a line like LimitNOFILE=32768 to the systemd unit file. You may adjust the file descriptor limits on running processes by using the prlimit utility::
+Also note that Payara may utilize more than the default number of file descriptors, especially when running batch jobs such as harvesting. We have increased ours by adding ulimit -n 32768 to our Payara init script. On operating systems which use systemd such as RHEL/derivative, file descriptor limits may be increased by adding a line like LimitNOFILE=32768 to the systemd unit file. You may adjust the file descriptor limits on running processes by using the prlimit utility::
 
 	# sudo prlimit --pid pid --nofile=32768:32768
 
@@ -98,7 +98,7 @@ PostgreSQL
 Installing PostgreSQL
 =======================
 
-The application has been tested with PostgreSQL versions up to 13. We recommend installing the latest version that is available for your OS distribution. *For example*, to install PostgreSQL 13 under RHEL/CentOS 7::
+The application has been tested with PostgreSQL versions up to 13. We recommend installing the latest version that is available for your OS distribution. *For example*, to install PostgreSQL 13 under RHEL7/derivative::
 
 	# yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm
 	# yum makecache fast
@@ -107,7 +107,7 @@ The application has been tested with PostgreSQL versions up to 13. We recommend 
 	# /usr/bin/systemctl start postgresql-13
 	# /usr/bin/systemctl enable postgresql-13
 
-For RHEL/CentOS 8 the process would be identical, except for the very first command - you would need to install the "EL-8" yum repository configuration instead. 
+For RHEL8/derivative the process would be identical, except for the very first command - you would need to install the "EL-8" yum repository configuration instead. 
 
 Configuring Database Access for the Dataverse Installation (and the Dataverse Software Installer)
 =================================================================================================
@@ -141,7 +141,7 @@ Configuring Database Access for the Dataverse Installation (and the Dataverse So
 
   The file ``postgresql.conf`` will be located in the same directory as the ``pg_hba.conf`` above.
 
-- **Important: PostgreSQL must be restarted** for the configuration changes to take effect! On RHEL/CentOS 7 and similar (provided you installed Postgres as instructed above)::
+- **Important: PostgreSQL must be restarted** for the configuration changes to take effect! On RHEL7/derivative and similar (provided you installed Postgres as instructed above)::
 
         # systemctl restart postgresql-13
 
@@ -193,7 +193,7 @@ Solr will warn about needing to increase the number of file descriptors and max 
         solr soft nofile 65000
         solr hard nofile 65000
 
-On operating systems which use systemd such as RHEL or CentOS 7, you may then add a line like LimitNOFILE=65000 for the number of open file descriptors and a line with LimitNPROC=65000 for the max processes to the systemd unit file, or adjust the limits on a running process using the prlimit tool::
+On operating systems which use systemd such as RHEL/derivative, you may then add a line like LimitNOFILE=65000 for the number of open file descriptors and a line with LimitNPROC=65000 for the max processes to the systemd unit file, or adjust the limits on a running process using the prlimit tool::
 
         # sudo prlimit --pid pid --nofile=65000:65000
 
@@ -211,7 +211,7 @@ Solr Init Script
 Please choose the right option for your underlying Linux operating system.
 It will not be necessary to execute both!
 
-For systems running systemd (like CentOS/RedHat since 7, Debian since 9, Ubuntu since 15.04), as root, download :download:`solr.service<../_static/installation/files/etc/systemd/solr.service>` and place it in ``/tmp``. Then start Solr and configure it to start at boot with the following commands::
+For systems running systemd (like RedHat or derivatives since 7, Debian since 9, Ubuntu since 15.04), as root, download :download:`solr.service<../_static/installation/files/etc/systemd/solr.service>` and place it in ``/tmp``. Then start Solr and configure it to start at boot with the following commands::
 
         cp /tmp/solr.service /etc/systemd/system
         systemctl daemon-reload
@@ -273,7 +273,7 @@ The Dataverse Software uses `ImageMagick <https://www.imagemagick.org>`_ to gene
 Installing and configuring ImageMagick
 ======================================
 
-On a Red Hat and similar Linux distributions, you can install ImageMagick with something like::
+On a Red Hat or derivative Linux distribution, you can install ImageMagick with something like::
 
 	# yum install ImageMagick
 
@@ -307,15 +307,15 @@ components and libraries. Please consult the instructions in the
 Installing R
 ============
 
-For RHEL/CentOS, the EPEL distribution is strongly recommended:
+For RHEL/derivative, the EPEL distribution is strongly recommended:
 
 If :fixedwidthplain:`yum` isn't configured to use EPEL repositories ( https://fedoraproject.org/wiki/EPEL ):
 
-RHEL/CentOS 8 users can install the epel-release RPM::
+RHEL8/derivative users can install the epel-release RPM::
 
        yum install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
 
-RHEL/CentOS 7 users can install the epel-release RPM::
+RHEL7/derivative users can install the epel-release RPM::
 
        yum install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 
@@ -323,9 +323,9 @@ RHEL 8 users will need to enable the CodeReady-Builder repository::
 
        subscription-manager repos --enable codeready-builder-for-rhel-8-x86_64-rpms
 
-CentOS 8 users will need to enable the PowerTools repository::
+Rocky or AlmaLinux 8.3+ users will need to enable the PowerTools repository::
 
-       dnf config-manager --enable PowerTools
+       dnf config-manager --enable powertools
 
 RHEL 7 users will want to log in to their organization's respective RHN interface, find the particular machine in question and:
 

--- a/doc/sphinx-guides/source/installation/r-rapache-tworavens.rst
+++ b/doc/sphinx-guides/source/installation/r-rapache-tworavens.rst
@@ -33,7 +33,7 @@ Please be warned:
 
 - This process may still require some system administration skills. 
 - The guide below is very Linux-specific. This process has been tested
-  on RedHat/CentOS servers only. In some ways it *may* actually be
+  on RedHat/derivative servers only. In some ways it *may* actually be
   easier to get it all installed on MacOS X (because
   MacOS X versions of third party R packages are available
   pre-compiled), or even on Windows. But it hasn't been attempted, and
@@ -137,7 +137,7 @@ change it to
 b. R:
 -----
 
-The simplest way to install R on RHEL/CentOS systems is with yum, using the EPEL repository::
+The simplest way to install R on RHEL/derivative systems is with yum, using the EPEL repository::
 
        yum install epel-release
        yum install R-core R-core-devel
@@ -169,7 +169,7 @@ Wipe clean any R packages that were left behind::
 c. rApache: 
 -----------
 
-We maintain the following rpms of rApache, built for the following version of RedHat/CentOS distribution:
+We maintain the following rpms of rApache, built for the following version of RedHat/derivative distribution:
 
 For RHEL/CentOS 6 and R 3.4, download :download:`rapache-1.2.6-rpm0.x86_64.rpm <../_static/installation/files/home/rpmbuild/rpmbuild/RPMS/x86_64/rapache-1.2.6-rpm0.x86_64.rpm>` and install it with::
 

--- a/doc/sphinx-guides/source/installation/shibboleth.rst
+++ b/doc/sphinx-guides/source/installation/shibboleth.rst
@@ -23,7 +23,7 @@ System Requirements
 
 Support for Shibboleth in the Dataverse Software is built on the popular `"mod_shib" Apache module, "shibd" daemon <https://shibboleth.net/products/service-provider.html>`_, and the `Embedded Discovery Service (EDS) <https://shibboleth.net/products/embedded-discovery-service.html>`_ Javascript library, all of which are distributed by the `Shibboleth Consortium <https://shibboleth.net>`_. EDS is bundled with the Dataverse Software, but ``mod_shib`` and ``shibd`` must be installed and configured per below.
 
-Only Red Hat Enterprise Linux (RHEL) and derivatives such as CentOS have been tested (x86_64 versions) by the Dataverse Project team. See https://wiki.shibboleth.net/confluence/display/SHIB2/NativeSPLinuxInstall for details and note that (according to that page) as of this writing Ubuntu and Debian are not offically supported by the Shibboleth project.
+Only Red Hat Enterprise Linux (RHEL) and derivatives have been tested (x86_64 versions) by the Dataverse Project team. See https://wiki.shibboleth.net/confluence/display/SHIB2/NativeSPLinuxInstall for details and note that (according to that page) as of this writing Ubuntu and Debian are not offically supported by the Shibboleth project.
 
 Install Apache
 ~~~~~~~~~~~~~~
@@ -50,7 +50,7 @@ Install ``wget`` if you don't have it already:
 
 ``yum install wget``
 
-If you are running el8 (RHEL/CentOS 8):
+If you are running el8 (RHEL/derivative 8):
 
 ``wget http://download.opensuse.org/repositories/security:/shibboleth/CentOS_8/security:shibboleth.repo``
 


### PR DESCRIPTION
**What this PR does / why we need it**: updates references to the deprecated CentOS 8 to instead say "a RHEL derivative such as RockyLinux or AlmaLinux." Also, as of 8.3, the `PowerTools` repo is now `powertools`

**Which issue(s) this PR closes**:

Closes #7470

**Special notes for your reviewer**: proofread carefully

**Suggestions on how to test this**: no functional changes, really.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: no

**Is there a release notes update needed for this change?**: no

**Additional documentation**: none
