### PR TITLE
#8175 fix manage templates

### DIFF
--- a/src/main/webapp/manage-templates.xhtml
+++ b/src/main/webapp/manage-templates.xhtml
@@ -3,7 +3,6 @@
       xmlns:h="http://java.sun.com/jsf/html"
       xmlns:f="http://java.sun.com/jsf/core"
       xmlns:ui="http://java.sun.com/jsf/facelets"
-      xmlns:fn="http://java.sun.com/jsp/jstl/functions"
       xmlns:p="http://primefaces.org/ui"
       xmlns:jsf="http://xmlns.jcp.org/jsf">
     <h:head>

--- a/src/main/webapp/metadataFragment.xhtml
+++ b/src/main/webapp/metadataFragment.xhtml
@@ -3,6 +3,7 @@
                 xmlns:f="http://java.sun.com/jsf/core"
                 xmlns:ui="http://java.sun.com/jsf/facelets"
                 xmlns:c="http://java.sun.com/jsp/jstl/core"
+                xmlns:fn="http://java.sun.com/jsp/jstl/functions"
                 xmlns:p="http://primefaces.org/ui"
                 xmlns:o="http://omnifaces.org/ui"
                 xmlns:jsf="http://xmlns.jcp.org/jsf">

--- a/src/main/webapp/template.xhtml
+++ b/src/main/webapp/template.xhtml
@@ -5,7 +5,6 @@
       xmlns:ui="http://java.sun.com/jsf/facelets"
       xmlns:p="http://primefaces.org/ui"
       xmlns:c="http://xmlns.jcp.org/jsp/jstl/core"
-      xmlns:fn="http://java.sun.com/jsp/jstl/functions"
       xmlns:o="http://omnifaces.org/ui"
       xmlns:jsf="http://xmlns.jcp.org/jsf">
     <h:head>


### PR DESCRIPTION
**What this PR does / why we need it**: Manage Templates page was broken due to missing imports. (Edit Templates would have been, too if you could get there.)

**Which issue(s) this PR closes**:

Closes #8175 Manage Dataset Templates broken in 5.7

**Special notes for your reviewer**: Also fixed a button label 

**Suggestions on how to test this**: See that you can get to the manage templates page and then add or edit a template.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: no

**Is there a release notes update needed for this change?**: no

**Additional documentation**: none
