### PR TITLE
prevent (some) special characters in metadata #8018

### DIFF
--- a/doc/release-notes/8018-special-characters.md
+++ b/doc/release-notes/8018-special-characters.md
@@ -1,0 +1,1 @@
+After upgrading, do an "index all" to remove special characters that have been removed from the database.

--- a/src/main/java/propertyFiles/Bundle.properties
+++ b/src/main/java/propertyFiles/Bundle.properties
@@ -2610,6 +2610,7 @@ editfilesfragment.label5=US-ASCII
 
 isrequired={0} is required.
 isrequired.conditional={0} is required if you choose to enter a value in any of the optional {1} fields.
+invalidcharacter=An invalid character such as form field (U+000C) or start of text (U+0002) was entered.
 draftversion=DRAFT VERSION
 deaccessionedversion=DEACCESSIONED VERSION
 

--- a/src/main/resources/db/migration/V5.8.0.1__8018-special-characters.sql
+++ b/src/main/resources/db/migration/V5.8.0.1__8018-special-characters.sql
@@ -1,0 +1,5 @@
+-- This list of characters also appears in DatasetFieldValidator.java
+-- Remove character: form feed (\f)
+UPDATE datasetfieldvalue SET value = regexp_replace(value, E'\f', '', 'g');
+-- Remove character: start of text (\u0002)
+UPDATE datasetfieldvalue SET value = regexp_replace(value, U&'\0002', '', 'g');

--- a/src/test/java/edu/harvard/iq/dataverse/DatasetFieldValidatorTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/DatasetFieldValidatorTest.java
@@ -58,6 +58,9 @@ public class DatasetFieldValidatorTest {
         testPrimitiveDatasetField("test isValid() for required primitive with empty value", true, "", datasetVersion, false);
         testPrimitiveDatasetField("test isValid() for required primitive with nonempty value",  true, "test", datasetVersion, true);
         testPrimitiveDatasetField("test isValid() for not required primitive", false, "", datasetVersion, true);
+        testPrimitiveDatasetField("test isValid() without special characters",  true, "test", datasetVersion, true); // true = valid
+        testPrimitiveDatasetField("test isValid() with special character: form feed",  true, "te\fst", datasetVersion, false); // false = not valid
+        testPrimitiveDatasetField("test isValid() with special character: start of text",  true, "te\u0002st", datasetVersion, false); // false = not valid
 
         // the compound tests are defined by parent/child1 required and child1/child2 values
         testCompoundDatasetField("test isValid() for false/false compound with empty/empty children", false, false, "", "", datasetVersion, true);

--- a/src/test/java/edu/harvard/iq/dataverse/api/ValidateIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/ValidateIT.java
@@ -1,0 +1,78 @@
+package edu.harvard.iq.dataverse.api;
+
+import com.jayway.restassured.RestAssured;
+import com.jayway.restassured.response.Response;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import javax.json.Json;
+import javax.json.JsonObjectBuilder;
+import static javax.ws.rs.core.Response.Status.CREATED;
+import static javax.ws.rs.core.Response.Status.FORBIDDEN;
+import static javax.ws.rs.core.Response.Status.OK;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class ValidateIT {
+
+    @BeforeClass
+    public static void setUp() {
+        RestAssured.baseURI = UtilIT.getRestAssuredBaseUri();
+    }
+
+    @Test
+    public void testValidate() throws IOException {
+        Response createUser = UtilIT.createRandomUser();
+        createUser.then().assertThat().statusCode(OK.getStatusCode());
+        String apiToken = UtilIT.getApiTokenFromResponse(createUser);
+        String username = UtilIT.getUsernameFromResponse(createUser);
+
+        UtilIT.makeSuperUser(username).then().assertThat().statusCode(OK.getStatusCode());
+
+        Response createUserNoPrivs = UtilIT.createRandomUser();
+        createUserNoPrivs.then().assertThat().statusCode(OK.getStatusCode());
+        String apiTokenNoPrivs = UtilIT.getApiTokenFromResponse(createUserNoPrivs);
+
+        Response createDataverseResponse = UtilIT.createRandomDataverse(apiToken);
+        createDataverseResponse.prettyPrint();
+        createDataverseResponse.then().assertThat()
+                .statusCode(CREATED.getStatusCode());
+
+        String dataverseAlias = UtilIT.getAliasFromResponse(createDataverseResponse);
+
+        Response createDataset = UtilIT.createRandomDatasetViaNativeApi(dataverseAlias, apiToken);
+        createDataset.prettyPrint();
+        createDataset.then().assertThat()
+                .statusCode(CREATED.getStatusCode());
+
+        Integer datasetId = UtilIT.getDatasetIdFromResponse(createDataset);
+        String datasetPid = UtilIT.getDatasetPersistentIdFromResponse(createDataset);
+        String badCharacter = "(\f)"; // form feed
+//        badCharacter = "{\u0002}"; // start of text (can't reproduce problem)
+//        badCharacter = "[\u000C]"; // form feed
+//        badCharacter = "(...)";
+
+        JsonObjectBuilder jsonUpdateObject = Json.createObjectBuilder().add("fields",
+                Json.createArrayBuilder()
+                        .add(Json.createObjectBuilder()
+                                .add("typeName", "title")
+                                .add("value", "MyTitle " + badCharacter)
+                        ));
+        String jsonUpdateString = jsonUpdateObject.build().toString();
+        Path jsonUpdatePath = Paths.get(java.nio.file.Files.createTempDirectory(null) + File.separator + "update.json");
+        java.nio.file.Files.write(jsonUpdatePath, jsonUpdateString.getBytes());
+        Response addDataToBadData = UtilIT.updateFieldLevelDatasetMetadataViaNative(datasetPid, jsonUpdatePath.toString(), apiToken);
+        addDataToBadData.prettyPrint();
+        addDataToBadData.then().assertThat().statusCode(FORBIDDEN.getStatusCode());
+
+//        Response datasetAsJson = UtilIT.nativeGet(datasetId, apiToken);
+//        datasetAsJson.prettyPrint();
+//        String junkText = "Junk\flives\u0002here.";
+//        String junkText = "Junk lives\u0002here.";
+//        Path junkPath = Paths.get("/tmp/junk.txt");
+//        Path junkPath = Paths.get("/tmp/junk-sot.txt");
+//        java.nio.file.Files.write(junkPath, junkText.getBytes());
+    }
+
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Special characters that are causing problems (such as an inability to edit dataset metadata) have been entered into the database. This pull request prevents specific special characters (form feed and start of text) from being entered and provides a SQL update script to remove them from the database.

**Which issue(s) this PR closes**:

Closes #8018

**Special notes for your reviewer**:

- Should we be handling more special characters? If so, which ones?
- Enforce at database level?
- See the "form feed" screenshot below. I would rather show the error if I can but the page becomes fairly broken. In Chrome you can see the error "Input is not proper UTF-8" under "partial-response" as in the screenshot below:

![Screen Shot 2021-11-09 at 2 15 49 PM](https://user-images.githubusercontent.com/21006/140989826-2fd97ea1-60c1-4cc2-89df-3d58e73b66aa.png)

**Suggestions on how to test this**:

- Try entering special characters like (form feed or start of text) into dataset fields such as description or title.
- Try creating or editing a dataset via API with the same special characters.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

Yes, if you enter a "start of text" character, you should see an error like this: "An invalid character such as form field (U+000C) or start of text (U+0002) was entered."

Here's a screenshot:

![Screen Shot 2021-11-09 at 1 58 01 PM](https://user-images.githubusercontent.com/21006/140988437-d14c8742-1a81-479b-a000-7ee063fdca79.png)

**Is there a release notes update needed for this change?**:

Note that if you enter a "form feed" character, you don't see the error and you are no longer to edit the page (the "Save Dataset" button is greyed out). See screenshots below.

![Screen Shot 2021-11-09 at 1 58 25 PM](https://user-images.githubusercontent.com/21006/140989235-cb9e42af-75b3-4c35-b606-960d9628a525.png)

![Screen Shot 2021-11-09 at 1 58 32 PM](https://user-images.githubusercontent.com/21006/140989258-861d0c68-06e9-4d63-8079-60da0995f6f0.png)


Yes, added.

**Additional documentation**:

None.