### PR TITLE
issue #5277: first implementation step for exporting related publicat…

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DOIDataCiteRegisterService.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DOIDataCiteRegisterService.java
@@ -563,7 +563,7 @@ class DataCiteMetadataTemplate {
                             }
                         }
                         if (StringUtils.isNotBlank(publicationIDType) && StringUtils.isNotBlank(publicationIDNumber)) {
-                            relatedIdentifiers.add(serializeIdenifier(publicationIDType, "Cites", publicationIDNumber));
+                            relatedIdentifiers.add(serializeIdenifier(publicationIDType, "IsCitedBy", publicationIDNumber));
                         }
                     }
                 }


### PR DESCRIPTION
…ion to DataCite

**What this PR does / why we need it**:

It was a feature request from our users, and as I found in the issue queue others also missed that related publications and also other "Related ..." metadata fields are not exported into DataCite metadata. 

**Which issue(s) this PR closes**:

It is a "baby step" towards a better solution. Its intention is to move forward the discussion and to highlight theoretical and practical topics.

**Special notes for your reviewer**:

**Suggestions on how to test this**:

1. modify an existing dataset or create a new one
2. add some values into Related Publications's ID Type and ID number field.
3. save it
4. publish it
5. click on Metadata > Export metadata > Datacite
6. check if there is a line similare to
```xml
<relatedIdentifier relatedIdentifierType="ARK" relationType="Cites">ark:222</relatedIdentifier>
```
in the `<relatedIdentifiers>` section.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

It changes the XML output of the DataCite export - see previous point.

**Is there a release notes update needed for this change?**:
If community accepts this approach, it would worth to mention in the release not since I believe it increases the number of connections between papers and dataset in the PID network, thus somehow it might increase the discoverability.

**Additional documentation**:

---

Related to #5277