### PR TITLE
Fix select box style issue

### DIFF
--- a/src/main/webapp/resources/css/structure.css
+++ b/src/main/webapp/resources/css/structure.css
@@ -655,7 +655,7 @@ div.edit-field div.ui-message {margin:6px 0;}
 /* TRUNCATION */
 div.more-block {text-align:center; padding-top:250px; width:100%; position:absolute; bottom:0; background:linear-gradient(180deg,hsla(0,0%,100%,0),#fff 80%);}
 button.desc-more-link {margin:0; padding:0;}
-div.less-block {text-align:center;};
+div.less-block {text-align:center;}
 
 /* Primefaces vs Bootstrap selectOneMenu fix */
 div.ui-selectonemenu.form-control {padding:0px;}


### PR DESCRIPTION
**What this PR does / why we need it**: Restores styling to appropriately align select widgets for controlled vocab field inputs.

**Which issue(s) this PR closes**:

Closes #7954

**Special notes for your reviewer**:

**Suggestions on how to test this**: Choose a field like the Journal Metadata/Type of Article field on demo (I think it has to be a controlled vocab/single selection field (so no checkboxes)). The change should center the select field back in the surrounding box.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: Just a bug fix - see issue for image of the problem

**Is there a release notes update needed for this change?**: No

**Additional documentation**: my first one character PR!
