### PR TITLE
Iqss/7952 extended traces api

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/api/Users.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Users.java
@@ -235,7 +235,7 @@ public class Users extends AbstractApiBean {
         }
     }
 
-    private List<String> elements = Arrays.asList("roleAssignments","dataversCreator", "dataversePublisher","datasetCreator", "datasetPublisher","dataFileCreator","dataFilePublisher","datasetVersionUsers","explicitGroups","guestbookEntries", "savedSearches");
+    private List<String> elements = Arrays.asList("roleAssignments","dataverseCreator", "dataversePublisher","datasetCreator", "datasetPublisher","dataFileCreator","dataFilePublisher","datasetVersionUsers","explicitGroups","guestbookEntries", "savedSearches");
     
     @GET
     @Path("{identifier}/traces/{element}")

--- a/src/main/java/edu/harvard/iq/dataverse/api/Users.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Users.java
@@ -259,7 +259,7 @@ public class Users extends AbstractApiBean {
             }
             JsonArray items=null;
             try {
-                items = jsonObj.build().getJsonObject(element).getJsonArray("items");
+                items = jsonObj.build().getJsonObject("traces").getJsonObject(element).getJsonArray("items");
             } catch(Exception e) {
                 return ok(jsonObj);
             }

--- a/src/main/java/edu/harvard/iq/dataverse/api/Users.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Users.java
@@ -13,6 +13,9 @@ import edu.harvard.iq.dataverse.engine.command.impl.ChangeUserIdentifierCommand;
 import edu.harvard.iq.dataverse.engine.command.impl.GetUserTracesCommand;
 import edu.harvard.iq.dataverse.engine.command.impl.MergeInAccountCommand;
 import edu.harvard.iq.dataverse.engine.command.impl.RevokeAllRolesCommand;
+import edu.harvard.iq.dataverse.metrics.MetricsUtil;
+import edu.harvard.iq.dataverse.util.FileUtil;
+
 import static edu.harvard.iq.dataverse.util.json.JsonPrinter.json;
 
 import java.util.ArrayList;
@@ -20,6 +23,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.logging.Logger;
 import javax.ejb.Stateless;
+import javax.json.JsonArray;
 import javax.json.JsonObjectBuilder;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.DELETE;
@@ -27,7 +31,12 @@ import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Request;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Variant;
 
 /**
  *
@@ -227,16 +236,34 @@ public class Users extends AbstractApiBean {
     }
 
     private List<String> elements = Arrays.asList("roleAssignments","dataversCreator", "dataversePublisher","datasetCreator", "datasetPublisher","dataFileCreator","dataFilePublisher","datasetVersionUsers","explicitGroups","guestbookEntries", "savedSearches");
+    
     @GET
     @Path("{identifier}/traces/{element}")
-    public Response getTraces(@PathParam("identifier") String identifier, @PathParam("element") String element) {
+    @Produces("text/csv, application/json")
+    public Response getTraces(@Context Request req, @PathParam("identifier") String identifier, @PathParam("element") String element) {
         try {
             AuthenticatedUser userToQuery = authSvc.getAuthenticatedUser(identifier);
             if(!elements.contains(element)) {
                 throw new BadRequestException("Not a valid element");
             }
             JsonObjectBuilder jsonObj = execCommand(new GetUserTracesCommand(createDataverseRequest(findUserOrDie()), userToQuery, null));
-            return ok(jsonObj);
+            
+            List<Variant> vars = Variant
+                    .mediaTypes(MediaType.valueOf(FileUtil.MIME_TYPE_CSV), MediaType.APPLICATION_JSON_TYPE)
+                    .add()
+                    .build();
+            MediaType requestedType = req.selectVariant(vars).getMediaType();
+            if ((requestedType != null) && (requestedType.equals(MediaType.APPLICATION_JSON_TYPE))) {
+                return ok(jsonObj);
+            
+            }
+            JsonArray items=null;
+            try {
+                items = jsonObj.build().getJsonObject(element).getJsonArray("items");
+            } catch(Exception e) {
+                return ok(jsonObj);
+            }
+            return ok(FileUtil.jsonArrayOfObjectsToCSV(items, items.getJsonObject(0).keySet().toArray(new String[0])), MediaType.valueOf(FileUtil.MIME_TYPE_CSV), "filedownloads.csv");
         } catch (WrappedResponse ex) {
             return ex.getResponse();
         }

--- a/src/main/java/edu/harvard/iq/dataverse/api/Users.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Users.java
@@ -14,9 +14,14 @@ import edu.harvard.iq.dataverse.engine.command.impl.GetUserTracesCommand;
 import edu.harvard.iq.dataverse.engine.command.impl.MergeInAccountCommand;
 import edu.harvard.iq.dataverse.engine.command.impl.RevokeAllRolesCommand;
 import static edu.harvard.iq.dataverse.util.json.JsonPrinter.json;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.logging.Logger;
 import javax.ejb.Stateless;
 import javax.json.JsonObjectBuilder;
+import javax.ws.rs.BadRequestException;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -214,7 +219,23 @@ public class Users extends AbstractApiBean {
     public Response getTraces(@PathParam("identifier") String identifier) {
         try {
             AuthenticatedUser userToQuery = authSvc.getAuthenticatedUser(identifier);
-            JsonObjectBuilder jsonObj = execCommand(new GetUserTracesCommand(createDataverseRequest(findUserOrDie()), userToQuery));
+            JsonObjectBuilder jsonObj = execCommand(new GetUserTracesCommand(createDataverseRequest(findUserOrDie()), userToQuery, null));
+            return ok(jsonObj);
+        } catch (WrappedResponse ex) {
+            return ex.getResponse();
+        }
+    }
+
+    private List<String> elements = Arrays.asList("roleAssignments","dataversCreator", "dataversePublisher","datasetCreator", "datasetPublisher","dataFileCreator","dataFilePublisher","datasetVersionUsers","explicitGroups","guestbookEntries", "savedSearches");
+    @GET
+    @Path("{identifier}/traces/{element}")
+    public Response getTraces(@PathParam("identifier") String identifier, @PathParam("element") String element) {
+        try {
+            AuthenticatedUser userToQuery = authSvc.getAuthenticatedUser(identifier);
+            if(!elements.contains(element)) {
+                throw new BadRequestException("Not a valid element");
+            }
+            JsonObjectBuilder jsonObj = execCommand(new GetUserTracesCommand(createDataverseRequest(findUserOrDie()), userToQuery, null));
             return ok(jsonObj);
         } catch (WrappedResponse ex) {
             return ex.getResponse();

--- a/src/main/java/edu/harvard/iq/dataverse/api/Users.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Users.java
@@ -246,7 +246,7 @@ public class Users extends AbstractApiBean {
             if(!elements.contains(element)) {
                 throw new BadRequestException("Not a valid element");
             }
-            JsonObjectBuilder jsonObj = execCommand(new GetUserTracesCommand(createDataverseRequest(findUserOrDie()), userToQuery, null));
+            JsonObjectBuilder jsonObj = execCommand(new GetUserTracesCommand(createDataverseRequest(findUserOrDie()), userToQuery, element));
             
             List<Variant> vars = Variant
                     .mediaTypes(MediaType.valueOf(FileUtil.MIME_TYPE_CSV), MediaType.APPLICATION_JSON_TYPE)
@@ -263,7 +263,7 @@ public class Users extends AbstractApiBean {
             } catch(Exception e) {
                 return ok(jsonObj);
             }
-            return ok(FileUtil.jsonArrayOfObjectsToCSV(items, items.getJsonObject(0).keySet().toArray(new String[0])), MediaType.valueOf(FileUtil.MIME_TYPE_CSV), "filedownloads.csv");
+            return ok(FileUtil.jsonArrayOfObjectsToCSV(items, items.getJsonObject(0).keySet().toArray(new String[0])), MediaType.valueOf(FileUtil.MIME_TYPE_CSV), element + ".csv");
         } catch (WrappedResponse ex) {
             return ex.getResponse();
         }

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/GetUserTracesCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/GetUserTracesCommand.java
@@ -214,6 +214,7 @@ public class GetUserTracesCommand extends AbstractCommand<JsonObjectBuilder> {
                                 .add("dataset", guestbookResponse.getDatasetVersion().getDataset().getGlobalId().asString())
                                 .add("version", guestbookResponse.getDatasetVersion().getSemanticVersion()));
                     }
+                    job.add("items", jab);
                 }
                 job.add("count", guestbookResponses.size());
                 // job.add("items", jab);

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/GetUserTracesCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/GetUserTracesCommand.java
@@ -210,14 +210,17 @@ public class GetUserTracesCommand extends AbstractCommand<JsonObjectBuilder> {
                     JsonArrayBuilder jab = Json.createArrayBuilder();
                     for (GuestbookResponse guestbookResponse : guestbookResponses) {
                         try {
-                        jab.add(Json.createObjectBuilder()
-                                .add("id", guestbookResponse.getId())
-                                .add("downloadType", guestbookResponse.getDownloadtype())
-                                .add("filename", guestbookResponse.getDataFile().getCurrentName())
-                                .add("date", guestbookResponse.getResponseDate())
-                                .add("guestbookName", guestbookResponse.getGuestbook().getName())
-                                .add("dataset", guestbookResponse.getDatasetVersion().getDataset().getGlobalId().asString())
-                                .add("version", guestbookResponse.getDatasetVersion().getSemanticVersion()));
+                            JsonObjectBuilder gbe = Json.createObjectBuilder()
+                                    .add("id", guestbookResponse.getId())
+                                    .add("downloadType", guestbookResponse.getDownloadtype())
+                                    .add("filename", guestbookResponse.getDataFile().getCurrentName())
+                                    .add("date", guestbookResponse.getResponseDate())
+                                    .add("guestbookName", guestbookResponse.getGuestbook().getName());
+                            if (guestbookResponse.getDatasetVersion().getDataset().getGlobalId() != null) {
+                                gbe.add("dataset", guestbookResponse.getDatasetVersion().getDataset().getGlobalId().asString());
+                            }
+                            gbe.add("version", guestbookResponse.getDatasetVersion().getSemanticVersion());
+                            jab.add(gbe);
                         } catch (NullPointerException npe) {
                             //Legacy/bad db entries
                             logger.warning("Guestbook id:" + guestbookResponse.getId() + " does not have required info.");

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/GetUserTracesCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/GetUserTracesCommand.java
@@ -220,7 +220,7 @@ public class GetUserTracesCommand extends AbstractCommand<JsonObjectBuilder> {
                                 .add("version", guestbookResponse.getDatasetVersion().getSemanticVersion()));
                         } catch (NullPointerException npe) {
                             //Legacy/bad db entries
-                            logger.warning("Dataset id:" + guestbookResponse.getDatasetVersion().getDataset().getId() + " does not have required info.");
+                            logger.warning("Guestbook id:" + guestbookResponse.getId() + " does not have required info.");
                         }
                     }
                     job.add("items", jab);

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/GetUserTracesCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/GetUserTracesCommand.java
@@ -30,11 +30,13 @@ public class GetUserTracesCommand extends AbstractCommand<JsonObjectBuilder> {
 
     private DataverseRequest request;
     private AuthenticatedUser user;
+    private String element;
 
-    public GetUserTracesCommand(DataverseRequest request, AuthenticatedUser user) {
+    public GetUserTracesCommand(DataverseRequest request, AuthenticatedUser user, String element) {
         super(request, (DvObject) null);
         this.request = request;
         this.user = user;
+        this.element = element;
     }
 
     @Override
@@ -47,180 +49,195 @@ public class GetUserTracesCommand extends AbstractCommand<JsonObjectBuilder> {
         }
         Long userId = user.getId();
         JsonObjectBuilder traces = Json.createObjectBuilder();
-//        List<Long> roleAssignments = ctxt.permissions().getDvObjectsUserHasRoleOn(user);
-        List<RoleAssignment> roleAssignments = ctxt.roleAssignees().getAssignmentsFor(user.getIdentifier());
-        if (roleAssignments != null && !roleAssignments.isEmpty()) {
-            JsonObjectBuilder job = Json.createObjectBuilder();
-            JsonArrayBuilder jab = Json.createArrayBuilder();
-            for (RoleAssignment roleAssignment : roleAssignments) {
-                jab.add(NullSafeJsonBuilder.jsonObjectBuilder()
-                        .add("id", roleAssignment.getId())
-                        .add("definitionPointName", roleAssignment.getDefinitionPoint().getCurrentName())
-                        .add("definitionPointIdentifier", roleAssignment.getDefinitionPoint().getIdentifier())
-                        .add("definitionPointId", roleAssignment.getDefinitionPoint().getId())
-                        .add("roleAlias", roleAssignment.getRole().getAlias())
-                        .add("roleName", roleAssignment.getRole().getName())
-                );
+        if (element == null || element.equals("roleAssignments")) {
+            // List<Long> roleAssignments =
+            // ctxt.permissions().getDvObjectsUserHasRoleOn(user);
+            List<RoleAssignment> roleAssignments = ctxt.roleAssignees().getAssignmentsFor(user.getIdentifier());
+            if (roleAssignments != null && !roleAssignments.isEmpty()) {
+                JsonObjectBuilder job = Json.createObjectBuilder();
+                JsonArrayBuilder jab = Json.createArrayBuilder();
+                for (RoleAssignment roleAssignment : roleAssignments) {
+                    jab.add(NullSafeJsonBuilder.jsonObjectBuilder()
+                            .add("id", roleAssignment.getId())
+                            .add("definitionPointName", roleAssignment.getDefinitionPoint().getCurrentName())
+                            .add("definitionPointIdentifier", roleAssignment.getDefinitionPoint().getIdentifier())
+                            .add("definitionPointId", roleAssignment.getDefinitionPoint().getId())
+                            .add("roleAlias", roleAssignment.getRole().getAlias())
+                            .add("roleName", roleAssignment.getRole().getName()));
+                }
+                job.add("count", roleAssignments.size());
+                job.add("items", jab);
+                traces.add("roleAssignments", job);
             }
-            job.add("count", roleAssignments.size());
-            job.add("items", jab);
-            traces.add("roleAssignments", job);
         }
-        List<Dataverse> dataversesCreated = ctxt.dataverses().findByCreatorId(userId);
-        if (dataversesCreated != null && !dataversesCreated.isEmpty()) {
-            JsonObjectBuilder job = Json.createObjectBuilder();
-            JsonArrayBuilder jab = Json.createArrayBuilder();
-            for (Dataverse dataverse : dataversesCreated) {
-                jab.add(Json.createObjectBuilder()
-                        .add("id", dataverse.getId())
-                        .add("alias", dataverse.getAlias())
-                );
+        if (element == null || element.equals("dataverseCreator")) {
+            List<Dataverse> dataversesCreated = ctxt.dataverses().findByCreatorId(userId);
+            if (dataversesCreated != null && !dataversesCreated.isEmpty()) {
+                JsonObjectBuilder job = Json.createObjectBuilder();
+                JsonArrayBuilder jab = Json.createArrayBuilder();
+                for (Dataverse dataverse : dataversesCreated) {
+                    jab.add(Json.createObjectBuilder()
+                            .add("id", dataverse.getId())
+                            .add("alias", dataverse.getAlias()));
+                }
+                job.add("count", dataversesCreated.size());
+                job.add("items", jab);
+                traces.add("dataverseCreator", job);
             }
-            job.add("count", dataversesCreated.size());
-            job.add("items", jab);
-            traces.add("dataverseCreator", job);
         }
-        List<Dataverse> dataversesPublished = ctxt.dataverses().findByReleaseUserId(userId);
-        if (dataversesPublished != null && !dataversesPublished.isEmpty()) {
-            JsonObjectBuilder job = Json.createObjectBuilder();
-            JsonArrayBuilder jab = Json.createArrayBuilder();
-            for (Dataverse dataverse : dataversesPublished) {
-                jab.add(Json.createObjectBuilder()
-                        .add("id", dataverse.getId())
-                        .add("alias", dataverse.getAlias())
-                );
+        if (element == null || element.equals("dataversePublisher")) {
+            List<Dataverse> dataversesPublished = ctxt.dataverses().findByReleaseUserId(userId);
+            if (dataversesPublished != null && !dataversesPublished.isEmpty()) {
+                JsonObjectBuilder job = Json.createObjectBuilder();
+                JsonArrayBuilder jab = Json.createArrayBuilder();
+                for (Dataverse dataverse : dataversesPublished) {
+                    jab.add(Json.createObjectBuilder()
+                            .add("id", dataverse.getId())
+                            .add("alias", dataverse.getAlias()));
+                }
+                job.add("count", dataversesPublished.size());
+                job.add("items", jab);
+                traces.add("dataversePublisher", job);
             }
-            job.add("count", dataversesPublished.size());
-            job.add("items", jab);
-            traces.add("dataversePublisher", job);
         }
-        List<Dataset> datasetsCreated = ctxt.datasets().findByCreatorId(userId);
-        if (datasetsCreated != null && !datasetsCreated.isEmpty()) {
-            JsonObjectBuilder job = Json.createObjectBuilder();
-            JsonArrayBuilder jab = Json.createArrayBuilder();
-            for (Dataset dataset : datasetsCreated) {
-                jab.add(Json.createObjectBuilder()
-                        .add("id", dataset.getId())
-                        .add("pid", dataset.getGlobalId().asString())
-                );
+        if (element == null || element.equals("datasetCreator")) {
+            List<Dataset> datasetsCreated = ctxt.datasets().findByCreatorId(userId);
+            if (datasetsCreated != null && !datasetsCreated.isEmpty()) {
+                JsonObjectBuilder job = Json.createObjectBuilder();
+                JsonArrayBuilder jab = Json.createArrayBuilder();
+                for (Dataset dataset : datasetsCreated) {
+                    jab.add(Json.createObjectBuilder()
+                            .add("id", dataset.getId())
+                            .add("pid", dataset.getGlobalId().asString()));
+                }
+                job.add("count", datasetsCreated.size());
+                job.add("items", jab);
+                traces.add("datasetCreator", job);
             }
-            job.add("count", datasetsCreated.size());
-            job.add("items", jab);
-            traces.add("datasetCreator", job);
         }
-        List<Dataset> datasetsPublished = ctxt.datasets().findByReleaseUserId(userId);
-        if (datasetsPublished != null && !datasetsPublished.isEmpty()) {
-            JsonObjectBuilder job = Json.createObjectBuilder();
-            JsonArrayBuilder jab = Json.createArrayBuilder();
-            for (Dataset dataset : datasetsPublished) {
-                jab.add(Json.createObjectBuilder()
-                        .add("id", dataset.getId())
-                        .add("pid", dataset.getGlobalId().asString())
-                );
+        if (element == null || element.equals("datasetPublisher")) {
+            List<Dataset> datasetsPublished = ctxt.datasets().findByReleaseUserId(userId);
+            if (datasetsPublished != null && !datasetsPublished.isEmpty()) {
+                JsonObjectBuilder job = Json.createObjectBuilder();
+                JsonArrayBuilder jab = Json.createArrayBuilder();
+                for (Dataset dataset : datasetsPublished) {
+                    jab.add(Json.createObjectBuilder()
+                            .add("id", dataset.getId())
+                            .add("pid", dataset.getGlobalId().asString()));
+                }
+                job.add("count", datasetsPublished.size());
+                job.add("items", jab);
+                traces.add("datasetPublisher", job);
             }
-            job.add("count", datasetsPublished.size());
-            job.add("items", jab);
-            traces.add("datasetPublisher", job);
         }
-        List<DataFile> dataFilesCreated = ctxt.files().findByCreatorId(userId);
-        if (dataFilesCreated != null && !dataFilesCreated.isEmpty()) {
-            JsonObjectBuilder job = Json.createObjectBuilder();
-            JsonArrayBuilder jab = Json.createArrayBuilder();
-            for (DataFile dataFile : dataFilesCreated) {
-                jab.add(Json.createObjectBuilder()
-                        .add("id", dataFile.getId())
-                        .add("filename", dataFile.getCurrentName())
-                        .add("datasetPid", dataFile.getOwner().getGlobalId().asString())
-                );
+        if (element == null || element.equals("dataFileCreator")) {
+            List<DataFile> dataFilesCreated = ctxt.files().findByCreatorId(userId);
+            if (dataFilesCreated != null && !dataFilesCreated.isEmpty()) {
+                JsonObjectBuilder job = Json.createObjectBuilder();
+                JsonArrayBuilder jab = Json.createArrayBuilder();
+                for (DataFile dataFile : dataFilesCreated) {
+                    jab.add(Json.createObjectBuilder()
+                            .add("id", dataFile.getId())
+                            .add("filename", dataFile.getCurrentName())
+                            .add("datasetPid", dataFile.getOwner().getGlobalId().asString()));
+                }
+                job.add("count", dataFilesCreated.size());
+                job.add("items", jab);
+                traces.add("dataFileCreator", job);
             }
-            job.add("count", dataFilesCreated.size());
-            job.add("items", jab);
-            traces.add("dataFileCreator", job);
         }
-        // TODO: Consider removing this because we don't seem to populate releaseuser_id for files.
-        List<DataFile> dataFilesPublished = ctxt.files().findByReleaseUserId(userId);
-        if (dataFilesPublished != null && !dataFilesPublished.isEmpty()) {
-            JsonObjectBuilder job = Json.createObjectBuilder();
-            JsonArrayBuilder jab = Json.createArrayBuilder();
-            for (DataFile dataFile : dataFilesPublished) {
-                jab.add(Json.createObjectBuilder()
-                        .add("id", dataFile.getId())
-                        .add("filename", dataFile.getCurrentName())
-                        .add("datasetPid", dataFile.getOwner().getGlobalId().asString())
-                );
+        if (element == null || element.equals("dataFilePublisher")) {
+            // TODO: Consider removing this because we don't seem to populate releaseuser_id
+            // for files.
+            List<DataFile> dataFilesPublished = ctxt.files().findByReleaseUserId(userId);
+            if (dataFilesPublished != null && !dataFilesPublished.isEmpty()) {
+                JsonObjectBuilder job = Json.createObjectBuilder();
+                JsonArrayBuilder jab = Json.createArrayBuilder();
+                for (DataFile dataFile : dataFilesPublished) {
+                    jab.add(Json.createObjectBuilder()
+                            .add("id", dataFile.getId())
+                            .add("filename", dataFile.getCurrentName())
+                            .add("datasetPid", dataFile.getOwner().getGlobalId().asString()));
+                }
+                job.add("count", dataFilesPublished.size());
+                job.add("items", jab);
+                traces.add("dataFilePublisher", job);
             }
-            job.add("count", dataFilesPublished.size());
-            job.add("items", jab);
-            traces.add("dataFileCreator", job);
         }
-        // These are the users who have published a version (or created a draft).
-        List<DatasetVersionUser> datasetVersionUsers = ctxt.datasetVersion().getDatasetVersionUsersByAuthenticatedUser(user);
-        if (datasetVersionUsers != null && !datasetVersionUsers.isEmpty()) {
-            JsonObjectBuilder job = Json.createObjectBuilder();
-            JsonArrayBuilder jab = Json.createArrayBuilder();
-            for (DatasetVersionUser datasetVersionUser : datasetVersionUsers) {
-                jab.add(Json.createObjectBuilder()
-                        .add("id", datasetVersionUser.getId())
-                        .add("dataset", datasetVersionUser.getDatasetVersion().getDataset().getGlobalId().asString())
-                        .add("version", datasetVersionUser.getDatasetVersion().getSemanticVersion())
-                );
+        if (element == null || element.equals("datasetVersionUsers")) {
+            // These are the users who have published a version (or created a draft).
+            List<DatasetVersionUser> datasetVersionUsers = ctxt.datasetVersion().getDatasetVersionUsersByAuthenticatedUser(user);
+            if (datasetVersionUsers != null && !datasetVersionUsers.isEmpty()) {
+                JsonObjectBuilder job = Json.createObjectBuilder();
+                JsonArrayBuilder jab = Json.createArrayBuilder();
+                for (DatasetVersionUser datasetVersionUser : datasetVersionUsers) {
+                    jab.add(Json.createObjectBuilder()
+                            .add("id", datasetVersionUser.getId())
+                            .add("dataset", datasetVersionUser.getDatasetVersion().getDataset().getGlobalId().asString())
+                            .add("version", datasetVersionUser.getDatasetVersion().getSemanticVersion()));
+                }
+                job.add("count", datasetVersionUsers.size());
+                job.add("items", jab);
+                traces.add("datasetVersionUsers", job);
             }
-            job.add("count", datasetVersionUsers.size());
-            job.add("items", jab);
-            traces.add("datasetVersionUsers", job);
         }
-        Set<ExplicitGroup> explicitGroups = ctxt.explicitGroups().findDirectlyContainingGroups(user);
-        if (explicitGroups != null && !explicitGroups.isEmpty()) {
-            JsonObjectBuilder job = Json.createObjectBuilder();
-            JsonArrayBuilder jab = Json.createArrayBuilder();
-            for (ExplicitGroup explicitGroup : explicitGroups) {
-                jab.add(Json.createObjectBuilder()
-                        .add("id", explicitGroup.getId())
-                        .add("name", explicitGroup.getDisplayName())
-                );
+        if (element == null || element.equals("explicitGroups")) {
+            Set<ExplicitGroup> explicitGroups = ctxt.explicitGroups().findDirectlyContainingGroups(user);
+            if (explicitGroups != null && !explicitGroups.isEmpty()) {
+                JsonObjectBuilder job = Json.createObjectBuilder();
+                JsonArrayBuilder jab = Json.createArrayBuilder();
+                for (ExplicitGroup explicitGroup : explicitGroups) {
+                    jab.add(Json.createObjectBuilder()
+                            .add("id", explicitGroup.getId())
+                            .add("name", explicitGroup.getDisplayName()));
+                }
+                job.add("count", explicitGroups.size());
+                job.add("items", jab);
+                traces.add("explicitGroups", job);
             }
-            job.add("count", explicitGroups.size());
-            job.add("items", jab);
-            traces.add("explicitGroups", job);
         }
-        List<GuestbookResponse> guestbookResponses = ctxt.responses().findByAuthenticatedUserId(user);
-        if (guestbookResponses != null && !guestbookResponses.isEmpty()) {
-            JsonObjectBuilder job = Json.createObjectBuilder();
-            // The feeling is that this is too much detail for now so we only show a count.
-//            JsonArrayBuilder jab = Json.createArrayBuilder();
-//            for (GuestbookResponse guestbookResponse : guestbookResponses) {
-//                jab.add(Json.createObjectBuilder()
-//                        .add("id", guestbookResponse.getId())
-//                        .add("downloadType", guestbookResponse.getDownloadtype())
-//                        .add("filename", guestbookResponse.getDataFile().getCurrentName())
-//                        .add("date", guestbookResponse.getResponseDate())
-//                        .add("guestbookName", guestbookResponse.getGuestbook().getName())
-//                        .add("dataset", guestbookResponse.getDatasetVersion().getDataset().getGlobalId().asString())
-//                        .add("version", guestbookResponse.getDatasetVersion().getSemanticVersion())
-//                );
-//            }
-            job.add("count", guestbookResponses.size());
-//            job.add("items", jab);
-            traces.add("guestbookEntries", job);
-        }
-        List<SavedSearch> savedSearchs = ctxt.savedSearches().findByAuthenticatedUser(user);
-        if (savedSearchs != null && !savedSearchs.isEmpty()) {
-            JsonObjectBuilder job = Json.createObjectBuilder();
-            JsonArrayBuilder jab = Json.createArrayBuilder();
-            for (SavedSearch savedSearch : savedSearchs) {
-                jab.add(Json.createObjectBuilder()
-                        .add("id", savedSearch.getId())
-                );
+        if (element == null || element.equals("guestbookEntries")) {
+            List<GuestbookResponse> guestbookResponses = ctxt.responses().findByAuthenticatedUserId(user);
+            if (guestbookResponses != null && !guestbookResponses.isEmpty()) {
+                JsonObjectBuilder job = Json.createObjectBuilder();
+                // The feeling is that this is too much detail for the call for all elements so
+                // we only show a count in that case.
+                if (element != null) {
+                    JsonArrayBuilder jab = Json.createArrayBuilder();
+                    for (GuestbookResponse guestbookResponse : guestbookResponses) {
+                        jab.add(Json.createObjectBuilder()
+                                .add("id", guestbookResponse.getId())
+                                .add("downloadType", guestbookResponse.getDownloadtype())
+                                .add("filename", guestbookResponse.getDataFile().getCurrentName())
+                                .add("date", guestbookResponse.getResponseDate())
+                                .add("guestbookName", guestbookResponse.getGuestbook().getName())
+                                .add("dataset", guestbookResponse.getDatasetVersion().getDataset().getGlobalId().asString())
+                                .add("version", guestbookResponse.getDatasetVersion().getSemanticVersion()));
+                    }
+                }
+                job.add("count", guestbookResponses.size());
+                // job.add("items", jab);
+                traces.add("guestbookEntries", job);
             }
-            job.add("count", savedSearchs.size());
-            job.add("items", jab);
-            traces.add("savedSearches", job);
+        }
+        if (element == null || element.equals("savedSearches")) {
+            List<SavedSearch> savedSearchs = ctxt.savedSearches().findByAuthenticatedUser(user);
+            if (savedSearchs != null && !savedSearchs.isEmpty()) {
+                JsonObjectBuilder job = Json.createObjectBuilder();
+                JsonArrayBuilder jab = Json.createArrayBuilder();
+                for (SavedSearch savedSearch : savedSearchs) {
+                    jab.add(Json.createObjectBuilder()
+                            .add("id", savedSearch.getId()));
+                }
+                job.add("count", savedSearchs.size());
+                job.add("items", jab);
+                traces.add("savedSearches", job);
+            }
         }
         JsonObjectBuilder result = Json.createObjectBuilder();
         result.add("user", Json.createObjectBuilder()
                 .add("identifier", user.getIdentifier())
-                .add("name", user.getName())
-        );
+                .add("name", user.getName()));
         result.add("traces", traces);
         return result;
     }

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/GetUserTracesCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/GetUserTracesCommand.java
@@ -20,6 +20,8 @@ import edu.harvard.iq.dataverse.util.json.NullSafeJsonBuilder;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.Set;
+import java.util.logging.Logger;
+
 import javax.json.Json;
 import javax.json.JsonArrayBuilder;
 import javax.json.JsonObjectBuilder;
@@ -28,6 +30,8 @@ import javax.json.JsonObjectBuilder;
 @RequiredPermissions({})
 public class GetUserTracesCommand extends AbstractCommand<JsonObjectBuilder> {
 
+    private static final Logger logger = Logger.getLogger(GetUserTracesCommand.class.getCanonicalName());
+    
     private DataverseRequest request;
     private AuthenticatedUser user;
     private String element;
@@ -205,6 +209,7 @@ public class GetUserTracesCommand extends AbstractCommand<JsonObjectBuilder> {
                 if (element != null) {
                     JsonArrayBuilder jab = Json.createArrayBuilder();
                     for (GuestbookResponse guestbookResponse : guestbookResponses) {
+                        try {
                         jab.add(Json.createObjectBuilder()
                                 .add("id", guestbookResponse.getId())
                                 .add("downloadType", guestbookResponse.getDownloadtype())
@@ -213,6 +218,10 @@ public class GetUserTracesCommand extends AbstractCommand<JsonObjectBuilder> {
                                 .add("guestbookName", guestbookResponse.getGuestbook().getName())
                                 .add("dataset", guestbookResponse.getDatasetVersion().getDataset().getGlobalId().asString())
                                 .add("version", guestbookResponse.getDatasetVersion().getSemanticVersion()));
+                        } catch (NullPointerException npe) {
+                            //Legacy/bad db entries
+                            logger.warning("Dataset id:" + guestbookResponse.getDatasetVersion().getDataset().getId() + " does not have required info.");
+                        }
                     }
                     job.add("items", jab);
                 }

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/GetUserTracesCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/GetUserTracesCommand.java
@@ -216,10 +216,12 @@ public class GetUserTracesCommand extends AbstractCommand<JsonObjectBuilder> {
                                     .add("filename", guestbookResponse.getDataFile().getCurrentName())
                                     .add("date", guestbookResponse.getResponseDate())
                                     .add("guestbookName", guestbookResponse.getGuestbook().getName());
-                            if (guestbookResponse.getDatasetVersion().getDataset().getGlobalId() != null) {
-                                gbe.add("dataset", guestbookResponse.getDatasetVersion().getDataset().getGlobalId().asString());
+                            if(guestbookResponse.getDataset().getGlobalId()!=null) {
+                                gbe.add("dataset", guestbookResponse.getDataset().getGlobalId().asString());
                             }
-                            gbe.add("version", guestbookResponse.getDatasetVersion().getSemanticVersion());
+                            if (guestbookResponse.getDatasetVersion() != null) {
+                                gbe.add("version", guestbookResponse.getDatasetVersion().getSemanticVersion());
+                            }
                             jab.add(gbe);
                         } catch (NullPointerException npe) {
                             //Legacy/bad db entries


### PR DESCRIPTION
**What this PR does / why we need it**: Extends the api/users/\<id\>/traces api to allow retrieval of specific types of traces independently.

**Which issue(s) this PR closes**:

Closes #7952 

**Special notes for your reviewer**: The extension also allows requesting csv or json outputs. CSV is the default, mirroring the metrics API but the default could be switched back to json if preferred.

Adding ?w=1 will help make the changes clearer: https://github.com/IQSS/dataverse/pull/7953/files?w=1

**Suggestions on how to test this**: 
Adding a -H 'Accept:application/json' or -H 'Accept:text/csv' header in your curl call will provide json or csv versions of the outout. 
Add any of the types listed in the issue onto a traces api call, e.g. /api/users/\<id\>/traces/datasetCreator and verify that it produces, with the Accept:application/json header, for all but one type, the same result as in the corresponding section of the existing /traces response. 

For the one exception .../guestbookEntries - verify that the total number of entries reported is consistent with what /traces reports (.../guestbookEntries adds per-entry info that isn't in the original /traces response.

Testing could also check that the text/csv header produces the same info, just formatted differently.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: No

**Is there a release notes update needed for this change?**: No

**Additional documentation**: Can document the new options if this goes forward
