### PR TITLE
IQSS/8036-DDI format errors

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/export/ddi/DdiExportUtil.java
+++ b/src/main/java/edu/harvard/iq/dataverse/export/ddi/DdiExportUtil.java
@@ -1425,7 +1425,8 @@ public class DdiExportUtil {
              * These days we return early to avoid this exposure.
              */
             if (dataFile.isRestricted()) {
-                return;
+                //Skip this file but don't exit the loop so that tabular info from non-restricted files still get written
+                continue;
             }
 
             if (dataFile != null && dataFile.isTabularData()) {

--- a/src/main/java/edu/harvard/iq/dataverse/export/ddi/DdiExportUtil.java
+++ b/src/main/java/edu/harvard/iq/dataverse/export/ddi/DdiExportUtil.java
@@ -1422,10 +1422,9 @@ public class DdiExportUtil {
              * included for restricted files but that meant that summary
              * statistics were exposed. (To get at these statistics, API users
              * should instead use the "Data Variable Metadata Access" endpoint.)
-             * These days we return early to avoid this exposure.
+             * These days we skip restricted files to avoid this exposure.
              */
             if (dataFile.isRestricted()) {
-                //Skip this file but don't exit the loop so that tabular info from non-restricted files still get written
                 continue;
             }
 


### PR DESCRIPTION
**What this PR does / why we need it**: Fixes the issue reported in #8036 where having a public tabular file and a restricted file cause a missing </codeBook> tag in the DDI XML. It also looks like, if the first file encountered was a restricted file, tabular files wouldn't have the info printed at all.

**Which issue(s) this PR closes**:

Closes #8036

**Special notes for your reviewer**:

**Suggestions on how to test this**: Just the test scenario in the issue

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: no

**Is there a release notes update needed for this change?**: no

**Additional documentation**: none
