### PR TITLE
Iqss/8247 flyout menu accessibility

### DIFF
--- a/src/main/webapp/dataset.xhtml
+++ b/src/main/webapp/dataset.xhtml
@@ -236,7 +236,7 @@
                                                                                  and DatasetPage.showComputeButton()}">
                                                             <li class="dropdown-header">#{bundle['dataset.accessBtn.header.compute']} <span class="glyphicon glyphicon-flash"/></li>
                                                             <li>
-                                                                <a tabindex="-1" href="#" id="computeBatch" class="btn-compute">#{bundle['dataset.compute.computeBtn']}</a>
+                                                                <a tabindex="0" id="computeBatch" class="btn-compute">#{bundle['dataset.compute.computeBtn']}</a>
                                                                 <ul class="dropdown-menu">
                                                                     <li>
                                                                         <!-- Compute dataset link -->
@@ -335,7 +335,7 @@
                                                         </li>
                                                         <ui:fragment rendered="#{(not empty DatasetPage.allowedExternalStatuses) and DatasetPage.canPublishDataset()}">
                                                             <li class="dropdown-submenu pull-left">
-                                                                <a tabindex="-1" href="#">#{bundle['dataset.changestatus']}</a>
+                                                            <a tabindex="0">#{bundle['dataset.changestatus']}</a>
                                                                 <ul class="dropdown-menu">
                                                                     <ui:repeat value="#{DatasetPage.allowedExternalStatuses}" var="status">
                                                                         <li>
@@ -387,7 +387,7 @@
                                                         <ui:fragment rendered="#{permissionsWrapper.canManagePermissions(DatasetPage.dataset) || permissionsWrapper.canManageFilesOnDataset(DatasetPage.dataset)}">
                                                             <li class="#{settingsWrapper.publicInstall ? '' : 'dropdown-submenu pull-left'}">
                                                                 <ui:fragment rendered="#{!settingsWrapper.publicInstall}">
-                                                                    <a tabindex="-1" href="#">#{bundle['dataset.editBtn.itemLabel.permissions']}</a>
+                                                                <a tabindex="0">#{bundle['dataset.editBtn.itemLabel.permissions']}</a>
                                                                     <ul class="dropdown-menu">
                                                                         <li jsf:rendered="#{permissionsWrapper.canManagePermissions(DatasetPage.dataset)}">
                                                                             <h:link id="manageDatasetPermissions" styleClass="ui-commandlink ui-widget" outcome="permissions-manage">

--- a/src/main/webapp/file-download-button-fragment.xhtml
+++ b/src/main/webapp/file-download-button-fragment.xhtml
@@ -203,8 +203,7 @@
     
     <!-- CITATION FILES DOWNLOAD OPTIONS -->
     <li class="dropdown-submenu pull-left" jsf:rendered="#{!anonymized}">
-        <script> function pressme(e) {e.target.parentElement.classList.toggle('open');return false;}</script>
-            <a tabindex="0" onkeypress="pressme(event)" >#{bundle['file.downloadBtn.format.citation']}</a>
+            <a tabindex="0">#{bundle['file.downloadBtn.format.citation']}</a>
         <ul class="dropdown-menu">
             <li>
                 <h:commandLink styleClass="btn-download" action="#{fileDownloadService.downloadDatafileCitationXML(fileMetadata)}">

--- a/src/main/webapp/file-download-button-fragment.xhtml
+++ b/src/main/webapp/file-download-button-fragment.xhtml
@@ -203,7 +203,8 @@
     
     <!-- CITATION FILES DOWNLOAD OPTIONS -->
     <li class="dropdown-submenu pull-left" jsf:rendered="#{!anonymized}">
-        <a tabindex="-1" href="javascript:void(0);">#{bundle['file.downloadBtn.format.citation']}</a>
+        <script> function pressme(e) {e.target.parentElement.classList.toggle('open');return false;}</script>
+            <a tabindex="0" onkeypress="pressme(event)" >#{bundle['file.downloadBtn.format.citation']}</a>
         <ul class="dropdown-menu">
             <li>
                 <h:commandLink styleClass="btn-download" action="#{fileDownloadService.downloadDatafileCitationXML(fileMetadata)}">

--- a/src/main/webapp/file-download-button-fragment.xhtml
+++ b/src/main/webapp/file-download-button-fragment.xhtml
@@ -234,7 +234,7 @@
         <!-- Aux Files in Bundle (DP, etc.)-->
         <ui:repeat var="auxFileType" value="#{auxiliaryFileServiceBean.findAuxiliaryFileTypes(fileMetadata.dataFile, true)}">
             <li class="dropdown-submenu pull-left">
-                <a tabindex="-1" href="javascript:void(0);">#{auxiliaryFileServiceBean.getFriendlyNameForType(auxFileType)}</a>
+                <a tabindex="0">#{auxiliaryFileServiceBean.getFriendlyNameForType(auxFileType)}</a>
                 <ul class="dropdown-menu">
                     <ui:repeat var="auxFile" value="#{auxiliaryFileServiceBean.findAuxiliaryFilesByType(fileMetadata.dataFile, auxFileType)}">
                         <li>
@@ -248,7 +248,7 @@
         </ui:repeat>
         <!--Other Aux Files (not in bundle)-->
         <li class="dropdown-submenu pull-left" jsf:rendered="#{not empty auxiliaryFileServiceBean.findOtherAuxiliaryFiles(fileMetadata.dataFile)}">
-            <a tabindex="-1" href="javascript:void(0);">#{bundle['file.auxfiles.unspecifiedTypes']}</a>
+            <a tabindex="0">#{bundle['file.auxfiles.unspecifiedTypes']}</a>
             <ul class="dropdown-menu">
                 <ui:repeat var="auxFile" value="#{auxiliaryFileServiceBean.findOtherAuxiliaryFiles(fileMetadata.dataFile)}">
                     <li>

--- a/src/main/webapp/filesFragment.xhtml
+++ b/src/main/webapp/filesFragment.xhtml
@@ -488,7 +488,7 @@
                         </a>
                     </ui:fragment>
                     <a type="button" style="padding:6px 8px;" class="btn-access-file btn btn-link bootstrap-button-tooltip dropdown-toggle" 
-                       title="#{bundle['file.accessBtn']}" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                       title="#{bundle['file.accessBtn']}" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" tabindex="0">
                         <span class="glyphicon glyphicon-download-alt"/><span class="sr-only">#{bundle['file.accessBtn']}</span><span class="caret"></span>
                     </a>
                     <ul class="dropdown-menu pull-right text-left">

--- a/src/main/webapp/filesFragment.xhtml
+++ b/src/main/webapp/filesFragment.xhtml
@@ -527,7 +527,8 @@
                                                         and DatasetPage.isFileDeleted(fileMetadata.dataFile)}">
                     <a type="button" class="btn-file-options btn btn-link bootstrap-button-tooltip dropdown-toggle #{DatasetPage.lockedFromEdits ? 'disabled' : ''}" 
                        disabled="#{DatasetPage.lockedFromEdits ? 'disabled' : ''}"
-                       title="#{bundle['file.optionsBtn']}" onclick="PF('fileAlreadyDeletedPrevious').show()">                        
+                       title="#{bundle['file.optionsBtn']}" onclick="PF('fileAlreadyDeletedPrevious').show()"
+                       tabindex="0">
                         <span class="glyphicon glyphicon-option-vertical"/><span class="sr-only">#{bundle['file.optionsBtn']}</span>
                     </a>                    
                 </div>                
@@ -538,7 +539,8 @@
                     <!-- Kebab / Edit / File Options Dropdown -->
                     <a type="button" class="btn-file-options btn btn-link bootstrap-button-tooltip dropdown-toggle #{DatasetPage.lockedFromEdits ? 'disabled' : ''}" 
                        disabled="#{DatasetPage.lockedFromEdits ? 'disabled' : ''}"
-                       title="#{bundle['file.optionsBtn']}" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                       title="#{bundle['file.optionsBtn']}" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"
+                       tabindex="0">
                         <span class="glyphicon glyphicon-option-vertical"/><span class="sr-only">#{bundle['file.optionsBtn']}</span><span class="caret"></span>
                     </a>
                     <ul class="dropdown-menu multi-level pull-right text-left">

--- a/src/main/webapp/resources/css/structure.css
+++ b/src/main/webapp/resources/css/structure.css
@@ -147,6 +147,7 @@ a.tooltip-icon:hover, a.tool-tip:focus, a.tool-tip:active {text-decoration: none
     min-width: 100%;
 }
 
+/*Open/Close is now handled by javascript (provides a delay on close for accessibility) - leaving this to work when javascript is disabled*/
 .dropdown-submenu:hover>.dropdown-menu {
     display: block;
 }

--- a/src/main/webapp/resources/js/dv_rebind_bootstrap_ui.js
+++ b/src/main/webapp/resources/js/dv_rebind_bootstrap_ui.js
@@ -366,13 +366,29 @@ function handle_dropdown_popup_scroll(){
 
 function enableSubMenus() {
     $('.dropdown-submenu>a').off('keydown').keydown(toggleSubMenu);
+    $('.dropdown-submenu>.dropdown-menu>li:last-of-type>a').off('keydown').keydown(closeOnTab);
+    $('.dropdown-submenu>.dropdown-menu>li:first-of-type>a').off('keydown').keydown(closeOnShiftTab);
     addMenuDelays();
 }
 
 function toggleSubMenu(event) {
-if ( event.which == 13 || event.which == 32 ) {
+if ( event.key == ' ' || event.key == 'Enter' ) {
       event.target.parentElement.classList.toggle('open');
     }
+}
+
+function closeOnTab(event) {
+        console.log(event.key);
+        if ( event.key == 'Tab') {
+        $(this).parent().parent().parent().removeClass('open');
+        }
+}
+
+function closeOnShiftTab(event) {
+        console.log(event.key);
+        if ( event.key == 'Tab' && event.shiftKey) {
+        $(this).parent().parent().parent().removeClass('open');
+        }
 }
 
 function addMenuDelays() {

--- a/src/main/webapp/resources/js/dv_rebind_bootstrap_ui.js
+++ b/src/main/webapp/resources/js/dv_rebind_bootstrap_ui.js
@@ -376,11 +376,22 @@ if ( event.which == 13 || event.which == 32 ) {
 }
 
 function addMenuDelays() {
-    $('.dropdown-submenu>a').off('mouseover').mouseover(function() {
-        $( this ).parent().addClass('open');
-    });
-    $('.dropdown-submenu>a').off('mouseout').mouseout(function() {
-            var obj =$( this ).parent();
-       setTimeout(function() {obj.removeClass('open');}, 1000);
+    $('.dropdown-submenu>a').each(function() {
+        var obj =$( this ).parent();
+        //First time - add open class upon mouseover
+        $(this).off('mouseover').mouseover(function() {
+            obj.addClass('open');
+        });
+        var closeMenuTimer;
+        //And add a mouseout function that will 
+        // a) remove that class after a delay, and 
+        // b) update the mouseover to remove the timer if it hasn't run yet (and re-add the open class if it has)
+        $(this).off('mouseout').mouseout(function() {
+            closeMenuTimer = setTimeout(function() {obj.removeClass('open');}, 1000);
+            $(this).off('mouseover').mouseover(function() {
+                obj.addClass('open');
+                clearTimeout(closeMenuTimer);
+            });
+        });
     });
 }

--- a/src/main/webapp/resources/js/dv_rebind_bootstrap_ui.js
+++ b/src/main/webapp/resources/js/dv_rebind_bootstrap_ui.js
@@ -49,6 +49,9 @@ function bind_bsui_components(){
         var dialog_id = this.jq.attr('id').split(/[:]+/).pop();
         handleResizeDialog(dialog_id);
     }
+    
+    //Fly-out sub-menu accessibility
+    enableSubMenus();
 }
 
 function bind_tooltip_popover(){
@@ -358,5 +361,26 @@ function handle_dropdown_popup_scroll(){
                 of: $(".DropdownPopup")
             });
         }
+    });
+}
+
+function enableSubMenus() {
+    $('.dropdown-submenu>a').off('keydown').keydown(toggleSubMenu(event));
+    addMenuDelays();
+}
+
+function toggleSubMenu(e) {
+if ( e.which == 13 || e.which == 32 ) {
+      e.target.parentElement.classList.toggle('open');
+    }
+    return false;
+}
+
+function addMenuDelay(e) {
+    $('.dropdown-submenu>a').off('mouseover').mouseover(function() {
+        $( this ).parent().addClass('open');
+    });
+    $('.dropdown-submenu>a').off('mouseout').mouseout(function() {
+        $( this ).parent().delay(1000).removeClass('open');
     });
 }

--- a/src/main/webapp/resources/js/dv_rebind_bootstrap_ui.js
+++ b/src/main/webapp/resources/js/dv_rebind_bootstrap_ui.js
@@ -365,22 +365,22 @@ function handle_dropdown_popup_scroll(){
 }
 
 function enableSubMenus() {
-    $('.dropdown-submenu>a').off('keydown').keydown(toggleSubMenu(event));
+    $('.dropdown-submenu>a').off('keydown').keydown(toggleSubMenu);
     addMenuDelays();
 }
 
-function toggleSubMenu(e) {
-if ( e.which == 13 || e.which == 32 ) {
-      e.target.parentElement.classList.toggle('open');
+function toggleSubMenu(event) {
+if ( event.which == 13 || event.which == 32 ) {
+      event.target.parentElement.classList.toggle('open');
     }
-    return false;
 }
 
-function addMenuDelay(e) {
+function addMenuDelays() {
     $('.dropdown-submenu>a').off('mouseover').mouseover(function() {
         $( this ).parent().addClass('open');
     });
     $('.dropdown-submenu>a').off('mouseout').mouseout(function() {
-        $( this ).parent().delay(1000).removeClass('open');
+            var obj =$( this ).parent();
+       setTimeout(function() {obj.removeClass('open');}, 1000);
     });
 }


### PR DESCRIPTION
**What this PR does / why we need it**: Addresses accessibility issues for menus and fly-out submenus. Specifically, it makes the file table kebab menus tab-able/focusable, it makes those submenus keyboard accessible (i.e. being able to tab to them and hit enter or space to open/close the fly-out submenu), and adds a delay in closing the submenu when the mouse stops hovering over the parent item.

**Which issue(s) this PR closes**:

Closes #8247 

**Special notes for your reviewer**: Seems like these submenus had tabindex="-1" attributes, causing them to be skipped from early in their histories - not sure why that was, or if the changes here mess with some intended functionality. FWIW: I added the required javascript into the dv_rebind_bootstrap_ui.js and have the mouse/keyboard event hooks removed/reinstalled whenever it's called. I was not sure whether/when the file table and dataset menus might be getting refreshed via ajax and thereby losing the event handlers. If anyone thinks the flyout menus never get updated, we can run them once at page launch.

**Suggestions on how to test this**: 
Keyboard: Type tabbing through the menus - the fly-out submenu parent items should be focusable and clicking space or return on them should open/close the submenu. When the submenu is open, you should be able to tab through it. Tabbing back to the parent item should let you hit return again to close the submenu.

Mouse: Hovering over a submenu should cause it to flyout as before. When you move the mouse away from the parent, i.e. to other entries in the parent menu, the submenu should close after 1 second instead of immediately.

Affected Menus:

- Dataset Compute menu in the explore tools (not sure how to configure this)
- Dataset edit/permissions, 
- Dataset/publish/change curation status, 
- File Access Kebab (now tab-able): File Citations and Aux file submenus
- File Edit Kebab (now tab-able)

Note that using the mouse and keyboard at the same time can be confusing (i.e. hitting enter on the parent item doesn't open/close the menu if the mouse is hovering on the item as well.)

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: Yes. The UI itself doesn't change, just the focus behavior so hard to mock up. One question I have - as currently implemented, once you hit enter to open a submenu, you can tab through it (forward or backward), but it doesn't auto-close when you tab through to the next main menu item. (You can tab back to the parent item and hit enter/space to close the submenu.) I didn't immediately find info on what should happen (stay open so you can tab forward/backward through the open submenu, or close when you leave the submenu and having to backtab to the parent and hit enter again to re-open it) - what is best practice? (And if different than the PR, should we add the scope here, make a new issue, etc.?)

**Is there a release notes update needed for this change?**:

**Additional documentation**:
