### PR TITLE
Sec36 - update Google Cloud Storage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,7 @@
         <commons.logging.version>1.2</commons.logging.version>
         <commons.lang3.version>3.12.0</commons.lang3.version>
         <httpcomponents.client.version>4.5.13</httpcomponents.client.version>
+        <google.cloud.version>0.157.0</google.cloud.version>
         <junit.version>4.13.1</junit.version>
         <junit.jupiter.version>5.7.0</junit.jupiter.version>
         <junit.vintage.version>${junit.jupiter.version}</junit.vintage.version>
@@ -146,7 +147,7 @@
             <dependency>
               <groupId>com.google.cloud</groupId>
               <artifactId>google-cloud-bom</artifactId>
-              <version>0.115.0-alpha</version>
+              <version>${google.cloud.version}</version>
               <type>pom</type>
               <scope>import</scope>
             </dependency>
@@ -617,7 +618,6 @@
         <dependency>
           <groupId>com.google.cloud</groupId>
           <artifactId>google-cloud-storage</artifactId>
-          <version>1.97.0</version>
         </dependency>
         
         


### PR DESCRIPTION
**What this PR does / why we need it**:
Updating the Google Cloud BOM to use a more recent version of the cloud libraries. Some contained security issues.

**Which issue(s) this PR closes**:

Closes IQSS/dataverse-security#36

**Special notes for your reviewer**:
We should think about moving the Guava and Gson deps to `<dependencyManagement>` with their version and add a version-less direct dependency. This way we properly align the Google Cloud libs with their version of Guava and Gson with ours.

Also, Google Auto Service is at v1.0 - we are using v1.0-rc2.

**Suggestions on how to test this**:
Well... Do everything to make Dataverse archive data to Google Cloud Storage. Or cross fingers. 

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
Nope.

**Is there a release notes update needed for this change?**:
Nope.

**Additional documentation**:
None.