### PR TITLE
chore(payara): update everything to Payara 5.2021.5 #8030

### DIFF
--- a/conf/docker-aio/0prep_deps.sh
+++ b/conf/docker-aio/0prep_deps.sh
@@ -4,10 +4,10 @@ if [ ! -d dv/deps ]; then
 fi
 wdir=`pwd`
 
-if [ ! -e dv/deps/payara-5.2021.4.zip ]; then
+if [ ! -e dv/deps/payara-5.2021.5.zip ]; then
 	echo "payara dependency prep"
 	# no more fiddly patching :)
-	wget https://s3-eu-west-1.amazonaws.com/payara.fish/Payara+Downloads/5.2021.4/payara-5.2021.4.zip  -O dv/deps/payara-5.2021.4.zip
+	wget https://s3-eu-west-1.amazonaws.com/payara.fish/Payara+Downloads/5.2021.5/payara-5.2021.5.zip  -O dv/deps/payara-5.2021.5.zip
 fi
 
 if [ ! -e dv/deps/solr-8.8.1dv.tgz ]; then

--- a/conf/docker-aio/c8.dockerfile
+++ b/conf/docker-aio/c8.dockerfile
@@ -24,7 +24,7 @@ COPY disableipv6.conf /etc/sysctl.d/
 RUN rm /etc/httpd/conf/*
 COPY httpd.conf /etc/httpd/conf 
 RUN cd /opt ; tar zxf /tmp/dv/deps/solr-8.8.1dv.tgz 
-RUN cd /opt ; unzip /tmp/dv/deps/payara-5.2021.4.zip ; ln -s /opt/payara5 /opt/glassfish4
+RUN cd /opt ; unzip /tmp/dv/deps/payara-5.2021.5.zip ; ln -s /opt/payara5 /opt/glassfish4
 
 # this copy of domain.xml is the result of running `asadmin set server.monitoring-service.module-monitoring-levels.jvm=LOW` on a default glassfish installation (aka - enable the glassfish REST monitir endpoint for the jvm`
 # this dies under Java 11, do we keep it?

--- a/doc/release-notes/7700-upgrade-payara.md
+++ b/doc/release-notes/7700-upgrade-payara.md
@@ -1,9 +1,9 @@
-### Payara 5.2021.4 (or Higher) Required
+### Payara 5.2021.5 (or Higher) Required
 
-Some changes in this release require an upgrade to Payara 5.2021.4 or higher.
+Some changes in this release require an upgrade to Payara 5.2021.5 or higher.
 
 Instructions on how to update can be found in the
-[Payara documentation](https://docs.payara.fish/community/docs/5.2021.4/documentation/user-guides/upgrade-payara.html)
+[Payara documentation](https://docs.payara.fish/community/docs/5.2021.5/documentation/user-guides/upgrade-payara.html)
 
 It would likely be safer to upgrade Payara first, while still running Dataverse 5.6, and then proceed with the steps
 below. Upgrading from an earlier version of Payara should be a straightforward process: 

--- a/doc/sphinx-guides/source/developers/dev-environment.rst
+++ b/doc/sphinx-guides/source/developers/dev-environment.rst
@@ -85,9 +85,9 @@ To install Payara, run the following commands:
 
 ``cd /usr/local``
 
-``sudo curl -O -L https://s3-eu-west-1.amazonaws.com/payara.fish/Payara+Downloads/5.2021.4/payara-5.2021.4.zip``
+``sudo curl -O -L https://s3-eu-west-1.amazonaws.com/payara.fish/Payara+Downloads/5.2021.5/payara-5.2021.5.zip``
 
-``sudo unzip payara-5.2021.4.zip``
+``sudo unzip payara-5.2021.5.zip``
 
 ``sudo chown -R $USER /usr/local/payara5``
 

--- a/doc/sphinx-guides/source/installation/prerequisites.rst
+++ b/doc/sphinx-guides/source/installation/prerequisites.rst
@@ -44,7 +44,7 @@ On RHEL/derivative you can make Java 11 the default with the ``alternatives`` co
 Payara
 ------
 
-Payara 5.2021.4 is recommended. Newer versions might work fine, regular updates are recommended.
+Payara 5.2021.5 is recommended. Newer versions might work fine, regular updates are recommended.
 
 Installing Payara
 =================
@@ -55,8 +55,8 @@ Installing Payara
 
 - Download and install Payara (installed in ``/usr/local/payara5`` in the example commands below)::
 
-	# wget https://s3-eu-west-1.amazonaws.com/payara.fish/Payara+Downloads/5.2021.4/payara-5.2021.4.zip
-	# unzip payara-5.2021.4.zip
+	# wget https://s3-eu-west-1.amazonaws.com/payara.fish/Payara+Downloads/5.2021.5/payara-5.2021.5.zip
+	# unzip payara-5.2021.5.zip
 	# mv payara5 /usr/local
 
 If you intend to install and run Payara under a service account (and we hope you do), chown -R the Payara hierarchy to root to protect it but give the service account access to the below directories:

--- a/downloads/download.sh
+++ b/downloads/download.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-curl -L -O https://s3-eu-west-1.amazonaws.com/payara.fish/Payara+Downloads/5.2021.4/payara-5.2021.4.zip
+curl -L -O https://s3-eu-west-1.amazonaws.com/payara.fish/Payara+Downloads/5.2021.5/payara-5.2021.5.zip
 curl -L -O https://archive.apache.org/dist/lucene/solr/8.8.1/solr-8.8.1.tgz
 curl -L -O https://search.maven.org/remotecontent?filepath=org/jboss/weld/weld-osgi-bundle/2.2.10.Final/weld-osgi-bundle-2.2.10.Final-glassfish4.jar
 curl -s -L http://sourceforge.net/projects/schemaspy/files/schemaspy/SchemaSpy%205.0.0/schemaSpy_5.0.0.jar/download > schemaSpy_5.0.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <skipUnitTests>false</skipUnitTests>
     
         <jakartaee-api.version>8.0.0</jakartaee-api.version>
-        <payara.version>5.2021.4</payara.version>
+        <payara.version>5.2021.5</payara.version>
         <postgresql.version>42.2.19</postgresql.version>
         <aws.version>1.11.762</aws.version>
         <commons.logging.version>1.2</commons.logging.version>

--- a/scripts/vagrant/setup.sh
+++ b/scripts/vagrant/setup.sh
@@ -52,7 +52,7 @@ SOLR_USER=solr
 echo "Ensuring Unix user '$SOLR_USER' exists"
 useradd $SOLR_USER || :
 DOWNLOAD_DIR='/dataverse/downloads'
-PAYARA_ZIP="$DOWNLOAD_DIR/payara-5.2021.4.zip"
+PAYARA_ZIP="$DOWNLOAD_DIR/payara-5.2021.5.zip"
 SOLR_TGZ="$DOWNLOAD_DIR/solr-8.8.1.tgz"
 if [ ! -f $PAYARA_ZIP ] || [ ! -f $SOLR_TGZ ]; then
     echo "Couldn't find $PAYARA_ZIP or $SOLR_TGZ! Running download script...."

--- a/src/main/java/edu/harvard/iq/dataverse/util/DataSourceProducer.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/DataSourceProducer.java
@@ -38,7 +38,7 @@ import javax.sql.DataSource;
 //})
 //
 // ... but at this time we don't think we need any. The full list
-// of properties can be found at https://docs.payara.fish/community/docs/5.2021.4/documentation/payara-server/jdbc/advanced-connection-pool-properties.html#full-list-of-properties
+// of properties can be found at https://docs.payara.fish/community/docs/5.2021.5/documentation/payara-server/jdbc/advanced-connection-pool-properties.html#full-list-of-properties
 //
 // All these properties cannot be configured via MPCONFIG as Payara doesn't support this (yet). To be enhanced.
 // See also https://github.com/payara/Payara/issues/5024


### PR DESCRIPTION
**What this PR does / why we need it**:
Update to latest Payara 5.2021.5 as just in time for a soonish Dataverse 5.6 release.

**Which issue(s) this PR closes**:

Closes #8030
Relates to #8012

**Special notes for your reviewer**:
None.

**Suggestions on how to test this**:
None.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
Nope.

**Is there a release notes update needed for this change?**:
There already is an (updated) release note from #7701 which can be reused.

**Additional documentation**:
None.