### PR TITLE
Fix for the bug in the implementation of storage dirs based on Alternative Persistent Identifiers

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/Dataset.java
+++ b/src/main/java/edu/harvard/iq/dataverse/Dataset.java
@@ -560,30 +560,36 @@ public class Dataset extends DvObjectContainer {
     }
     
     public String getProtocolForFileStorage(){
-         String retVal = getProtocol();            
+        String retVal = getProtocol();            
         if (this.getAlternativePersistentIndentifiers() != null && !this.getAlternativePersistentIndentifiers().isEmpty()) {
-            for (AlternativePersistentIdentifier api : this.getAlternativePersistentIndentifiers()) {
-                retVal = api.getProtocol();
+            for (AlternativePersistentIdentifier altpid : this.getAlternativePersistentIndentifiers()) {
+                if (altpid.isStorageLocationDesignator()) {
+                    retVal = altpid.getProtocol();
+                }
             }
         }
         return retVal;         
     }
     
     public String getAuthorityForFileStorage(){
-         String retVal = getAuthority();            
+        String retVal = getAuthority();            
         if (this.getAlternativePersistentIndentifiers() != null && !this.getAlternativePersistentIndentifiers().isEmpty()) {
-            for (AlternativePersistentIdentifier api : this.getAlternativePersistentIndentifiers()) {
-                retVal = api.getAuthority();
+            for (AlternativePersistentIdentifier altpid : this.getAlternativePersistentIndentifiers()) {
+                if (altpid.isStorageLocationDesignator()) {
+                    retVal = altpid.getAuthority();
+                }
             }
         }
         return retVal;         
     }
     
     public String getIdentifierForFileStorage(){
-         String retVal = getIdentifier();            
+        String retVal = getIdentifier();            
         if (this.getAlternativePersistentIndentifiers() != null && !this.getAlternativePersistentIndentifiers().isEmpty()) {
-            for (AlternativePersistentIdentifier api : this.getAlternativePersistentIndentifiers()) {
-                retVal = api.getIdentifier();
+            for (AlternativePersistentIdentifier altpid : this.getAlternativePersistentIndentifiers()) {
+                if (altpid.isStorageLocationDesignator()) {
+                    retVal = altpid.getIdentifier();
+                }
             }
         }
         return retVal;         


### PR DESCRIPTION
**What this PR does / why we need it**:

See the issue description. 
In short, this will allow us (the IQSS) to reorganize our prod. S3 folders, so that ALL the datafiles are stored in directories named after the primary  DOI of each dataset; regardless of whether the dataset has a legacy handle or not (for ease of storage management etc.)
It should also prevent another installation from potentially running into problems; if, for example, they end up with multiple AlternativePersistentIdentfiers per dataset. (Not very likely, but possible). 


**Which issue(s) this PR closes**:

Closes #7925

**Special notes for your reviewer**:
In line with the "small" designation, this PR only has a straightforward code fix in it; no extra tests, etc. But please note that we do have a RestAssured test for this migration API. It's normally disabled, because it requires a working handlenet setup. But if enabled, it confirms that the API is still working seamlessly after these changes.



**Suggestions on how to test this**:
This will be a little longer to explain than it was to fix; but, not rocket science either, just tedious...
The test would recreate what we want to accomplish w/ our prod. file storage; but may be easier to test with `file:` as the storage driver. 
1. Create a dataset with a handle, upload a file. Make note of the dataset db id and the file directory where the file is stored; it'll be something like `/usr/local/payara5/glassfish/domains/domain1/files/20.500.12050/XXXXX`
2. Run the handle-to-doi migration API (`api/admin/{id}/reregisterHDLToPID`); if successful, the dvobject table entry will have a new persistent identifier/protocol/authority, reflecting the new DOI. The old handle will be saved in the table `AlternativePersistentIdentifier`. File download should still be working, with the physical file still stored in the old directory, noted above. This is how this migration is supposed to work, to make it easier and to avoid having to require renaming the directories. This is where we are in our own prod., as of now. 
3. Now rename the directory after the new DOI that was assigned in step 2. above. Something like `mv /usr/local/payara5/glassfish/domains/domain1/files/20.500.12050/XXXXX /usr/local/payara5/glassfish/domains/domain1/files/10.70122/FK2/YYYYY`. File download should **stop working** now. 
4. Set the boolean `storagelocationdesignator` in the `AlternativePersistentIdentifier` table entry to `false`. File download should start working again.  


**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
n/a 

**Is there a release notes update needed for this change?**:
No, I don't think we need to announce anything. Because everything will keep working as it was advertised. If anyone tries to rename the storage directories after a migration, it will work the way it was supposed to work all along. And nobody has ever attempted that yet based on what we know/on the fact that nobody has ever complained.


**Additional documentation**:
