### PR TITLE
8161 - clarify required permissions for private URL creation

### DIFF
--- a/doc/sphinx-guides/source/user/dataset-management.rst
+++ b/doc/sphinx-guides/source/user/dataset-management.rst
@@ -503,9 +503,9 @@ If you have a Contributor role (can edit metadata, upload files, and edit files,
 Private URL to Review Unpublished Dataset
 =========================================
 
-**Note:** Creation requires the *ManageDatasetPermissions* right for your dataset, usually given by :ref:`roles <permissions>` *Curator* or *Administrator*.
-
 Creating a Private URL for your dataset allows you to share your dataset (for viewing and downloading of files) before it is published to a wide group of individuals who may not have a user account on the Dataverse installation. Anyone you send the Private URL to will not have to log into the Dataverse installation to view the dataset.
+
+**Note:** To create a Private URL, you must have the *ManageDatasetPermissions* permission for your dataset, usually given by the :ref:`roles <permissions>` *Curator* or *Administrator*.
 
 #. Go to your unpublished dataset
 #. Select the “Edit” button


### PR DESCRIPTION
**What this PR does / why we need it**:
Make it more obvious what permissions are required for you to create a private URL

**Which issue(s) this PR closes**:

Closes #8161

**Special notes for your reviewer**:
None?

**Suggestions on how to test this**:
Docs change only. Not testing required.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
Docs change only.

**Is there a release notes update needed for this change?**:
Nope.

**Additional documentation**:
None.