### PR TITLE
7431 fixing invalid oai pmh response

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/harvest/server/web/servlet/OAIServlet.java
+++ b/src/main/java/edu/harvard/iq/dataverse/harvest/server/web/servlet/OAIServlet.java
@@ -46,13 +46,9 @@ import java.io.ByteArrayOutputStream;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.io.OutputStreamWriter;
-import java.io.Writer;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.logging.Logger;
-import java.util.zip.DeflaterOutputStream;
-import java.util.zip.GZIPOutputStream;
 import javax.ejb.EJB;
 import javax.mail.internet.InternetAddress;
 import javax.servlet.ServletConfig;

--- a/src/main/java/edu/harvard/iq/dataverse/harvest/server/xoai/XlistRecords.java
+++ b/src/main/java/edu/harvard/iq/dataverse/harvest/server/xoai/XlistRecords.java
@@ -1,4 +1,3 @@
-
 package edu.harvard.iq.dataverse.harvest.server.xoai;
 
 import com.lyncode.xml.exceptions.XmlWriteException;

--- a/src/main/java/edu/harvard/iq/dataverse/harvest/server/xoai/Xrecord.java
+++ b/src/main/java/edu/harvard/iq/dataverse/harvest/server/xoai/Xrecord.java
@@ -1,4 +1,3 @@
-
 package edu.harvard.iq.dataverse.harvest.server.xoai;
 
 import com.lyncode.xoai.model.oaipmh.Header;
@@ -17,6 +16,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import org.apache.poi.util.ReplacingInputStream;
 
 /**
  *
@@ -85,7 +85,11 @@ public class Xrecord extends Record {
                 if (dataset != null && formatName != null) {
                     InputStream inputStream = null;
                     try {
-                        inputStream = ExportService.getInstance().getExport(dataset, formatName);
+                        inputStream = new ReplacingInputStream(
+                            ExportService.getInstance().getExport(dataset, formatName),
+                            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
+                            ""
+                        );
                     } catch (ExportException ex) {
                         inputStream = null;
                     }
@@ -101,7 +105,6 @@ public class Xrecord extends Record {
             }
         }
         outputStream.flush();
-
     }
     
     private String itemHeaderToString(Header header) {

--- a/src/test/java/edu/harvard/iq/dataverse/api/HarvestingServerIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/HarvestingServerIT.java
@@ -18,6 +18,7 @@ import org.junit.Ignore;
 import static com.jayway.restassured.RestAssured.given;
 import java.util.List;
 import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 
 /**
@@ -162,6 +163,20 @@ public class HarvestingServerIT {
         assertEquals(1, ret.size());
         // And the record should be the dataset we have just created:
         assertEquals(datasetPersistentId, listIdentifiersResponse.getBody().xmlPath().getString("OAI-PMH.ListIdentifiers.header.identifier"));
+
+        Response listRecordsResponse = UtilIT.getOaiListRecords(setName, "oai_dc");
+        assertEquals(OK.getStatusCode(), listRecordsResponse.getStatusCode());
+        List listRecords = listRecordsResponse.getBody().xmlPath().getList("OAI-PMH.ListRecords.record");
+
+        assertNotNull(listRecords);
+        assertEquals(1, listRecords.size());
+        assertEquals(datasetPersistentId, listRecordsResponse.getBody().xmlPath().getString("OAI-PMH.ListRecords.record[0].header.identifier"));
+
+        // assert that Datacite format does not contain the XML prolog
+        Response listRecordsResponseDatacite = UtilIT.getOaiListRecords(setName, "Datacite");
+        assertEquals(OK.getStatusCode(), listRecordsResponseDatacite.getStatusCode());
+        String body = listRecordsResponseDatacite.getBody().asString();
+        assertFalse(body.contains("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"));
 
         // And now run GetRecord on the OAI record for the dataset:
         Response getRecordResponse = UtilIT.getOaiRecord(datasetPersistentId, "oai_dc");

--- a/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
@@ -2359,7 +2359,12 @@ public class UtilIT {
         String apiPath = String.format("/oai?verb=ListIdentifiers&set=%s&metadataPrefix=%s", setName, metadataFormat);
         return given().get(apiPath);
     }
-    
+
+    static Response getOaiListRecords(String setName, String metadataFormat) {
+        String apiPath = String.format("/oai?verb=ListRecords&set=%s&metadataPrefix=%s", setName, metadataFormat);
+        return given().get(apiPath);
+    }
+
     static Response changeAuthenticatedUserIdentifier(String oldIdentifier, String newIdentifier, String apiToken) {
         Response response;
         String path = String.format("/api/users/%s/changeIdentifier/%s", oldIdentifier, newIdentifier );


### PR DESCRIPTION
**What this PR does / why we need it**: The ListRecords OAI-PMH response contains XML prolog for each records, which makes the XML invalid.

**Which issue(s) this PR closes**:

Closes #7431 

**Special notes for your reviewer**: ListRecords did not had any integration tests, now I added some.

**Suggestions on how to test this**: It extends the integration tests in `HarvestingServerIT.testOaiFunctionality()` method. You can also test it via checking the URL https://localhost:8080/oai?verb=ListRecords&metadataPrefix=Datacite in a browser. (Note: there might be other XML issues independent from this one, e.g. the dataverse-sample-data project creates dataset which has a '&' character in a field, and it is not escaped into '&amp;' as expected.)

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: no

**Is there a release notes update needed for this change?**: It might be mention that this issue has been fixed and it improves the interoperability of Dataverse, since this issue breaks not just the browser display, but triggers and error in the XML processors of the harvesters.

**Additional documentation**: no
