### PR TITLE
Getting rid of log4j1 in the war file

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -98,7 +98,7 @@
         </module>
         -->
         <module name="IllegalImport">
-            <property name="illegalPkgs" value="org.apache.commons.lang"/>
+            <property name="illegalPkgs" value="org.apache.commons.lang, org.apache.log4j"/>
         </module>
         <!-- <module name="RedundantImport"/> -->
         <!-- <module name="UnusedImports">

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,8 @@
         <payara.version>5.2021.5</payara.version>
         <postgresql.version>42.2.19</postgresql.version>
         <aws.version>1.11.762</aws.version>
-        <slf4j.version>1.7.32</slf4j.version>
+        <slf4j.version>1.7.35</slf4j.version>
+	<reload4j.version>1.2.18.4</reload4j.version>
         <commons.io.version>2.11.0</commons.io.version>
         <commons.logging.version>1.2</commons.logging.version>
         <commons.lang3.version>3.12.0</commons.lang3.version>
@@ -225,14 +226,23 @@
             </dependency>
             <!-- In *theory* the log4j12 bridge should not be made convergent, as WE decide which way logs flow.
                  Libraries should *only* rely on the api package. But sometimes... :-/ -->
+            <!-- Replacing the dependency slf4j-log4j12 with slf4j-reload4j, -->
+            <!-- in order to make sure we are getting rid of log4j for good... -->
+            <!-- it may not be necessary, to include slf4j-reload4j explicitly -->
+            <!-- but shouldn't hurt either (? L.A. - Jan. 2022) --> 
             <dependency>
                 <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-log4j12</artifactId>
+                <artifactId>slf4j-reload4j</artifactId>
                 <version>${slf4j.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>jcl-over-slf4j</artifactId>
+                <version>${slf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>jul-to-slf4j</artifactId>
                 <version>${slf4j.version}</version>
             </dependency>
             
@@ -252,7 +262,25 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-jdk14</artifactId>
         </dependency>
-        
+	<dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+	<dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+        </dependency>
+	<dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jul-to-slf4j</artifactId>
+        </dependency>
+	<!-- reload4j is a drop-in security patch/replacement for log4j1. -->
+	<!-- (https://reload4j.qos.ch/) -->
+	<dependency>
+            <groupId>ch.qos.reload4j</groupId>
+            <artifactId>reload4j</artifactId>
+            <version>${reload4j.version}</version>
+        </dependency>
         <dependency>
             <groupId>org.passay</groupId>
             <artifactId>passay</artifactId>
@@ -573,6 +601,10 @@
         <!-- is still buggy. As an experiment, I'm using -->
         <!-- a patched version I built locally. -->
         <!-- (pull requests pending - L.A. -->
+	<!-- These locally-built XOAI libraries are still a serious debt -->
+	<!-- that needs to be addressed. Adding explicit "exclusion" entries -->
+	<!-- below for the immediate purpose of getting rid of the log4j library -->
+	<!-- that was being added to the project via these dependencies. (L.A. - Jan. 2022) -->
         <dependency>
             <groupId>com.lyncode</groupId>
             <artifactId>xoai-common</artifactId>
@@ -582,11 +614,23 @@
             <groupId>com.lyncode</groupId>
             <artifactId>xoai-data-provider</artifactId>
             <version>4.1.0-header-patch</version>
+	    <exclusions>
+                <exclusion>
+                     <groupId>log4j</groupId>
+                   <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.lyncode</groupId>
             <artifactId>xoai-service-provider</artifactId>
             <version>4.1.0-header-patch</version>
+	    <exclusions>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- Added for AutoService -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <postgresql.version>42.2.19</postgresql.version>
         <aws.version>1.11.762</aws.version>
         <slf4j.version>1.7.35</slf4j.version>
-	<reload4j.version>1.2.18.4</reload4j.version>
+        <reload4j.version>1.2.18.4</reload4j.version>
         <commons.io.version>2.11.0</commons.io.version>
         <commons.logging.version>1.2</commons.logging.version>
         <commons.lang3.version>3.12.0</commons.lang3.version>
@@ -224,17 +224,6 @@
                 <artifactId>slf4j-jdk14</artifactId>
                 <version>${slf4j.version}</version>
             </dependency>
-            <!-- In *theory* the log4j12 bridge should not be made convergent, as WE decide which way logs flow.
-                 Libraries should *only* rely on the api package. But sometimes... :-/ -->
-            <!-- Replacing the dependency slf4j-log4j12 with slf4j-reload4j, -->
-            <!-- in order to make sure we are getting rid of log4j for good... -->
-            <!-- it may not be necessary, to include slf4j-reload4j explicitly -->
-            <!-- but shouldn't hurt either (? L.A. - Jan. 2022) --> 
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-reload4j</artifactId>
-                <version>${slf4j.version}</version>
-            </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>jcl-over-slf4j</artifactId>
@@ -262,26 +251,8 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-jdk14</artifactId>
         </dependency>
+        
 	<dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-        </dependency>
-	<dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>jcl-over-slf4j</artifactId>
-        </dependency>
-	<dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>jul-to-slf4j</artifactId>
-        </dependency>
-	<!-- reload4j is a drop-in security patch/replacement for log4j1. -->
-	<!-- (https://reload4j.qos.ch/) -->
-	<dependency>
-            <groupId>ch.qos.reload4j</groupId>
-            <artifactId>reload4j</artifactId>
-            <version>${reload4j.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.passay</groupId>
             <artifactId>passay</artifactId>
             <version>1.6.0</version>
@@ -601,10 +572,11 @@
         <!-- is still buggy. As an experiment, I'm using -->
         <!-- a patched version I built locally. -->
         <!-- (pull requests pending - L.A. -->
-	<!-- These locally-built XOAI libraries are still a serious debt -->
-	<!-- that needs to be addressed. Adding explicit "exclusion" entries -->
-	<!-- below for the immediate purpose of getting rid of the log4j library -->
-	<!-- that was being added to the project via these dependencies. (L.A. - Jan. 2022) -->
+        <!-- These locally-built XOAI libraries are still a serious debt -->
+        <!-- that needs to be addressed. Adding explicit "exclusion" entries -->
+        <!-- below for the immediate purpose of getting rid of the log4j library -->
+        <!-- that was being added to the project via these dependencies. (L.A. - Jan. 2022) -->
+        <!-- (note the reload4j explicitly added below as a replacement! -->
         <dependency>
             <groupId>com.lyncode</groupId>
             <artifactId>xoai-common</artifactId>
@@ -614,10 +586,10 @@
             <groupId>com.lyncode</groupId>
             <artifactId>xoai-data-provider</artifactId>
             <version>4.1.0-header-patch</version>
-	    <exclusions>
+            <exclusions>
                 <exclusion>
-                     <groupId>log4j</groupId>
-                   <artifactId>log4j</artifactId>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -625,12 +597,20 @@
             <groupId>com.lyncode</groupId>
             <artifactId>xoai-service-provider</artifactId>
             <version>4.1.0-header-patch</version>
-	    <exclusions>
+            <exclusions>
                 <exclusion>
                     <groupId>log4j</groupId>
                     <artifactId>log4j</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <!-- reload4j is a drop-in security patch/replacement for log4j1. -->
+        <!-- it is here because the XOAI libraries above need it. -->
+        <!-- (https://reload4j.qos.ch/) -->
+        <dependency>
+            <groupId>ch.qos.reload4j</groupId>
+            <artifactId>reload4j</artifactId>
+            <version>${reload4j.version}</version>
         </dependency>
         <!-- Added for AutoService -->
         <dependency>

--- a/src/main/java/edu/harvard/iq/dataverse/EjbDataverseEngine.java
+++ b/src/main/java/edu/harvard/iq/dataverse/EjbDataverseEngine.java
@@ -51,8 +51,6 @@ import javax.persistence.PersistenceContext;
 import javax.validation.ConstraintViolation;
 import javax.validation.ConstraintViolationException;
 
-//import org.apache.log4j.lf5.LogLevel;
-
 /**
  * An EJB capable of executing {@link Command}s in a JEE environment.
  *

--- a/src/main/java/edu/harvard/iq/dataverse/EjbDataverseEngine.java
+++ b/src/main/java/edu/harvard/iq/dataverse/EjbDataverseEngine.java
@@ -51,7 +51,7 @@ import javax.persistence.PersistenceContext;
 import javax.validation.ConstraintViolation;
 import javax.validation.ConstraintViolationException;
 
-import org.apache.log4j.lf5.LogLevel;
+//import org.apache.log4j.lf5.LogLevel;
 
 /**
  * An EJB capable of executing {@link Command}s in a JEE environment.

--- a/src/main/java/edu/harvard/iq/dataverse/harvest/server/xoai/XdataProvider.java
+++ b/src/main/java/edu/harvard/iq/dataverse/harvest/server/xoai/XdataProvider.java
@@ -14,16 +14,16 @@ import com.lyncode.xoai.dataprovider.parameters.OAIRequest;
 import com.lyncode.xoai.dataprovider.repository.Repository;
 import com.lyncode.xoai.services.api.DateProvider;
 import com.lyncode.xoai.services.impl.UTCDateProvider;
-import org.apache.log4j.Logger;
-
 import static com.lyncode.xoai.dataprovider.parameters.OAIRequest.Parameter.*;
+
+import java.util.logging.Logger;
 
 /**
  *
  * @author Leonid Andreev
  */
 public class XdataProvider {
-    private static Logger log = Logger.getLogger(XdataProvider.class);
+    private static Logger log = Logger.getLogger(XdataProvider.class.getCanonicalName());
 
     public static XdataProvider dataProvider (Context context, Repository repository) {
         return new XdataProvider(context, repository);
@@ -59,7 +59,7 @@ public class XdataProvider {
     }
 
     public OAIPMH handle (OAIRequest requestParameters) throws OAIException {
-        log.debug("Handling OAI request");
+        log.fine("Handling OAI request");
         Request request = new Request(repository.getConfiguration().getBaseUrl())
                 .withVerbType(requestParameters.get(Verb))
                 .withResumptionToken(requestParameters.get(ResumptionToken))
@@ -98,7 +98,7 @@ public class XdataProvider {
                     break;
             }
         } catch (HandlerException e) {
-            log.debug(e.getMessage(), e);
+            log.fine("HandlerException when executing "+request.getVerbType()+": " + e.getMessage());
             response.withError(errorsHandler.handle(e));
         }
 

--- a/src/main/java/edu/harvard/iq/dataverse/util/bagit/OREMap.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/bagit/OREMap.java
@@ -35,7 +35,6 @@ import javax.json.JsonObjectBuilder;
 import javax.json.JsonValue;
 
 import org.apache.commons.lang3.exception.ExceptionUtils;
-//import org.apache.log4j.lf5.LogLevel;
 
 public class OREMap {
 

--- a/src/main/java/edu/harvard/iq/dataverse/util/bagit/OREMap.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/bagit/OREMap.java
@@ -35,7 +35,7 @@ import javax.json.JsonObjectBuilder;
 import javax.json.JsonValue;
 
 import org.apache.commons.lang3.exception.ExceptionUtils;
-import org.apache.log4j.lf5.LogLevel;
+//import org.apache.log4j.lf5.LogLevel;
 
 public class OREMap {
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Self-explanatory - this PR gets rid of the log4j-1.2.14 jar we've been shipping as part of the war file.

**Which issue(s) this PR closes**:

Closes IQSS/dataverse-security#48

**Special notes for your reviewer**:

The surprising part here is that it really looks like none of our 3rd party dependencies are actually using log4j; with the single exception of XOAI - the unsupported dependency that we built ourselves. It's long overdue for an overhaul; this will be handled as a separate issue. 

**Suggestions on how to test this**:

The main (and easily verifiable) goal is for the .war file to no longer contain log4j-1.2.14.jar. Jenkins/restassured tests still passing should ensure that nothing has been broken in the process. 

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
