### PR TITLE
IQSS/8263-Fix Google analytics button tracking

### DIFF
--- a/doc/sphinx-guides/source/_static/installation/files/var/www/dataverse/branding/analytics-code.html
+++ b/doc/sphinx-guides/source/_static/installation/files/var/www/dataverse/branding/analytics-code.html
@@ -117,7 +117,7 @@
       var row = target.parents('tr')[0];
       if(row != null) {
         //finds the file id/DOI in the Dataset page
-        label = $(row).find('div.file-metadata-block > a').attr('href');
+        label = $(row).find('td.col-file-metadata  a').attr('href');
       } else {
         //finds the file id/DOI in the file page
         label = $('#fileForm').attr('action');


### PR DESCRIPTION
**What this PR does / why we need it**:
The change in the reverted commit tried to make an element selector in the analytics-code.html file more precise. Unfortunately, the sub-element  chosen only appears in some of the views that have the buttons that should be tracked, so the change stopped tracking of those buttons (the download menus in the file table - only the editFilesFragment tracking worked, tracking in the filesFragment broke with this change).

The only change in this PR is to revert the commit that made this change: Changed selector in analytics exmaple (sic) to be more precise [#6725], commit 1e5951fe35257dc0d0a110590475fa54ae55db36.

**Which issue(s) this PR closes**:

Closes #8263

**Special notes for your reviewer**:

**Suggestions on how to test this**: @kcondon discovered this via a null pointer error reported in the java console. With the updated anayltics-code.html configured, that error should be gone when a download button is clicked in the view mode for a dataset. One could also check Google for the actual button click event (which, if it doesn't appear might indicate other issues with analytics reporting). 

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: no

**Is there a release notes update needed for this change?**: - The fact that Google analytics wasn't catching download button events for view mode - what you'd expect for published dataset versions - might be relevant, but I don't know that many people were using that (not actually sure, but there haven't been any (?) questions about it.)

**Additional documentation**:
