### PR TITLE
Fix for #8053 - avoid setting lock on as-yet-uncomitted dataset

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/PublishDatasetCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/PublishDatasetCommand.java
@@ -136,10 +136,25 @@ public class PublishDatasetCommand extends AbstractPublishDatasetCommand<Publish
             info += validatePhysicalFiles ? "Validating Datafiles Asynchronously" : "";
             
             AuthenticatedUser user = request.getAuthenticatedUser();
-            DatasetLock lock = new DatasetLock(DatasetLock.Reason.finalizePublication, user);
-            lock.setDataset(theDataset);
-            lock.setInfo(info);
-            ctxt.datasets().addDatasetLock(theDataset, lock);
+            /*
+             * datasetExternallyReleased is only true in the case of the
+             * Dataverses.importDataset() and importDatasetDDI() methods. In that case, we
+             * are still in the transaction that creates theDataset, so
+             * A) Trying to create a DatasetLock referncing that dataset in a new 
+             * transaction (as ctxt.datasets().addDatasetLock() does) will fail since the 
+             * dataset doesn't yet exist, and 
+             * B) a lock isn't needed because no one can be trying to edit it yet (as it
+             * doesn't exist).
+             * Thus, we can/need to skip creating the lock. Since the calls to removeLocks
+             * in FinalizeDatasetPublicationCommand search for and remove existing locks, if
+             * one doesn't exist, the removal is a no-op in this case.
+             */
+            if (!datasetExternallyReleased) {
+                DatasetLock lock = new DatasetLock(DatasetLock.Reason.finalizePublication, user);
+                lock.setDataset(theDataset);
+                lock.setInfo(info);
+                ctxt.datasets().addDatasetLock(theDataset, lock);
+            }
             theDataset = ctxt.em().merge(theDataset);
             // The call to FinalizePublicationCommand has been moved to the new @onSuccess()
             // method:

--- a/src/main/java/edu/harvard/iq/dataverse/workflow/WorkflowServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/workflow/WorkflowServiceBean.java
@@ -135,7 +135,11 @@ public class WorkflowServiceBean {
             /*
              * Sleep here briefly to make sure the database update from the callers
              * transaction completes which avoids any concurrency/optimistic lock issues.
-             * Note: 1 second appears long enough, but shorter delays may work
+             * Note: 1 second appears long enough, but shorter delays may work.
+             * One example:
+             * the Dataverses.importDataset()/importDatasetDDI() calls with release=yes will
+             * trigger a prepublish workflow on a dataset that isn't committed to the
+             * database until the API call completes.
              */
             try {
                 Thread.sleep(1000);


### PR DESCRIPTION
**What this PR does / why we need it**: Fixes the Dataverses datasets/:import and :importddi API calls when release=yes

**Which issue(s) this PR closes**:

Closes #8053

**Special notes for your reviewer**: These two API calls, with release=yes appear to be the only two cases where a dataset is being created and published within the same transaction. Unfortunately, updates to the Publish command to create a DatasetLock in a separate transaction (which allow setting the lock earlier than waiting for the Publish (and potential workflow starting) to complete) fail as shown in the issue in this case - as the dataset has not yet been committed. The solution here just avoids trying to set a lock in this case (as no one can be editing the Dataset yet anyway). Alternately, I did verify that running the initial Import/CreateDataset command in a separate transaction, so that it completes before Publish is called, would also work. This would mean that any real problem in the Publish command would result in the dataset being imported but not released/published - that might be useful, but it's a change in functionality, whereas avoiding the lock appears to not affect anything aside from fixing the bug.

**Suggestions on how to test this**: Use release=true in the :import and :importddi API calls

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: no

**Is there a release notes update needed for this change?**: no

**Additional documentation**: I added notes in the code
