### PR TITLE
Add anonymized access methods to FileMetadata

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/FileMetadata.java
+++ b/src/main/java/edu/harvard/iq/dataverse/FileMetadata.java
@@ -374,23 +374,19 @@ public class FileMetadata implements Serializable {
         }
         return "";
     }
-     
-    public String getFileCitation(){
-         return getFileCitation(false);
-     }
-     
 
-    
-     
-    public String getFileCitation(boolean html){
-         return new DataCitation(this).toString(html);
-     }
-    
-    public String getDirectFileCitation(boolean html){
-    	return new DataCitation(this, true).toString(html);
+    public String getFileCitation(){
+        return getFileCitation(false, false);
     }
-    
-        
+
+    public String getFileCitation(boolean html, boolean anonymized){
+         return new DataCitation(this).toString(html, anonymized);
+    }
+
+    public String getDirectFileCitation(boolean html, boolean anonymized){
+        return new DataCitation(this, true).toString(html, anonymized);
+    }
+
     public DatasetVersion getDatasetVersion() {
         return datasetVersion;
     }


### PR DESCRIPTION
**What this PR does / why we need it**: adds missing methods to FileMetadata needed for the anonymized access functionality

**Which issue(s) this PR closes**:

Closes #7989 

**Special notes for your reviewer**:

**Suggestions on how to test this**: Without the PR, I think access to the file page is broken. With this PR, access should be restored and, if using an anonymized access Private URL, the file citation shown will be anonymized, not have citation download buttons (and the dataset citation will be anonymized as well.)

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
