### PR TITLE
8204 - handle empty AllowedCurationLabels setting

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/util/SystemConfig.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/SystemConfig.java
@@ -1,7 +1,6 @@
 package edu.harvard.iq.dataverse.util;
 
 import com.ocpsoft.pretty.PrettyContext;
-import com.rometools.utils.Strings;
 
 import edu.harvard.iq.dataverse.DataFile;
 import edu.harvard.iq.dataverse.Dataset;
@@ -1125,7 +1124,7 @@ public class SystemConfig {
     public Map<String, String[]> getCurationLabels() {
         Map<String, String[]> labelMap = new HashMap<String, String[]>();
         String setting = settingsService.getValueForKey(SettingsServiceBean.Key.AllowedCurationLabels, "");
-        if (!Strings.isEmpty(setting)) {
+        if (!setting.isEmpty()) {
             try {
                 JsonReader jsonReader = Json.createReader(new StringReader(setting));
 


### PR DESCRIPTION
**What this PR does / why we need it**: Fixes warning in log when the setting is empty/not set. See issue for details.

**Which issue(s) this PR closes**:

Closes #8204

**Special notes for your reviewer**:

**Suggestions on how to test this**:

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
