### PR TITLE
document Payara logging bug and suggested fix

### DIFF
--- a/doc/release-notes/5.6-release-notes.md
+++ b/doc/release-notes/5.6-release-notes.md
@@ -50,6 +50,8 @@ Some changes in this release require an upgrade to Payara 5.2021.5 or higher. (S
 
 Instructions on how to update can be found in the [Payara documentation](https://docs.payara.fish/community/docs/5.2021.4/documentation/user-guides/upgrade-payara.html) We've included the necessary steps below, but we recommend that you review the Payara upgrade instructions as it could be helpful during any troubleshooting.
 
+Installations upgrading from a previous Payara version shouldn't encounter a logging configuration bug in Payara-5.2021.5, but if your server.log fills with repeated notes about logging configuration and WELD complaints about loading beans, see the paragraph on `logging.properties` in the [installation guide](https://guides.dataverse.org/en/5.6/installation/installation-main.html#running-the-dataverse-software-installer)
+
 ### Enhancement to DDI Metadata Exports
 
 To increase support for internationalization and to improve compliance with CESSDA requirements, DDI exports now have a holdings element with a URI attribute whose value is the URL form of the dataset PID.
@@ -125,6 +127,6 @@ In the following commands we assume that Payara 5 is installed in `/usr/local/pa
 
 Note that you can skip this step if your installation uses the default-style, randomly-generated six alphanumeric character-long identifiers for your datasets! This is the case with most Dataverse installations.
 
-The underlying database framework has been modified in this release, to make it easier for installations  to create custom procedures for generating identifier strings that suit their needs. Your current configuration will  be automatically updated by the database upgrade (Flyway) script incorporated in the release. No manual configuration changes should be necessary. However, after the upgrade, we recommend that you confirm that your installation can still create new datasets, and that they are still assigned sequential numeric identifiers. In the unlikely chance that this is no longer working, please re-create the stored procedure following the steps described in the documentation for the `:IdentifierGenerationStyle` setting in the *Configuration* section of the Installation Guide for this release (v5.6).
+The underlying database framework has been modified in this release, to make it easier for installations  to create custom procedures for generating identifier strings that suit their needs. Your current configuration will be automatically updated by the database upgrade (Flyway) script incorporated in the release. No manual configuration changes should be necessary. However, after the upgrade, we recommend that you confirm that your installation can still create new datasets, and that they are still assigned sequential numeric identifiers. In the unlikely chance that this is no longer working, please re-create the stored procedure following the steps described in the documentation for the `:IdentifierGenerationStyle` setting in the *Configuration* section of the Installation Guide for this release (v5.6).
 
 (Running the script supplied there will NOT overwrite the position on the sequence you are currently using!)

--- a/doc/sphinx-guides/source/_static/installation/files/usr/local/payara5/glassfish/domains/domain1/config/logging.properties
+++ b/doc/sphinx-guides/source/_static/installation/files/usr/local/payara5/glassfish/domains/domain1/config/logging.properties
@@ -1,0 +1,166 @@
+#
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+# Copyright (c) 2013 Oracle and/or its affiliates. All rights reserved.
+#
+# The contents of this file are subject to the terms of either the GNU
+# General Public License Version 2 only ("GPL") or the Common Development
+# and Distribution License("CDDL") (collectively, the "License").  You
+# may not use this file except in compliance with the License.  You can
+# obtain a copy of the License at
+# https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+# or packager/legal/LICENSE.txt.  See the License for the specific
+# language governing permissions and limitations under the License.
+#
+# When distributing the software, include this License Header Notice in each
+# file and include the License file at packager/legal/LICENSE.txt.
+#
+# GPL Classpath Exception:
+# Oracle designates this particular file as subject to the "Classpath"
+# exception as provided by Oracle in the GPL Version 2 section of the License
+# file that accompanied this code.
+#
+# Modifications:
+# If applicable, add the following below the License Header, with the fields
+# enclosed by brackets [] replaced by your own identifying information:
+# "Portions Copyright [year] [name of copyright owner]"
+#
+# Contributor(s):
+# If you wish your version of this file to be governed by only the CDDL or
+# only the GPL Version 2, indicate your decision by adding "[Contributor]
+# elects to include this software in this distribution under the [CDDL or GPL
+# Version 2] license."  If you don't indicate a single choice of license, a
+# recipient has the option to distribute your version of this file under
+# either the CDDL, the GPL Version 2 or to extend the choice of license to
+# its licensees as provided above.  However, if you add GPL Version 2 code
+# and therefore, elected the GPL Version 2 license, then the option applies
+# only if the new code is made subject to such option by the copyright
+# holder.
+#
+# Portions Copyright [2016-2021] [Payara Foundation and/or its affiliates]
+
+#GlassFish logging.properties list
+#Update June 13 2012
+
+#All attributes details
+handlers=java.util.logging.ConsoleHandler
+handlerServices=com.sun.enterprise.server.logging.GFFileHandler,com.sun.enterprise.server.logging.SyslogHandler
+java.util.logging.ConsoleHandler.formatter=com.sun.enterprise.server.logging.UniformLogFormatter
+java.util.logging.FileHandler.count=1
+java.util.logging.FileHandler.formatter=java.util.logging.XMLFormatter
+java.util.logging.FileHandler.limit=50000
+java.util.logging.FileHandler.pattern=%h/java%u.log
+com.sun.enterprise.server.logging.GFFileHandler.compressOnRotation=false
+com.sun.enterprise.server.logging.GFFileHandler.excludeFields=
+com.sun.enterprise.server.logging.GFFileHandler.file=${com.sun.aas.instanceRoot}/logs/server.log
+com.sun.enterprise.server.logging.GFFileHandler.flushFrequency=1
+com.sun.enterprise.server.logging.GFFileHandler.formatter=com.sun.enterprise.server.logging.ODLLogFormatter
+com.sun.enterprise.server.logging.GFFileHandler.level=ALL
+com.sun.enterprise.server.logging.GFFileHandler.logStandardStreams=true
+com.sun.enterprise.server.logging.GFFileHandler.logtoConsole=false
+com.sun.enterprise.server.logging.GFFileHandler.logtoFile=true
+com.sun.enterprise.server.logging.GFFileHandler.maxHistoryFiles=0
+com.sun.enterprise.server.logging.GFFileHandler.multiLineMode=true
+com.sun.enterprise.server.logging.GFFileHandler.retainErrorsStasticsForHours=0
+com.sun.enterprise.server.logging.GFFileHandler.rotationLimitInBytes=2000000
+com.sun.enterprise.server.logging.GFFileHandler.rotationOnDateChange=false
+com.sun.enterprise.server.logging.GFFileHandler.rotationTimelimitInMinutes=0
+com.sun.enterprise.server.logging.SyslogHandler.level=ALL
+com.sun.enterprise.server.logging.SyslogHandler.useSystemLogging=false
+log4j.logger.org.hibernate.validator.util.Version=warn
+com.sun.enterprise.server.logging.UniformLogFormatter.ansiColor=true
+
+#Payara Notification logging properties
+fish.payara.enterprise.server.logging.PayaraNotificationFileHandler.compressOnRotation=false
+fish.payara.enterprise.server.logging.PayaraNotificationFileHandler.file=${com.sun.aas.instanceRoot}/logs/notification.log
+fish.payara.enterprise.server.logging.PayaraNotificationFileHandler.formatter=com.sun.enterprise.server.logging.ODLLogFormatter
+fish.payara.enterprise.server.logging.PayaraNotificationFileHandler.logtoFile=true
+fish.payara.enterprise.server.logging.PayaraNotificationFileHandler.maxHistoryFiles=0
+fish.payara.enterprise.server.logging.PayaraNotificationFileHandler.rotationLimitInBytes=2000000
+fish.payara.enterprise.server.logging.PayaraNotificationFileHandler.rotationOnDateChange=false
+fish.payara.enterprise.server.logging.PayaraNotificationFileHandler.rotationTimelimitInMinutes=0
+fish.payara.deprecated.jsonlogformatter.underscoreprefix=false
+
+#All log level details
+
+.level=INFO
+ShoalLogger.level=CONFIG
+com.hazelcast.level=WARNING
+java.util.logging.ConsoleHandler.level=FINEST
+javax.enterprise.resource.corba.level=INFO
+javax.enterprise.resource.javamail.level=INFO
+javax.enterprise.resource.jdo.level=INFO
+javax.enterprise.resource.jms.level=INFO
+javax.enterprise.resource.jta.level=INFO
+javax.enterprise.resource.resourceadapter.level=INFO
+javax.enterprise.resource.sqltrace.level=FINE
+javax.enterprise.resource.webcontainer.jsf.application.level=INFO
+javax.enterprise.resource.webcontainer.jsf.config.level=INFO
+javax.enterprise.resource.webcontainer.jsf.context.level=INFO
+javax.enterprise.resource.webcontainer.jsf.facelets.level=INFO
+javax.enterprise.resource.webcontainer.jsf.lifecycle.level=INFO
+javax.enterprise.resource.webcontainer.jsf.managedbean.level=INFO
+javax.enterprise.resource.webcontainer.jsf.renderkit.level=INFO
+javax.enterprise.resource.webcontainer.jsf.resource.level=INFO
+javax.enterprise.resource.webcontainer.jsf.taglib.level=INFO
+javax.enterprise.resource.webcontainer.jsf.timing.level=INFO
+javax.enterprise.system.container.cmp.level=INFO
+javax.enterprise.system.container.ejb.level=INFO
+javax.enterprise.system.container.ejb.mdb.level=INFO
+javax.enterprise.system.container.web.level=INFO
+javax.enterprise.system.core.classloading.level=INFO
+javax.enterprise.system.core.config.level=INFO
+javax.enterprise.system.core.level=INFO
+javax.enterprise.system.core.security.level=INFO
+javax.enterprise.system.core.selfmanagement.level=INFO
+javax.enterprise.system.core.transaction.level=INFO
+javax.enterprise.system.level=INFO
+javax.enterprise.system.ssl.security.level=INFO
+javax.enterprise.system.tools.admin.level=INFO
+javax.enterprise.system.tools.backup.level=INFO
+javax.enterprise.system.tools.deployment.common.level=WARNING
+javax.enterprise.system.tools.deployment.dol.level=WARNING
+javax.enterprise.system.tools.deployment.level=INFO
+javax.enterprise.system.util.level=INFO
+javax.enterprise.system.webservices.registry.level=INFO
+javax.enterprise.system.webservices.rpc.level=INFO
+javax.enterprise.system.webservices.saaj.level=INFO
+javax.level=INFO
+javax.mail.level=INFO
+javax.org.glassfish.persistence.level=INFO
+org.apache.catalina.level=INFO
+org.apache.coyote.level=INFO
+org.apache.jasper.level=INFO
+org.eclipse.persistence.session.level=INFO
+org.glassfish.admingui.level=INFO
+org.glassfish.naming.level=INFO
+org.jvnet.hk2.osgiadapter.level=INFO
+
+javax.enterprise.resource.corba.level=INFO
+javax.enterprise.resource.jta.level=INFO
+javax.enterprise.system.webservices.saaj.level=INFO
+javax.enterprise.system.container.ejb.level=INFO
+javax.enterprise.system.container.ejb.mdb.level=INFO
+javax.enterprise.resource.javamail.level=INFO
+javax.enterprise.system.webservices.rpc.level=INFO
+javax.enterprise.system.container.web.level=INFO
+javax.enterprise.resource.jms.level=INFO
+javax.enterprise.system.webservices.registry.level=INFO
+javax.enterprise.resource.webcontainer.jsf.application.level=INFO
+javax.enterprise.resource.webcontainer.jsf.resource.level=INFO
+javax.enterprise.resource.webcontainer.jsf.config.level=INFO
+javax.enterprise.resource.webcontainer.jsf.context.level=INFO
+javax.enterprise.resource.webcontainer.jsf.facelets.level=INFO
+javax.enterprise.resource.webcontainer.jsf.lifecycle.level=INFO
+javax.enterprise.resource.webcontainer.jsf.managedbean.level=INFO
+javax.enterprise.resource.webcontainer.jsf.renderkit.level=INFO
+javax.enterprise.resource.webcontainer.jsf.taglib.level=INFO
+javax.enterprise.resource.webcontainer.jsf.timing.level=INFO
+javax.org.glassfish.persistence.level=INFO
+javax.enterprise.system.tools.backup.level=INFO
+javax.mail.level=INFO
+org.glassfish.admingui.level=INFO
+org.glassfish.naming.level=INFO
+org.eclipse.persistence.session.level=INFO
+javax.enterprise.system.tools.deployment.dol.level=WARNING
+javax.enterprise.system.tools.deployment.common.level=WARNING

--- a/doc/sphinx-guides/source/installation/installation-main.rst
+++ b/doc/sphinx-guides/source/installation/installation-main.rst
@@ -100,6 +100,10 @@ The Dataverse Software uses JHOVE_ to help identify the file format (CSV, PNG, e
 
 .. _JHOVE: http://jhove.openpreservation.org
 
+**A note about Payara-5.2021.5:** as of this writing there exists a logging configuration bug in Payara-5.2021.5. Any change to the logging configuration results in the contents of ``/usr/local/payara/glassfish/domains/domain1/config/logging.properties`` getting clobbered. In the absence of a proper logging configuration, Payara logs a number of WELD INFO entries on Payara launch, then proceeds to attempt to update its logging configuration approximately twice a second. This will result in unnecessarily junked-up system logs.
+
+This bug appears to be triggered in new Payara installations during the Dataverse installation routine. As the ``default-logging.properties`` file doesn't match the ``logging.proprties`` file distributed with Payara, we are offering :download:`a copy of it here<../_static/files/usr/local/payara5/glassfish/domains/domain1/config/logging.properties>`. Simply stopping Payara, replacing the file, and starting Payara should correct the issue.
+
 Logging In
 ----------
 

--- a/doc/sphinx-guides/source/installation/installation-main.rst
+++ b/doc/sphinx-guides/source/installation/installation-main.rst
@@ -102,7 +102,7 @@ The Dataverse Software uses JHOVE_ to help identify the file format (CSV, PNG, e
 
 **A note about Payara-5.2021.5:** as of this writing there exists a logging configuration bug in Payara-5.2021.5. Any change to the logging configuration results in the contents of ``/usr/local/payara/glassfish/domains/domain1/config/logging.properties`` getting clobbered. In the absence of a proper logging configuration, Payara logs a number of WELD INFO entries on Payara launch, then proceeds to attempt to update its logging configuration approximately twice a second. This will result in unnecessarily junked-up system logs.
 
-This bug appears to be triggered in new Payara installations during the Dataverse installation routine. As the ``default-logging.properties`` file doesn't match the ``logging.proprties`` file distributed with Payara, we are offering :download:`a copy of it here<../_static/files/usr/local/payara5/glassfish/domains/domain1/config/logging.properties>`. Simply stopping Payara, replacing the file, and starting Payara should correct the issue.
+This bug appears to be triggered in new Payara installations during the Dataverse installation routine. As the ``default-logging.properties`` file doesn't match the ``logging.proprties`` file distributed with Payara, we are offering :download:`a copy of it here<../_static/installation/files/usr/local/payara5/glassfish/domains/domain1/config/logging.properties>`. Simply stopping Payara, replacing the file, and starting Payara should correct the issue.
 
 Logging In
 ----------


### PR DESCRIPTION
**What this PR does / why we need it**: document Payara logging bug new installations and possibly existing installations may encounter in Payara-5.2021.5

**Which issue(s) this PR closes**:

Closes #8048 

**Special notes for your reviewer**: My change to the `The underlying database framework` line was simply to correct a double space typo between `will be`, nothing more.

**Suggestions on how to test this**: make any logging config change through the asadmin `set-log-file-format` command, and/or run the Dataverse installer.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: no

**Is there a release notes update needed for this change?**: yes

**Additional documentation**: I reported this at https://github.com/payara/Payara/issues/5368 but note that the Dataverse installation routine itself seems to trigger this behavior.
