### PR TITLE
118 file level perms performance

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/ManageFilePermissionsPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/ManageFilePermissionsPage.java
@@ -115,6 +115,17 @@ public class ManageFilePermissionsPage implements java.io.Serializable {
     }
     
     
+    private boolean backingShowDeleted = true;
+
+    public String showDeletedCheckboxChange() {
+
+        if (backingShowDeleted != showDeleted) {
+            initMaps();
+            backingShowDeleted = showDeleted;
+        }
+        return "";
+    }
+    
     public String init() {
         if (dataset.getId() != null) {
             dataset = datasetService.find(dataset.getId());
@@ -136,17 +147,22 @@ public class ManageFilePermissionsPage implements java.io.Serializable {
         // initialize files and usergroup list
         roleAssigneeMap.clear();
         fileMap.clear();
-        fileAccessRequestMap.clear();        
+        fileAccessRequestMap.clear();   
                
         for (DataFile file : dataset.getFiles()) {
             
-            boolean fileIsDeleted = !((dataset.getLatestVersion().isDraft() && file.getFileMetadata().getDatasetVersion().isDraft())
-                    || (dataset.getLatestVersion().isReleased() && file.getFileMetadata().getDatasetVersion().equals(dataset.getLatestVersion())));
             // only include if the file is restricted (or its draft version is restricted)
             //Added a null check in case there are files that have no metadata records SEK 
             //for 6587 make sure that a file is in the current version befor adding to the fileMap SEK 2/11/2020
-                if (file.getFileMetadata() != null && (file.isRestricted() || file.getFileMetadata().isRestricted())
-                    && (!fileIsDeleted || isShowDeleted())) {
+                if (file.getFileMetadata() != null && (file.isRestricted() || file.getFileMetadata().isRestricted())) {
+                    //only test if file is deleted if it's restricted
+                    boolean fileIsDeleted = !((dataset.getLatestVersion().isDraft() && file.getFileMetadata().getDatasetVersion().isDraft())
+                            || (dataset.getLatestVersion().isReleased() && file.getFileMetadata().getDatasetVersion().equals(dataset.getLatestVersion())));
+
+                    if (!isShowDeleted() && fileIsDeleted) {
+                        //if don't show deleted and is deleted get out.
+                        break;
+                    }
                 // we get the direct role assignments assigned to the file
                 List<RoleAssignment> ras = roleService.directRoleAssignments(file);
                 List<RoleAssignmentRow> raList = new ArrayList<>(ras.size());

--- a/src/main/java/edu/harvard/iq/dataverse/ManageFilePermissionsPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/ManageFilePermissionsPage.java
@@ -117,13 +117,13 @@ public class ManageFilePermissionsPage implements java.io.Serializable {
     
     private boolean backingShowDeleted = true;
 
-    public String showDeletedCheckboxChange() {
+    public void showDeletedCheckboxChange() {
 
         if (backingShowDeleted != showDeleted) {
             initMaps();
             backingShowDeleted = showDeleted;
         }
-        return "";
+
     }
     
     public String init() {

--- a/src/main/java/edu/harvard/iq/dataverse/ManageFilePermissionsPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/ManageFilePermissionsPage.java
@@ -160,8 +160,8 @@ public class ManageFilePermissionsPage implements java.io.Serializable {
                             || (dataset.getLatestVersion().isReleased() && file.getFileMetadata().getDatasetVersion().equals(dataset.getLatestVersion())));
 
                     if (!isShowDeleted() && fileIsDeleted) {
-                        //if don't show deleted and is deleted get out.
-                        break;
+                        //if don't show deleted and is deleted go to next file...
+                        continue;
                     }
                 // we get the direct role assignments assigned to the file
                 List<RoleAssignment> ras = roleService.directRoleAssignments(file);

--- a/src/main/webapp/permissions-manage-files.xhtml
+++ b/src/main/webapp/permissions-manage-files.xhtml
@@ -50,7 +50,7 @@
                                             </p:commandLink>
                                         </div>
                                         <div class="panel-group">
-                                            <p:selectBooleanCheckbox value="#{manageFilePermissionsPage.showDeleted}" itemLabel="#{bundle['dataverse.permissionsFiles.files.includeDeleted']}" onchange="#{manageFilePermissionsPage.init()}">
+                                            <p:selectBooleanCheckbox value="#{manageFilePermissionsPage.showDeleted}" itemLabel="#{bundle['dataverse.permissionsFiles.files.includeDeleted']}"  onchange="#{manageFilePermissionsPage.showDeletedCheckboxChange()}">
                                                 <p:ajax update="filesFragment, usersGroups"/>
                                             </p:selectBooleanCheckbox>
                                         </div>
@@ -156,7 +156,7 @@
                                     </p:fragment>
                                     <p:fragment id="filesFragment">
                                         <div class="panel-group">
-                                            <p:selectBooleanCheckbox value="#{manageFilePermissionsPage.showDeleted}" itemLabel="#{bundle['dataverse.permissionsFiles.files.includeDeleted']}" onchange="#{manageFilePermissionsPage.init()}">
+                                            <p:selectBooleanCheckbox value="#{manageFilePermissionsPage.showDeleted}" itemLabel="#{bundle['dataverse.permissionsFiles.files.includeDeleted']}" onchange="#{manageFilePermissionsPage.showDeletedCheckboxChange()}">
                                                 <p:ajax update="filesFragment, usersGroups"/>
                                             </p:selectBooleanCheckbox>
                                         </div>


### PR DESCRIPTION
**What this PR does / why we need it**: Improves performance of the Manage File Permissions page. It is timing out for a dataset with many files.

**Which issue(s) this PR closes**:

Closes #
https://github.com/IQSS/dataverse.harvard.edu/issues/118

**Special notes for your reviewer**:
Most gains are achieved by adding a method for the onchange event of the Show Deleted Files button. Prior to this the init maps was being called three times on page load. Also stopped checking for "deleted" if the file was not restricted.

**Suggestions on how to test this**:
Try a dataset with a lot of restricted files and see that the page loads faster without losing any functionality.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: No

**Is there a release notes update needed for this change?**: No

**Additional documentation**:None