### PR TITLE
IQSS/8352-show release date in version table

### DIFF
--- a/src/main/webapp/dataset-versions.xhtml
+++ b/src/main/webapp/dataset-versions.xhtml
@@ -143,8 +143,8 @@
 
         <!-- date column -->
         <p:column headerText="#{bundle['file.dataFilesTab.versions.headers.published']}" class="col-sm-2">
-            <ui:fragment><!-- rendered="#{ !empty(versionTab) and !empty(versionTab.versionDate) }"-->
-                <h:outputText id="versionDate" value="#{versionTab.versionDate}" />
+            <ui:fragment><!-- rendered="#{ !empty(versionTab) and !empty(versionTab.releaseDate) }"-->
+                <h:outputText id="versionDate" value="#{versionTab.publicationDateAsString}" />
             </ui:fragment>
         </p:column><!-- end: date column -->
     </p:dataTable>

--- a/src/main/webapp/file-versions.xhtml
+++ b/src/main/webapp/file-versions.xhtml
@@ -136,7 +136,7 @@
         <!-- end: contributor column -->
         <!-- date column -->
         <p:column headerText="#{bundle['file.dataFilesTab.versions.headers.published']}" class="col-sm-2">
-            <h:outputText id="versionDate" value="#{versionTab.datasetVersion.versionDate}" />
+            <h:outputText id="versionDate" value="#{versionTab.datasetVersion.publicationDateAsString}" />
         </p:column>
         <!-- end: date column -->
     </p:dataTable>


### PR DESCRIPTION
**What this PR does / why we need it**: Currently, the version tables (dataset and file page) show an updated date when the 'Update Current Version' functionality is used, which is confusing since the idea of updating the current version is to avoid creating a new version with a new date. The underlying cause is use of the lastupdatetime, which is changed when the version is updated rather than the releasetime, which is set when the version is published. This PR just changes which date is used for display in the version tables.

**Which issue(s) this PR closes**:

Closes #8352

**Special notes for your reviewer**:

**Suggestions on how to test this**:  Use the Update Current Version option as a superuser to republish an existing dataset version and verify that the version date shown in the version tables does not change (since the displays only show the date (not time), you'll either need an old version (created before today) or wait or backdate, etc. 

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: As is, the PR changes the date displayed in the version table from a format like "Apr 10, 2020" to "2020-4-10" which is consistent with how the publication date and other dates are shown on the metadata tab. A method could be added to keep the current date format if desired.

**Is there a release notes update needed for this change?**:

**Additional documentation**:
