### PR TITLE
IQSS/8276 - skip validation when embargo isn't enabled.

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/SettingsWrapper.java
+++ b/src/main/java/edu/harvard/iq/dataverse/SettingsWrapper.java
@@ -360,36 +360,39 @@ public class SettingsWrapper implements java.io.Serializable {
     
     public void validateEmbargoDate(FacesContext context, UIComponent component, Object value)
             throws ValidatorException {
-        UIComponent cb = component.findComponent("embargoCheckbox");
-        UIInput endComponent = (UIInput) cb;
-        boolean removedState = false;
-        if (endComponent != null) {
-            try {
-                removedState = (Boolean) endComponent.getSubmittedValue();
-            } catch (NullPointerException npe) {
-                // Do nothing - checkbox is not being shown (and is therefore not checked)
+        if (isEmbargoAllowed()) {
+            UIComponent cb = component.findComponent("embargoCheckbox");
+            UIInput endComponent = (UIInput) cb;
+            boolean removedState = false;
+            if (endComponent != null) {
+                try {
+                    removedState = (Boolean) endComponent.getSubmittedValue();
+                } catch (NullPointerException npe) {
+                    // Do nothing - checkbox is not being shown (and is therefore not checked)
+                }
             }
-        }
-        if (!removedState && value == null) {
-            String msgString = BundleUtil.getStringFromBundle("embargo.date.required");
-            FacesMessage msg = new FacesMessage(msgString);
-            msg.setSeverity(FacesMessage.SEVERITY_ERROR);
-            throw new ValidatorException(msg);
-        }
-        Embargo newE = new Embargo(((LocalDate) value), null);
-        if (!isValidEmbargoDate(newE)) {
-            String minDate = getMinEmbargoDate().format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
-            String maxDate = getMaxEmbargoDate().format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
-            String msgString = BundleUtil.getStringFromBundle("embargo.date.invalid", Arrays.asList(minDate, maxDate));
-            // If we don't throw an exception here, the datePicker will use it's own
-            // vaidator and display a default message. The value for that can be set by
-            // adding validatorMessage="#{bundle['embargo.date.invalid']}" (a version with
-            // no params) to the datepicker
-            // element in file-edit-popup-fragment.html, but it would be better to catch all
-            // problems here (so we can show a message with the min/max dates).
-            FacesMessage msg = new FacesMessage(msgString);
-            msg.setSeverity(FacesMessage.SEVERITY_ERROR);
-            throw new ValidatorException(msg);
+            if (!removedState && value == null) {
+                String msgString = BundleUtil.getStringFromBundle("embargo.date.required");
+                FacesMessage msg = new FacesMessage(msgString);
+                msg.setSeverity(FacesMessage.SEVERITY_ERROR);
+                throw new ValidatorException(msg);
+            }
+            Embargo newE = new Embargo(((LocalDate) value), null);
+            if (!isValidEmbargoDate(newE)) {
+                String minDate = getMinEmbargoDate().format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+                String maxDate = getMaxEmbargoDate().format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+                String msgString = BundleUtil.getStringFromBundle("embargo.date.invalid",
+                        Arrays.asList(minDate, maxDate));
+                // If we don't throw an exception here, the datePicker will use it's own
+                // vaidator and display a default message. The value for that can be set by
+                // adding validatorMessage="#{bundle['embargo.date.invalid']}" (a version with
+                // no params) to the datepicker
+                // element in file-edit-popup-fragment.html, but it would be better to catch all
+                // problems here (so we can show a message with the min/max dates).
+                FacesMessage msg = new FacesMessage(msgString);
+                msg.setSeverity(FacesMessage.SEVERITY_ERROR);
+                throw new ValidatorException(msg);
+            }
         }
     }
 


### PR DESCRIPTION
**What this PR does / why we need it**:  This fixes items in the file page menus that are now (v5.8) broken when the new embargo functionality is not enabled (which would be the default). The change avoids an NPE when the empty embargo (from the dialog that isn't shown) is found to be invalid and then getMaxDate() returns null and the code tries to format it for display in the error message (which also wouldn't show).

**Which issue(s) this PR closes**:

Closes #8276

**Special notes for your reviewer**: any ideas as to why the validation runs and caused a problem on the file page but the same menu on the dataset appears to work fine would be welcome. This PR should fix the problem but if there is a difference between the .xhtml code in the two places that stops the overall embargo validation (and potentially the restrict access validation currently being developed) from running, it might be worth adding that to the file page as well.

**Suggestions on how to test this**: Unset the MaxEmbargoDurationInMonths setting and/or set it to 0 and confirm that all entries in the file page access and edit menus work.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**: Could report that this fixes a bug introduced in 5.8 that breaks some actions on the file page menus (see the issue for the list I know of).

**Additional documentation**:
