### PR TITLE
get "create dataset" working again #7986

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
@@ -1852,7 +1852,6 @@ public class DatasetPage implements java.io.Serializable {
             }
 
             // init the citation
-            // TODO: Need to do this after privateUrl is initialized?
             displayCitation = dataset.getCitation(true, workingVersion, isAnonymizedAccess());
             logger.fine("Citation: " + displayCitation);
 

--- a/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
@@ -1851,6 +1851,11 @@ public class DatasetPage implements java.io.Serializable {
                 JsfHelper.addWarningMessage(retrieveDatasetVersionResponse.getDifferentVersionMessage());//BundleUtil.getStringFromBundle("dataset.message.metadataSuccess"));
             }
 
+            // init the citation
+            // TODO: Need to do this after privateUrl is initialized?
+            displayCitation = dataset.getCitation(true, workingVersion, isAnonymizedAccess());
+            logger.fine("Citation: " + displayCitation);
+
             if(workingVersion.isPublished()) {
                 MakeDataCountEntry entry = new MakeDataCountEntry(FacesContext.getCurrentInstance(), dvRequestService, workingVersion);
                 mdcLogService.logEntry(entry);
@@ -1984,11 +1989,6 @@ public class DatasetPage implements java.io.Serializable {
                         BundleUtil.getStringFromBundle("dataset.privateurl.infoMessageReviewer"));
             }
         }
-
-        // init the citation
-        //Need to do this after privateUrl is initialized (
-        displayCitation = dataset.getCitation(true, workingVersion, isAnonymizedAccess());
-        logger.fine("Citation: " + displayCitation);
 
         displayLockInfo(dataset);
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Ever since pull request #7908 was merged, non-dataverseAdmin users have been unable to create a dataset. Here's what they see:

<img width="1256" alt="Screen Shot 2021-06-30 at 2 31 42 PM" src="https://user-images.githubusercontent.com/21006/124013355-32854b80-d9b0-11eb-9e90-25ab15210fe3.png">


**Which issue(s) this PR closes**:

Closes #7986

**Special notes for your reviewer**:

As mentioned in the issue, something happened with citation:

java.lang.NullPointerException
	at edu.harvard.iq.dataverse.DatasetAuthor.isEmpty(DatasetAuthor.java:87)
	at edu.harvard.iq.dataverse.DataCitation.lambda$getAuthorsAndProducersFrom$1(DataCitation.java:746)

I noticed the "init the citation" code got moved in pull request #7908 so I put it back where it was. I'm not sure why it said "Need to do this after privateUrl is initialized" though so I left that as a TODO.

**Suggestions on how to test this**:

Create a dataset as a normal user, not dataverseAdmin.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No.

**Is there a release notes update needed for this change?**:

No. Just a bug fix.

**Additional documentation**:

None.