### PR TITLE
7720 s3 redirects for auxiliary files

### DIFF
--- a/doc/release-notes/7720-extended-s3-redirects.md
+++ b/doc/release-notes/7720-extended-s3-redirects.md
@@ -2,10 +2,9 @@
 
 If your installation uses S3 for storage, and have "direct downloads" enabled, please note that, as of this release, it will cover the following download types that were not handled by redirects in the earlier versions: saved originals of tabular data files, cached RData frames, resized thumbnails for image files and other auxiliary files. In other words, all the forms of the file download API that take extra arguments, such as "format" or "imageThumb" - for example:
 
-```
-   /api/access/datafile/12345?format=original
-   /api/access/datafile/:persistentId?persistentId=doi:1234/ABCDE/FGHIJ?imageThumb=true
-```
+`/api/access/datafile/12345?format=original`
+
+`/api/access/datafile/:persistentId?persistentId=doi:1234/ABCDE/FGHIJ?imageThumb=true`
 
 etc., that were previously excluded.
 

--- a/doc/release-notes/7720-extended-s3-redirects.md
+++ b/doc/release-notes/7720-extended-s3-redirects.md
@@ -1,8 +1,11 @@
 ### Extended support for S3 Download Redirects ("Direct Downloads").
 
 If your installation uses S3 for storage, and have "direct downloads" enabled, please note that, as of this release, it will cover the following download types that were not handled by redirects in the earlier versions: saved originals of tabular data files, cached RData frames, resized thumbnails for image files and other auxiliary files. In other words, all the forms of the file download API that take extra arguments, such as "format" or "imageThumb" - for example:
+
 `/api/access/datafile/12345?format=original`
+
 `/api/access/datafile/:persistentId?persistentId=doi:1234/ABCDE/FGHIJ?imageThumb=true`
+
 etc., that were previously excluded.
 
 This change should not in any way affect the web GUI users. Since browsers follow redirects automatically. Some API users may experience problems, if they use it in a way that does not expect to receive a redirect response. For example, if a user has a script where they expect to download a saved original of an ingested tabular file with the following command:

--- a/doc/release-notes/7720-extended-s3-redirects.md
+++ b/doc/release-notes/7720-extended-s3-redirects.md
@@ -1,6 +1,6 @@
 ### Extended support for S3 Download Redirects ("Direct Downloads").
 
-If your installation uses S3 for storage, and have "direct downloads" enabled, please note that, as of this release, it will cover the following download types that were not handled by redirects in the earlier versions: saved originals of tabular data files, cached RData frames, resized thumbnails for image files and other auxiliary files. In other words, all the forms of the file download API that take extra arguments, such as "format" or "imageThumb" - for example:
+If your installation uses S3 for storage, and you have "direct downloads" enabled, please note that, as of this release, it will cover the following download types that were not handled by redirects in the earlier versions: saved originals of tabular data files, cached RData frames, resized thumbnails for image files and other auxiliary files. In other words, all the forms of the file download API that take extra arguments, such as "format" or "imageThumb" - for example:
 
 `/api/access/datafile/12345?format=original`
 

--- a/doc/release-notes/7720-extended-s3-redirects.md
+++ b/doc/release-notes/7720-extended-s3-redirects.md
@@ -1,6 +1,6 @@
 ### Extended support for S3 Download Redirects ("Direct Downloads").
 
-If your installation uses S3 for storage, and you have "direct downloads" enabled, please note that, as of this release, it will cover the following download types that were not handled by redirects in the earlier versions: saved originals of tabular data files, cached RData frames, resized thumbnails for image files and other auxiliary files. In other words, all the forms of the file download API that take extra arguments, such as "format" or "imageThumb" - for example:
+If your installation uses S3 for storage and you have "direct downloads" enabled, please note that it will now cover the following download types that were not handled by redirects in the earlier versions: saved originals of tabular data files, cached RData frames, resized thumbnails for image files and other auxiliary files. In other words, all the forms of the file download API that take extra arguments, such as "format" or "imageThumb" - for example:
 
 `/api/access/datafile/12345?format=original`
 
@@ -8,7 +8,7 @@ If your installation uses S3 for storage, and you have "direct downloads" enable
 
 etc., that were previously excluded.
 
-This change should not in any way affect the web GUI users. Since browsers follow redirects automatically. Some API users may experience problems, if they use it in a way that does not expect to receive a redirect response. For example, if a user has a script where they expect to download a saved original of an ingested tabular file with the following command:
+Since browsers follow redirects automatically, this change should not in any way affect the web GUI users. However, some API users may experience problems, if they use it in a way that does not expect to receive a redirect response. For example, if a user has a script where they expect to download a saved original of an ingested tabular file with the following command:
 
 `curl https://yourhost.edu/api/access/datafile/12345?format=original > orig.dta`
 

--- a/doc/release-notes/7720-extended-s3-redirects.md
+++ b/doc/release-notes/7720-extended-s3-redirects.md
@@ -1,0 +1,16 @@
+### Extended support for S3 Download Redirects ("Direct Downloads").
+
+If your installation uses S3 for storage, and have "direct downloads" enabled, please note that, as of this release, it will cover the following download types that were not handled by redirects in the earlier versions: saved originals of tabular data files, cached RData frames, resized thumbnails for image files and other auxiliary files. In other words, all the forms of the file download API that take extra arguments, such as "format" or "imageThumb" - for example:
+`/api/access/datafile/12345?format=original`
+`/api/access/datafile/:persistentId?persistentId=doi:1234/ABCDE/FGHIJ?imageThumb=true`
+etc., that were previously excluded.
+
+This change should not in any way affect the web GUI users. Since browsers follow redirects automatically. Some API users may experience problems, if they use it in a way that does not expect to receive a redirect response. For example, if a user has a script where they expect to download a saved original of an ingested tabular file with the following command:
+
+`curl https://yourhost.edu/api/access/datafile/12345?format=original > orig.dta`
+
+it will fail to save the file when it receives a 303 (redirect) response instead of 200. So they will need to add "-L" to the command line above, to instruct curl to follow redirects:
+
+`curl -L https://yourhost.edu/api/access/datafile/12345?format=original > orig.dta`
+
+Most of your API users have likely figured it out already, since you enabled S3 redirects for "straightforward" downloads in your installation. But we feel it was worth a heads up, just in case. 

--- a/doc/release-notes/7720-extended-s3-redirects.md
+++ b/doc/release-notes/7720-extended-s3-redirects.md
@@ -4,7 +4,7 @@ If your installation uses S3 for storage, and have "direct downloads" enabled, p
 
 `/api/access/datafile/12345?format=original`
 
-`/api/access/datafile/:persistentId?persistentId=doi:1234/ABCDE/FGHIJ?imageThumb=true`
+`/api/access/datafile/:persistentId?persistentId=doi:1234/ABCDE/FGHIJ&imageThumb=true`
 
 etc., that were previously excluded.
 

--- a/doc/release-notes/7720-extended-s3-redirects.md
+++ b/doc/release-notes/7720-extended-s3-redirects.md
@@ -2,9 +2,10 @@
 
 If your installation uses S3 for storage, and have "direct downloads" enabled, please note that, as of this release, it will cover the following download types that were not handled by redirects in the earlier versions: saved originals of tabular data files, cached RData frames, resized thumbnails for image files and other auxiliary files. In other words, all the forms of the file download API that take extra arguments, such as "format" or "imageThumb" - for example:
 
-`/api/access/datafile/12345?format=original`
-
-`/api/access/datafile/:persistentId?persistentId=doi:1234/ABCDE/FGHIJ?imageThumb=true`
+```
+   /api/access/datafile/12345?format=original
+   /api/access/datafile/:persistentId?persistentId=doi:1234/ABCDE/FGHIJ?imageThumb=true
+```
 
 etc., that were previously excluded.
 

--- a/src/main/java/edu/harvard/iq/dataverse/api/DownloadInstanceWriter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/DownloadInstanceWriter.java
@@ -3,13 +3,12 @@
  * To change this template file, choose Tools | Templates
  * and open the template in the editor.
  */
-
 package edu.harvard.iq.dataverse.api;
 
 import edu.harvard.iq.dataverse.AuxiliaryFile;
 import java.lang.reflect.Type;
 import java.lang.annotation.Annotation;
-import java.io.InputStream; 
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.IOException;
 
@@ -30,6 +29,7 @@ import edu.harvard.iq.dataverse.engine.command.exception.CommandException;
 import edu.harvard.iq.dataverse.engine.command.impl.CreateGuestbookResponseCommand;
 import edu.harvard.iq.dataverse.makedatacount.MakeDataCountLoggingServiceBean;
 import edu.harvard.iq.dataverse.makedatacount.MakeDataCountLoggingServiceBean.MakeDataCountEntry;
+import edu.harvard.iq.dataverse.util.FileUtil;
 import java.io.File;
 import java.io.FileInputStream;
 import java.net.URI;
@@ -53,13 +53,12 @@ import org.apache.tika.mime.MimeTypes;
  */
 @Provider
 public class DownloadInstanceWriter implements MessageBodyWriter<DownloadInstance> {
-    
+
     @Inject
     MakeDataCountLoggingServiceBean mdcLogService;
-    
+
     private static final Logger logger = Logger.getLogger(DownloadInstanceWriter.class.getCanonicalName());
 
-    
     @Override
     public boolean isWriteable(Class<?> clazz, Type type, Annotation[] annotation, MediaType mediaType) {
         return clazz == DownloadInstance.class;
@@ -70,51 +69,187 @@ public class DownloadInstanceWriter implements MessageBodyWriter<DownloadInstanc
         return -1;
         //return getFileSize(di);
     }
-    
+
     @Override
     public void writeTo(DownloadInstance di, Class<?> clazz, Type type, Annotation[] annotation, MediaType mediaType, MultivaluedMap<String, Object> httpHeaders, OutputStream outstream) throws IOException, WebApplicationException {
 
-        
         if (di.getDownloadInfo() != null && di.getDownloadInfo().getDataFile() != null) {
             DataAccessRequest daReq = new DataAccessRequest();
-            
-            
-            
+
             DataFile dataFile = di.getDownloadInfo().getDataFile();
             StorageIO<DataFile> storageIO = DataAccess.getStorageIO(dataFile, daReq);
-                        
+
             if (storageIO != null) {
                 try {
                     storageIO.open();
                 } catch (IOException ioex) {
                     //throw new WebApplicationException(Response.Status.SERVICE_UNAVAILABLE);
                     logger.log(Level.INFO, "Datafile {0}: Failed to locate and/or open physical file. Error message: {1}", new Object[]{dataFile.getId(), ioex.getLocalizedMessage()});
-                    throw new NotFoundException("Datafile "+dataFile.getId()+": Failed to locate and/or open physical file.");
+                    throw new NotFoundException("Datafile " + dataFile.getId() + ": Failed to locate and/or open physical file.");
                 }
-                
+
+                // Before we do anything else, check if this download can be handled 
+                // by a redirect to remote storage (only supported on S3, as of 5.4):
+                if (storageIO instanceof S3AccessIO && ((S3AccessIO) storageIO).downloadRedirectEnabled()) {
+
+                    // Even if the above is true, there are a few cases where a  
+                    // redirect is not applicable. 
+                    // For example, for a tabular file, we can redirect a request 
+                    // for a saved original; but CANNOT if it is a column subsetting 
+                    // request (must be streamed in real time locally); or a format
+                    // conversion that hasn't been cached and saved on S3 yet. 
+                    boolean redirectSupported = true;
+                    String auxiliaryTag = null;
+                    String auxiliaryType = null;
+                    String auxiliaryFileName = null; 
+
+                    if ("imageThumb".equals(di.getConversionParam())) {
+
+                        // Can redirect - but only if already generated and cached.
+                        int requestedSize = 0;
+                        if (!"".equals(di.getConversionParamValue())) {
+                            try {
+                                requestedSize = new Integer(di.getConversionParamValue());
+                            } catch (java.lang.NumberFormatException ex) {
+                                // it's ok, the default size will be used.
+                            }
+                        }
+
+                        auxiliaryTag = ImageThumbConverter.THUMBNAIL_SUFFIX + (requestedSize > 0 ? requestedSize : ImageThumbConverter.DEFAULT_THUMBNAIL_SIZE);
+
+                        if (isAuxiliaryObjectCached(storageIO, auxiliaryTag)) {
+                            auxiliaryType = ImageThumbConverter.THUMBNAIL_MIME_TYPE;
+                            String fileName = storageIO.getFileName();
+                            if (fileName != null) {
+                                auxiliaryFileName = fileName.replaceAll("\\.[^\\.]*$", ImageThumbConverter.THUMBNAIL_FILE_EXTENSION);
+                            }
+                        } else {
+                            redirectSupported = false;
+                        }
+
+                    } else if (di.getAuxiliaryFile() != null) {
+                        // We should support redirects to auxiliary files too.
+                    
+                        auxiliaryTag = di.getAuxiliaryFile().getFormatTag();
+                        String auxVersion = di.getAuxiliaryFile().getFormatVersion();
+                        if (auxVersion != null) {
+                            auxiliaryTag = auxiliaryTag + "_" + auxVersion;
+                        }
+                    
+                        if (isAuxiliaryObjectCached(storageIO, auxiliaryTag)) {
+                            String fileExtension = getFileExtension(di.getAuxiliaryFile());
+                            auxiliaryFileName = storageIO.getFileName() + "." + auxiliaryTag + fileExtension;
+                            auxiliaryType = di.getAuxiliaryFile().getContentType();
+                        } else {
+                            redirectSupported = false;
+                        }
+
+                    } else if (dataFile.isTabularData()) {
+                        // Many separate special cases here.
+
+                        if (di.getConversionParam() != null) {
+                            if (di.getConversionParam().equals("format")) {
+
+                                if ("original".equals(di.getConversionParamValue())) {
+                                    auxiliaryTag = StoredOriginalFile.SAVED_ORIGINAL_FILENAME_EXTENSION;
+                                    auxiliaryType = dataFile.getOriginalFileFormat(); 
+                                    auxiliaryFileName = dataFile.getOriginalFileName();
+                                } else {
+                                    // format conversions - can redirect, but only if 
+                                    // it has been cached already. 
+
+                                    auxiliaryTag = di.getConversionParamValue();
+                                    if (isAuxiliaryObjectCached(storageIO, auxiliaryTag)) {
+                                        auxiliaryType = di.getServiceFormatType(di.getConversionParam(), auxiliaryTag);
+                                        auxiliaryFileName = FileUtil.replaceExtension(storageIO.getFileName(), auxiliaryTag);
+                                    } else {
+                                        redirectSupported = false;
+                                    }
+                                }
+                            } else if (!di.getConversionParam().equals("noVarHeader")) {
+                                // This is a subset request - can't do. 
+                                redirectSupported = false;
+                            }
+                        } else {
+                            redirectSupported = false;
+                        }
+                    }
+
+                    if (redirectSupported) {
+                        // definitely close the (still open) S3 input stream, 
+                        // since we are not going to use it. The S3 documentation
+                        // emphasizes that it is very important not to leave these
+                        // lying around un-closed, since they are going to fill 
+                        // up the S3 connection pool!
+                        try {
+                            storageIO.getInputStream().close();
+                        } catch (IOException ioex) {
+                        }
+                        // [attempt to] redirect: 
+                        String redirect_url_str;
+                        try {
+                            redirect_url_str = ((S3AccessIO) storageIO).generateTemporaryS3Url(auxiliaryTag, auxiliaryType, auxiliaryFileName);
+                        } catch (IOException ioex) {
+                            redirect_url_str = null;
+                        }
+
+                        if (redirect_url_str == null) {
+                            throw new ServiceUnavailableException();
+                        }
+
+                        logger.fine("Data Access API: direct S3 url: " + redirect_url_str);
+                        URI redirect_uri;
+
+                        try {
+                            redirect_uri = new URI(redirect_url_str);
+                        } catch (URISyntaxException ex) {
+                            logger.info("Data Access API: failed to create S3 redirect url (" + redirect_url_str + ")");
+                            redirect_uri = null;
+                        }
+                        if (redirect_uri != null) {
+                            // increment the download count, if necessary:
+                            if (di.getGbr() != null) {
+                                try {
+                                    logger.fine("writing guestbook response, for an S3 download redirect.");
+                                    Command<?> cmd = new CreateGuestbookResponseCommand(di.getDataverseRequestService().getDataverseRequest(), di.getGbr(), di.getGbr().getDataFile().getOwner());
+                                    di.getCommand().submit(cmd);
+                                    MakeDataCountEntry entry = new MakeDataCountEntry(di.getRequestUriInfo(), di.getRequestHttpHeaders(), di.getDataverseRequestService(), di.getGbr().getDataFile());
+                                    mdcLogService.logEntry(entry);
+                                } catch (CommandException e) {
+                                }
+                            }
+
+                            // finally, issue the redirect:
+                            Response response = Response.seeOther(redirect_uri).build();
+                            logger.fine("Issuing redirect to the file location on S3.");
+                            throw new RedirectionException(response);
+                        }
+                        throw new ServiceUnavailableException();
+                    }
+                }
+
                 if (di.getConversionParam() != null) {
                     // Image Thumbnail and Tabular data conversion: 
                     // NOTE: only supported on local files, as of 4.0.2!
                     // NOTE: should be supported on all files for which StorageIO drivers
                     // are available (but not on harvested files1) -- L.A. 4.6.2
-                    
-                    if (di.getConversionParam().equals("imageThumb") && !dataFile.isHarvested()) { 
+
+                    if (di.getConversionParam().equals("imageThumb") && !dataFile.isHarvested()) {
                         if ("".equals(di.getConversionParamValue())) {
-                            storageIO = ImageThumbConverter.getImageThumbnailAsInputStream(storageIO, ImageThumbConverter.DEFAULT_THUMBNAIL_SIZE); 
+                            storageIO = ImageThumbConverter.getImageThumbnailAsInputStream(storageIO, ImageThumbConverter.DEFAULT_THUMBNAIL_SIZE);
                         } else {
                             try {
                                 int size = new Integer(di.getConversionParamValue());
-                                if (size > 0) {                                    
+                                if (size > 0) {
                                     storageIO = ImageThumbConverter.getImageThumbnailAsInputStream(storageIO, size);
                                 }
                             } catch (java.lang.NumberFormatException ex) {
                                 storageIO = ImageThumbConverter.getImageThumbnailAsInputStream(storageIO, ImageThumbConverter.DEFAULT_THUMBNAIL_SIZE);
                             }
-                            
+
                             // and, since we now have tabular data files that can 
                             // have thumbnail previews... obviously, we don't want to 
                             // add the variable header to the image stream!
-                            
                             storageIO.setNoVarHeader(Boolean.TRUE);
                             storageIO.setVarHeader(null);
                         }
@@ -124,7 +259,7 @@ public class DownloadInstanceWriter implements MessageBodyWriter<DownloadInstanc
                         // tab files tagged as "geospatial"). We are going to assume that you can 
                         // do only ONE thing at a time - request the thumbnail for the file, or 
                         // request any tabular-specific services. 
-                        
+
                         if (di.getConversionParam().equals("noVarHeader")) {
                             logger.fine("tabular data with no var header requested");
                             storageIO.setNoVarHeader(Boolean.TRUE);
@@ -133,43 +268,42 @@ public class DownloadInstanceWriter implements MessageBodyWriter<DownloadInstanc
                             // Conversions, and downloads of "stored originals" are 
                             // now supported on all DataFiles for which StorageIO 
                             // access drivers are available.
-                            
+
                             if ("original".equals(di.getConversionParamValue())) {
                                 logger.fine("stored original of an ingested file requested");
                                 storageIO = StoredOriginalFile.retreive(storageIO);
                             } else {
                                 // Other format conversions: 
-                                logger.fine("format conversion on a tabular file requested ("+di.getConversionParamValue()+")");
-                                String requestedMimeType = di.getServiceFormatType(di.getConversionParam(), di.getConversionParamValue()); 
+                                logger.fine("format conversion on a tabular file requested (" + di.getConversionParamValue() + ")");
+                                String requestedMimeType = di.getServiceFormatType(di.getConversionParam(), di.getConversionParamValue());
                                 if (requestedMimeType == null) {
                                     // default mime type, in case real type is unknown;
                                     // (this shouldn't happen in real life - but just in case): 
                                     requestedMimeType = "application/octet-stream";
-                                } 
-                                storageIO = 
-                                        DataConverter.performFormatConversion(dataFile, 
-                                        storageIO, 
-                                        di.getConversionParamValue(), requestedMimeType);
-                            } 
+                                }
+                                storageIO
+                                        = DataConverter.performFormatConversion(dataFile,
+                                                storageIO,
+                                                di.getConversionParamValue(), requestedMimeType);
+                            }
                         } else if (di.getConversionParam().equals("subset")) {
                             logger.fine("processing subset request.");
-                            
+
                             // TODO: 
                             // If there are parameters on the list that are 
                             // not valid variable ids, or if the do not belong to 
                             // the datafile referenced - I simply skip them; 
                             // perhaps I should throw an invalid argument exception 
                             // instead. 
-                            
                             if (di.getExtraArguments() != null && di.getExtraArguments().size() > 0) {
-                                logger.fine("processing extra arguments list of length "+di.getExtraArguments().size());
-                                List <Integer> variablePositionIndex = new ArrayList<>();
+                                logger.fine("processing extra arguments list of length " + di.getExtraArguments().size());
+                                List<Integer> variablePositionIndex = new ArrayList<>();
                                 String subsetVariableHeader = null;
                                 for (int i = 0; i < di.getExtraArguments().size(); i++) {
-                                    DataVariable variable = (DataVariable)di.getExtraArguments().get(i);
+                                    DataVariable variable = (DataVariable) di.getExtraArguments().get(i);
                                     if (variable != null) {
                                         if (variable.getDataTable().getDataFile().getId().equals(dataFile.getId())) {
-                                            logger.fine("adding variable id "+variable.getId()+" to the list.");
+                                            logger.fine("adding variable id " + variable.getId() + " to the list.");
                                             variablePositionIndex.add(variable.getFileOrder());
                                             if (subsetVariableHeader == null) {
                                                 subsetVariableHeader = variable.getName();
@@ -180,9 +314,9 @@ public class DownloadInstanceWriter implements MessageBodyWriter<DownloadInstanc
                                         } else {
                                             logger.warning("variable does not belong to this data file.");
                                         }
-                                    }  
+                                    }
                                 }
-                                
+
                                 if (variablePositionIndex.size() > 0) {
 
                                     try {
@@ -222,10 +356,9 @@ public class DownloadInstanceWriter implements MessageBodyWriter<DownloadInstanc
                             } else {
                                 logger.fine("empty list of extra arguments.");
                             }
-                        } 
+                        }
                     }
-                    
-                    
+
                     if (storageIO == null) {
                         //throw new WebApplicationException(Response.Status.SERVICE_UNAVAILABLE);
                         // 404/not found may be a better return code option here
@@ -234,8 +367,11 @@ public class DownloadInstanceWriter implements MessageBodyWriter<DownloadInstanc
                     }
                 } else if (di.getAuxiliaryFile() != null) {
                     // Make sure to close the InputStream for the main datafile: 
-                    try {storageIO.getInputStream().close();} catch (IOException ioex) {}
-                    String auxTag = di.getAuxiliaryFile().getFormatTag(); 
+                    try {
+                        storageIO.getInputStream().close();
+                    } catch (IOException ioex) {
+                    }
+                    String auxTag = di.getAuxiliaryFile().getFormatTag();
                     String auxVersion = di.getAuxiliaryFile().getFormatVersion();
                     if (auxVersion != null) {
                         auxTag = auxTag + "_" + auxVersion;
@@ -246,65 +382,16 @@ public class DownloadInstanceWriter implements MessageBodyWriter<DownloadInstanc
                     auxStreamIO.setFileName(storageIO.getFileName() + "." + auxTag + fileExtension);
                     auxStreamIO.setMimeType(di.getAuxiliaryFile().getContentType());
                     storageIO = auxStreamIO;
-                    
-                } else {
-                    if (storageIO instanceof S3AccessIO && !(dataFile.isTabularData()) && ((S3AccessIO) storageIO).downloadRedirectEnabled()) {
-                        // definitely close the (still open) S3 input stream, 
-                        // since we are not going to use it. The S3 documentation
-                        // emphasizes that it is very important not to leave these
-                        // lying around un-closed, since they are going to fill 
-                        // up the S3 connection pool!
-                        try {storageIO.getInputStream().close();} catch (IOException ioex) {}
-                        // [attempt to] redirect: 
-                        String redirect_url_str; 
-                        try {
-                            redirect_url_str = ((S3AccessIO)storageIO).generateTemporaryS3Url();
-                        } catch (IOException ioex) {
-                            redirect_url_str = null; 
-                        }
-                        
-                        if (redirect_url_str == null) {
-                            throw new ServiceUnavailableException();
-                        }
-                        
-                        logger.fine("Data Access API: direct S3 url: "+redirect_url_str);
-                        URI redirect_uri; 
 
-                        try {
-                            redirect_uri = new URI(redirect_url_str);
-                        } catch (URISyntaxException ex) {
-                            logger.info("Data Access API: failed to create S3 redirect url ("+redirect_url_str+")");
-                            redirect_uri = null; 
-                        }
-                        if (redirect_uri != null) {
-                            // increment the download count, if necessary:
-                            if (di.getGbr() != null) {
-                                try {
-                                    logger.fine("writing guestbook response, for an S3 download redirect.");
-                                    Command<?> cmd = new CreateGuestbookResponseCommand(di.getDataverseRequestService().getDataverseRequest(), di.getGbr(), di.getGbr().getDataFile().getOwner());
-                                    di.getCommand().submit(cmd);
-                                    MakeDataCountEntry entry = new MakeDataCountEntry(di.getRequestUriInfo(), di.getRequestHttpHeaders(), di.getDataverseRequestService(), di.getGbr().getDataFile());
-                                    mdcLogService.logEntry(entry);
-                                } catch (CommandException e) {
-                                }
-                            }
-                            
-                            // finally, issue the redirect:
-                            Response response = Response.seeOther(redirect_uri).build();
-                            logger.fine("Issuing redirect to the file location on S3.");
-                            throw new RedirectionException(response);
-                        }
-                        throw new ServiceUnavailableException();
-                    }
-                }
-                
+                } 
+
                 InputStream instream = storageIO.getInputStream();
                 if (instream != null) {
                     // headers:
-                    
-                    String fileName = storageIO.getFileName(); 
-                    String mimeType = storageIO.getMimeType(); 
-                    
+
+                    String fileName = storageIO.getFileName();
+                    String mimeType = storageIO.getMimeType();
+
                     // Provide both the "Content-disposition" and "Content-Type" headers,
                     // to satisfy the widest selection of browsers out there. 
                     // Encode the filename as UTF-8, then deal with spaces. "encode" changes
@@ -312,29 +399,27 @@ public class DownloadInstanceWriter implements MessageBodyWriter<DownloadInstanc
                     String finalFileName = URLEncoder.encode(fileName, "UTF-8").replaceAll("\\+", "%20");
                     httpHeaders.add("Content-disposition", "attachment; filename=\"" + finalFileName + "\"");
                     httpHeaders.add("Content-Type", mimeType + "; name=\"" + finalFileName + "\"");
-                    
-                    long contentSize; 
-                    boolean useChunkedTransfer = false; 
+
+                    long contentSize;
+                    boolean useChunkedTransfer = false;
                     //if ((contentSize = getFileSize(di, storageIO.getVarHeader())) > 0) {
                     if ((contentSize = getContentSize(storageIO)) > 0) {
-                        logger.fine("Content size (retrieved from the AccessObject): "+contentSize);
-                        httpHeaders.add("Content-Length", contentSize); 
+                        logger.fine("Content size (retrieved from the AccessObject): " + contentSize);
+                        httpHeaders.add("Content-Length", contentSize);
                     } else {
                         //httpHeaders.add("Transfer-encoding", "chunked");
                         //useChunkedTransfer = true;
                     }
-                    
+
                     // (the httpHeaders map must be modified *before* writing any
                     // data in the output stream!)
-                                                              
                     int bufsize;
-                    byte [] bffr = new byte[4*8192];
-                    byte [] chunkClose = "\r\n".getBytes();
-                    
+                    byte[] bffr = new byte[4 * 8192];
+                    byte[] chunkClose = "\r\n".getBytes();
+
                     // before writing out any bytes from the input stream, flush
                     // any extra content, such as the variable header for the 
                     // subsettable files: 
-                    
                     if (storageIO.getVarHeader() != null) {
                         if (storageIO.getVarHeader().getBytes().length > 0) {
                             if (useChunkedTransfer) {
@@ -363,14 +448,12 @@ public class DownloadInstanceWriter implements MessageBodyWriter<DownloadInstanc
                         String chunkClosing = "0\r\n\r\n";
                         outstream.write(chunkClosing.getBytes());
                     }
-                    
-                    
-                    logger.fine("di conversion param: "+di.getConversionParam()+", value: "+di.getConversionParamValue());
-                    
+
+                    logger.fine("di conversion param: " + di.getConversionParam() + ", value: " + di.getConversionParamValue());
+
                     // Downloads of thumbnail images (scaled down, low-res versions of graphic image files) and 
                     // "preprocessed metadata" records for tabular data files are NOT considered "real" downloads, 
                     // so these should not produce guestbook entries: 
-                    
                     if (di.getGbr() != null && !(isThumbnailDownload(di) || isPreprocessedMetadataDownload(di))) {
                         try {
                             logger.fine("writing guestbook response.");
@@ -378,22 +461,31 @@ public class DownloadInstanceWriter implements MessageBodyWriter<DownloadInstanc
                             di.getCommand().submit(cmd);
                             MakeDataCountEntry entry = new MakeDataCountEntry(di.getRequestUriInfo(), di.getRequestHttpHeaders(), di.getDataverseRequestService(), di.getGbr().getDataFile());
                             mdcLogService.logEntry(entry);
-                        } catch (CommandException e) {}
+                        } catch (CommandException e) {
+                        }
                     } else {
                         logger.fine("not writing guestbook response");
-                    } 
-                    
+                    }
+
                     instream.close();
-                    outstream.close(); 
+                    outstream.close();
                     return;
                 }
             }
         }
-        
+
         throw new NotFoundException();
 
     }
 
+    private boolean isAuxiliaryObjectCached(StorageIO storageIO, String auxiliaryTag) {
+        try {
+            return storageIO.isAuxObjectCached(auxiliaryTag);
+        } catch (IOException cachedIOE) {
+            return false; 
+        }
+    }
+    
     private String getFileExtension(AuxiliaryFile auxFile) {
         String fileExtension = "";
         if (auxFile == null) {
@@ -412,46 +504,56 @@ public class DownloadInstanceWriter implements MessageBodyWriter<DownloadInstanc
     }
 
     private boolean isThumbnailDownload(DownloadInstance downloadInstance) {
-        if (downloadInstance == null) return false; 
-        
-        if (downloadInstance.getConversionParam() == null) return false; 
-        
+        if (downloadInstance == null) {
+            return false;
+        }
+
+        if (downloadInstance.getConversionParam() == null) {
+            return false;
+        }
+
         return downloadInstance.getConversionParam().equals("imageThumb");
     }
-    
+
     private boolean isPreprocessedMetadataDownload(DownloadInstance downloadInstance) {
-        if (downloadInstance == null) return false; 
-        
-        if (downloadInstance.getConversionParam() == null) return false; 
-        
-        if (downloadInstance.getConversionParamValue() == null) return false; 
-        
+        if (downloadInstance == null) {
+            return false;
+        }
+
+        if (downloadInstance.getConversionParam() == null) {
+            return false;
+        }
+
+        if (downloadInstance.getConversionParamValue() == null) {
+            return false;
+        }
+
         return downloadInstance.getConversionParam().equals("format") && downloadInstance.getConversionParamValue().equals("prep");
     }
-    
+
     private long getContentSize(StorageIO<?> accessObject) {
-        long contentSize = 0; 
-        
+        long contentSize = 0;
+
         if (accessObject.getSize() > -1) {
-            contentSize+=accessObject.getSize();
+            contentSize += accessObject.getSize();
             if (accessObject.getVarHeader() != null) {
                 if (accessObject.getVarHeader().getBytes().length > 0) {
-                    contentSize+=accessObject.getVarHeader().getBytes().length;
+                    contentSize += accessObject.getVarHeader().getBytes().length;
                 }
             }
             return contentSize;
         }
         return -1;
     }
-    
+
     private long getFileSize(DownloadInstance di) {
         return getFileSize(di, null);
     }
-    
+
     private long getFileSize(DownloadInstance di, String extraHeader) {
-        if (di.getDownloadInfo() != null && di.getDownloadInfo().getDataFile() != null) {           
+        if (di.getDownloadInfo() != null && di.getDownloadInfo().getDataFile() != null) {
             DataFile df = di.getDownloadInfo().getDataFile();
-            
+
             // For non-tabular files, we probably know the file size: 
             // (except for when this is a thumbNail rquest on an image file - 
             // because the size will obviously be different... can still be 
@@ -462,7 +564,7 @@ public class DownloadInstanceWriter implements MessageBodyWriter<DownloadInstanc
                     return df.getFilesize();
                 }
             }
-            
+
             // For Tabular files:
             // If it's just a straight file download, it's pretty easy - we 
             // already know the size of the file on disk (just like in the 
@@ -471,7 +573,6 @@ public class DownloadInstanceWriter implements MessageBodyWriter<DownloadInstanc
             // size to the total... But the cases when it's a format conversion 
             // and, especially, subsets are of course trickier. (these are not
             // supported yet).
-            
             if (df.isTabularData() && (di.getConversionParam() == null || "".equals(di.getConversionParam()))) {
                 long fileSize = df.getFilesize();
                 if (fileSize > 0) {

--- a/src/main/java/edu/harvard/iq/dataverse/dataaccess/ImageThumbConverter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/dataaccess/ImageThumbConverter.java
@@ -59,6 +59,7 @@ import java.util.Base64;
 public class ImageThumbConverter {
     public static String THUMBNAIL_SUFFIX = "thumb";
     public static String THUMBNAIL_MIME_TYPE = "image/png";
+    public static String THUMBNAIL_FILE_EXTENSION = ".png";
 
     public static int DEFAULT_CARDIMAGE_SIZE = 48;
     public static int DEFAULT_THUMBNAIL_SIZE = 64;
@@ -158,7 +159,7 @@ public class ImageThumbConverter {
 
             String fileName = storageIO.getFileName();
             if (fileName != null) {
-                fileName = fileName.replaceAll("\\.[^\\.]*$", ".png");
+                fileName = fileName.replaceAll("\\.[^\\.]*$", THUMBNAIL_FILE_EXTENSION);
                 inputStreamIO.setFileName(fileName);
             }
             return inputStreamIO;

--- a/src/main/java/edu/harvard/iq/dataverse/dataaccess/StoredOriginalFile.java
+++ b/src/main/java/edu/harvard/iq/dataverse/dataaccess/StoredOriginalFile.java
@@ -39,7 +39,7 @@ public class StoredOriginalFile {
         
     }
     
-    private static final String SAVED_ORIGINAL_FILENAME_EXTENSION = "orig";
+    public static final String SAVED_ORIGINAL_FILENAME_EXTENSION = "orig";
     
     public static StorageIO<DataFile> retreive(StorageIO<DataFile> storageIO) {
         String originalMimeType;


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR extends support for S3 redirects to the extra (auxiliary) files that are stored in addition to the main physical file: saved originals and cached RData frames for tabular files; resized thumbnails for image files; and uploaded auxiliary files (like the OpenDP ones), for which we don't currently support direct S3 downloads.

**Which issue(s) this PR closes**:

Closes #7720

**Special notes for your reviewer**:

The original issue specifically has the "stored originals" in the title. But, as was discussed during the planning meeting, we wanted to implement this redirect support for all the types where it is possible. (i.e. for all the files that are cached and/or stored on S3). 

No reason NOT to support S3 redirect on any of these file types, is there? 

The implementation is a bit of a mess of special cases, added to the part of the code that's already messy. But I have an open issue for refactoring/cleaning it up for real (#7721). 

**Suggestions on how to test this**:

Testing it may be a little tedious - all the download types listed will need to be tested, and confirmed that they are now being redirected, AND working properly, as before. (for example, for a saved original that is a stata file, the downloaded file should have the correct name with the .dta extension... etc.)

Any software clients that are currently expecting to just get a 200, and the file, from our API (i.e., not following redirects automatically) may experience temporary difficulties when this is deployed. One case we should probably test is Data Explorer. (it downloads the "prep" file from the application; this will become a redirect as of this PR). 

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

no

**Is there a release notes update needed for this change?**:

yes

**Additional documentation**:
