### PR TITLE
prevent test from failing because dv alias is an integer #6863

### DIFF
--- a/src/test/java/edu/harvard/iq/dataverse/api/FileMetadataIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/FileMetadataIT.java
@@ -41,7 +41,9 @@ public class FileMetadataIT {
     public void setUpDataverse() {
         try {
             // create random test name
-            testName = UUID.randomUUID().toString().substring(0, 8);
+            // "abc" added so the name/alias isn't an integer, a requirement for dataverse creation.
+            // Longer term, consider switching to UtilIT.getRandomDvAlias (and rewriting these tests).
+            testName = "abc" + UUID.randomUUID().toString().substring(0, 8);
             // create user and set token
             token = given()
                     .body("{"


### PR DESCRIPTION
**What this PR does / why we need it**:

Makes sure the alias used when creating a dataverse is never just an integer, which is not allowed.

(It's only sometimes an integer, of course, randomly.)

This was previously fixed for other tests in pull request #3898.

**Which issue(s) this PR closes**:

Closes #6863

**Special notes for your reviewer**:

None.

**Suggestions on how to test this**:

I ran `uuidgen | cut -c1-8` a few times locally to see if I ever get just an integer. I got bored before I did. I'd say if the API tests pass, that's probably good enough.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No.

**Is there a release notes update needed for this change?**:

No.

**Additional documentation**:

None.