### PR TITLE
Identify geojson file types

### DIFF
--- a/doc/release-notes/8261-geojson.md
+++ b/doc/release-notes/8261-geojson.md
@@ -1,0 +1,3 @@
+.geojson files are now correctly identified as GeoJSON files rather than "unknown".
+
+A full re-index is needed to update the facets, as well as optionally running the "redetect file type" API on existing GeoJSON files.

--- a/src/main/java/propertyFiles/MimeTypeDetectionByFileExtension.properties
+++ b/src/main/java/propertyFiles/MimeTypeDetectionByFileExtension.properties
@@ -4,6 +4,7 @@ dbf=application/dbf
 dcm=application/dicom
 docx=application/vnd.openxmlformats-officedocument.wordprocessingml.document
 emf=application/x-emf
+geojson=application/geo+json
 h5=application/x-h5
 hdf=application/x-hdf
 hdf5=application/x-hdf5

--- a/src/main/java/propertyFiles/MimeTypeDisplay.properties
+++ b/src/main/java/propertyFiles/MimeTypeDisplay.properties
@@ -107,6 +107,7 @@ application/x-emf=Extended Metafile
 application/x-h5=Hierarchical Data Format
 application/x-hdf=Hierarchical Data Format
 application/x-hdf5=Hierarchical Data Format
+application/geo+json=GeoJSON
 application/json=JSON
 application/mathematica=Mathematica
 application/matlab-mat=MATLAB Data

--- a/src/main/java/propertyFiles/MimeTypeFacets.properties
+++ b/src/main/java/propertyFiles/MimeTypeFacets.properties
@@ -106,6 +106,7 @@ application/x-emf=Data
 application/x-h5=Data
 application/x-hdf=Data
 application/x-hdf5=Data
+application/geo+json=Data
 application/json=Data
 application/mathematica=Data
 application/matlab-mat=Data


### PR DESCRIPTION
**What this PR does / why we need it**:

Mark .geojson files with the correct file type, and add the GeoJSON display name.

**Which issue(s) this PR closes**:

Closes #8261 

**Suggestions on how to test this**:

Upload a .geojson file and confirm the file type/content type is set correctly. An example file is linked in the issue.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No

**Is there a release notes update needed for this change?**:

Based on #5934 and #7502, I think a full re-index is needed to update the facets, as well as optionally running the "redetect file type" API on existing GeoJSON files.
