### PR TITLE
IQSS/8356 - Fix metadatalanguage choice display in sub dataverses

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/SettingsWrapper.java
+++ b/src/main/java/edu/harvard/iq/dataverse/SettingsWrapper.java
@@ -519,19 +519,18 @@ public class SettingsWrapper implements java.io.Serializable {
         String mlLabel = Locale.getDefault().getDisplayLanguage();
         Dataverse parent = target.getOwner();
         boolean fromAncestor=false;
-        if(parent != null) {
-            mlLabel = parent.getEffectiveMetadataLanguage();
-            //recurse dataverse chain to root and if any have a metadata language set, fromAncestor is true
-            while(parent!=null) {
-                if(!parent.getMetadataLanguage().equals(DvObjectContainer.UNDEFINED_METADATA_LANGUAGE_CODE)) {
-                    fromAncestor=true;
-                    break;
-                }
-                parent=parent.getOwner();
+        if (parent != null) {
+            fromAncestor=true;
+            String mlCode = parent.getEffectiveMetadataLanguage();
+            // If it's 'undefined', it's the global default
+            if (mlCode.equals(DvObjectContainer.UNDEFINED_METADATA_LANGUAGE_CODE)) {
+                //so it's not from an ancestor
+                fromAncestor=false;
+                //and we need to lookup the global default
+                mlCode = getDefaultMetadataLanguage();
             }
-        }
-        if(mlLabel.equals(DvObjectContainer.UNDEFINED_METADATA_LANGUAGE_CODE)) {
-            mlLabel = getBaseMetadataLanguageMap(false).get(getDefaultMetadataLanguage());
+            // Get the label for the language code found
+            mlLabel = getBaseMetadataLanguageMap(false).get(mlCode);
         }
         if(fromAncestor) {
             mlLabel = mlLabel + " " + BundleUtil.getStringFromBundle("dataverse.inherited");


### PR DESCRIPTION
**What this PR does / why we need it**: When a metadatalanguage setting was inherited from a parent dataverse, the display incorrectly showed the language code (e.g. en) instead of the name (e.g. English). This PR fixes that and simplifies some of the logic for getting the name for display.

**Which issue(s) this PR closes**:

Closes #8356

**Special notes for your reviewer**:

**Suggestions on how to test this**: See the issue for the problem scenario, with screen captures - that scenario should be fixed now and nothing else w.r.t. choosing a metadatalanguage should be broken.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
