### PR TITLE
Implement usage of user supplied handle for authentication. This is an optional parameter.

### DIFF
--- a/doc/sphinx-guides/source/installation/config.rst
+++ b/doc/sphinx-guides/source/installation/config.rst
@@ -1549,10 +1549,11 @@ By default this setting is absent and the Dataverse Software assumes it to be fa
 :HandleAuthHandle
 +++++++++++++++++++++++++
 
-Specific for Handle PIDs. Set this setting to <prefix/suffix> to be used on a global handle service when the public key is NOT stored in the default handle.
-By default this setting is absent and the Dataverse Software assumes it to be not set.
+Specific for Handle PIDs. Set this setting to <prefix>/<suffix> to be used on a global handle service when the public key is NOT stored in the default handle.
+By default this setting is absent and the Dataverse Software assumes it to be not set. If the public key for instance is stored in handle: 21.T12996/USER01.
+For this handle the prefix is '21.T12996' and the suffix is 'USER01'. The command to execute is then:
 
-``curl -X PUT -d '<prefix/<suffix>' http://localhost:8080/api/admin/settings/:HandleAuthHandle``
+``curl -X PUT -d '21.T12996/USER01' http://localhost:8080/api/admin/settings/:HandleAuthHandle``
 
 .. _:FileValidationOnPublishEnabled:
 

--- a/doc/sphinx-guides/source/installation/config.rst
+++ b/doc/sphinx-guides/source/installation/config.rst
@@ -205,6 +205,7 @@ Here are the configuration options for handles:
 - :ref:`:IdentifierGenerationStyle <:IdentifierGenerationStyle>` (optional)
 - :ref:`:DataFilePIDFormat <:DataFilePIDFormat>` (optional)
 - :ref:`:IndependentHandleService <:IndependentHandleService>` (optional)
+- :ref:`:HandleAuthHandle <:HandleAuthHandle>` (optional)
 
 Note: If you are **minting your own handles** and plan to set up your own handle service, please refer to `Handle.Net documentation <http://handle.net/hnr_documentation.html>`_.
 
@@ -1542,6 +1543,16 @@ Specific for Handle PIDs. Set this setting to true if you want to use a Handle s
 By default this setting is absent and the Dataverse Software assumes it to be false.
 
 ``curl -X PUT -d 'true' http://localhost:8080/api/admin/settings/:IndependentHandleService``
+
+.. _:HandleAuthHandle:
+
+:HandleAuthHandle
++++++++++++++++++++++++++
+
+Specific for Handle PIDs. Set this setting to <prefix/suffix> to be used on a global handle service when the public key is NOT stored in the default handle.
+By default this setting is absent and the Dataverse Software assumes it to be not set.
+
+``curl -X PUT -d '<prefix/<suffix>' http://localhost:8080/api/admin/settings/:HandleAuthHandle``
 
 .. _:FileValidationOnPublishEnabled:
 

--- a/src/main/java/edu/harvard/iq/dataverse/HandlenetServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/HandlenetServiceBean.java
@@ -314,7 +314,7 @@ public class HandlenetServiceBean extends AbstractGlobalIdServiceBean {
     
     private String getAuthenticationHandle(String handlePrefix) {
         logger.log(Level.FINE,"getAuthenticationHandle");
-        if (systemConfig.getHandleAuthHandle()) {
+        if (systemConfig.getHandleAuthHandle()!=null) {
             return systemConfig.getHandleAuthHandle();
         } else if (systemConfig.isIndependentHandleService()) {
             return handlePrefix + "/ADMIN";

--- a/src/main/java/edu/harvard/iq/dataverse/HandlenetServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/HandlenetServiceBean.java
@@ -314,7 +314,9 @@ public class HandlenetServiceBean extends AbstractGlobalIdServiceBean {
     
     private String getAuthenticationHandle(String handlePrefix) {
         logger.log(Level.FINE,"getAuthenticationHandle");
-        if (systemConfig.isIndependentHandleService()) {
+        if (systemConfig.getHandleAuthHandle()) {
+            return systemConfig.getHandleAuthHandle();
+        } else if (systemConfig.isIndependentHandleService()) {
             return handlePrefix + "/ADMIN";
         } else {
             return "0.NA/" + handlePrefix;

--- a/src/main/java/edu/harvard/iq/dataverse/settings/SettingsServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/settings/SettingsServiceBean.java
@@ -357,6 +357,11 @@ public class SettingsServiceBean {
         IndependentHandleService,
 
         /**
+        Handle to use for authentication if the default is not being used
+        */
+        HandleAuthHandle,
+
+        /**
          * Archiving can be configured by providing an Archiver class name (class must extend AstractSubmitToArchiverCommand)
          * and a list of settings that should be passed to the Archiver.
          * Note: 

--- a/src/main/java/edu/harvard/iq/dataverse/util/SystemConfig.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/SystemConfig.java
@@ -1045,8 +1045,8 @@ public class SystemConfig {
     
     }
     
-    public string getHandleAuthHandle() {
-        string HandleAuthHandle = settingsService.getValueForKey(SettingsServiceBean.Key.HandleAuthHandle, null);
+    public String getHandleAuthHandle() {
+        String HandleAuthHandle = settingsService.getValueForKey(SettingsServiceBean.Key.HandleAuthHandle, null);
         return HandleAuthHandle;
     }
 

--- a/src/main/java/edu/harvard/iq/dataverse/util/SystemConfig.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/SystemConfig.java
@@ -1046,8 +1046,8 @@ public class SystemConfig {
     }
     
     public String getHandleAuthHandle() {
-        String HandleAuthHandle = settingsService.getValueForKey(SettingsServiceBean.Key.HandleAuthHandle, null);
-        return HandleAuthHandle;
+        String handleAuthHandle = settingsService.getValueForKey(SettingsServiceBean.Key.HandleAuthHandle, null);
+        return handleAuthHandle;
     }
 
     public String getMDCLogPath() {

--- a/src/main/java/edu/harvard/iq/dataverse/util/SystemConfig.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/SystemConfig.java
@@ -1047,7 +1047,7 @@ public class SystemConfig {
     
     public string getHandleAuthHandle() {
         string HandleAuthHandle = settingsService.getValueForKey(SettingsServiceBean.Key.HandleAuthHandle, null);
-        return HandleAuthHandle
+        return HandleAuthHandle;
     }
 
     public String getMDCLogPath() {

--- a/src/main/java/edu/harvard/iq/dataverse/util/SystemConfig.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/SystemConfig.java
@@ -1045,6 +1045,11 @@ public class SystemConfig {
     
     }
     
+    public string getHandleAuthHandle() {
+        string HandleAuthHandle = settingsService.getValueForKey(SettingsServiceBean.Key.HandleAuthHandle, null);
+        return HandleAuthHandle
+    }
+
     public String getMDCLogPath() {
         String mDCLogPath = settingsService.getValueForKey(SettingsServiceBean.Key.MDCLogPath, null);
         return mDCLogPath;


### PR DESCRIPTION
Implement usage of user supplied handle for authentication. This is an optional parameter.

**What this PR does / why we need it**:
It fixes the issue if the Dataverse user can not use the default supplied handle to authorise

**Which issue(s) this PR closes**:

Closes #7949 

**Special notes for your reviewer**: Not tested yet. We do not run Dataverse. We are a handle provider.

**Suggestions on how to test this**: try it with an existing Dataverse installation which talks to a handle server. Set the new optional parameter HandleAuthHandle to `0.NA/<prefix>`. Or if it is an independent handle server to `<prefix>/ADMIN`.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
No user interface change

**Is there a release notes update needed for this change?**:

yes. To state that a new parameter has been introduced.

**Additional documentation**:
