### PR TITLE
bump Postgres to version 13

### DIFF
--- a/conf/docker-aio/c8.dockerfile
+++ b/conf/docker-aio/c8.dockerfile
@@ -1,10 +1,11 @@
 FROM centos:8
 # OS dependencies
-# PG 10 is the default in centos8; keep the repo comment for when we bump to 11+
-#RUN yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm
+# IQSS now recommends Postgres 13.
+RUN dnf -qy module disable postgresql
+RUN yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm
 
 RUN echo "fastestmirror=true" >> /etc/dnf/dnf.conf
-RUN yum install -y java-11-openjdk-devel postgresql-server sudo epel-release unzip curl httpd python2 diffutils
+RUN yum install -y java-11-openjdk-devel postgresql13-server sudo epel-release unzip curl httpd python2 diffutils
 RUN yum install -y jq lsof awscli
 
 # for older search scripts
@@ -29,10 +30,10 @@ RUN cd /opt ; unzip /tmp/dv/deps/payara-5.2020.6.zip ; ln -s /opt/payara5 /opt/g
 # this dies under Java 11, do we keep it?
 #COPY domain-restmonitor.xml /opt/payara5/glassfish/domains/domain1/config/domain.xml
 
-RUN sudo -u postgres /usr/bin/initdb /var/lib/pgsql/data
+RUN sudo -u postgres /usr/pgsql-13/bin/initdb -D /var/lib/pgsql/13/data
 
 # copy configuration related files
-RUN cp /tmp/dv/pg_hba.conf /var/lib/pgsql/data/
+RUN cp /tmp/dv/pg_hba.conf /var/lib/pgsql/13/data/
 RUN cp -r /opt/solr-8.8.1/server/solr/configsets/_default /opt/solr-8.8.1/server/solr/collection1
 RUN cp /tmp/dv/schema*.xml /opt/solr-8.8.1/server/solr/collection1/conf/
 RUN cp /tmp/dv/solrconfig.xml /opt/solr-8.8.1/server/solr/collection1/conf/solrconfig.xml

--- a/conf/docker-aio/entrypoint.bash
+++ b/conf/docker-aio/entrypoint.bash
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 export LANG=en_US.UTF-8
-sudo -u postgres /usr/bin/pg_ctl start -D /var/lib/pgsql/data &
+sudo -u postgres /usr/pgsql-13/bin/pg_ctl start -D /var/lib/pgsql/13/data &
 cd /opt/solr-8.8.1/
 # TODO: Run Solr as non-root and remove "-force".
 bin/solr start -force
@@ -9,8 +9,8 @@ bin/solr create_core -c collection1 -d server/solr/collection1/conf -force
 # start apache, in both foreground and background...
 apachectl -DFOREGROUND &
 
-# TODO: Run Glassfish as non-root.
-cd /opt/glassfish4
+# TODO: Run Payara as non-root.
+cd /opt/payara5
 bin/asadmin start-domain --debug
 sleep infinity
 

--- a/scripts/vagrant/setup.sh
+++ b/scripts/vagrant/setup.sh
@@ -35,16 +35,15 @@ echo "export MAVEN_HOME=/opt/maven" >> /etc/profile.d/maven.sh
 echo "export PATH=/opt/maven/bin:${PATH}" >> /etc/profile.d/maven.sh
 chmod 0755 /etc/profile.d/maven.sh
 
-# disable centos8 postgresql module and install postgresql10-server
-# note: postgresql10 because 9.6 isn't backwards compatible with python3-psycopg2
+# disable centos8 postgresql module and install postgresql13-server
 dnf -qy module disable postgresql
 dnf install -qy https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm
-dnf install -qy postgresql10-server
-/usr/pgsql-10/bin/postgresql-10-setup initdb
-/usr/bin/systemctl stop postgresql-10
-cp /dataverse/conf/vagrant/var/lib/pgsql/data/pg_hba.conf /var/lib/pgsql/10/data/pg_hba.conf
-/usr/bin/systemctl start postgresql-10
-/usr/bin/systemctl enable postgresql-10
+dnf install -qy postgresql13-server
+/usr/pgsql-13/bin/postgresql-13-setup initdb
+/usr/bin/systemctl stop postgresql-13
+cp /dataverse/conf/vagrant/var/lib/pgsql/data/pg_hba.conf /var/lib/pgsql/13/data/pg_hba.conf
+/usr/bin/systemctl start postgresql-13
+/usr/bin/systemctl enable postgresql-13
 
 PAYARA_USER=dataverse
 echo "Ensuring Unix user '$PAYARA_USER' exists"


### PR DESCRIPTION
**What this PR does / why we need it**: IQSS now recommends Postgres version 13, issue #7660 notes that docker-aio and vagrant needed updating.

**Which issue(s) this PR closes**:

Closes #7660 

**Special notes for your reviewer**: none

**Suggestions on how to test this**: test with `vagrant up` and the instructions in docker-aio's readme.md

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: no

**Is there a release notes update needed for this change?**: no

**Additional documentation**: none
