### PR TITLE
use Odum's fork, which uses -W instead of --keep-going

### DIFF
--- a/.github/workflows/guides_build_sphinx.yml
+++ b/.github/workflows/guides_build_sphinx.yml
@@ -9,6 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: ammaraskar/sphinx-action@master
+    - uses: OdumInstitute/sphinx-action@master
       with:
         docs-folder: "doc/sphinx-guides/"


### PR DESCRIPTION
**What this PR does / why we need it**: ammaraskar's action hard-codes --keep-going, which breaks the desired functionality of `-W`

I forked the action, bumped Sphinx to 3.5.4 to match, and changed `--keep-going` to `-W` for our purposes.

**Which issue(s) this PR closes**:

Closes #8117 

**Special notes for your reviewer**: none

**Suggestions on how to test this**: submit a dummy documentation pull request against OdumInstitute/dataverse/8117

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: no

**Is there a release notes update needed for this change?**: no

**Additional documentation**: none
