### PR TITLE
7823 dirindex web browsing and docs

### DIFF
--- a/doc/sphinx-guides/source/api/native-api.rst
+++ b/doc/sphinx-guides/source/api/native-api.rst
@@ -825,13 +825,19 @@ through the Dataverse application.
 
 For example, if you have a dataset version with 2 files, one with the folder named "subfolder":
 
+|image1|
+
 .. |image1| image:: ./img/dataset_page_files_view.png
 
 or, as viewed as a tree on the dataset page:
 
+|image2|
+
 .. |image2| image:: ./img/dataset_page_tree_view.png
 
 The output of the API for the top-level folder (``/api/datasets/{dataset}/dirindex/``) will be as follows:
+
+|image3|
 
 .. |image3| image:: ./img/index_view_top.png
 
@@ -850,6 +856,8 @@ with the underlying html source:
     </table></body></html>
 
 The ``/dirindex/?folder=subfolder`` link above will produce the following view:
+
+|image4|
 
 .. |image4| image:: ./img/index_view_subfolder.png
 

--- a/src/main/java/edu/harvard/iq/dataverse/api/Datasets.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Datasets.java
@@ -497,7 +497,7 @@ public class Datasets extends AbstractApiBean {
         
         String indexFileName = folderName.equals("") ? ".index.html"
                 : ".index-" + folderName.replace('/', '_') + ".html";
-        response.setHeader("Content-disposition", "attachment; filename=\"" + indexFileName + "\"");
+        response.setHeader("Content-disposition", "filename=\"" + indexFileName + "\"");
 
         
         return Response.ok()


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request lets people use their web browsers on the "dirindex" API feature. That is, you can navigate to a URL like http://localhost:8080/api/datasets/67/dirindex in your browser and see files (and sometimes folders).

Given a dataset like this with files in folders...

<img width="1148" alt="Screen Shot 2021-05-21 at 2 03 37 PM" src="https://user-images.githubusercontent.com/21006/119182285-b6a6f380-ba40-11eb-8b17-eba95c502d26.png">

... here's how "dirindex" looks...

<img width="1000" alt="Screen Shot 2021-05-21 at 2 01 02 PM" src="https://user-images.githubusercontent.com/21006/119182407-dc33fd00-ba40-11eb-97b4-223ff1bd04bb.png">

... and if you drill down into a directory, it looks like this:

<img width="1000" alt="Screen Shot 2021-05-21 at 2 04 05 PM" src="https://user-images.githubusercontent.com/21006/119182290-b73f8a00-ba40-11eb-8420-17bb80fdce57.png">

This pull request also corrects the documentation for this feature, adding images that were in the source but not rendered on the page. Compare below (with images) to https://guides.dataverse.org/en/5.5/api/native-api.html#view-dataset-files-and-folders-as-a-directory-index

<img width="455" alt="Screen Shot 2021-05-21 at 2 20 13 PM" src="https://user-images.githubusercontent.com/21006/119182218-a1ca6000-ba40-11eb-86d7-1d2e59fd3423.png">

**Which issue(s) this PR closes**:

Closes #7823

**Special notes for your reviewer**:

We do want images in the docs, right? I assume that was the intention. I made the images live in 86b70b7. 

**Suggestions on how to test this**:

Make sure you can use a web browser on dirindex as described above and in the docs.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No but I think we should someday consider linking to this view from the UI since it can be used in a web browser. It would make the feature more discoverable than it is now, somewhat buried in the API Guide.

**Is there a release notes update needed for this change?**:

I don't think so. It's just a bug fix. My reading of the docs is that this is how it was intended to work all along, given the screenshots already in the docs.

**Additional documentation**:

None but (again) I did fix the images.