### PR TITLE
show breadcrumbs for direct child of root datasets #7257

### DIFF
--- a/doc/release-notes/7257-breadcrumbs.md
+++ b/doc/release-notes/7257-breadcrumbs.md
@@ -1,0 +1,1 @@
+Datasets in the root Dataverse collection now show breadcrumbs that have have a link back to the root Dataverse collection. (This was the behavior for Dataverse 4.)

--- a/src/main/webapp/dataverse_header.xhtml
+++ b/src/main/webapp/dataverse_header.xhtml
@@ -240,7 +240,7 @@
                 </div>
             </div>
         </div>
-        <p:fragment id="breadCrumbPanel" rendered="#{dataverseHeaderFragment.breadcrumbs.size() > 2 or (dataverseHeaderFragment.breadcrumbs.size() > 1 and dataverseHeaderFragment.breadcrumbs[1].dvObject.instanceofDataverse)}">
+        <p:fragment id="breadCrumbPanel" rendered="#{dataverseHeaderFragment.breadcrumbs.size() > 1}">
         <div id="breadcrumbNavBlock" class="container" jsf:rendered="#{dataverseHeaderFragment.breadcrumbs.size() > 1}">
             <ui:repeat value="#{dataverseHeaderFragment.breadcrumbs}" var="breadcrumb" varStatus="status">
                 <h:outputText value=" > " styleClass="breadcrumbCarrot" rendered="#{!status.first}"/>


### PR DESCRIPTION
**What this PR does / why we need it**:

In Dataverse 4, we always showed breadcrumbs for datasets in root. As part of the Dataverse 5 redesign (in pull request #6909 for #6684), we hid breadcrumbs for datasets in root. This pull request reverts that commit (95d7e04), restoring the behavior back to how it was.

**Which issue(s) this PR closes**:

Closes #7257

**Special notes for your reviewer**:

The commit above that changed the behavior between 4 and 5 is mentioned above.

**Suggestions on how to test this**:

Create datasets in root and non-root collections. Observe that the breadcrumbs are present in both cases.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

Yes, here's a dataset in the root collection with breadcrumbs.

![Screen Shot 2021-08-24 at 2 35 47 PM](https://user-images.githubusercontent.com/21006/130672942-873a8690-e4e6-49fe-8e4b-5cc4c8d3ed62.png)

**Is there a release notes update needed for this change?**:

Yes, included.

**Additional documentation**:

None.