### PR TITLE
#8180 - reset the validateFilesOutcome flag upon files table selection change

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
@@ -3067,12 +3067,17 @@ public class DatasetPage implements java.io.Serializable {
 
     public void setSelectAllFiles(boolean selectAllFiles) {
         this.selectAllFiles = selectAllFiles;
+        //Reset param in page see #8180
+        setValidateFilesOutcome(null);
     }
 
     public void toggleAllSelected(){
         //This is here so that if the user selects all on the dataset page
         // s/he will get all files on download
         this.selectAllFiles = !this.selectAllFiles;
+        //Reset param in page see #8180
+        setValidateFilesOutcome(null);
+
     }
 
 

--- a/src/main/webapp/filesFragment.xhtml
+++ b/src/main/webapp/filesFragment.xhtml
@@ -53,12 +53,12 @@
                  rendered="#{DatasetPage.fileDisplayTable and (DatasetPage.workingVersion != null)}"
                  emptyMessage="#{DatasetPage.workingVersion.fileMetadatas.size() == 0 ? bundle['file.notFound.tip'] : bundle['file.notFound.search']}">
         <p:ajax event="page" listener="#{DatasetPage.fileListingPaginatorListener}" update="filesTable" process="@this"  oncomplete="refreshPaginator(),rebindCommand()"  immediate="true"/>
-        <p:ajax event="toggleSelect" listener="#{DatasetPage.toggleAllSelected()}" update="filesTable"  process="@this" oncomplete="rebindCommand()"  /> 
-        <p:ajax event="rowUnselectCheckbox" listener="#{DatasetPage.setSelectAllFiles(false)}" update="filesTable" process="@this" oncomplete="rebindCommand()"  />
-        <p:ajax event="rowSelect" listener="#{DatasetPage.setSelectAllFiles(false)}" update="filesTable" process="@this" oncomplete="rebindCommand()" />
-        <p:ajax event="rowSelectCheckbox" listener="#{DatasetPage.setSelectAllFiles(false)}" update="filesTable" process="@this" oncomplete="rebindCommand()"  />
-        <p:ajax event="rowUnselect" listener="#{DatasetPage.setSelectAllFiles(false)}" update="filesTable" process="@this" oncomplete="rebindCommand()" />
-        <p:ajax event="rowDblselect" listener="#{DatasetPage.setSelectAllFiles(false)}" update="filesTable" process="@this" oncomplete="rebindCommand()" />
+        <p:ajax event="toggleSelect" listener="#{DatasetPage.toggleAllSelected()}" update="@form:validateFilesOutcome, filesTable"  process="@this" oncomplete="rebindCommand()"  /> 
+        <p:ajax event="rowUnselectCheckbox" listener="#{DatasetPage.setSelectAllFiles(false)}" update="@form:validateFilesOutcome, filesTable" process="@this" oncomplete="rebindCommand()"  />
+        <p:ajax event="rowSelect" listener="#{DatasetPage.setSelectAllFiles(false)}" update="@form:validateFilesOutcome, filesTable" process="@this" oncomplete="rebindCommand()" />
+        <p:ajax event="rowSelectCheckbox" listener="#{DatasetPage.setSelectAllFiles(false)}" update="@form:validateFilesOutcome, filesTable" process="@this" oncomplete="rebindCommand()"  />
+        <p:ajax event="rowUnselect" listener="#{DatasetPage.setSelectAllFiles(false)}" update="@form:validateFilesOutcome, filesTable" process="@this" oncomplete="rebindCommand()" />
+        <p:ajax event="rowDblselect" listener="#{DatasetPage.setSelectAllFiles(false)}" update="@form:validateFilesOutcome, filesTable" process="@this" oncomplete="rebindCommand()" />
 
         <f:facet name="header">
             <div class="row form-inline" jsf:id="cloudStorageBlock" jsf:rendered="#{DatasetPage.showComputeButton()}">

--- a/src/main/webapp/filesFragment.xhtml
+++ b/src/main/webapp/filesFragment.xhtml
@@ -42,6 +42,9 @@
 
     <!-- Files Table -->
     <!-- TABLESTYLE + WIDTH:AUTO FIX COL WIDTH OVERFLOW HIDDEN, MIN-WIDTH 100% ADDED FOR TABLE CONTENT LESS THAN 100% https://stackoverflow.com/a/38582318 -->
+    <ui:remove>
+        <!--TODO - consider moving the validateFilesOutcome param here/ other refactoring to simplify managing selection state - see issue #8180/PR #8182 -->
+    </ui:remove>
     <p:dataTable id="filesTable" 
                  rows="10" paginator="#{DatasetPage.fileMetadatasSearch.size() gt 10}" paginatorPosition="bottom"
                  paginatorTemplate="{FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} #{bundle['file.dynamicCounter.filesPerPage']} {RowsPerPageDropdown}"


### PR DESCRIPTION
**What this PR does / why we need it**: The PR avoids having an incorrect download dialog show up in the case described in the issue.

**Which issue(s) this PR closes**:

Closes #8180

**Special notes for your reviewer**: 

All the ways the selection change end up having the setSelectAllFiles()
or toggleAllSelected() methods as listeners, so the validateFilesOutcome
var is set to null in those. The update for all the methods then adds
the in-page param of the same name so that calls to showPopup() work
properly. See #8180.

Questions/concerns I have - 

- I've only added the validateFilesOutcome param to the updates to avoid resending the whole form (with all the menus on the page, etc.), but this means that, post selection update, things like the hidden dialogs are still incorrect. Since they only show after an action (like the download button), which should be updating the form and getting correct values, I think this is OK. However, if anyone can see other issues where stale info outside the filesTable is problematic, we could/should update the whole form.
- A root cause here is that the popup dialog that must understand the filesTable state, and the validateFilesOutcome param are both in the dataset.xhtml page rather than filesFragment, so just updating the filesTable, which selection changes currently do, doesn't update them. My guess is that things could be refactored to put those dialogs and the param in the filesTable or at least some other fragment that could be updated without referencing/updating the datasetForm itself. With my solution we're only updating the validateFilesOutcome param, so it's efficient, but if the answer to the first question is that we need to update the whole form, perhaps refactoring would be better?

**Suggestions on how to test this**: Follow the issue - basically have one restricted and one public file. Select both, hit download, cancel. Now unselect the restricted file and hit download. Pre-PR the public file should download but the warning dialog that you've also selected a restricted file still shows. Post-PR, the dialog won't show. Assuming this merges post-embargo, one could also test with actively embargoed files - the results should be the same.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: only by correcting the buggy flow.

**Is there a release notes update needed for this change?**: no.

**Additional documentation**:
