### PR TITLE
7790 remove files of deleted draft

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
@@ -2777,13 +2777,21 @@ public class DatasetPage implements java.io.Serializable {
 
     public String deleteDatasetVersion() {
         DeleteDatasetVersionCommand cmd;
+        
+        Map<Long, String> deleteStorageLocations = datafileService.getPhysicalFilesToDelete(dataset.getLatestVersion());
+        boolean deleteCommandSuccess = false;
         try {
             cmd = new DeleteDatasetVersionCommand(dvRequestService.getDataverseRequest(), dataset);
             commandEngine.submit(cmd);
             JsfHelper.addSuccessMessage(BundleUtil.getStringFromBundle("datasetVersion.message.deleteSuccess"));
+            deleteCommandSuccess = true;
         } catch (CommandException ex) {
             JH.addMessage(FacesMessage.SEVERITY_FATAL, BundleUtil.getStringFromBundle("dataset.message.deleteFailure"));
             logger.severe(ex.getMessage());
+        }
+        
+        if (deleteCommandSuccess && !deleteStorageLocations.isEmpty()) {
+            datafileService.finalizeFileDeletes(deleteStorageLocations);
         }
 
         return returnToDatasetOnly();


### PR DESCRIPTION
**What this PR does / why we need it**: Deleting a dataset version from the dataset page does not remove the physical files that had been added to that version. Because of this there are files in storage that were never part of a published or current draft dataset version.

**Which issue(s) this PR closes**:

Closes #7790 Deleting a draft of a published dataset does not remove files added in that draft

**Special notes for your reviewer**: Not much since the code had already been written for the delete draft version via the api/

**Suggestions on how to test this**: Add files to a draft version. See that they are saved to the file system. Delete that draft and verify they have been removed while those files from previous published versions remain. 

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: No

**Is there a release notes update needed for this change?**:
No. unless we want to note that existing files created for deleted versions prior to this change will not be removed by this change. There's a separate issue for that clean up.
**Additional documentation**: None