### PR TITLE
Missing anonymization in files version table for anon PrivateURLs

### DIFF
--- a/src/main/webapp/file-versions.xhtml
+++ b/src/main/webapp/file-versions.xhtml
@@ -130,7 +130,8 @@
         </p:column>
         <!-- contributor column -->
         <p:column headerText="#{bundle['file.dataFilesTab.versions.headers.contributors']}" class="col-sm-3">
-            <h:outputText value="#{versionTab.contributorNames}" />
+            <h:outputText value="#{versionTab.contributorNames}" rendered="#{!anonymized}" />
+            <h:outputText value="#{bundle['file.dataFilesTab.versions.headers.contributors.withheld']}" rendered="#{anonymized}" />
         </p:column>
         <!-- end: contributor column -->
         <!-- date column -->


### PR DESCRIPTION
**What this PR does / why we need it**: This PR removes contributor names from the version table on the files page when you access the dataset with an anonymized PrivateURL

**Which issue(s) this PR closes**:

Closes #8298

**Special notes for your reviewer**:

**Suggestions on how to test this**: Use a privateURL with anonymization on and look in the contributor column of the file page version table - you should see that the names are withheld. This is how it already works for the dataset page version table so you can compare/verify - if you see names in the dataset page version table, there's probably some config issue with the PrivateURL.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**: could/should notify people of the leak?

**Additional documentation**:
