### PR TITLE
Updates to address External Vocab Support UI issues

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DatasetFieldServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetFieldServiceBean.java
@@ -641,11 +641,12 @@ public class DatasetFieldServiceBean implements java.io.Serializable {
      */
     public boolean isValidCVocValue(DatasetFieldType dft, String value) {
         JsonObject jo = getCVocConf(true).get(dft.getId());
-        JsonArray vocabs = jo.getJsonArray("vocabs");
+        JsonObject vocabs = jo.getJsonObject("vocabs");
         boolean valid = false;
         boolean couldBeFreeText = true;
         boolean freeTextAllowed = jo.getBoolean("allow-free-text", false);
-        for (JsonObject vocab : vocabs.getValuesAs(JsonObject.class)) {
+        for (String vocabName : vocabs.keySet()) {
+            JsonObject vocab = vocabs.getJsonObject(vocabName);
             String baseUri = vocab.getString("uriSpace");
             if (value.startsWith(baseUri)) {
                 valid = true;

--- a/src/main/webapp/metadataFragment.xhtml
+++ b/src/main/webapp/metadataFragment.xhtml
@@ -9,7 +9,7 @@
         <p:fragment>
            <p:autoUpdate/>
         <ui:repeat value="#{DatasetPage.vocabScripts}" var="vocabScriptUrl">
-           <script defer="defer" src="#{vocabScriptUrl}?version=#{systemConfig.getVersion()}"/>
+           <script src="#{vocabScriptUrl}?version=#{systemConfig.getVersion()}"/>
         </ui:repeat>
         </p:fragment>
         <c:set var="cvocConf" value="#{DatasetPage.getCVocConf()}"/>
@@ -328,7 +328,7 @@
     $(document).ready(function() {
       //The select2 widget used in external vocab scripts has trouble determining the width of an input field if it is initially hidden
       //Starting with the metadatablocks displayed and collapsing them here is a work-around to fix that.
-      if(#{!cvocConf.isEmpty()}) {
+      if(#{(editMode != 'CREATE') && !cvocConf.isEmpty()}) {
         for(let i=1;i< #{fn:length(metadataBlocks)};i++) {
           $('#panelCollapse'+i).collapse('hide');
         }

--- a/src/main/webapp/resources/css/structure.css
+++ b/src/main/webapp/resources/css/structure.css
@@ -1011,9 +1011,7 @@ progress::-webkit-progress-value {
         display:inline;
         background:#ffffff;
 }
-.select2-container {
-        display: inline!important;
-}
+
 .select2-container .select2-selection--single .select2-selection__rendered {
         display:inline-block!important;
         max-width:90%

--- a/src/main/webapp/search/advanced.xhtml
+++ b/src/main/webapp/search/advanced.xhtml
@@ -127,6 +127,7 @@
                                                         <f:passThroughAttribute name="data-cvoc-allowfreetext" value="#{cvoc.getBoolean('allow-free-text', false)}"/>
                                                         <f:passThroughAttribute name="data-cvoc-parent" value="#{cvoc.getString('field-name','')}"/>
                                                         <f:passThroughAttribute name="data-cvoc-managedfields" value="#{cvoc.get('managed-fields').toString()}"/>
+                                                        <f:passThroughAttribute name="data-cvoc-placeholder" value=""/>
                                                     </p:inputText>
                                                 </ui:fragment>
                                                 <div class="ui-inputfield form-control select-scroll-block" jsf:rendered="#{!empty item.controlledVocabularyValues}">


### PR DESCRIPTION
**What this PR does / why we need it**: This PR includes minor changes that simplify solving issues reported at https://github.com/gdcc/dataverse-external-vocab-support/issues w.r.t. the UI changes generated by external vocab scripts.

**Which issue(s) this PR closes**:

Closes #

**Special notes for your reviewer**: The commits reference the specific issues in the repo above. There are matching changes to the scripts in some cases.

**Suggestions on how to test this**:  Could retest as for the main ext vocab PR. THe changes here and the updates in the other repo should resolve all 4 issues there:
  * There shouldn't be any watermark/placeholder in the input for a configured field on the advanced search page
  * Fields should look Okay on the dataset create page
  * Fields should show a down-arrow/indicate you can expand them to see a list of choices
  * field names should be updated (no changes in the PR, just tsv updates in the other repo)

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: ~no - changes are from the scripts. The issues in that repo do have UI snapshots to show the results when the changes here and in that repo are combined.

**Is there a release notes update needed for this change?**: hopefully makes the same release as the main PR

**Additional documentation**:
