### PR TITLE
switch docker-aio to Rocky, correct run-test-suite.sh path

### DIFF
--- a/conf/docker-aio/c8.dockerfile
+++ b/conf/docker-aio/c8.dockerfile
@@ -1,4 +1,4 @@
-FROM centos:8
+FROM rockylinux/rockylinux:latest
 # OS dependencies
 # IQSS now recommends Postgres 13.
 RUN dnf -qy module disable postgresql

--- a/conf/docker-aio/run-test-suite.sh
+++ b/conf/docker-aio/run-test-suite.sh
@@ -6,7 +6,7 @@ if [ -z "$dvurl" ]; then
 	dvurl="http://localhost:8084"
 fi
 
-integrationtests=$(<../../tests/integration-tests.txt)
+integrationtests=$(<tests/integration-tests.txt)
 
 # Please note the "dataverse.test.baseurl" is set to run for "all-in-one" Docker environment.
 # TODO: Rather than hard-coding the list of "IT" classes here, add a profile to pom.xml.


### PR DESCRIPTION
**What this PR does / why we need it**: update docker-aio to use RockyLinux, correct path in run-test-suite.sh

**Which issue(s) this PR closes**:

Closes #7965

**Special notes for your reviewer**: none

**Suggestions on how to test this**: follow instructions in conf/docker-aio/readme.md. Note that I got test failures which are likely unrelated to the changes included in this PR.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: no

**Is there a release notes update needed for this change?**: no

**Additional documentation**: no
