### PR TITLE
Fix typo in native API docs

### DIFF
--- a/doc/sphinx-guides/source/api/native-api.rst
+++ b/doc/sphinx-guides/source/api/native-api.rst
@@ -3556,7 +3556,7 @@ Validate an existing check sum value against one newly calculated from the saved
 Physical Files Validation in a Dataset
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The following validates all the physical files in the dataset spcified, by recalculating the checksums and comparing them against the values saved in the database::
+The following validates all the physical files in the dataset specified, by recalculating the checksums and comparing them against the values saved in the database::
 
   $SERVER_URL/api/admin/validate/dataset/files/{datasetId}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a typo in the Native API docs ("specified").