### PR TITLE
update rserve documentation

### DIFF
--- a/doc/sphinx-guides/source/installation/prerequisites.rst
+++ b/doc/sphinx-guides/source/installation/prerequisites.rst
@@ -365,9 +365,9 @@ network connections on a dedicated port. This requires some extra
 configuration and we provide a script for setting it up.
 
 You'll want to obtain local copies of the Rserve setup files found in
-https://github.com/IQSS/dataverse/tree/develop/scripts/r/rserve
+:fixedwidthplain:`scripts/r/rserve/<../../../../scripts/r/rserve/>`
 either by cloning a local copy of the IQSS repository:
-:fixedwidthplain:`git clone https://github.com/IQSS/dataverse.git`
+:fixedwidthplain:`git clone -b master https://github.com/IQSS/dataverse.git`
 or by downloading the files individually.
 
 Run the script as follows (as root)::

--- a/doc/sphinx-guides/source/installation/prerequisites.rst
+++ b/doc/sphinx-guides/source/installation/prerequisites.rst
@@ -362,7 +362,14 @@ The Dataverse Software uses `Rserve <https://rforge.net/Rserve/>`_ to communicat
 to R. Rserve is installed as a library package, as described in the
 step above. It runs as a daemon process on the server, accepting
 network connections on a dedicated port. This requires some extra
-configuration and we provide a  script (:fixedwidthplain:`scripts/r/rserve/rserve-setup.sh`) for setting it up.
+configuration and we provide a script, rserve-setup.sh, for setting it up.
+
+You'll want to obtain local copies of the Rserve setup files found in
+https://github.com/IQSS/dataverse/tree/develop/scripts/r/rserve
+either by cloning a local copy of the IQSS repository:
+:fixedwidthplain:`git clone https://github.com/IQSS/dataverse.git`
+or by downloading the files individually.
+
 Run the script as follows (as root)::
 
     cd <DATAVERSE SOURCE TREE>/scripts/r/rserve

--- a/doc/sphinx-guides/source/installation/prerequisites.rst
+++ b/doc/sphinx-guides/source/installation/prerequisites.rst
@@ -362,7 +362,7 @@ The Dataverse Software uses `Rserve <https://rforge.net/Rserve/>`_ to communicat
 to R. Rserve is installed as a library package, as described in the
 step above. It runs as a daemon process on the server, accepting
 network connections on a dedicated port. This requires some extra
-configuration and we provide a script, rserve-setup.sh, for setting it up.
+configuration and we provide a script for setting it up.
 
 You'll want to obtain local copies of the Rserve setup files found in
 https://github.com/IQSS/dataverse/tree/develop/scripts/r/rserve


### PR DESCRIPTION
**What this PR does / why we need it**: currently the Rserve documentation mentions individual scripts used to install Rserve and where to find them, but there is no explicit link or mention that one needs all files in the subdirectory. This PR links to the directory and spells out that one needs copies of all files contained therein.

**Which issue(s) this PR closes**:

Closes #7893

**Special notes for your reviewer**: none

**Suggestions on how to test this**: none

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: none

**Is there a release notes update needed for this change?**: no

**Additional documentation**: none
