### PR TITLE
IQSS/8348-dont remove expired token #8348

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/authorization/AuthenticationServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/authorization/AuthenticationServiceBean.java
@@ -380,14 +380,7 @@ public class AuthenticationServiceBean {
         }
         if (tokens.size() == 1) {
             // Normal case - one token that may or may not have expired
-            ApiToken token = tokens.get(0);
-            if (token.getExpireTime().before(latest)) {
-                // Don't return an expired token which is unusable, delete it instead
-                em.remove(token);
-                return null;
-            } else {
-                return tokens.get(0);
-            }
+            return tokens.get(0);
         } else {
             // We have more than one due to https://github.com/IQSS/dataverse/issues/6389 or
             // similar, so we should delete all but one token.


### PR DESCRIPTION
What this PR does / why we need it: Code added in #6394 automatically removed expired API Tokens which a) is potentially confusing (you thought you had a token) and b) avoids the existing logic that would show the expired token and a warning to create a new one.

Which issue(s) this PR closes:

Closes #8348

Special notes for your reviewer:

Suggestions on how to test this: Create an apitoken, backdate its expiretime in the db to be before now, and refresh the API Token tab. The expired token should display and show a warning message about needing to refresh it. Current code just shows no token exists if your old one has expired.

Does this PR introduce a user interface change? If mockups are available, please link/include them here:

Is there a release notes update needed for this change?:

Additional documentation: