### PR TITLE
IQSS/8398 - move bag when complete

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/LocalSubmitToArchiveCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/LocalSubmitToArchiveCommand.java
@@ -15,27 +15,14 @@ import edu.harvard.iq.dataverse.util.bagit.OREMap;
 import edu.harvard.iq.dataverse.workflow.step.Failure;
 import edu.harvard.iq.dataverse.workflow.step.WorkflowStepResult;
 
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.PipedInputStream;
-import java.io.PipedOutputStream;
-import java.nio.charset.Charset;
-import java.security.DigestInputStream;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.logging.Logger;
-
 
 import java.io.File;
 import java.io.FileOutputStream;
 
-import org.apache.commons.codec.binary.Hex;
-
 import org.apache.commons.io.FileUtils;
-
-
 
 @RequiredPermissions(Permission.PublishDataset)
 public class LocalSubmitToArchiveCommand extends AbstractSubmitToArchiveCommand implements Command<DatasetVersion> {
@@ -47,14 +34,14 @@ public class LocalSubmitToArchiveCommand extends AbstractSubmitToArchiveCommand 
     }
 
     @Override
-    public WorkflowStepResult performArchiveSubmission(DatasetVersion dv, ApiToken token, Map<String, String> requestedSettings) {
+    public WorkflowStepResult performArchiveSubmission(DatasetVersion dv, ApiToken token,
+            Map<String, String> requestedSettings) {
         logger.fine("In LocalCloudSubmitToArchive...");
         String localPath = requestedSettings.get(":BagItLocalPath");
-
+        String zipName = null;
         try {
 
             Dataset dataset = dv.getDataset();
-
 
             if (dataset.getLockFor(Reason.finalizePublication) == null
                     && dataset.getLockFor(Reason.FileValidationFailed) == null) {
@@ -64,26 +51,33 @@ public class LocalSubmitToArchiveCommand extends AbstractSubmitToArchiveCommand 
 
                 DataCitation dc = new DataCitation(dv);
                 Map<String, String> metadata = dc.getDataCiteMetadata();
-                String dataciteXml = DOIDataCiteRegisterService.getMetadataFromDvObject(
-                        dv.getDataset().getGlobalId().asString(), metadata, dv.getDataset());
+                String dataciteXml = DOIDataCiteRegisterService
+                        .getMetadataFromDvObject(dv.getDataset().getGlobalId().asString(), metadata, dv.getDataset());
 
-
-                FileUtils.writeStringToFile(new File(localPath+"/"+spaceName + "-datacite.v" + dv.getFriendlyVersionNumber()+".xml"), dataciteXml);
+                FileUtils.writeStringToFile(
+                        new File(localPath + "/" + spaceName + "-datacite.v" + dv.getFriendlyVersionNumber() + ".xml"),
+                        dataciteXml, StandardCharsets.UTF_8);
                 BagGenerator bagger = new BagGenerator(new OREMap(dv, false), dataciteXml);
                 bagger.setAuthenticationKey(token.getTokenString());
-                bagger.generateBag(new FileOutputStream(localPath+"/"+spaceName + "v" + dv.getFriendlyVersionNumber() + ".zip"));
+                zipName = localPath + "/" + spaceName + "v" + dv.getFriendlyVersionNumber() + ".zip";
+                bagger.generateBag(new FileOutputStream(zipName + ".partial"));
 
+                File srcFile = new File(zipName + ".partial");
+                File destFile = new File(zipName);
 
-                logger.fine("Localhost Submission step: Content Transferred");
-                StringBuffer sb = new StringBuffer("file://"+localPath+"/"+spaceName + "v" + dv.getFriendlyVersionNumber() + ".zip");
-                dv.setArchivalCopyLocation(sb.toString());
-
+                if (srcFile.renameTo(destFile)) {
+                    logger.fine("Localhost Submission step: Content Transferred");
+                    dv.setArchivalCopyLocation("file://" + zipName);
+                } else {
+                    logger.warning("Unable to move " + zipName + ".partial to " + zipName);
+                }
             } else {
-                logger.warning("Localhost Submision Workflow aborted: Dataset locked for finalizePublication, or because file validation failed");
+                logger.warning(
+                        "Localhost Submision Workflow aborted: Dataset locked for finalizePublication, or because file validation failed");
                 return new Failure("Dataset locked");
             }
-        }  catch (Exception e) {
-            logger.warning(e.getLocalizedMessage() + "here");
+        } catch (Exception e) {
+            logger.warning("Failed to archive " + zipName + " : " + e.getLocalizedMessage());
             e.printStackTrace();
         }
         return WorkflowStepResult.OK;


### PR DESCRIPTION
**What this PR does / why we need it**: This change makes it easier to determine when an archived bag is complete and can be used in further processing.

**Which issue(s) this PR closes**:

Closes #8398 

**Special notes for your reviewer**: PR also includes some cleanup: reformat, remove unused imports, improved log message.

**Suggestions on how to test this**: Configure local archiving, verify that a Bag file (and datacite.xml file) are produced as before. Nominally watch as the Bag is produced and see that the file is initially named with a ".partial" extension which is dropped when the file is complete/has it's final size.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: no

**Is there a release notes update needed for this change?**: no

**Additional documentation**:
