### PR TITLE
increase MAXIMUM_INGEST_LOCK_DURATION for slower storage

### DIFF
--- a/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
@@ -53,7 +53,7 @@ public class UtilIT {
     private static final String API_TOKEN_KEY = "apiToken";
     private static final String BUILTIN_USER_KEY = "burrito";
     private static final String EMPTY_STRING = "";
-    public static final int MAXIMUM_INGEST_LOCK_DURATION = 3;
+    public static final int MAXIMUM_INGEST_LOCK_DURATION = 15;
     public static final int MAXIMUM_PUBLISH_LOCK_DURATION = 15;
     
     private static SwordConfigurationImpl swordConfiguration = new SwordConfigurationImpl();


### PR DESCRIPTION
**What this PR does / why we need it**: the current lock duration of 3 seconds is too short on my local storage.

**Which issue(s) this PR closes**:

Closes #7869 

**Special notes for your reviewer**: none

**Suggestions on how to test this**: run integration test suite on slower storage

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: no

**Is there a release notes update needed for this change?**: no

**Additional documentation**: my 100th pull request!