### PR TITLE
add fixmissingoriginalsizes API call to 5.0 upgrade prerequisites

### DIFF
--- a/doc/release-notes/5.0-release-notes.md
+++ b/doc/release-notes/5.0-release-notes.md
@@ -219,7 +219,7 @@ Starting with release 4.10 the size of the saved original file (for an ingested 
 
 `/api/admin/datafiles/integrity/fixmissingoriginalsizes`
 
-(see the documentation note in the Native API guide, under "[Datafile Integrity](https://guides.dataverse.org/en/latest/api/native-api.html#datafile-integrity)").
+(see the documentation note in the Native API guide, under "[Datafile Integrity](https://guides.dataverse.org/en/5.0/api/native-api.html#datafile-integrity)").
 
 To check your installation, issue this command:
 

--- a/doc/release-notes/5.0-release-notes.md
+++ b/doc/release-notes/5.0-release-notes.md
@@ -219,11 +219,11 @@ Starting with release 4.10 the size of the saved original file (for an ingested 
 
 `/api/admin/datafiles/integrity/fixmissingoriginalsizes`
 
-(see the documentation note in the Native API guide, under "[Datafile Integrity](https://guides.dataverse.org/en/5.0/api/native-api.html#datafile-integrity)").
+(See the documentation note in the Native API guide, under "[Datafile Integrity](https://guides.dataverse.org/en/5.0/api/native-api.html#datafile-integrity)").
 
 To check your installation, issue this command:
 
-   `curl https://localhost/api/admin/datafiles/integrity/fixmissingoriginalsizes`
+   `curl http://localhost:8080/api/admin/datafiles/integrity/fixmissingoriginalsizes`
 
 ### Upgrade from Glassfish 4.1 to Payara 5
 

--- a/doc/release-notes/5.0-release-notes.md
+++ b/doc/release-notes/5.0-release-notes.md
@@ -213,6 +213,18 @@ If this is a new installation, please see our [Installation Guide](http://guides
 
 ## Upgrade Instructions
 
+### Prerequisite: Retroactively store original file size
+
+Starting with release 4.10 the size of the saved original file (for an ingested tabular datafile) is stored in the database. We provided the following API that retrieve and permanently store the sizes for any already existing saved originals:
+
+`/api/admin/datafiles/integrity/fixmissingoriginalsizes`
+
+(see the documentation note in the Native API guide, under "[Datafile Integrity](https://guides.dataverse.org/en/latest/api/native-api.html#datafile-integrity)").
+
+To check your installation, issue this command:
+
+   `curl https://localhost/api/admin/datafiles/integrity/fixmissingoriginalsizes`
+
 ### Upgrade from Glassfish 4.1 to Payara 5
 
 The instructions below describe the upgrade procedure based on moving an existing glassfish4 domain directory under Payara. We recommend this method instead of setting up a brand-new Payara domain using the installer because it appears to be the easiest way to recreate your current configuration and preserve all your data.


### PR DESCRIPTION
**What this PR does / why we need it**:

The fixmissingoriginalsizes API step was optional in version 4.n, but required for 5.0, and not mentioned in the release notes. This has tripped up a number of installations as they upgrade.

**Which issue(s) this PR closes**:

Closes #8123

**Special notes for your reviewer**: none

**Suggestions on how to test this**: compare against existing documentation

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: no

**Is there a release notes update needed for this change?**: yes

**Additional documentation**: none
