### PR TITLE
#8193 strip commas from email response

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/GuestbookResponseServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/GuestbookResponseServiceBean.java
@@ -185,14 +185,14 @@ public class GuestbookResponseServiceBean {
             // string fields, or the structure of the file will be broken. -- L.A.
             
             // Guestbook name: 
-            sb.append(((String)result[1]).replace(',', ' '));
+            sb.append("\"" + (String)result[1] + "\"");
             sb.append(SEPARATOR);
 
             
             // Dataset name: 
             Integer datasetId = (Integer) result[2];
             String datasetTitle = datasetTitles.get(datasetId);
-            sb.append(datasetTitle == null ? "" : datasetTitle.replace(',', ' '));
+            sb.append(datasetTitle == null ? "" : "\"" +  datasetTitle + "\"");
             sb.append(SEPARATOR);
             
             // Dataset persistent identifier: 
@@ -211,7 +211,7 @@ public class GuestbookResponseServiceBean {
             sb.append(SEPARATOR);
 
             // file name: 
-            sb.append(((String)result[5]).replace(',', ' '));
+            sb.append("\"" + (String)result[5] + "\"" );
             sb.append(SEPARATOR);
 
             // file id (numeric):
@@ -224,19 +224,19 @@ public class GuestbookResponseServiceBean {
             sb.append(SEPARATOR);
             
             // name supplied in the guestbook response: 
-            sb.append(result[7] == null ? "" : ((String)result[7]).replace(',', ' '));
+            sb.append(result[7] == null ? "" : "\"" + (String)result[7] + "\"");
             sb.append(SEPARATOR);
             
             // email: 
-            sb.append(result[8] == null ? "" : ((String)result[8]).replace(',', ' '));
+            sb.append(result[8] == null ? "" : "\"" + (String)result[8] + "\"");           
             sb.append(SEPARATOR);
             
             // institution:
-            sb.append(result[9] == null ? "" : ((String)result[9]).replace(',', ' '));
+            sb.append(result[9] == null ? "" : "\"" + (String)result[9] + "\"");
             sb.append(SEPARATOR);
             
             // position: 
-            sb.append(result[10] == null ? "" : ((String)result[10]).replace(',', ' '));
+            sb.append(result[10] == null ? "" : "\"" + (String)result[10] + "\"");
             
             // Finally, custom questions and answers, if present:
             
@@ -401,7 +401,7 @@ public class GuestbookResponseServiceBean {
                 if (asString) {
                     // as combined strings of comma-separated question and answer values
                     
-                    String qa = SEPARATOR + ((String)response[0]).replace(',', ' ') + SEPARATOR + (response[1] == null ? "" : ((String)response[1]).replace(',', ' '));
+                    String qa = SEPARATOR + ("\"" + (String)response[0] + "\"") + SEPARATOR + (response[1] == null ? "" : "\"" + (String)response[1] + "\"");
 
                     if (ret.containsKey(responseId)) {
                         ret.put(responseId, ret.get(responseId) + qa);

--- a/src/main/java/edu/harvard/iq/dataverse/GuestbookResponseServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/GuestbookResponseServiceBean.java
@@ -8,7 +8,6 @@ package edu.harvard.iq.dataverse;
 import edu.harvard.iq.dataverse.authorization.users.AuthenticatedUser;
 import edu.harvard.iq.dataverse.authorization.users.User;
 import edu.harvard.iq.dataverse.externaltools.ExternalTool;
-import edu.harvard.iq.dataverse.util.BundleUtil;
 import edu.harvard.iq.dataverse.util.StringUtil;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -25,9 +24,6 @@ import javax.ejb.EJB;
 import javax.ejb.Stateless;
 import javax.ejb.TransactionAttribute;
 import javax.ejb.TransactionAttributeType;
-import javax.faces.application.FacesMessage;
-import javax.faces.component.UIInput;
-import javax.faces.context.FacesContext;
 import javax.faces.model.SelectItem;
 import javax.inject.Named;
 import javax.persistence.EntityManager;
@@ -185,14 +181,15 @@ public class GuestbookResponseServiceBean {
             // string fields, or the structure of the file will be broken. -- L.A.
             
             // Guestbook name: 
-            sb.append("\"" + (String)result[1] + "\"");
+            sb.append(StringEscapeUtils.escapeCsv((String)result[1]));
             sb.append(SEPARATOR);
 
             
             // Dataset name: 
             Integer datasetId = (Integer) result[2];
             String datasetTitle = datasetTitles.get(datasetId);
-            sb.append(datasetTitle == null ? "" : "\"" +  datasetTitle + "\"");
+            sb.append(datasetTitle == null ? "" : StringEscapeUtils.escapeCsv(datasetTitle));
+            System.out.print(StringEscapeUtils.escapeCsv(datasetTitle));
             sb.append(SEPARATOR);
             
             // Dataset persistent identifier: 
@@ -211,7 +208,7 @@ public class GuestbookResponseServiceBean {
             sb.append(SEPARATOR);
 
             // file name: 
-            sb.append("\"" + (String)result[5] + "\"" );
+            sb.append(StringEscapeUtils.escapeCsv((String)result[5]));
             sb.append(SEPARATOR);
 
             // file id (numeric):
@@ -224,19 +221,19 @@ public class GuestbookResponseServiceBean {
             sb.append(SEPARATOR);
             
             // name supplied in the guestbook response: 
-            sb.append(result[7] == null ? "" : "\"" + (String)result[7] + "\"");
+            sb.append(result[7] == null ? "" : StringEscapeUtils.escapeCsv((String)result[7]));
             sb.append(SEPARATOR);
             
             // email: 
-            sb.append(result[8] == null ? "" : "\"" + (String)result[8] + "\"");           
+            sb.append(result[8] == null ? "" : StringEscapeUtils.escapeCsv((String)result[8]));           
             sb.append(SEPARATOR);
             
             // institution:
-            sb.append(result[9] == null ? "" : "\"" + (String)result[9] + "\"");
+            sb.append(result[9] == null ? "" : StringEscapeUtils.escapeCsv((String)result[9]));
             sb.append(SEPARATOR);
             
             // position: 
-            sb.append(result[10] == null ? "" : "\"" + (String)result[10] + "\"");
+            sb.append(result[10] == null ? "" : StringEscapeUtils.escapeCsv((String)result[10]));
             
             // Finally, custom questions and answers, if present:
             

--- a/src/main/java/edu/harvard/iq/dataverse/GuestbookResponseServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/GuestbookResponseServiceBean.java
@@ -228,7 +228,7 @@ public class GuestbookResponseServiceBean {
             sb.append(SEPARATOR);
             
             // email: 
-            sb.append(result[8] == null ? "" : result[8]);
+            sb.append(result[8] == null ? "" : ((String)result[8]).replace(',', ' '));
             sb.append(SEPARATOR);
             
             // institution:

--- a/src/main/java/edu/harvard/iq/dataverse/GuestbookResponseServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/GuestbookResponseServiceBean.java
@@ -189,7 +189,6 @@ public class GuestbookResponseServiceBean {
             Integer datasetId = (Integer) result[2];
             String datasetTitle = datasetTitles.get(datasetId);
             sb.append(datasetTitle == null ? "" : StringEscapeUtils.escapeCsv(datasetTitle));
-            System.out.print(StringEscapeUtils.escapeCsv(datasetTitle));
             sb.append(SEPARATOR);
             
             // Dataset persistent identifier: 


### PR DESCRIPTION
**What this PR does / why we need it**: fixes broken csv output from guestbook responses download

**Which issue(s) this PR closes**:

Closes #8193 Commas in email addresses breaks guestbook csv download

**Special notes for your reviewer**: Instead of removing commas from the email response, which had been the approach for all other responses, now all responses are enclosed in double quotes allowing the commas to remain without breaking the csv display

**Suggestions on how to test this**:

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**: