### PR TITLE
IQSS/8252: Correct error response to 403/forbidden in test

### DIFF
--- a/src/test/java/edu/harvard/iq/dataverse/api/AccessIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/AccessIT.java
@@ -520,7 +520,7 @@ public class AccessIT {
 
         listAccessRequestResponse = UtilIT.getAccessRequestList(tabFile3IdRestrictedNew.toString(), apiTokenRando);
         listAccessRequestResponse.prettyPrint();
-        assertEquals(400, listAccessRequestResponse.getStatusCode());
+        assertEquals(403, listAccessRequestResponse.getStatusCode());
 
         Response rejectFileAccessResponse = UtilIT.rejectFileAccessRequest(tabFile3IdRestrictedNew.toString(), "@" + apiIdentifierRando, apiToken);
         assertEquals(200, rejectFileAccessResponse.getStatusCode());


### PR DESCRIPTION
**What this PR does / why we need it**: #8174 included a fix to report a request to the api/access/datafile/{id}/listRequests endpoint with a bad apikey to return 403/Forbidden instead of 400/Bad Request. The related AccessIT test wasn't updated to match.

**Which issue(s) this PR closes**:

Closes #8252 

**Special notes for your reviewer**:

**Suggestions on how to test this**: Just run the IT tests / the AccessIT tests in particular.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: no

**Is there a release notes update needed for this change?**:

**Additional documentation**:
