### PR TITLE
#7906 delete extra space from the end of an API success message.

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/api/Admin.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Admin.java
@@ -379,9 +379,8 @@ public class Admin extends AbstractApiBean {
         authSvc.removeAuthentictedUserItems(au);
         
         authSvc.deleteAuthenticatedUser(au.getId());
-        return ok("AuthenticatedUser " + au.getIdentifier() + " deleted. ");
-
-    }  
+        return ok("AuthenticatedUser " + au.getIdentifier() + " deleted.");
+    }
 
     @POST
     @Path("authenticatedUsers/{identifier}/deactivate")

--- a/src/test/java/edu/harvard/iq/dataverse/api/AdminIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/AdminIT.java
@@ -71,10 +71,15 @@ public class AdminIT {
 
         Response deleteNonSuperuser = UtilIT.deleteUser(nonSuperuserUsername);
         assertEquals(200, deleteNonSuperuser.getStatusCode());
+        assertEquals(
+          "{\"status\":\"OK\",\"data\":{\"message\":\"AuthenticatedUser @" + nonSuperuserUsername + " deleted.\"}}",
+          deleteNonSuperuser.getBody().asString());
 
         Response deleteSuperuser = UtilIT.deleteUser(superuserUsername);
         assertEquals(200, deleteSuperuser.getStatusCode());
-
+        assertEquals(
+          "{\"status\":\"OK\",\"data\":{\"message\":\"AuthenticatedUser @" + superuserUsername + " deleted.\"}}",
+          deleteSuperuser.getBody().asString());
     }
 
     

--- a/src/test/java/edu/harvard/iq/dataverse/api/AdminIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/AdminIT.java
@@ -71,17 +71,10 @@ public class AdminIT {
 
         Response deleteNonSuperuser = UtilIT.deleteUser(nonSuperuserUsername);
         assertEquals(200, deleteNonSuperuser.getStatusCode());
-        assertEquals(
-          "{\"status\":\"OK\",\"data\":{\"message\":\"AuthenticatedUser @" + nonSuperuserUsername + " deleted.\"}}",
-          deleteNonSuperuser.getBody().asString());
 
         Response deleteSuperuser = UtilIT.deleteUser(superuserUsername);
         assertEquals(200, deleteSuperuser.getStatusCode());
-        assertEquals(
-          "{\"status\":\"OK\",\"data\":{\"message\":\"AuthenticatedUser @" + superuserUsername + " deleted.\"}}",
-          deleteSuperuser.getBody().asString());
     }
-
     
     @Test
     public void testFilterAuthenticatedUsersForbidden() throws Exception {


### PR DESCRIPTION
**What this PR does / why we need it**: When an administrator delete a user, s/he receives a JSON message containing a string: "AuthenticatedUser [identifier] deleted. ". At the end of this message there is an unwanted extra space.

**Which issue(s) this PR closes**:

Closes #7906 

**Special notes for your reviewer**: no

**Suggestions on how to test this**: no

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: no

**Is there a release notes update needed for this change?**: no

**Additional documentation**: no
