### PR TITLE
8085 decoupling tsv

### DIFF
--- a/doc/sphinx-guides/source/admin/metadatacustomization.rst
+++ b/doc/sphinx-guides/source/admin/metadatacustomization.rst
@@ -364,49 +364,51 @@ Each of the three main sections own sets of properties:
 #controlledVocabulary (enumerated) properties
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-+-----------------------+-----------------------+-----------------------+
-| **Property**          | **Purpose**           | **Allowed values and  |
-|                       |                       | restrictions**        |
-+-----------------------+-----------------------+-----------------------+
-| DatasetField          | Specifies the         | Must reference an     |
-|                       | #datasetField to which| existing              |
-|                       | this entry applies.   | #datasetField.        |
-|                       |                       | As a best practice,   |
-|                       |                       | the value should      |
-|                       |                       | reference a           |
-|                       |                       | #datasetField in the  |
-|                       |                       | current metadata      |
-|                       |                       | block definition. (It |
-|                       |                       | is technically        |
-|                       |                       | possible to reference |
-|                       |                       | an existing           |
-|                       |                       | #datasetField from    |
-|                       |                       | another metadata      |
-|                       |                       | block.)               |
-+-----------------------+-----------------------+-----------------------+
-| Value                 | A short display       | Free text             |
-|                       | string, representing  |                       |
-|                       | an enumerated value   |                       |
-|                       | for this field. If    |                       |
-|                       | the identifier        |                       |
-|                       | property is empty,    |                       |
-|                       | this value is used as |                       |
-|                       | the identifier.       |                       |
-+-----------------------+-----------------------+-----------------------+
-| identifier            | A string used to      | Free text             |
-|                       | encode the selected   |                       |
-|                       | enumerated value of a |                       |
-|                       | field. If this        |                       |
-|                       | property is empty,    |                       |
-|                       | the value of the      |                       |
-|                       | “Value” field is used |                       |
-|                       | as the identifier.    |                       |
-+-----------------------+-----------------------+-----------------------+
-| displayOrder          | Control the order in  | Non-negative integer. |
-|                       | which the enumerated  |                       |
-|                       | values are displayed  |                       |
-|                       | for selection.        |                       |
-+-----------------------+-----------------------+-----------------------+
+.. list-table::
+    :widths: 10 5 40 40 5
+    :header-rows: 1
+    :align: left
+
+    * - | Property
+        | (Column header)
+      - Column index
+      - Purpose
+      - Allowed values and restrictions
+      - Mandatory
+    * - ``#controlledVocabulary``
+      - 0
+      - Intentionally left blank
+      - (none)
+      - Y
+    * - ``DatasetField``
+      - 1
+      - References the ``#datasetField`` to which this entry applies.
+      - Must reference an existing ``#datasetField``.
+
+        As a best practice, the value should reference a ``#datasetField`` in the current metadata block definition.
+
+        (It is technically possible to reference an existing ``#datasetField`` from another metadata block.)
+      - Y
+    * - ``Value``
+      - 2
+      - A short display string, representing an enumerated value for this field. If the identifier property is empty, this value is used as the identifier.
+      - Free text
+      - Y
+    * - ``identifier``
+      - 3
+      - A string used to encode the selected enumerated value of a field. If this property is empty, the value of the ``Value`` field is used as the ``identifier``.
+      - Either an URL, an URI or free text matching ASCII characters, digits and ``+``, ``-``, ``_``
+      - N
+    * - ``displayOrder``
+      - 4
+      - Control the order in which the enumerated values are displayed for selection.
+      - Non-negative integer
+      - Y
+    * - ``altValue``
+      - 5..n
+      - Provide alternative values for this entry. Column may be repeated as often as necessary.
+      - Free text
+      - N
 
 FieldType definitions
 ~~~~~~~~~~~~~~~~~~~~~

--- a/pom.xml
+++ b/pom.xml
@@ -404,6 +404,13 @@
             <scope>provided</scope>
         </dependency>
         
+        <!-- CSV, TSV, fixed width parsing & bean data binding -->
+        <dependency>
+            <groupId>com.univocity</groupId>
+            <artifactId>univocity-parsers</artifactId>
+            <version>2.9.1</version>
+        </dependency>
+    
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>

--- a/scripts/api/data/metadatablocks/citation.tsv
+++ b/scripts/api/data/metadatablocks/citation.tsv
@@ -79,7 +79,7 @@
 	originOfSources	Origin of Sources	For historical materials, information about the origin of the sources and the rules followed in establishing the sources should be specified.		textbox	75		FALSE	FALSE	FALSE	FALSE	FALSE	FALSE		citation
 	characteristicOfSources	Characteristic of Sources Noted	Assessment of characteristics and source material.		textbox	76		FALSE	FALSE	FALSE	FALSE	FALSE	FALSE		citation
 	accessToSources	Documentation and Access to Sources	Level of documentation of the original sources.		textbox	77		FALSE	FALSE	FALSE	FALSE	FALSE	FALSE		citation
-#controlledVocabulary	DatasetField	Value	identifier	displayOrder											
+#controlledVocabulary	DatasetField	Value	identifier	displayOrder	altValue										
 	subject	Agricultural Sciences	D01	0											
 	subject	Arts and Humanities	D0	1											
 	subject	Astronomy and Astrophysics	D1	2											

--- a/scripts/api/data/metadatablocks/geospatial.tsv
+++ b/scripts/api/data/metadatablocks/geospatial.tsv
@@ -12,7 +12,7 @@
 	eastLongitude	East Longitude	Easternmost coordinate delimiting the geographic extent of the Dataset. A valid range of values,  expressed in decimal degrees, is -180,0 <= East Bounding Longitude Value <= 180,0.		text	8		FALSE	FALSE	FALSE	FALSE	FALSE	FALSE	geographicBoundingBox	geospatial
 	northLongitude	North Latitude	Northernmost coordinate delimiting the geographic extent of the Dataset. A valid range of values,  expressed in decimal degrees, is -90,0 <= North Bounding Latitude Value <= 90,0.		text	9		FALSE	FALSE	FALSE	FALSE	FALSE	FALSE	geographicBoundingBox	geospatial
 	southLongitude	South Latitude	Southernmost coordinate delimiting the geographic extent of the Dataset. A valid range of values,  expressed in decimal degrees, is -90,0 <= South Bounding Latitude Value <= 90,0.		text	10		FALSE	FALSE	FALSE	FALSE	FALSE	FALSE	geographicBoundingBox	geospatial
-#controlledVocabulary	DatasetField	Value	identifier	displayOrder											
+#controlledVocabulary	DatasetField	Value	identifier	displayOrder	altValue	altValue	altValue	altValue							
 	country	Afghanistan		0											
 	country	Albania		1											
 	country	Algeria		2											

--- a/src/main/java/edu/harvard/iq/dataverse/ControlledVocabularyValue.java
+++ b/src/main/java/edu/harvard/iq/dataverse/ControlledVocabularyValue.java
@@ -1,22 +1,21 @@
-/*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
- */
-
 package edu.harvard.iq.dataverse;
 
+import com.univocity.parsers.annotations.Parsed;
+import com.univocity.parsers.annotations.Validate;
 import edu.harvard.iq.dataverse.util.BundleUtil;
+import edu.harvard.iq.dataverse.util.metadata.Placeholder;
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.logging.Logger;
 import java.util.MissingResourceException;
+import java.util.stream.Collectors;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -38,11 +37,41 @@ public class ControlledVocabularyValue implements Serializable  {
     
     private static final Logger logger = Logger.getLogger(ControlledVocabularyValue.class.getCanonicalName());
     
-    public static final Comparator<ControlledVocabularyValue> DisplayOrder = new Comparator<ControlledVocabularyValue>() {
-        @Override
-        public int compare(ControlledVocabularyValue o1, ControlledVocabularyValue o2) {
-            return Integer.compare( o1.getDisplayOrder(), o2.getDisplayOrder() );
-    }};
+    /**
+     * Identifiers are used to match either URLs (Term), URIs (PID) or string containing only A-Z, a-z, 0-9, _, + and -
+     * (If no identifier is set, the value will be used, so it may contain spaces in the end. But IF you provide
+     *  an identifier, you do it for good reasons. Any real identifiers out there don't contain whitespace for a reason)
+     */
+    public static final String IDENTIFIER_MATCH_REGEX = "^(\\w+:(\\/\\/)?[\\w\\-+&@#/%?=~|!:,.;]*[\\w\\-+&@#/%=~|]|[\\w\\-\\+]+)$";
+    public static final Comparator<ControlledVocabularyValue> DisplayOrder = Comparator.comparingInt(ControlledVocabularyValue::getDisplayOrder);
+    
+    public enum Headers {
+        DATASET_FIELD(Constants.DATASET_FIELD),
+        VALUE(Constants.VALUE),
+        IDENTIFIER(Constants.IDENTIFIER),
+        DISPLAY_ORDER(Constants.DISPLAY_ORDER),
+        ALT_VALUES(Constants.ALT_VALUES);
+    
+        public static final class Constants {
+            public final static String DATASET_FIELD = "DatasetField";
+            public final static String VALUE = "Value";
+            public final static String IDENTIFIER = "identifier";
+            public final static String DISPLAY_ORDER = "displayOrder";
+            public final static String ALT_VALUES = "altValue";
+        }
+    
+        private final String key;
+        Headers(String key) {
+            this.key = key;
+        }
+        public String key() {
+            return this.key;
+        }
+    
+        public static String[] keys() {
+            return Arrays.stream(values()).map(Headers::key).collect(Collectors.toUnmodifiableList()).toArray(new String[]{});
+        }
+    }
 
     public ControlledVocabularyValue() {
     }
@@ -71,9 +100,11 @@ public class ControlledVocabularyValue implements Serializable  {
     public String getStrValue() {
         return strValue;
     }
+    
+    @Parsed(field = Headers.Constants.VALUE)
+    @Validate
     public void setStrValue(String strValue) {
         this.strValue = strValue;
-        
     }
     
     private String identifier;
@@ -82,15 +113,29 @@ public class ControlledVocabularyValue implements Serializable  {
         return identifier;
     }
 
+    @Parsed(field = Headers.Constants.IDENTIFIER)
+    @Validate(nullable = true, matches = IDENTIFIER_MATCH_REGEX)
     public void setIdentifier(String identifier) {
         this.identifier = identifier;
     }
     
     
-    
     private int displayOrder;
-    public int getDisplayOrder() { return this.displayOrder;}
-    public void setDisplayOrder(int displayOrder) {this.displayOrder = displayOrder;} 
+    public int getDisplayOrder() {
+        return this.displayOrder;
+    }
+    public void setDisplayOrder(int displayOrder) {
+        this.displayOrder = displayOrder;
+    }
+    /**
+     * Set display order value from String. Allow only positive integers >= 0.
+     * @param displayOrder
+     */
+    @Parsed(field = Headers.Constants.DISPLAY_ORDER)
+    @Validate(matches = "^\\d+$")
+    public void setDisplayOrder(String displayOrder) {
+        this.displayOrder = Integer.parseInt(displayOrder);
+    }
        
     
     @ManyToOne
@@ -102,6 +147,13 @@ public class ControlledVocabularyValue implements Serializable  {
     public void setDatasetFieldType(DatasetFieldType datasetFieldType) {
         this.datasetFieldType = datasetFieldType;
     }
+    
+    @Parsed(field = Headers.Constants.DATASET_FIELD)
+    @Validate(matches = DatasetFieldType.FIELD_NAME_REGEX)
+    private void setDatasetFieldType(String datasetFieldType) {
+        this.datasetFieldType = new Placeholder.DatasetFieldType();
+        this.datasetFieldType.setName(datasetFieldType);
+    }
   
     @OneToMany(mappedBy = "controlledVocabularyValue", cascade = {CascadeType.REMOVE, CascadeType.MERGE, CascadeType.PERSIST}, orphanRemoval=true)
     private Collection<ControlledVocabAlternate> controlledVocabAlternates = new ArrayList<>();
@@ -112,6 +164,23 @@ public class ControlledVocabularyValue implements Serializable  {
 
     public void setControlledVocabAlternates(Collection<ControlledVocabAlternate> controlledVocabAlternates) {
         this.controlledVocabAlternates = controlledVocabAlternates;
+    }
+    
+    /**
+     * A hacky workaround to allow arbitrary numbers of "altValue" columns in the TSV file, providing
+     * alternative values for the controlled vocabulary value.
+     * @param alternative
+     */
+    @Parsed(field = Headers.Constants.ALT_VALUES)
+    @Validate(nullable = true, allowBlanks = true)
+    private void addControlledVocabAlternates(String alternative) {
+        if (alternative == null || alternative.isBlank()) {
+            return;
+        }
+        ControlledVocabAlternate alt = new Placeholder.ControlledVocabAlternate();
+        alt.setControlledVocabularyValue(this);
+        alt.setStrValue(alternative);
+        this.controlledVocabAlternates.add(alt);
     }
 
     public String getLocaleStrValue() {

--- a/src/main/java/edu/harvard/iq/dataverse/DatasetFieldType.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetFieldType.java
@@ -297,6 +297,7 @@ public class DatasetFieldType implements Serializable, Comparable<DatasetFieldTy
     }
 
     @Parsed(field = Headers.Constants.TITLE)
+    @Validate
     public void setTitle(String title) {
         this.title = title;
     }
@@ -316,6 +317,7 @@ public class DatasetFieldType implements Serializable, Comparable<DatasetFieldTy
     }
     
     @Parsed(field = Headers.Constants.ALLOW_CONTROLLED_VOCABULARY)
+    @Validate
     @BooleanString(trueStrings = {"true", "TRUE"}, falseStrings = {"false", "FALSE"})
     public void setAllowControlledVocabulary(boolean allowControlledVocabulary) {
         this.allowControlledVocabulary = allowControlledVocabulary;
@@ -332,6 +334,7 @@ public class DatasetFieldType implements Serializable, Comparable<DatasetFieldTy
     }
     
     @Parsed(field = Headers.Constants.ALLOW_MULTIPLES)
+    @Validate
     @BooleanString(trueStrings = {"true", "TRUE"}, falseStrings = {"false", "FALSE"})
     public void setAllowMultiples(boolean allowMultiples) {
         this.allowMultiples = allowMultiples;
@@ -342,6 +345,7 @@ public class DatasetFieldType implements Serializable, Comparable<DatasetFieldTy
     }
 
     @Parsed(field = Headers.Constants.FIELD_TYPE)
+    @Validate
     @UpperCase
     @EnumOptions(selectors = EnumSelector.NAME)
     public void setFieldType(FieldType fieldType) {
@@ -367,6 +371,7 @@ public class DatasetFieldType implements Serializable, Comparable<DatasetFieldTy
     }
     
     @Parsed(field = Headers.Constants.FACETABLE)
+    @Validate
     @BooleanString(trueStrings = {"true", "TRUE"}, falseStrings = {"false", "FALSE"})
     public void setFacetable(boolean facetable) {
         this.facetable = facetable;
@@ -391,6 +396,7 @@ public class DatasetFieldType implements Serializable, Comparable<DatasetFieldTy
     }
 
     @Parsed(field = { Headers.Constants.DISPLAY_ON_CREATE, Headers.Constants.DISPLAY_ON_CREATE_V43 })
+    @Validate
     @BooleanString(trueStrings = {"true", "TRUE"}, falseStrings = {"false", "FALSE"})
     public void setDisplayOnCreate(boolean displayOnCreate) {
         this.displayOnCreate = displayOnCreate;
@@ -544,6 +550,7 @@ public class DatasetFieldType implements Serializable, Comparable<DatasetFieldTy
     }
     
     @Parsed(field = Headers.Constants.REQUIRED)
+    @Validate
     @BooleanString(trueStrings = {"true", "TRUE"}, falseStrings = {"false", "FALSE"})
     public void setRequired(boolean required) {
         this.required = required;
@@ -556,6 +563,7 @@ public class DatasetFieldType implements Serializable, Comparable<DatasetFieldTy
     }
     
     @Parsed(field = Headers.Constants.ADVANCED_SEARCH_FIELD)
+    @Validate
     @BooleanString(trueStrings = {"true", "TRUE"}, falseStrings = {"false", "FALSE"})
     public void setAdvancedSearchFieldType(boolean advancedSearchFieldType) {
         this.advancedSearchFieldType = advancedSearchFieldType;

--- a/src/main/java/edu/harvard/iq/dataverse/DatasetFieldType.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetFieldType.java
@@ -80,6 +80,7 @@ public class DatasetFieldType implements Serializable, Comparable<DatasetFieldTy
             public final static String ALLOW_MULTIPLES = "allowmultiples";
             public final static String FACETABLE = "facetable";
             public final static String DISPLAY_ON_CREATE = "displayoncreate";
+            public final static String DISPLAY_ON_CREATE_V43 = "showabovefold";
             public final static String REQUIRED = "required";
             public final static String PARENT = "parent";
             public final static String METADATA_BLOCK = "metadatablock_id";
@@ -389,7 +390,7 @@ public class DatasetFieldType implements Serializable, Comparable<DatasetFieldTy
         return displayOnCreate;
     }
 
-    @Parsed(field = Headers.Constants.DISPLAY_ON_CREATE)
+    @Parsed(field = { Headers.Constants.DISPLAY_ON_CREATE, Headers.Constants.DISPLAY_ON_CREATE_V43 })
     @BooleanString(trueStrings = {"true", "TRUE"}, falseStrings = {"false", "FALSE"})
     public void setDisplayOnCreate(boolean displayOnCreate) {
         this.displayOnCreate = displayOnCreate;

--- a/src/main/java/edu/harvard/iq/dataverse/DatasetFieldType.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetFieldType.java
@@ -21,11 +21,11 @@ import javax.persistence.*;
  */
 @NamedQueries({
         @NamedQuery(name="DatasetFieldType.findByName",
-                            query= "SELECT dsfType FROM DatasetFieldType dsfType WHERE dsfType.name=:name"),
-	@NamedQuery(name = "DatasetFieldType.findAllFacetable",
-			    query= "select dsfType from DatasetFieldType dsfType WHERE dsfType.facetable = true and dsfType.title != '' order by dsfType.id"),
+                    query= "SELECT dsfType FROM DatasetFieldType dsfType WHERE dsfType.name=:name"),
+        @NamedQuery(name = "DatasetFieldType.findAllFacetable",
+                    query= "select dsfType from DatasetFieldType dsfType WHERE dsfType.facetable = true and dsfType.title != '' order by dsfType.id"),
         @NamedQuery(name = "DatasetFieldType.findFacetableByMetadaBlock",
-			    query= "select dsfType from DatasetFieldType dsfType WHERE dsfType.facetable = true and dsfType.title != '' and dsfType.metadataBlock.id = :metadataBlockId order by dsfType.id")
+                    query= "select dsfType from DatasetFieldType dsfType WHERE dsfType.facetable = true and dsfType.title != '' and dsfType.metadataBlock.id = :metadataBlockId order by dsfType.id")
 })
 @Entity
 @Table(indexes = {@Index(columnList="metadatablock_id"),@Index(columnList="parentdatasetfieldtype_id")})
@@ -307,11 +307,11 @@ public class DatasetFieldType implements Serializable, Comparable<DatasetFieldTy
     private String uri;
 
     public String getUri() {
-    	return uri;
+        return uri;
     }
 
     public void setUri(String uri) {
-    	this.uri=uri;
+        this.uri=uri;
     }
     
     /**

--- a/src/main/java/edu/harvard/iq/dataverse/MetadataBlock.java
+++ b/src/main/java/edu/harvard/iq/dataverse/MetadataBlock.java
@@ -40,6 +40,8 @@ import javax.persistence.Transient;
 @Entity
 public class MetadataBlock implements Serializable {
     
+    public static final String BLOCK_NAME_REGEX = "^[a-z][\\w]+$";
+    
     /**
      * Reusable definition of headers used for parsing this model class from data (TSV, JSON, manual, ...)
      * Using the Headers.Constants class to work around annotations not able to use enum values (a Java limitation).
@@ -98,7 +100,7 @@ public class MetadataBlock implements Serializable {
     
     @Parsed(field = Headers.Constants.NAME)
     // Docs: No spaces or punctuation, except underscore. By convention, should start with a letter, and use lower camel case
-    @Validate(matches = "^[a-z][\\w]+$")
+    @Validate(matches = BLOCK_NAME_REGEX)
     public void setName(String name) {
         this.name = name;
     }

--- a/src/main/java/edu/harvard/iq/dataverse/util/metadata/Placeholder.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/metadata/Placeholder.java
@@ -1,0 +1,11 @@
+package edu.harvard.iq.dataverse.util.metadata;
+
+/**
+ * This class provides some simple markers, so we con distinguish if we need to replace a placeholder with
+ * a real object from the database/... when handing over after parsing
+ */
+public class Placeholder {
+    public static final class Dataverse extends edu.harvard.iq.dataverse.Dataverse {}
+    public static final class MetadataBlock extends edu.harvard.iq.dataverse.MetadataBlock {}
+    public static final class DatasetFieldType extends edu.harvard.iq.dataverse.DatasetFieldType {}
+}

--- a/src/main/java/edu/harvard/iq/dataverse/util/metadata/Placeholder.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/metadata/Placeholder.java
@@ -1,5 +1,7 @@
 package edu.harvard.iq.dataverse.util.metadata;
 
+import edu.harvard.iq.dataverse.ControlledVocabAlternate;
+
 /**
  * This class provides some simple markers, so we con distinguish if we need to replace a placeholder with
  * a real object from the database/... when handing over after parsing
@@ -8,4 +10,5 @@ public class Placeholder {
     public static final class Dataverse extends edu.harvard.iq.dataverse.Dataverse {}
     public static final class MetadataBlock extends edu.harvard.iq.dataverse.MetadataBlock {}
     public static final class DatasetFieldType extends edu.harvard.iq.dataverse.DatasetFieldType {}
+    public static final class ControlledVocabAlternate extends edu.harvard.iq.dataverse.ControlledVocabAlternate {}
 }

--- a/src/test/java/edu/harvard/iq/dataverse/DatasetFieldTypeTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/DatasetFieldTypeTest.java
@@ -5,17 +5,36 @@
  */
 package edu.harvard.iq.dataverse;
 
+import com.univocity.parsers.common.DataProcessingException;
+import com.univocity.parsers.common.DataValidationException;
+import com.univocity.parsers.common.processor.BeanListProcessor;
+import com.univocity.parsers.tsv.TsvParser;
+import com.univocity.parsers.tsv.TsvParserSettings;
 import edu.harvard.iq.dataverse.search.SolrField;
-import java.util.Collection;
+import edu.harvard.iq.dataverse.util.metadata.Placeholder;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EmptySource;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
-import java.util.Set;
-import javax.faces.model.SelectItem;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  *
@@ -23,33 +42,157 @@ import static org.junit.Assert.*;
  */
 public class DatasetFieldTypeTest {
     
-    public DatasetFieldTypeTest() {
+    static BeanListProcessor<DatasetFieldType> datasetFieldTypeProcessor = new BeanListProcessor<>(DatasetFieldType.class);
+    static TsvParser parser;
+    static TsvParserSettings settings = new TsvParserSettings();
+    
+    static Map<DatasetFieldType.Headers, String> subject = new HashMap<>();
+    
+    @BeforeAll
+    static void setUpClass() {
+        settings.setProcessor(datasetFieldTypeProcessor);
+        settings.setHeaderExtractionEnabled(true);
+        // TODO: replace this char with a global constant (introduced when creating the parsing bean)
+        settings.getFormat().setComment('\'');
+        parser = new TsvParser(settings);
+    }
+
+    @BeforeEach
+    void setUp() {
+        subject.clear();
+        subject.put(DatasetFieldType.Headers.NAME, "test");
+        subject.put(DatasetFieldType.Headers.TITLE, "Testfield");
+        subject.put(DatasetFieldType.Headers.DESCRIPTION, "A little test");
+        subject.put(DatasetFieldType.Headers.WATERMARK, "Type here...");
+        subject.put(DatasetFieldType.Headers.FIELD_TYPE, "none");
+        subject.put(DatasetFieldType.Headers.DISPLAY_ORDER, "1");
+        subject.put(DatasetFieldType.Headers.DISPLAY_FORMAT, "");
+        subject.put(DatasetFieldType.Headers.ADVANCED_SEARCH_FIELD, "FALSE");
+        subject.put(DatasetFieldType.Headers.ALLOW_CONTROLLED_VOCABULARY, "FALSE");
+        subject.put(DatasetFieldType.Headers.ALLOW_MULTIPLES, "FALSE");
+        subject.put(DatasetFieldType.Headers.FACETABLE, "FALSE");
+        subject.put(DatasetFieldType.Headers.DISPLAY_ON_CREATE, "FALSE");
+        subject.put(DatasetFieldType.Headers.REQUIRED, "FALSE");
+        subject.put(DatasetFieldType.Headers.PARENT, "");
+        subject.put(DatasetFieldType.Headers.METADATA_BLOCK, "test");
+        subject.put(DatasetFieldType.Headers.TERM_URI, "");
     }
     
-    @BeforeClass
-    public static void setUpClass() {
+    @Test
+    public void parseUnmodifiedSubject() {
+        // given (remember - subject will be RESET before every test!)
+        StringReader subjectUnderTest = new StringReader(generateDatasetFieldTSV(subject));
+        // when
+        parser.parse(subjectUnderTest);
+        // then
+        assertEquals(1, datasetFieldTypeProcessor.getBeans().size());
+        assertNotNull(datasetFieldTypeProcessor.getBeans().get(0));
+        assertNotNull(datasetFieldTypeProcessor.getBeans().get(0).getName());
     }
     
-    @AfterClass
-    public static void tearDownClass() {
+    private static Stream<Arguments> booleanOptionsMatrix(List<String> testValues) {
+        List<Arguments> args = new ArrayList<>();
+        // create a "matrix" with stream in stream and flattening afterwards.
+        testValues.stream()
+            .map(tv -> DatasetFieldType.Headers.booleanKeys()
+                .stream()
+                .map(h -> Arguments.of(h, tv))
+                .collect(Collectors.toUnmodifiableList()))
+            .forEach(args::addAll);
+        return args.stream();
     }
     
-    @Before
-    public void setUp() {
+    private static Stream<Arguments> booleanOptionsInvalidMatrix() {
+        return booleanOptionsMatrix(List.of("blubb", "1234", "0", "1"));
     }
     
-    @After
-    public void tearDown() {
+    private static Stream<Arguments> booleanOptionsValidMatrix() {
+        return booleanOptionsMatrix(List.of("true", "TRUE", "false", "FALSE"));
     }
-
-
-
-    /**
-     * Test of setInclude method, of class DatasetFieldType.
-     */
-
-
-
+    
+    @ParameterizedTest
+    @MethodSource("booleanOptionsInvalidMatrix")
+    public void parseInvalidBooleanOpt(DatasetFieldType.Headers key, String boolOpt) {
+        // given (remember - subject will be RESET before every test!)
+        subject.put(key, boolOpt);
+        StringReader subjectUnderTest = new StringReader(generateDatasetFieldTSV(subject));
+        // when & then
+        assertThrows(DataProcessingException.class, () -> parser.parse(subjectUnderTest));
+    }
+    
+    @ParameterizedTest
+    @MethodSource("booleanOptionsValidMatrix")
+    public void parseValidBooleanOpt(DatasetFieldType.Headers key, String boolOpt) {
+        // given (remember - subject will be RESET before every test!)
+        subject.put(key, boolOpt);
+        StringReader subjectUnderTest = new StringReader(generateDatasetFieldTSV(subject));
+        // when
+        parser.parse(subjectUnderTest);
+        // then
+        assertEquals(1, datasetFieldTypeProcessor.getBeans().size());
+        assertNotNull(datasetFieldTypeProcessor.getBeans().get(0));
+    }
+    
+    @ParameterizedTest
+    @ValueSource(strings = {"-1", "-100", "0.00", "abc", "_foobar!"})
+    public void parseInvalidDisplayOrder(String displayOrder) {
+        // given (remember - subject will be RESET before every test!)
+        subject.put(DatasetFieldType.Headers.DISPLAY_ORDER, displayOrder);
+        StringReader subjectUnderTest = new StringReader(generateDatasetFieldTSV(subject));
+        // when & then
+        assertThrows(DataValidationException.class, () -> parser.parse(subjectUnderTest));
+    }
+    
+    @ParameterizedTest
+    @ValueSource(strings = {".foobar", "!foo", "foo!", "_foo_", "-foo-foo", "foo.", "_foo.foo_", "1foo", ".bar"})
+    public void parseInvalidName(String name) {
+        // given (remember - subject will be RESET before every test!)
+        subject.put(DatasetFieldType.Headers.NAME, name);
+        StringReader subjectUnderTest = new StringReader(generateDatasetFieldTSV(subject));
+        // when & then
+        assertThrows(DataValidationException.class, () -> parser.parse(subjectUnderTest));
+    }
+    
+    @ParameterizedTest
+    @EmptySource
+    @ValueSource(strings = {"hello", "HelloMyName", "hello_my_name_is", "_foo.bar", "foo.bar", "_foo", "foo_"})
+    void parseValidParentName(String parent) {
+        // given
+        subject.put(DatasetFieldType.Headers.PARENT, parent);
+        StringReader reader = new StringReader(generateDatasetFieldTSV(subject));
+        
+        // when
+        parser.parse(reader);
+        List<DatasetFieldType> blocks = datasetFieldTypeProcessor.getBeans();
+        
+        // then
+        assertEquals(1, blocks.size());
+        if (!parent.isEmpty()) {
+            assertNotNull(blocks.get(0).getParentDatasetFieldType());
+            assertTrue(blocks.get(0).getParentDatasetFieldType() instanceof DatasetFieldType);
+            assertTrue(blocks.get(0).getParentDatasetFieldType() instanceof Placeholder.DatasetFieldType);
+            assertEquals(parent, blocks.get(0).getParentDatasetFieldType().getName());
+        }
+    }
+    
+    @ParameterizedTest
+    @ValueSource(strings = {"hello", "helloMyName", "hello_my_name_is", "foobar_", "foo213bar", "foo1234", "foo_"})
+    void parseValidMetadataBlock(String block) {
+        // given
+        subject.put(DatasetFieldType.Headers.METADATA_BLOCK, block);
+        StringReader reader = new StringReader(generateDatasetFieldTSV(subject));
+        
+        // when
+        parser.parse(reader);
+        List<DatasetFieldType> blocks = datasetFieldTypeProcessor.getBeans();
+        
+        // then
+        assertEquals(1, blocks.size());
+        assertNotNull(blocks.get(0).getMetadataBlock());
+        assertTrue(blocks.get(0).getMetadataBlock() instanceof MetadataBlock);
+        assertTrue(blocks.get(0).getMetadataBlock() instanceof Placeholder.MetadataBlock);
+        assertEquals(block, blocks.get(0).getMetadataBlock().getName());
+    }
 
 
     /**
@@ -127,7 +270,22 @@ public class DatasetFieldTypeTest {
         assertEquals(true, solrField.isAllowedToBeMultivalued());
         
     }
-
-
+    
+    private static final String header = "#datasetField\t" + String.join("\t", DatasetFieldType.Headers.keys());
+    
+    /**
+     * This method simply inserts all the values from the map into a line, combined by \t and adds a "header" line before it.
+     * It does this based on the {@link MetadataBlock.Headers} enum value order, which is the same as in the TSV definition.
+     * Nonpresent values will be inserted as blank strings.
+     *
+     * @param values
+     * @return
+     */
+    public static String generateDatasetFieldTSV(Map<DatasetFieldType.Headers, String> values) {
+        List<String> fieldValues = Arrays.stream(DatasetFieldType.Headers.values())
+            .map(k -> values.getOrDefault(k, ""))
+            .collect(Collectors.toList());
+        return header + settings.getFormat().getLineSeparatorString() + "\t" + String.join("\t", fieldValues);
+    }
     
 }

--- a/src/test/java/edu/harvard/iq/dataverse/DatasetFieldTypeTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/DatasetFieldTypeTest.java
@@ -193,6 +193,29 @@ public class DatasetFieldTypeTest {
         assertTrue(blocks.get(0).getMetadataBlock() instanceof Placeholder.MetadataBlock);
         assertEquals(block, blocks.get(0).getMetadataBlock().getName());
     }
+    
+    @Test
+    void parseBackwardCompatibleDisplayOnCreate() {
+        // given
+        subject.put(DatasetFieldType.Headers.DISPLAY_ON_CREATE, "true");
+        String tsv = generateDatasetFieldTSV(subject);
+        StringReader reader1 = new StringReader(tsv);
+        StringReader reader2 = new StringReader(tsv.replace(DatasetFieldType.Headers.Constants.DISPLAY_ON_CREATE, DatasetFieldType.Headers.Constants.DISPLAY_ON_CREATE_V43));
+    
+        // when
+        parser.parse(reader1);
+        assertEquals(1, datasetFieldTypeProcessor.getBeans().size());
+        DatasetFieldType field1 = datasetFieldTypeProcessor.getBeans().get(0);
+    
+        parser.parse(reader2);
+        assertEquals(1, datasetFieldTypeProcessor.getBeans().size());
+        DatasetFieldType field2 = datasetFieldTypeProcessor.getBeans().get(0);
+    
+        // then
+        assertEquals(field1, field2);
+        assertTrue(field1.isDisplayOnCreate());
+        assertTrue(field2.isDisplayOnCreate());
+    }
 
 
     /**

--- a/src/test/java/edu/harvard/iq/dataverse/util/metadata/ControlledVocabularyValueParsingTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/util/metadata/ControlledVocabularyValueParsingTest.java
@@ -1,0 +1,163 @@
+package edu.harvard.iq.dataverse.util.metadata;
+
+import com.univocity.parsers.common.DataValidationException;
+import com.univocity.parsers.common.processor.BeanListProcessor;
+import com.univocity.parsers.tsv.TsvParser;
+import com.univocity.parsers.tsv.TsvParserSettings;
+import edu.harvard.iq.dataverse.ControlledVocabularyValue;
+import edu.harvard.iq.dataverse.DatasetFieldType;
+import edu.harvard.iq.dataverse.MetadataBlock;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.io.StringReader;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ControlledVocabularyValueTest {
+    
+    static BeanListProcessor<ControlledVocabularyValue> controlledVocabularyValueProcessor = new BeanListProcessor<>(ControlledVocabularyValue.class);
+    static TsvParser parser;
+    static TsvParserSettings settings = new TsvParserSettings();
+    
+    @BeforeAll
+    static void setUp() {
+        settings.setProcessor(controlledVocabularyValueProcessor);
+        settings.setHeaderExtractionEnabled(true);
+        // TODO: replace this char with a global constant (introduced when creating the parsing bean)
+        settings.getFormat().setComment('\'');
+        parser = new TsvParser(settings);
+    }
+    
+    @ParameterizedTest
+    @EmptySource
+    @ValueSource(strings = {"   "})
+    public void parseInvalidValue(String value) {
+        // given
+        StringReader subjectUnderTest = new StringReader(generateCvvTSV(Map.of(
+            ControlledVocabularyValue.Headers.DATASET_FIELD, "test",
+            ControlledVocabularyValue.Headers.VALUE, value,
+            ControlledVocabularyValue.Headers.DISPLAY_ORDER, "0")));
+        // when & then
+        assertThrows(DataValidationException.class, () -> parser.parse(subjectUnderTest));
+    }
+    
+    @ParameterizedTest
+    @ValueSource(strings = {"https://www^^", "doi:1234^", "hello my name", "hello!", "hello#"})
+    public void parseInvalidIdentifier(String identifier) {
+        // given
+        StringReader subjectUnderTest = new StringReader(generateCvvTSV(Map.of(
+            ControlledVocabularyValue.Headers.DATASET_FIELD, "test",
+            ControlledVocabularyValue.Headers.VALUE, "test",
+            ControlledVocabularyValue.Headers.DISPLAY_ORDER, "0",
+            ControlledVocabularyValue.Headers.IDENTIFIER, identifier)));
+        // when & then
+        assertThrows(DataValidationException.class, () -> parser.parse(subjectUnderTest));
+    }
+    
+    @ParameterizedTest
+    @EmptySource
+    @ValueSource(strings = {"https://skosmos/foo#bar", "doi:1234", "hello_my-name", "foo+bar"})
+    public void parseValidIdentifier(String identifier) {
+        // given
+        StringReader subjectUnderTest = new StringReader(generateCvvTSV(Map.of(
+            ControlledVocabularyValue.Headers.DATASET_FIELD, "test",
+            ControlledVocabularyValue.Headers.VALUE, "test",
+            ControlledVocabularyValue.Headers.DISPLAY_ORDER, "0",
+            ControlledVocabularyValue.Headers.IDENTIFIER, identifier)));
+        // when
+        parser.parse(subjectUnderTest);
+        // then
+        assertEquals(1, controlledVocabularyValueProcessor.getBeans().size());
+        if (!identifier.isEmpty()) {
+            assertEquals(identifier, controlledVocabularyValueProcessor.getBeans().get(0).getIdentifier());
+        } else {
+            assertNull(controlledVocabularyValueProcessor.getBeans().get(0).getIdentifier());
+        }
+    }
+    
+    @ParameterizedTest
+    @ValueSource(strings = {"-1", "-100", "0.00", "abc", "_foobar!"})
+    public void parseInvalidDisplayOrder(String displayOrder) {
+        // given
+        StringReader subjectUnderTest = new StringReader(generateCvvTSV(Map.of(
+                ControlledVocabularyValue.Headers.DATASET_FIELD, "test",
+                ControlledVocabularyValue.Headers.VALUE, "test",
+                ControlledVocabularyValue.Headers.DISPLAY_ORDER, displayOrder)));
+        // when & then
+        assertThrows(DataValidationException.class, () -> parser.parse(subjectUnderTest));
+    }
+    
+    @ParameterizedTest
+    @ValueSource(strings = {".foobar", "!foo", "foo!", "_foo_", "-foo-foo", "foo.", "_foo.foo_", "1foo", ".bar"})
+    public void parseInvalidDatasetFieldTypeName(String fieldName) {
+        // given
+        StringReader subjectUnderTest = new StringReader(generateCvvTSV(Map.of(
+            ControlledVocabularyValue.Headers.DATASET_FIELD, fieldName,
+            ControlledVocabularyValue.Headers.VALUE, "test",
+            ControlledVocabularyValue.Headers.DISPLAY_ORDER, "0")));
+        // when & then
+        assertThrows(DataValidationException.class, () -> parser.parse(subjectUnderTest));
+    }
+    
+    @Test
+    public void parseAlternateValues() {
+        // given
+        String t1 = "test1";
+        String t2 = "test2";
+        String tsv = generateCvvTSV(Map.of(
+                ControlledVocabularyValue.Headers.DATASET_FIELD, "test",
+                ControlledVocabularyValue.Headers.VALUE, "test",
+                ControlledVocabularyValue.Headers.DISPLAY_ORDER, "0"),
+                List.of(t1, t2));
+        StringReader subjectUnderTest = new StringReader(tsv);
+        // when
+        parser.parse(subjectUnderTest);
+        // then
+        assertEquals(1, controlledVocabularyValueProcessor.getBeans().size());
+        
+        ControlledVocabularyValue result = controlledVocabularyValueProcessor.getBeans().get(0);
+        
+        assertFalse(result.getControlledVocabAlternates().isEmpty());
+        assertTrue(result.getControlledVocabAlternates().stream().allMatch(a -> a instanceof Placeholder.ControlledVocabAlternate));
+        
+        assertEquals(2, result.getControlledVocabAlternates().size());
+        assertTrue(result.getControlledVocabAlternates().stream().anyMatch(a -> t1.equals(a.getStrValue())));
+        assertTrue(result.getControlledVocabAlternates().stream().anyMatch(a -> t2.equals(a.getStrValue())));
+    }
+    
+    private static final String header = "#controlledVocabulary\t" + String.join("\t", ControlledVocabularyValue.Headers.keys());
+    
+    /**
+     * This method simply inserts all the values from the map into a line, combined by \t and adds a "header" line before it.
+     * It does this based on the {@link MetadataBlock.Headers} enum value order, which is the same as in the TSV definition.
+     * Nonpresent values will be inserted as blank strings.
+     *
+     * @param values
+     * @return
+     */
+    public static String generateCvvTSV(Map<ControlledVocabularyValue.Headers, String> values) {
+        List<String> fieldValues = Arrays.stream(ControlledVocabularyValue.Headers.values())
+            .map(k -> values.getOrDefault(k, ""))
+            .collect(Collectors.toList());
+        return header + settings.getFormat().getLineSeparatorString() + "\t" + String.join("\t", fieldValues);
+    }
+    
+    public static String generateCvvTSV(Map<ControlledVocabularyValue.Headers, String> values, List<String> altValues) {
+        List<String> fieldValues = Arrays.stream(ControlledVocabularyValue.Headers.values())
+            .map(k -> values.getOrDefault(k, ""))
+            .collect(Collectors.toList());
+        
+        String headerWithAlts = header + ("\t"+ControlledVocabularyValue.Headers.Constants.ALT_VALUES).repeat(altValues.size()-1);
+        
+        return headerWithAlts + settings.getFormat().getLineSeparatorString() +
+            "\t" + String.join("\t", fieldValues) + String.join("\t", altValues);
+    }
+}

--- a/src/test/java/edu/harvard/iq/dataverse/util/metadata/MetadataBlockParsingTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/util/metadata/MetadataBlockParsingTest.java
@@ -32,7 +32,9 @@ class MetadataBlockParsingTest {
     @BeforeAll
     static void setUp() {
         settings.setProcessor(metadataBlockProcessor);
-        settings.setHeaders(MetadataBlock.Headers.keys());
+        settings.setHeaderExtractionEnabled(true);
+        // TODO: replace this char with a global constant (introduced when creating the parsing bean)
+        settings.getFormat().setComment('\'');
         parser = new TsvParser(settings);
     }
     
@@ -165,6 +167,8 @@ class MetadataBlockParsingTest {
         assertThrows(DataValidationException.class, () -> parser.parse(reader));
     }
     
+    private static final String header = "#metadatablock\t" + String.join("\t", MetadataBlock.Headers.keys());
+    
     /**
      * This method simply inserts all the values from the map into a line, combined by \t and adds a "header" line before it.
      * It does this based on the {@link MetadataBlock.Headers} enum value order, which is the same as in the TSV definition.
@@ -177,6 +181,6 @@ class MetadataBlockParsingTest {
         List<String> fieldValues = Arrays.stream(MetadataBlock.Headers.values())
                                          .map(k -> values.getOrDefault(k, ""))
                                          .collect(Collectors.toList());
-        return "unused header line" + settings.getFormat().getLineSeparatorString() + String.join("\t", fieldValues);
+        return header + settings.getFormat().getLineSeparatorString() + "\t" + String.join("\t", fieldValues);
     }
 }

--- a/src/test/java/edu/harvard/iq/dataverse/util/metadata/MetadataBlockParsingTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/util/metadata/MetadataBlockParsingTest.java
@@ -1,0 +1,182 @@
+package edu.harvard.iq.dataverse.util.metadata;
+
+import com.univocity.parsers.common.DataValidationException;
+import com.univocity.parsers.common.processor.BeanListProcessor;
+import com.univocity.parsers.tsv.TsvParser;
+import com.univocity.parsers.tsv.TsvParserSettings;
+import edu.harvard.iq.dataverse.Dataverse;
+import edu.harvard.iq.dataverse.MetadataBlock;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.io.StringReader;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class MetadataBlockParsingTest {
+    
+    static BeanListProcessor<MetadataBlock> metadataBlockProcessor = new BeanListProcessor<>(MetadataBlock.class);
+    static TsvParser parser;
+    static TsvParserSettings settings = new TsvParserSettings();
+    static final String LONGER_THAN_256_CHARS = "Jx7Agh8hSs4EwkCHzxwXQHOVYiL0i79n4hxeP1PbVRgkmRyUqB9dlFSoFbqCmoZ0OUCPHLOz" +
+        "JMAZeTDxI3dj7QAQG6UuNBUaFDgyG40TRK6X3FiA0f8p4LZBHQC1HIbpIw7wiNmDoEfbrGHehAgbXWDDEXelGL4TXhSxHXIqfgNaLD9fNnk" +
+        "XXcqNsuWMvkDQNrKhUWFQQybhHWS8jh62AjRWEvqFXvqVAnrgZ8xFnRiSpDkubsGuZWZqRFVN6wSPd9sp0GrpEWa5eCv0oFtQLHx0";
+    
+    @BeforeAll
+    static void setUp() {
+        settings.setProcessor(metadataBlockProcessor);
+        settings.setHeaders(MetadataBlock.Headers.keys());
+        parser = new TsvParser(settings);
+    }
+    
+    @ParameterizedTest
+    @ValueSource(strings = {"hello", "helloMyName", "hello_my_name", "h1234"})
+    void setName_AllValid(String name) {
+        // given
+        StringReader reader = new StringReader(generateMetadataBlockTSV(
+            Map.of(MetadataBlock.Headers.NAME, name,
+                   MetadataBlock.Headers.DISPLAY_NAME, "display")));
+        
+        // when
+        parser.parse(reader);
+        List<MetadataBlock> blocks = metadataBlockProcessor.getBeans();
+        
+        // then
+        assertEquals(1, blocks.size());
+        assertEquals(name, blocks.get(0).getName());
+    }
+    
+    @ParameterizedTest
+    @EmptySource
+    @ValueSource(strings = {"1234", "!", "hello+", "Hello", "hello-my_name_is", "what-s-up-5", "1234-foobar"})
+    void setName_AllInvalid(String name) {
+        // given
+        StringReader reader = new StringReader(generateMetadataBlockTSV(
+            Map.of(MetadataBlock.Headers.NAME, name,
+                   MetadataBlock.Headers.DISPLAY_NAME, "display")));
+        
+        // when & then
+        assertThrows(DataValidationException.class, () -> parser.parse(reader));
+    }
+    
+    @ParameterizedTest
+    @EmptySource
+    @ValueSource(strings = {"https://demo.dataverse.org/foobar", "http://demo.dataverse.org/foobar"})
+    void setNamespaceUri_Valid(String uri) {
+        // given
+        StringReader reader = new StringReader(generateMetadataBlockTSV(
+            Map.of(MetadataBlock.Headers.NAME, "test",
+                   MetadataBlock.Headers.DISPLAY_NAME, "display",
+                   MetadataBlock.Headers.NAMESPACE_URI, uri)));
+    
+        // when
+        parser.parse(reader);
+        List<MetadataBlock> blocks = metadataBlockProcessor.getBeans();
+    
+        // then
+        assertEquals(1, blocks.size());
+        assertEquals(uri, Optional.ofNullable(blocks.get(0).getNamespaceUri()).orElse(""));
+    }
+    
+    @ParameterizedTest
+    @ValueSource(strings = {"//demo.dataverse.org/foobar", "doi://demo.dataverse.org/foobar"})
+    void setNamespaceUri_Invalid(String uri) {
+        // given
+        StringReader reader = new StringReader(generateMetadataBlockTSV(
+            Map.of(MetadataBlock.Headers.NAME, "test",
+                   MetadataBlock.Headers.DISPLAY_NAME, "display",
+                   MetadataBlock.Headers.NAMESPACE_URI, uri)));
+    
+        // when & then
+        assertThrows(DataValidationException.class, () -> parser.parse(reader));
+    }
+    
+    @ParameterizedTest
+    @ValueSource(strings = {"hello", "H 1234", "Hello this is my Name", "1234 Foo Bar Town", "DO NOT USE!!!"})
+    void setDisplayName_AllValid(String displayName) {
+        // given
+        StringReader reader = new StringReader(generateMetadataBlockTSV(
+            Map.of(MetadataBlock.Headers.DISPLAY_NAME, displayName,
+                MetadataBlock.Headers.NAME, "test")));
+        
+        // when
+        parser.parse(reader);
+        List<MetadataBlock> blocks = metadataBlockProcessor.getBeans();
+        
+        // then
+        assertEquals(1, blocks.size());
+        assertEquals(displayName, blocks.get(0).getDisplayName());
+    }
+    
+    @ParameterizedTest
+    @EmptySource
+    @ValueSource(strings = {" \t", "\t hello", "   Hello Hello", LONGER_THAN_256_CHARS})
+    void setDisplayName_AllInvalid(String displayName) {
+        // given
+        StringReader reader = new StringReader(generateMetadataBlockTSV(
+            Map.of(MetadataBlock.Headers.NAME, displayName,
+                MetadataBlock.Headers.DISPLAY_NAME, "display")));
+        
+        // when & then
+        assertThrows(DataValidationException.class, () -> parser.parse(reader));
+    }
+    
+    @ParameterizedTest
+    @EmptySource
+    @ValueSource(strings = {"hello", "HelloMyName", "hello_my_name_is", "hello-im-marc", "_foo-bar", "1234-test", "test-1234", "hello123"})
+    void setOwner_AllValid(String owner) {
+        // given
+        StringReader reader = new StringReader(generateMetadataBlockTSV(
+            Map.of(MetadataBlock.Headers.DISPLAY_NAME, "test",
+                   MetadataBlock.Headers.NAME, "test",
+                   MetadataBlock.Headers.OWNER, owner)));
+        
+        // when
+        parser.parse(reader);
+        List<MetadataBlock> blocks = metadataBlockProcessor.getBeans();
+        
+        // then
+        assertEquals(1, blocks.size());
+        if (!owner.isEmpty()) {
+            assertNotNull(blocks.get(0).getOwner());
+            assertTrue(blocks.get(0).getOwner() instanceof Dataverse);
+            assertTrue(blocks.get(0).getOwner() instanceof Placeholder.Dataverse);
+            assertEquals(owner, blocks.get(0).getOwner().getAlias());
+        }
+    }
+    
+    @ParameterizedTest
+    @ValueSource(strings = {"1234", "hello+", "Hello!"})
+    void setOwner_AllInvalid(String owner) {
+        // given
+        StringReader reader = new StringReader(generateMetadataBlockTSV(
+            Map.of(MetadataBlock.Headers.OWNER, owner,
+                   MetadataBlock.Headers.DISPLAY_NAME, "display",
+                   MetadataBlock.Headers.NAME, "test")));
+        
+        // when & then
+        assertThrows(DataValidationException.class, () -> parser.parse(reader));
+    }
+    
+    /**
+     * This method simply inserts all the values from the map into a line, combined by \t and adds a "header" line before it.
+     * It does this based on the {@link MetadataBlock.Headers} enum value order, which is the same as in the TSV definition.
+     * Nonpresent values will be inserted as blank strings.
+     *
+     * @param values
+     * @return
+     */
+    public static String generateMetadataBlockTSV(Map<MetadataBlock.Headers, String> values) {
+        List<String> fieldValues = Arrays.stream(MetadataBlock.Headers.values())
+                                         .map(k -> values.getOrDefault(k, ""))
+                                         .collect(Collectors.toList());
+        return "unused header line" + settings.getFormat().getLineSeparatorString() + String.join("\t", fieldValues);
+    }
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Testing, reuse for tests and future features with TSV based metadata schema files need abstraction and parsing outside the API code, where currently the conversion happens.

This PR is about to change the underlying infrastructure for this, add lots of testing and implement actual checks on restrictions like no circular deps of fields, max depth of compounds etc etc etc.

This is a blocker :zap: for #5989

**Which issue(s) this PR closes**:

Closes #8085

**Special notes for your reviewer**:
None yet.

**Suggestions on how to test this**:
Extensive unit and integration testing will be provided.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
Nope.

**Is there a release notes update needed for this change?**:
I don't think so, as it's part of the code infrastructure.

**Additional documentation**:
None yet. (Might make the docs on metadata blocks more precise in a few places)
