### PR TITLE
issue #8333: improve documentation of reExportAll

### DIFF
--- a/doc/sphinx-guides/source/admin/metadataexport.rst
+++ b/doc/sphinx-guides/source/admin/metadataexport.rst
@@ -23,6 +23,8 @@ In addition to the automated exports, a Dataverse installation admin can start a
 The former will attempt to export all the published, local (non-harvested) datasets that haven't been exported yet. 
 The latter will *force* a re-export of every published, local dataset, regardless of whether it has already been exported or not. 
 
+These calls return a status message informing the administrator, that the process has been launched (``{"status":"WORKFLOW_IN_PROGRESS"}``). The administrator can check the progress of the process via log files: ``[Payara directory]/glassfish/domains/domain1/logs/export_[time stamp].log``.
+
 Note, that creating, modifying, or re-exporting an OAI set will also attempt to export all the unexported datasets found in the set.
 
 Export Failures

--- a/doc/sphinx-guides/source/installation/config.rst
+++ b/doc/sphinx-guides/source/installation/config.rst
@@ -1722,6 +1722,8 @@ Note: After making a change to this setting, a reExportAll needs to be run befor
 
 This will *force* a re-export of every published, local dataset, regardless of whether it has already been exported or not.
 
+The call returns a status message informing the administrator, that the process has been launched (``{"status":"WORKFLOW_IN_PROGRESS"}``). The administrator can check the progress of the process via log files: ``[Payara directory]/glassfish/domains/domain1/logs/export_[time stamp].log``.
+
 :NavbarAboutUrl
 +++++++++++++++
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The output of ReExportAll returns a status message, but the documentation doesn't inform the user how to check the progress of reindexing process. This PR informs the user about a dedicated log file, which can be used to track the progress.

**Which issue(s) this PR closes**:

This is a temporary solution for the problem raised by  #8333 

**Special notes for your reviewer**:

**Suggestions on how to test this**:

You have to rrebuild documentation then check the output:
```
cd doc/sphinx-guides
make clean ; make html
firefox build/html/admin/metadataexport.html 
firefox build/html/installation/config.html 
```

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No

**Is there a release notes update needed for this change?**:

No

**Additional documentation**:

No