### PR TITLE
8094 Experimental CI Java 17 Maven Unittest build

### DIFF
--- a/.github/workflows/maven_unit_test.yml
+++ b/.github/workflows/maven_unit_test.yml
@@ -10,15 +10,17 @@ on:
 
 jobs:
     unittest:
-        name: (JDK ${{ matrix.jdk }} / ${{ matrix.os }}) Unit Tests
+        name: (${{ matrix.status}} / JDK ${{ matrix.jdk }}) Unit Tests
         strategy:
             fail-fast: false
             matrix:
                 jdk: [ '11' ]
                 experimental: [false]
+                status:  ["Stable"]
                 include:
                     - jdk: '17'
                       experimental: true
+                      status: "Experimental"
         continue-on-error: ${{ matrix.experimental }}
         runs-on: ubuntu-latest
         steps:

--- a/.github/workflows/maven_unit_test.yml
+++ b/.github/workflows/maven_unit_test.yml
@@ -37,7 +37,7 @@ jobs:
                 key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
                 restore-keys: ${{ runner.os }}-m2
           - name: Build with Maven
-            run: mvn -DcompilerArgument=-Xlint:unchecked -P all-unit-tests clean test
+            run: mvn -DcompilerArgument=-Xlint:unchecked -Dtarget.java.version=${{ matrix.jdk }} -P all-unit-tests clean test
           - name: Maven Code Coverage
             env:
                 CI_NAME: github

--- a/.github/workflows/maven_unit_test.yml
+++ b/.github/workflows/maven_unit_test.yml
@@ -14,12 +14,13 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                os: [ ubuntu-latest ]
                 jdk: [ '11' ]
-                #include:
-                #    -   os: ubuntu-latest
-                #        jdk: '16'
-        runs-on: ${{ matrix.os }}
+                experimental: [false]
+                include:
+                    - jdk: '17'
+                      experimental: true
+        continue-on-error: ${{ matrix.experimental }}
+        runs-on: ubuntu-latest
         steps:
           - uses: actions/checkout@v2
           - name: Set up JDK ${{ matrix.jdk }}

--- a/pom.xml
+++ b/pom.xml
@@ -916,7 +916,7 @@
             <plugin>
                 <!-- https://stackoverflow.com/questions/46177921/how-to-run-unit-tests-in-excludedgroups-in-maven -->
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.2</version>
+                <version>3.0.0-M5</version>
                 <configuration>
                     <!-- testsToExclude come from the profile-->
                     <excludedGroups>${testsToExclude}</excludedGroups>

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
         <argLine>-Duser.timezone=${project.timezone} -Dfile.encoding=${project.build.sourceEncoding} -Duser.language=${project.language} -Duser.region=${project.region}</argLine>
         <skipUnitTests>false</skipUnitTests>
     
+        <target.java.version>11</target.java.version>
         <jakartaee-api.version>8.0.0</jakartaee-api.version>
         <payara.version>5.2021.5</payara.version>
         <postgresql.version>42.2.19</postgresql.version>
@@ -826,6 +827,16 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <release>${target.java.version}</release>
+                    <!-- for use with `mvn -DcompilerArgument=-Xlint:unchecked compile` -->
+                    <compilerArgument>${compilerArgument}</compilerArgument>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>2.3</version>
                 <configuration>
@@ -947,26 +958,6 @@
             <id>all-unit-tests</id>
         </profile>
         <!-- TODO: Add a profile to run API tests (integration tests that end in IT.java. See conf/docker-aio/run-test-suite.sh -->
-      <profile>
-        <id>Java9Plus</id>
-        <activation>
-          <jdk>[1.9</jdk>
-        </activation>
-        <build>
-          <plugins>
-            <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-compiler-plugin</artifactId>
-              <version>3.8.0</version>
-              <configuration>
-                <release>11</release>
-                <!-- for use with `mvn -DcompilerArgument=-Xlint:unchecked compile` -->
-                <compilerArgument>${compilerArgument}</compilerArgument>
-              </configuration>
-            </plugin>
-          </plugins>
-        </build>
-      </profile>
         <profile>
             <id>tc</id>
             <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <mockito.version>2.28.2</mockito.version>
         <flyway.version>5.2.4</flyway.version>
         <jhove.version>1.20.1</jhove.version>
-        <jacoco.version>0.8.6</jacoco.version>
+        <jacoco.version>0.8.7</jacoco.version>
     </properties>
     <pluginRepositories>
         <pluginRepository>

--- a/src/main/java/edu/harvard/iq/dataverse/harvest/server/xoai/XlistRecordsHandler.java
+++ b/src/main/java/edu/harvard/iq/dataverse/harvest/server/xoai/XlistRecordsHandler.java
@@ -1,29 +1,37 @@
 package edu.harvard.iq.dataverse.harvest.server.xoai;
 
 import com.lyncode.xml.exceptions.XmlWriteException;
-import com.lyncode.xoai.dataprovider.handlers.*;
-import com.lyncode.xoai.dataprovider.exceptions.*;
+import com.lyncode.xoai.dataprovider.exceptions.BadArgumentException;
+import com.lyncode.xoai.dataprovider.exceptions.CannotDisseminateFormatException;
+import com.lyncode.xoai.dataprovider.exceptions.CannotDisseminateRecordException;
+import com.lyncode.xoai.dataprovider.exceptions.DoesNotSupportSetsException;
+import com.lyncode.xoai.dataprovider.exceptions.HandlerException;
+import com.lyncode.xoai.dataprovider.exceptions.NoMatchesException;
+import com.lyncode.xoai.dataprovider.exceptions.NoMetadataFormatsException;
+import com.lyncode.xoai.dataprovider.exceptions.OAIException;
+import com.lyncode.xoai.dataprovider.handlers.VerbHandler;
 import com.lyncode.xoai.dataprovider.handlers.results.ListItemsResults;
 import com.lyncode.xoai.dataprovider.handlers.helpers.ItemHelper;
 import com.lyncode.xoai.dataprovider.handlers.helpers.ItemRepositoryHelper;
-import com.lyncode.xoai.dataprovider.handlers.helpers.ResumptionTokenHelper;
 import com.lyncode.xoai.dataprovider.handlers.helpers.SetRepositoryHelper;
 import com.lyncode.xoai.dataprovider.model.Context;
 import com.lyncode.xoai.dataprovider.model.Item;
 import com.lyncode.xoai.dataprovider.model.MetadataFormat;
 import com.lyncode.xoai.dataprovider.model.Set;
-import com.lyncode.xoai.model.oaipmh.*;
 import com.lyncode.xoai.dataprovider.parameters.OAICompiledRequest;
 import com.lyncode.xoai.dataprovider.repository.Repository;
+import com.lyncode.xoai.model.oaipmh.Header;
+import com.lyncode.xoai.model.oaipmh.ListRecords;
+import com.lyncode.xoai.model.oaipmh.Metadata;
+import com.lyncode.xoai.model.oaipmh.Record;
+import com.lyncode.xoai.model.oaipmh.ResumptionToken;
 import com.lyncode.xoai.xml.XSLPipeline;
 import com.lyncode.xoai.xml.XmlWriter;
 import edu.harvard.iq.dataverse.Dataset;
 
 import javax.xml.stream.XMLStreamException;
-import javax.xml.transform.TransformerException;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.util.List;
 
 /**


### PR DESCRIPTION
**What this PR does / why we need it**:

This adds an experimental build on the Github Workflows for IQSS/dataverse using Java 17. It's easier to recognise what fails with Java 17 if this becomes a part of regular CI.

**Which issue(s) this PR closes**:

Relates to #8094 

**Special notes for your reviewer**:
Well take a look at the failing CI which should not fail the entire build (which is good)

**Suggestions on how to test this**:
See build log of the PR

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
Nope, dev only.

**Is there a release notes update needed for this change?**:
Nope.

**Additional documentation**:
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idcontinue-on-error