### PR TITLE
bump maven version and link, switch to RockyLinux

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,7 +4,7 @@
 VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = "bento/centos-8.2"
+  config.vm.box = "bento/rockylinux-8.4"
 
   config.vm.provider "virtualbox" do |vbox|
     vbox.cpus = 4

--- a/scripts/vagrant/setup.sh
+++ b/scripts/vagrant/setup.sh
@@ -24,11 +24,10 @@ alternatives --set java /usr/lib/jvm/jre-11-openjdk/bin/java
 java -version
 
 # maven included in centos8 requires 1.8.0 - download binary instead
-# current version is 3.6.3 - requires newer jacoco.pom.xml
-wget -q https://www-us.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz
-tar xfz apache-maven-3.6.3-bin.tar.gz
+wget -q https://archive.apache.org/dist/maven/maven-3/3.8.2/binaries/apache-maven-3.8.2-bin.tar.gz
+tar xfz apache-maven-3.8.2-bin.tar.gz
 mkdir /opt/maven
-mv apache-maven-3.6.3/* /opt/maven/
+mv apache-maven-3.8.2/* /opt/maven/
 echo "export JAVA_HOME=/usr/lib/jvm/jre-openjdk" > /etc/profile.d/maven.sh
 echo "export M2_HOME=/opt/maven" >> /etc/profile.d/maven.sh
 echo "export MAVEN_HOME=/opt/maven" >> /etc/profile.d/maven.sh


### PR DESCRIPTION
**What this PR does / why we need it**:

Correct Maven link in vagrant scripts, bump to current version of Maven, switch to RockyLinux since CentOS proper EOLs soon.

**Which issue(s) this PR closes**:

Closes #8104

**Special notes for your reviewer**: none

**Suggestions on how to test this**: `vagrant up`

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: no

**Is there a release notes update needed for this change?**: no

**Additional documentation**: none
