### PR TITLE
IQSS/8386 Fix file replace

### DIFF
--- a/src/main/webapp/file-info-fragment.xhtml
+++ b/src/main/webapp/file-info-fragment.xhtml
@@ -25,7 +25,7 @@
     -->            
     </ui:remove>
     
-    <p:outputPanel id="fileInfoInclude-filesTable-#{fileMetadata.label}" styleClass="media">
+    <p:outputPanel id="fileInfoInclude-filesTable" styleClass="media">
         <div class="media-left col-file-thumb" style="padding-top:4px;">
             <div class="media-object thumbnail-block text-center">
                 <span class="icon-#{dataFileServiceBean.getFileThumbnailClass(fileMetadata.dataFile)} file-thumbnail-icon text-muted" jsf:rendered="#{!fileDownloadHelper.canDownloadFile(fileMetadata) or !dataFileServiceBean.isThumbnailAvailable(fileMetadata.dataFile)}"/>


### PR DESCRIPTION
This reverts commit 9f97755011234f915c4533064294fbff5544a078.

**What this PR does / why we need it**: This change broke the file replace page and isn't needed. (A similar but working change was needed elsewhere and I erroneously assumed it was needed here. Further testing shows a) this does not work (see issue) and b) isn't needed as PrimeFaces already makes the id unique in this case (prefixing row number, etc.)

**Which issue(s) this PR closes**:

Closes #8386 

**Special notes for your reviewer**:

**Suggestions on how to test this**: File replace page should now appear/work. The fact that it isn't needed could be tested ny running the Deque/Axe plugin and verifying that there are no duplicate id issues appearing - either on the file replace page and/or in the file upload page with multiple files added.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**: no - original issue isn't even in a release yet.

**Additional documentation**:
