### PR TITLE
prevent page from blowing up if no remind msg in bundle #7975

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DatasetServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetServiceBean.java
@@ -732,21 +732,30 @@ public class DatasetServiceBean implements java.io.Serializable {
     //depends on dataset state and user privleges
     public String getReminderString(Dataset dataset, boolean canPublishDataset) {
 
+        String reminderString;
+
         if(!dataset.isReleased() ){
             //messages for draft state.
             if (canPublishDataset){
-                return BundleUtil.getStringFromBundle("dataset.message.publish.remind.draft");
+                reminderString = BundleUtil.getStringFromBundle("dataset.message.publish.remind.draft");
             } else {
-                return BundleUtil.getStringFromBundle("dataset.message.submit.remind.draft");
+                reminderString = BundleUtil.getStringFromBundle("dataset.message.submit.remind.draft");
             }            
         } else{
             //messages for new version - post-publish
             if (canPublishDataset){
-                return BundleUtil.getStringFromBundle("dataset.message.publish.remind.version");
+                reminderString = BundleUtil.getStringFromBundle("dataset.message.publish.remind.version");
             } else {
-                return BundleUtil.getStringFromBundle("dataset.message.submit.remind.version");
+                reminderString = BundleUtil.getStringFromBundle("dataset.message.submit.remind.version");
             }           
         }             
+
+        if (reminderString != null) {
+            return reminderString;
+        } else {
+            logger.warning("Unable to get reminder string from bundle. Returning empty string.");
+            return "";
+        }
     }
     
     public void updateLastExportTimeStamp(Long datasetId) {


### PR DESCRIPTION
**What this PR does / why we need it**:

If the "remind" bundle strings add in PR #7707 and then tweaked in PR #7734 are missing (as could happen when Bundle files from a translation haven't been updated), the page blows up (hangs with a NullPointerException due to a null being used with a `.concat` operation) when you try to create a dataset or edit the draft.

The solution in this PR is to omit the "remind" message, show the user the old, shorter message, and log to server.log a message that reads "Unable to get reminder string from bundle. Returning empty string."

**Which issue(s) this PR closes**:

Closes #7975

**Special notes for your reviewer**:

This seems easier that writing our own version of `.concat` with null checking.

**Suggestions on how to test this**:

Create and edit datasets with users that do and don't have the ability to publish. Here are the messages to remove from Bundle.properties during testing:

- dataset.message.publish.remind.draft=If it's ready for sharing, please <b>publish</b> it.
- dataset.message.submit.remind.draft=If it's ready for sharing, please <b>submit it for review</b>.
- dataset.message.publish.remind.version=If it's ready for sharing, please <b>publish</b> it so that others can see these changes.
- dataset.message.submit.remind.version=If it's ready for sharing, please <b>submit it for review</b> so that others can see these changes.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

Yes, a slight change. If the installation of Dataverse is missing the "remind" strings in the Bundle, instead of the full message in green below, the reminder ("If it's ready...") will be omitted.

<img width="778" alt="Screen Shot 2021-06-30 at 1 11 50 PM" src="https://user-images.githubusercontent.com/21006/124004911-7b380700-d9a6-11eb-9b7a-215f2afce7ac.png">

**Is there a release notes update needed for this change?**:

No. Just a bug fix.

**Additional documentation**:

No.