### PR TITLE
500 Error on template page

### DIFF
--- a/src/main/webapp/dataset-license-terms.xhtml
+++ b/src/main/webapp/dataset-license-terms.xhtml
@@ -38,7 +38,7 @@
                                </ui:fragment>
                                <ui:fragment rendered="#{empty editMode and empty termsOfUseAndAccess.license}">
                                    <p>
-                                       <h:outputText value="#{DatasetUtil:getLicenseName(DatasetPage.workingVersion).concat(' ')}" escape="false"/>
+                                       <h:outputText value="#{bundle['license.custom'].concat(' ')}" escape="false"/>
                                        <h:outputText value="#{bundle['file.dataFilesTab.terms.list.license.customterms.txt']}" escape="false"/>
                                    </p>
                                </ui:fragment>


### PR DESCRIPTION
per @pdurbin - Template page was giving 500 error. This was due to DatasetUtil:getLicenseName being used here without DatasetUtil having its functions include. Since we only need the custom terms string here, that can be included directly.

**What this PR does / why we need it**:

**Which issue(s) this PR closes**:

Closes #

**Special notes for your reviewer**:

**Suggestions on how to test this**: Check the template page - a) it should work, and b) Viewing one with custom terms should show "Custom Dataset Terms — the following Custom Dataset Terms have been defined for this dataset." in the License/Data Use Agreement area

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: no

**Is there a release notes update needed for this change?**: bug was only in dev so far

**Additional documentation**:
