### PR TITLE
Fix Metrics API Error response

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/makedatacount/MakeDataCountUtil.java
+++ b/src/main/java/edu/harvard/iq/dataverse/makedatacount/MakeDataCountUtil.java
@@ -87,7 +87,15 @@ public class MakeDataCountUtil {
                     }
                 }
             }
-            throw new IllegalArgumentException("MetricType must be one of these values: " + Arrays.asList(MetricType.values()) + ".");
+            throw new IllegalArgumentException("MetricType must be one of these values: " + getMetricNameList() + ".");
+        }
+        
+        private static List<String> getMetricNameList() {
+           ArrayList<String> names = new ArrayList<String>();
+           for(MetricType mt: MetricType.values()) {
+               names.add(mt.text);
+           }
+            return names;
         }
 
         @Override


### PR DESCRIPTION
**What this PR does / why we need it**: This PR fixes the error response when an invalid metric is requested in the MakeDataCount api

**Which issue(s) this PR closes**:

Closes #7872

**Special notes for your reviewer**: Not sure how we missed an IT test not passing? FWIW: metrics like viewsTotal are a combination of two metrics and in #7178 I changed the MetricType.toString() method to give the combination to simplify making the db queries. I didn't realize that toString was getting implicitly called in generating an error response for the API. I added a new method to get the list of names directly to handle the error response.

**Suggestions on how to test this**: Should pass the IT tests.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
