### PR TITLE
IQSS/8032 Add optional flag to trigger update of PID at provider during migrate

### DIFF
--- a/doc/sphinx-guides/source/admin/dataverses-datasets.rst
+++ b/doc/sphinx-guides/source/admin/dataverses-datasets.rst
@@ -41,7 +41,7 @@ Recursively assigns the users and groups having a role(s),that are in the set co
     curl -H "X-Dataverse-key: $API_TOKEN" http://$SERVER/api/admin/dataverse/$dataverse-alias/addRoleAssignmentsToChildren
     
 Configure a Dataverse Collection to store all new files in a specific file store
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 To direct new files (uploaded when datasets are created or edited) for all datasets in a given Dataverse collection, the store can be specified via the API as shown below, or by editing the 'General Information' for a Dataverse collection on the Dataverse collection page. Only accessible to superusers. ::
  
@@ -110,6 +110,8 @@ Mints a new identifier for a dataset previously registered with a handle. Only a
 
     curl -H "X-Dataverse-key: $API_TOKEN" -X POST http://$SERVER/api/admin/$dataset-id/reregisterHDLToPID
     
+.. _send-metadata-to-pid-provider:
+
 Send Dataset metadata to PID provider
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/doc/sphinx-guides/source/developers/dataset-migration-api.rst
+++ b/doc/sphinx-guides/source/developers/dataset-migration-api.rst
@@ -51,6 +51,8 @@ datePublished is the only metadata supported in this call.
 
 An optional query parameter: updatepidatprovider (default is false) can be set to true to automatically update the metadata and targetUrl of the PID at the provider. With this set true, the result of this call will be that the PID redirects to this dataset rather than the dataset in the source repository.
 
+.. code-block:: bash
+
   curl -H 'Content-Type: application/jsonld' -H X-Dataverse-key:$API_TOKEN -X POST -d '{"schema:datePublished": "2020-10-26","@context":{ "schema":"http://schema.org/"}}' "$SERVER_URL/api/datasets/{id}/actions/:releasemigrated?updatepidatprovider=true"
 
-  If the parameter is not added and set to true, other existing APIs can be used to update the PID at the provider later, e.g. :ref:`send-metadata-to-pid-provider`
+If the parameter is not added and set to true, other existing APIs can be used to update the PID at the provider later, e.g. :ref:`send-metadata-to-pid-provider`

--- a/doc/sphinx-guides/source/developers/dataset-migration-api.rst
+++ b/doc/sphinx-guides/source/developers/dataset-migration-api.rst
@@ -45,7 +45,7 @@ The call above creates a Dataset. Once it is created, other APIs can be used to 
   export API_TOKEN=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
   export SERVER_URL=https://demo.dataverse.org
  
-  curl -H 'Content-Type: application/jsonld' -H X-Dataverse-key:$API_TOKEN -X POST -d '{"schema:datePublished": "2020-10-26","@context":{ "schema":"http://schema.org/"}}' "$SERVER_URL/api/datasets/{id}/actions/:releasemigrated"
+  curl -H 'Content-Type: application/ld+json' -H X-Dataverse-key:$API_TOKEN -X POST -d '{"schema:datePublished": "2020-10-26","@context":{ "schema":"http://schema.org/"}}' "$SERVER_URL/api/datasets/{id}/actions/:releasemigrated"
 
 datePublished is the only metadata supported in this call.
 
@@ -53,6 +53,6 @@ An optional query parameter: updatepidatprovider (default is false) can be set t
 
 .. code-block:: bash
 
-  curl -H 'Content-Type: application/jsonld' -H X-Dataverse-key:$API_TOKEN -X POST -d '{"schema:datePublished": "2020-10-26","@context":{ "schema":"http://schema.org/"}}' "$SERVER_URL/api/datasets/{id}/actions/:releasemigrated?updatepidatprovider=true"
+  curl -H 'Content-Type: application/ld+json' -H X-Dataverse-key:$API_TOKEN -X POST -d '{"schema:datePublished": "2020-10-26","@context":{ "schema":"http://schema.org/"}}' "$SERVER_URL/api/datasets/{id}/actions/:releasemigrated?updatepidatprovider=true"
 
 If the parameter is not added and set to true, other existing APIs can be used to update the PID at the provider later, e.g. :ref:`send-metadata-to-pid-provider`

--- a/doc/sphinx-guides/source/developers/dataset-migration-api.rst
+++ b/doc/sphinx-guides/source/developers/dataset-migration-api.rst
@@ -7,6 +7,7 @@ This experimental migration API offers an additional option with some potential 
 
 * metadata can be specified using the json-ld format used in the OAI-ORE metadata export
 * existing publication dates and PIDs are maintained (currently limited to the case where the PID can be managed by the Dataverse software, e.g. where the authority and shoulder match those the software is configured for)
+* updating the PID at the provider can be done immediately or later (with other existing APIs)
 * adding files can be done via the standard APIs, including using direct-upload to S3
 
 This API consists of 2 calls: one to create an initial Dataset version, and one to 'republish' the dataset through Dataverse with a specified publication date.
@@ -47,3 +48,9 @@ The call above creates a Dataset. Once it is created, other APIs can be used to 
   curl -H 'Content-Type: application/jsonld' -H X-Dataverse-key:$API_TOKEN -X POST -d '{"schema:datePublished": "2020-10-26","@context":{ "schema":"http://schema.org/"}}' "$SERVER_URL/api/datasets/{id}/actions/:releasemigrated"
 
 datePublished is the only metadata supported in this call.
+
+An optional query parameter: updatepidatprovider (default is false) can be set to true to automatically update the metadata and targetUrl of the PID at the provider. With this set true, the result of this call will be that the PID redirects to this dataset rather than the dataset in the source repository.
+
+  curl -H 'Content-Type: application/jsonld' -H X-Dataverse-key:$API_TOKEN -X POST -d '{"schema:datePublished": "2020-10-26","@context":{ "schema":"http://schema.org/"}}' "$SERVER_URL/api/datasets/{id}/actions/:releasemigrated?updatepidatprovider=true"
+
+  If the parameter is not added and set to true, other existing APIs can be used to update the PID at the provider later, e.g. :ref:`send-metadata-to-pid-provider`

--- a/src/main/java/edu/harvard/iq/dataverse/api/Datasets.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Datasets.java
@@ -1206,7 +1206,7 @@ public class Datasets extends AbstractApiBean {
     @POST
     @Path("{id}/actions/:releasemigrated")
     @Consumes("application/ld+json, application/json-ld")
-    public Response publishMigratedDataset(String jsonldBody, @PathParam("id") String id) {
+    public Response publishMigratedDataset(String jsonldBody, @PathParam("id") String id, @DefaultValue("false") @QueryParam ("updatepidatprovider") boolean contactPIDProvider) {
         try {
             AuthenticatedUser user = findAuthenticatedUserOrDie();
             if (!user.isSuperuser()) {
@@ -1270,11 +1270,11 @@ public class Datasets extends AbstractApiBean {
                 if (prePubWf.isPresent()) {
                     // Start the workflow, the workflow will call FinalizeDatasetPublication later
                     wfService.start(prePubWf.get(),
-                            new WorkflowContext(createDataverseRequest(user), ds, TriggerType.PrePublishDataset, false),
+                            new WorkflowContext(createDataverseRequest(user), ds, TriggerType.PrePublishDataset, !contactPIDProvider),
                             false);
                 } else {
                     FinalizeDatasetPublicationCommand cmd = new FinalizeDatasetPublicationCommand(ds,
-                            createDataverseRequest(user), false);
+                            createDataverseRequest(user), !contactPIDProvider);
                     ds = commandEngine.submit(cmd);
                 }
             } catch (CommandException ex) {

--- a/src/main/java/edu/harvard/iq/dataverse/util/json/JSONLDUtil.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/json/JSONLDUtil.java
@@ -104,12 +104,6 @@ public class JSONLDUtil {
                 LocalDateTime dateTime = getDateTimeFrom(dateString);
                 ds.setModificationTime(Timestamp.valueOf(dateTime));
             }
-            try {
-                logger.fine("Output dsv: " + new OREMap(dsv, false).getOREMap().toString());
-            } catch (Exception e) {
-                // TODO Auto-generated catch block
-                e.printStackTrace();
-            }
         }
         return ds;
     }


### PR DESCRIPTION
**What this PR does / why we need it**:  Disables updating the PID at the provider during the /api/datasets/\<id\>/actions/:releasemigrated call unless ?updatepidatprovider=true is added to the URL.

**Which issue(s) this PR closes**:

Closes #8032

**Special notes for your reviewer**: This is probably safer than the just merged API call which will try to change the PID at the provider by default.

**Suggestions on how to test this**: Should be able to repeat the migrate tests and verify that the DOI doesn't redirect without the param and does when it is true.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: no

**Is there a release notes update needed for this change?**: no

**Additional documentation**: added notes about the new param
