### PR TITLE
add default size limits for thumbnail generation #8160

### DIFF
--- a/doc/release-notes/8160-thumbnail-limit.md
+++ b/doc/release-notes/8160-thumbnail-limit.md
@@ -1,1 +1,1 @@
-New defaults have been added for when to create thumbnails for images and PDFS. The default is 3 MB for images, 1 MB for PDFs. Previously, there was no default.
+New defaults have been added for when to create thumbnails for images and PDFs. The default is 3 MB for images, 1 MB for PDFs. Previously, there was no default.

--- a/doc/release-notes/8160-thumbnail-limit.md
+++ b/doc/release-notes/8160-thumbnail-limit.md
@@ -1,0 +1,1 @@
+New defaults have been added for when to create thumbnails for images and PDFS. The default is 3 MB for images, 1 MB for PDFs. Previously, there was no default.

--- a/doc/sphinx-guides/source/developers/tips.rst
+++ b/doc/sphinx-guides/source/developers/tips.rst
@@ -78,6 +78,17 @@ Netbeans Connector Chrome Extension
 
 For faster iteration while working on JSF pages, it is highly recommended that you install the Netbeans Connector Chrome Extension listed in the :doc:`tools` section. When you save XHTML or CSS files, you will see the changes immediately. Hipsters call this "hot reloading". :)
 
+Thumbnails
+----------
+
+In order for thumnails to be generated for PDFs, you need to install ImageMagick and configure Dataverse to use the ``convert`` binary.
+
+Assuming you're using Homebrew:
+
+``brew install imagemagick``
+
+Then configure the JVM option mentioned in :ref:`install-imagemagick` to the path to ``convert`` which for Homebrew is usually ``/usr/local/bin/convert``.
+
 Database Schema Exploration
 ---------------------------
 

--- a/doc/sphinx-guides/source/installation/config.rst
+++ b/doc/sphinx-guides/source/installation/config.rst
@@ -1146,12 +1146,12 @@ For overriding the default path to the ``convert`` binary from ImageMagick (``/u
 dataverse.dataAccess.thumbnail.image.limit
 ++++++++++++++++++++++++++++++++++++++++++
 
-For limiting the size (in bytes) of thumbnail images generated from files.
+For limiting the size (in bytes) of thumbnail images generated from files. The default is 3000000 bytes (3 MB).
 
 dataverse.dataAccess.thumbnail.pdf.limit
 ++++++++++++++++++++++++++++++++++++++++
 
-For limiting the size (in bytes) of thumbnail images generated from files.
+For limiting the size (in bytes) of thumbnail images generated from files. The default is 1000000 bytes (1 MB).
 
 .. _doi.baseurlstring:
 

--- a/doc/sphinx-guides/source/installation/prerequisites.rst
+++ b/doc/sphinx-guides/source/installation/prerequisites.rst
@@ -265,6 +265,8 @@ or you may install it manually::
         # chmod +x jq
         # jq --version
 
+.. _install-imagemagick:
+
 ImageMagick
 -----------
 
@@ -279,8 +281,6 @@ On a Red Hat or derivative Linux distribution, you can install ImageMagick with 
 
 (most RedHat systems will have it pre-installed).
 When installed using standard ``yum`` mechanism, above, the executable for the ImageMagick convert utility will be located at ``/usr/bin/convert``. No further configuration steps will then be required.
-
-On MacOS you can compile ImageMagick from sources, or use one of the popular installation frameworks, such as brew.
 
 If the installed location of the convert executable is different from ``/usr/bin/convert``, you will also need to specify it in your Payara configuration using the JVM option, below. For example::
 

--- a/src/main/java/edu/harvard/iq/dataverse/dataaccess/ImageThumbConverter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/dataaccess/ImageThumbConverter.java
@@ -36,6 +36,7 @@ import javax.imageio.stream.ImageOutputStream;
 
 import edu.harvard.iq.dataverse.DataFile;
 import edu.harvard.iq.dataverse.util.FileUtil;
+import edu.harvard.iq.dataverse.util.SystemConfig;
 import java.io.ByteArrayOutputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
@@ -176,7 +177,7 @@ public class ImageThumbConverter {
 
     private static boolean generatePDFThumbnail(StorageIO<DataFile> storageIO, int size) {
         if (isPdfFileOverSizeLimit(storageIO.getDataFile().getFilesize())) {
-            logger.fine("Image file too large (" + storageIO.getDataFile().getFilesize() + " bytes) - skipping");
+            logger.fine("PDF file too large (" + storageIO.getDataFile().getFilesize() + " bytes) - skipping");
             return false;
         }
 
@@ -925,27 +926,7 @@ public class ImageThumbConverter {
     }
 
     private static long getThumbnailSizeLimit(String type) {
-        String option = null;
-        if ("Image".equals(type)) {
-            option = System.getProperty("dataverse.dataAccess.thumbnail.image.limit");
-        } else if ("PDF".equals(type)) {
-            option = System.getProperty("dataverse.dataAccess.thumbnail.pdf.limit");
-        }
-        Long limit = null;
-
-        if (option != null && !option.equals("")) {
-            try {
-                limit = new Long(option);
-            } catch (NumberFormatException nfe) {
-                limit = null;
-            }
-        }
-
-        if (limit != null) {
-            return limit.longValue();
-        }
-
-        return 0;
+        return SystemConfig.getThumbnailSizeLimit(type);
     }
 
     private static boolean isImageMagickInstalled() {

--- a/src/main/java/edu/harvard/iq/dataverse/settings/SettingsServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/settings/SettingsServiceBean.java
@@ -212,12 +212,6 @@ public class SettingsServiceBean {
         /* the number of files the GUI user is allowed to upload in one batch, 
             via drag-and-drop, or through the file select dialog */
         MultipleUploadFilesLimit,
-        /* Size limits for generating thumbnails on the fly */
-        /* (i.e., we'll attempt to generate a thumbnail on the fly if the 
-         * size of the file is less than this)
-        */
-        ThumbnailSizeLimitImage,
-        ThumbnailSizeLimitPDF,
         /* return email address for system emails such as notifications */
         SystemEmail, 
         /* size limit for Tabular data file ingests */

--- a/src/main/java/edu/harvard/iq/dataverse/util/SystemConfig.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/SystemConfig.java
@@ -123,6 +123,8 @@ public class SystemConfig {
     private static final String JVM_TIMER_SERVER_OPTION = "dataverse.timerServer";
     
     private static final long DEFAULT_GUESTBOOK_RESPONSES_DISPLAY_LIMIT = 5000L; 
+    private static final long DEFAULT_THUMBNAIL_SIZE_LIMIT_IMAGE = 3000000L; // 3 MB
+    private static final long DEFAULT_THUMBNAIL_SIZE_LIMIT_PDF = 1000000L; // 1 MB
     
     public final static String DEFAULTCURATIONLABELSET = "DEFAULT";
     public final static String CURATIONLABELSDISABLED = "DISABLED";
@@ -488,29 +490,28 @@ public class SystemConfig {
         return 500000;
     }
 
-    // TODO: (?)
-    // create sensible defaults for these things? -- 4.2.2
     public long getThumbnailSizeLimitImage() {
-        long limit = getThumbnailSizeLimit("Image");
-        return limit == 0 ? 500000 : limit;
-    } 
-    
-    public long getThumbnailSizeLimitPDF() {
-        long limit = getThumbnailSizeLimit("PDF");
-        return limit == 0 ? 500000 : limit;
+        return getThumbnailSizeLimit("Image");
     }
-    
-    public long getThumbnailSizeLimit(String type) {
+
+    public long getThumbnailSizeLimitPDF() {
+        return getThumbnailSizeLimit("PDF");
+    }
+
+    public static long getThumbnailSizeLimit(String type) {
         String option = null; 
         
         //get options via jvm options
         
         if ("Image".equals(type)) {
             option = System.getProperty("dataverse.dataAccess.thumbnail.image.limit");
+            return getLongLimitFromStringOrDefault(option, DEFAULT_THUMBNAIL_SIZE_LIMIT_IMAGE);
         } else if ("PDF".equals(type)) {
             option = System.getProperty("dataverse.dataAccess.thumbnail.pdf.limit");
+            return getLongLimitFromStringOrDefault(option, DEFAULT_THUMBNAIL_SIZE_LIMIT_PDF);
         }
 
+        // Zero (0) means no limit.
         return getLongLimitFromStringOrDefault(option, 0L);
     }
     

--- a/src/test/java/edu/harvard/iq/dataverse/api/IndexIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/IndexIT.java
@@ -32,10 +32,6 @@ public class IndexIT {
         makeSureTokenlessSearchIsEnabled.then().assertThat()
                 .statusCode(OK.getStatusCode());
 
-        Response remove = UtilIT.deleteSetting(SettingsServiceBean.Key.ThumbnailSizeLimitImage);
-        remove.then().assertThat()
-                .statusCode(200);
-
     }
 
   

--- a/src/test/java/edu/harvard/iq/dataverse/api/SearchIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/SearchIT.java
@@ -50,10 +50,6 @@ public class SearchIT {
         makeSureTokenlessSearchIsEnabled.then().assertThat()
                 .statusCode(OK.getStatusCode());
 
-        Response remove = UtilIT.deleteSetting(SettingsServiceBean.Key.ThumbnailSizeLimitImage);
-        remove.then().assertThat()
-                .statusCode(200);
-
     }
 
     @Test

--- a/src/test/java/edu/harvard/iq/dataverse/util/SystemConfigTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/util/SystemConfigTest.java
@@ -47,4 +47,12 @@ class SystemConfigTest {
         int actualResult = SystemConfig.getIntLimitFromStringOrDefault(inputString, 5);
         assertEquals(expectedResult, actualResult);
     }
+
+    @Test
+    void testGetThumbnailSizeLimit() {
+        assertEquals(3000000l, SystemConfig.getThumbnailSizeLimit("Image"));
+        assertEquals(1000000l, SystemConfig.getThumbnailSizeLimit("PDF"));
+        assertEquals(0l, SystemConfig.getThumbnailSizeLimit("NoSuchType"));
+    }
+
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Large TIFF files especially cause problems when Dataverse tries to make thumbnails. Here we add as defaults, the settings used by Harvard Dataverse which are 3 MB for images and 1 MB for PDFs.

**Which issue(s) this PR closes**:

Closes #8160 - Add sensible defaults for thumbnail generation size limit

Closes #8176 - Upload of large TIFF file caused dataset timeout

**Special notes for your reviewer**:

I removed unused database settings.

**Suggestions on how to test this**:

Please see docs for the defaults and how to set them.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No.

**Is there a release notes update needed for this change?**:

Yes, included.

**Additional documentation**:

Included. I updated the dev guide to explain how to get thumbnails to be generated for PDFs.