### PR TITLE
Make FakePID provider smarter

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/pidproviders/FakePidProviderServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/pidproviders/FakePidProviderServiceBean.java
@@ -3,27 +3,65 @@ package edu.harvard.iq.dataverse.pidproviders;
 import edu.harvard.iq.dataverse.AbstractGlobalIdServiceBean;
 import edu.harvard.iq.dataverse.DvObject;
 import edu.harvard.iq.dataverse.GlobalId;
+import edu.harvard.iq.dataverse.engine.command.impl.CreateNewDatasetCommand;
+import edu.harvard.iq.dataverse.engine.command.impl.ImportDatasetCommand;
+import edu.harvard.iq.dataverse.util.FileUtil;
 
+import java.lang.StackWalker.StackFrame;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.logging.Logger;
+import java.util.stream.Stream;
+
 import javax.ejb.Stateless;
 
 @Stateless
 public class FakePidProviderServiceBean extends AbstractGlobalIdServiceBean {
 
+    private static final Logger logger = Logger.getLogger(FakePidProviderServiceBean.class.getCanonicalName());
+
     @Override
     public boolean alreadyExists(DvObject dvo) throws Exception {
-    	/* Direct upload creates an identifier prior to calling the CreateNewDatasetCommand - if this is true, that call fails.
-    	 * In that case, the local test (DatasetServiceBean.isIdentifierLocallyUnique()) correctly returns false since it tests the database.
-    	 * This provider could do the same check or use some other method to test alreadyExists(DvObject) =true failures. (no tests found currently) 
-    	 */
-        return false;
+        /*
+         * This method is called in cases where the 'right' answer can be true or false:
+         * 
+         * When called via CreateNewDatasetCommand (direct upload case), we expect
+         * 'false' as the response, whereas when called from ImportDatasetCommand or
+         * DeleteDataFileCommand, we expect 'true' as a confirmation that the expected
+         * PID exists.
+         * 
+         * This method now checks the stack and can send true/false as expected by the
+         * calling command as the right default/normal case.
+         *
+         * Alternately, this method could check the database as is done in
+         * DatasetServiceBean.isIdentifierLocallyUnique() (needs a similar method for
+         * DataFiles and could be refactored to only have one query for both).
+         */
+        StackWalker walker = StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE);
+        if (walker.walk(this::getCallingClass)) {
+            logger.fine("Called from CreateNewDatasetCommand");
+            return false;
+        }
+        return true;
+    }
+
+    private boolean getCallingClass(Stream<StackFrame> stackFrameStream) {
+        /*
+         * If/when other cases require a true response from the alreadyExists method,
+         * add those class names to the test below.
+         */
+        return stackFrameStream
+                .filter(frame -> frame.getDeclaringClass().getSimpleName()
+                        .equals(CreateNewDatasetCommand.class.getSimpleName()))
+                .findFirst().map(f -> true).orElse(false);
     }
     
     @Override
     public boolean alreadyExists(GlobalId globalId) throws Exception {
+        //Could use the same method as above to return false if/when needed.
         return true;
     }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes the FakePIDProviderServiceBean check the calling stack to appropriately return false or true for the alreadyExists(DVObject) method to match the default expectation of the caller (see the issue for a longer description).

**Which issue(s) this PR closes**:

Closes #8153 

**Special notes for your reviewer**: This only affects the FakePIDProvider. There are probably other ways to deal with this, but this seemed fairly flexible w.r.t. handling future changes. The underlying issue is that this provider isn't really keeping state. It could be made stateful (either tracking PIDs internally or querying PIDs in the DVObject table). 
Also note that there is a bug - the change that allowed direct upload to work with the FakeProvider, that switched this method to return false broke other API calls (anyone who called alreadyExists(DVObject) instead of alreadyExists(GlobalId)) which wasn't noticed at the time.

**Suggestions on how to test this**: Run the FakePIDProvider and verify that direct uploads to S3 work (e.g. via the UI) and that a call to the import dataset API works.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: no

**Is there a release notes update needed for this change?**: no

**Additional documentation**:
