### PR TITLE
explicitly init Postgres DB with UTF-8 encoding, bump Maven to 3.8.4

### DIFF
--- a/conf/docker-aio/0prep_deps.sh
+++ b/conf/docker-aio/0prep_deps.sh
@@ -6,7 +6,6 @@ wdir=`pwd`
 
 if [ ! -e dv/deps/payara-5.2021.5.zip ]; then
 	echo "payara dependency prep"
-	# no more fiddly patching :)
 	wget https://s3-eu-west-1.amazonaws.com/payara.fish/Payara+Downloads/5.2021.5/payara-5.2021.5.zip  -O dv/deps/payara-5.2021.5.zip
 fi
 

--- a/conf/docker-aio/1prep.sh
+++ b/conf/docker-aio/1prep.sh
@@ -12,10 +12,10 @@ cd ../../
 cp -r scripts conf/docker-aio/testdata/
 cp doc/sphinx-guides/source/_static/util/createsequence.sql conf/docker-aio/testdata/doc/sphinx-guides/source/_static/util/
 
-wget -q https://downloads.apache.org/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz
-tar xfz apache-maven-3.6.3-bin.tar.gz
+wget -q https://downloads.apache.org/maven/maven-3/3.8.4/binaries/apache-maven-3.8.4-bin.tar.gz
+tar xfz apache-maven-3.8.4-bin.tar.gz
 mkdir maven
-mv apache-maven-3.6.3/* maven/
+mv apache-maven-3.8.4/* maven/
 echo "export JAVA_HOME=/usr/lib/jvm/jre-openjdk" > maven/maven.sh
 echo "export M2_HOME=../maven" >> maven/maven.sh
 echo "export MAVEN_HOME=../maven" >> maven/maven.sh

--- a/conf/docker-aio/c8.dockerfile
+++ b/conf/docker-aio/c8.dockerfile
@@ -30,7 +30,7 @@ RUN cd /opt ; unzip /tmp/dv/deps/payara-5.2021.5.zip ; ln -s /opt/payara5 /opt/g
 # this dies under Java 11, do we keep it?
 #COPY domain-restmonitor.xml /opt/payara5/glassfish/domains/domain1/config/domain.xml
 
-RUN sudo -u postgres /usr/pgsql-13/bin/initdb -D /var/lib/pgsql/13/data
+RUN sudo -u postgres /usr/pgsql-13/bin/initdb -D /var/lib/pgsql/13/data -E 'UTF-8'
 
 # copy configuration related files
 RUN cp /tmp/dv/pg_hba.conf /var/lib/pgsql/13/data/


### PR DESCRIPTION
**What this PR does / why we need it**:

Postgres' initdb utility, called from within c8.dockerfile, seems to have lost its ability to infer locale and defaults to SQL_ASCII, which causes Flyway to die when applying @pdurbin's UTF-8 character clean-up script. Specify UTF-8 when initializing DB. Bump maven just to give docker-aio a little love.

**Which issue(s) this PR closes**:

Closes #8272

**Special notes for your reviewer**: none

**Suggestions on how to test this**: standard docker-aio quickstart

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: no

**Is there a release notes update needed for this change?**: no

**Additional documentation**: none
