### PR TITLE
document missing Grizzly JVM-option

### DIFF
--- a/doc/release-notes/5.4-release-notes.md
+++ b/doc/release-notes/5.4-release-notes.md
@@ -274,8 +274,6 @@ Add the following JVM options to the `<config name="server-config"><java-config>
 
 `<jvm-options>[9|]--add-opens=java.logging/java.util.logging=ALL-UNNAMED</jvm-options>`  
 
-Add/Confirm the Existence of the Following JVM Option to/in the `<config name="server-config"><java-config>` section:
-
 `<jvm-options>[1.8.0u251|]-Xbootclasspath/a:${com.sun.aas.installRoot}/lib/grizzly-npn-api.jar</jvm-options>`
 
 6\. Start Payara

--- a/doc/release-notes/5.4-release-notes.md
+++ b/doc/release-notes/5.4-release-notes.md
@@ -274,6 +274,10 @@ Add the following JVM options to the `<config name="server-config"><java-config>
 
 `<jvm-options>[9|]--add-opens=java.logging/java.util.logging=ALL-UNNAMED</jvm-options>`  
 
+Add/Confirm the Existence of the Following JVM Option to/in the `<config name="server-config"><java-config>` section:
+
+`<jvm-options>[1.8.0u251|]-Xbootclasspath/a:${com.sun.aas.installRoot}/lib/grizzly-npn-api.jar</jvm-options>`
+
 6\. Start Payara
 
 - `service payara start`

--- a/doc/release-notes/5.6-release-notes.md
+++ b/doc/release-notes/5.6-release-notes.md
@@ -106,15 +106,19 @@ In the following commands we assume that Payara 5 is installed in `/usr/local/pa
 
 5\. Replace the brand new payara/glassfish/domains/domain1 with your old, preserved `domain1`
 
-6\. Start Payara
+6\. In domain.xml, add/confirm the existence of the following JVM option to/in the `<config name="server-config"><java-config>` section:
+
+`<jvm-options>[1.8.0u251|]-Xbootclasspath/a:${com.sun.aas.installRoot}/lib/grizzly-npn-api.jar</jvm-options>`
+
+7\. Start Payara
 
 - `service payara start`
   
-7\. Deploy this version.
+8\. Deploy this version.
 
 - `$PAYARA/bin/asadmin deploy dataverse-5.6.war`
 
-8\. Restart payara
+9\. Restart payara
 
 - `service payara stop`
 - `service payara start`


### PR DESCRIPTION
**What this PR does / why we need it**: without the JVM option in question, Payara throws a `java.lang.NoClassDefFoundError: org/glassfish/grizzly/npn/AlpnServerNegotiator` error at startup

**Which issue(s) this PR closes**:

Closes #8054 

**Special notes for your reviewer**: none

**Suggestions on how to test this**: perhaps launch Payara without, then with this JVM option.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: no

**Is there a release notes update needed for this change?**: yes

**Additional documentation**: none
