### PR TITLE
correct 2nd and 6th occurrences of dataverse.files.directory in config.html

### DIFF
--- a/doc/sphinx-guides/source/installation/config.rst
+++ b/doc/sphinx-guides/source/installation/config.rst
@@ -242,7 +242,7 @@ As for the "Remote only" authentication mode, it means that:
 File Storage: Using a Local Filesystem and/or Swift and/or S3 object stores
 ---------------------------------------------------------------------------
 
-By default, a Dataverse installation stores all data files (files uploaded by end users) on the filesystem at ``/usr/local/payara5/glassfish/domains/domain1/files``. This path can vary based on answers you gave to the installer (see the :ref:`dataverse-installer` section of the Installation Guide) or afterward by reconfiguring the ``dataverse.files.directory`` JVM option described below.
+By default, a Dataverse installation stores all data files (files uploaded by end users) on the filesystem at ``/usr/local/payara5/glassfish/domains/domain1/files``. This path can vary based on answers you gave to the installer (see the :ref:`dataverse-installer` section of the Installation Guide) or afterward by reconfiguring the ``dataverse.files.id.directory`` JVM option described below.
 
 A Dataverse installation can alternately store files in a Swift or S3-compatible object store, and can now be configured to support multiple stores at once. With a multi-store configuration, the location for new files can be controlled on a per-Dataverse collection basis.
 
@@ -1027,8 +1027,8 @@ dataverse.siteUrl
 	``<jvm-options>-Ddataverse.fqdn=dataverse.example.edu</jvm-options>``
 	``<jvm-options>-Ddataverse.siteUrl=http://${dataverse.fqdn}:8080</jvm-options>``
 
-dataverse.files.directory
-+++++++++++++++++++++++++
+dataverse.files.id.directory
+++++++++++++++++++++++++++++
 
 This is how you configure the path to which files uploaded by users are stored.
 


### PR DESCRIPTION
**What this PR does / why we need it**: updates multi-store documentation to distinguish `dataverse.files.<id>.directory` from `dataverse.files.directory` 

**Which issue(s) this PR closes**:

Closes #7861 

**Special notes for your reviewer**: suggest qqmyers to review

**Suggestions on how to test this**: set options in a test instance with multiple stores configured

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: no

**Is there a release notes update needed for this change?**: no

**Additional documentation**: none
