### PR TITLE
bump apache commons-compress to 1.21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -584,7 +584,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.19</version>
+            <version>1.21</version>
         </dependency>
         <dependency>
             <groupId>org.duracloud</groupId>


### PR DESCRIPTION
**What this PR does / why we need it**: addresses CVE-2021-36090

**Which issue(s) this PR closes**:

Closes #40

**Special notes for your reviewer**: I would ask @qqmyers to review this.

**Suggestions on how to test this**: To my understanding, this is only used in the BagIt exporter code.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: no

**Is there a release notes update needed for this change?**: no

**Additional documentation**: none
