### PR TITLE
6070 reviewdog checkstyle

### DIFF
--- a/.github/workflows/reviewdog_checkstyle.yml
+++ b/.github/workflows/reviewdog_checkstyle.yml
@@ -1,0 +1,21 @@
+name: Maven CheckStyle Task
+on:
+   pull_request:
+       paths:
+           - "**.java"
+
+jobs:
+    checkstyle_job:
+        runs-on: ubuntu-latest
+        name: Checkstyle job
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v2
+            - name: Run check style
+              uses: nikitasavinov/checkstyle-action@master
+              with:
+                  fail_on_error: true
+                  reporter: github-pr-review
+                  checkstyle_config: checkstyle.xml
+                  github_token: ${{ secrets.GITHUB_TOKEN }}
+


### PR DESCRIPTION
**What this PR does / why we need it**:
Now that #7801 has been merged and #6070 is resolved, we should make sure that no one reintroduces using the Apache Commons Lang v2 library by misusing a transitive dependency.

This PR will create a Github Action using @reviewdog to bark on any ***NEW*** `checkstyle` violations (not the existing), which includes making imports from the Java package invalid.

**Which issue(s) this PR closes**:
Relates to #6070

**Special notes for your reviewer**:
See #7886 for a demo (although it does not yet use inline review comments as used from a fork).

**Suggestions on how to test this**:
See the demo ;-)

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
Nope.

**Is there a release notes update needed for this change?**:
Nope.

**Additional documentation**:
We can enable more rules in the future. It would be good to check for code styling on new PRs and not rely on humans for that chore task.