### PR TITLE
only run regex replaces on DBs with UTF8 encoding #8278

### DIFF
--- a/src/main/resources/db/migration/V5.8.0.2__8018-invalid-characters.sql
+++ b/src/main/resources/db/migration/V5.8.0.2__8018-invalid-characters.sql
@@ -1,7 +1,14 @@
--- This list of characters also appears in DatasetFieldValidator.java
--- Remove character: form feed (\f)
-UPDATE datasetfieldvalue SET value = regexp_replace(value, E'\f', '', 'g');
--- Remove character: start of text (\u0002)
-UPDATE datasetfieldvalue SET value = regexp_replace(value, U&'\0002', '', 'g');
--- Remove character: not a character (\ufffe)
-UPDATE datasetfieldvalue SET value = regexp_replace(value, U&'\FFFE', '', 'g');
+DO $$
+BEGIN
+-- Run on UTF8 only. It's known to fail on SQL_ASCII encoding.
+IF EXISTS (SELECT 1 FROM information_schema.character_sets WHERE character_set_name='UTF8') THEN
+  -- This list of characters also appears in DatasetFieldValidator.java
+  -- Remove character: form feed (\f)
+  UPDATE datasetfieldvalue SET value = regexp_replace(value, E'\f', '', 'g');
+  -- Remove character: start of text (\u0002)
+  UPDATE datasetfieldvalue SET value = regexp_replace(value, U&'\0002', '', 'g');
+  -- Remove character: not a character (\ufffe)
+  UPDATE datasetfieldvalue SET value = regexp_replace(value, U&'\FFFE', '', 'g');
+END IF;
+END
+$$


### PR DESCRIPTION
**What this PR does / why we need it**:

Deployment fails if the encoding is `SQL_ASCII`. Here we only run the regex replaces if the database is `UTF8`.

**Which issue(s) this PR closes**:

Closes #8278

**Special notes for your reviewer**:

Devs will need to delete the old "V5.8.0.2__8018-invalid-characters.sql" SQL migration from their flyway table because the checksum is changing.

**Suggestions on how to test this**:

Make sure the replaces still happen

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No.

**Is there a release notes update needed for this change?**:

No.

**Additional documentation**:

No