### PR TITLE
8171- remove script reference on manage file permissions dialog

### DIFF
--- a/src/main/webapp/permissions-manage-files.xhtml
+++ b/src/main/webapp/permissions-manage-files.xhtml
@@ -291,9 +291,6 @@
                                             <p:ajax process="@this" event="itemSelect" />
                                             <p:ajax process="@this" event="itemUnselect" />
                                         </p:autoComplete>
-                                        <script>
-                                            handle_dropdown_popup_scroll();
-                                        </script>
                                         <p:message for="userGroupNameAssign" display="text"/>
                                     </div>
                                 </div>


### PR DESCRIPTION
**What this PR does / why we need it**: removes a warning in the console 
**Which issue(s) this PR closes**:

Closes #8171

**Special notes for your reviewer**: - a trivial fix - just looks like #7627 missed one instance on this page.

**Suggestions on how to test this**: Go to the dataset/manage file permission pane and check the browser console for the error - should be gone with this PR

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: no

**Is there a release notes update needed for this change?**:

**Additional documentation**:
