### PR TITLE
fix for the null pointer in isHarvested() method. (#7849)

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DataFile.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DataFile.java
@@ -763,12 +763,6 @@ public class DataFile extends DvObject implements Comparable {
     
     public boolean isHarvested() {
         
-        // (storageIdentifier is not nullable - so no need to check for null
-        // pointers below):
-        if (this.getStorageIdentifier().startsWith("http://") || this.getStorageIdentifier().startsWith("https://")) {
-            return true;
-        }
-        
         Dataset ownerDataset = this.getOwner();
         if (ownerDataset != null) {
             return ownerDataset.isHarvested(); 

--- a/src/main/java/edu/harvard/iq/dataverse/util/FileUtil.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/FileUtil.java
@@ -1668,7 +1668,7 @@ public class FileUtil implements java.io.Serializable  {
             return false;
         }
         
-        if (file.isHarvested() || "".equals(file.getStorageIdentifier())) {
+        if (file.isHarvested() || StringUtil.isEmpty(file.getStorageIdentifier())) {
             return false;
         }
         


### PR DESCRIPTION
**What this PR does / why we need it**:

See the issue description, but largely self-explanatory. 

**Which issue(s) this PR closes**:

Closes #7849

**Special notes for your reviewer**:

**Suggestions on how to test this**:

Without this fix, trying to index a harvested dataset that has a file with a NULL in the storageidentifier filed, dvobject table, results in a failure to index and a stack trace in the log file. (Can provide queries for creating a test case in a db, if needed). 


**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
