### PR TITLE
Required single value controlledVocabulary field cannot be left empty when saving template

### DIFF
--- a/src/main/webapp/metadataFragment.xhtml
+++ b/src/main/webapp/metadataFragment.xhtml
@@ -219,7 +219,7 @@
                                                     <div class="form-group dataset-field-values">
                                                         <div class="form-col-container col-sm-9 edit-field">
                                                             <p:selectOneMenu value="#{dsf.singleControlledVocabularyValue}" converter="controlledVocabularyValueConverter" style="width: auto !important; max-width:100%; min-width:200px;" styleClass="form-control primitive"
-                                                                             id="unique1" required="#{dsf.required}" rendered="#{!dsf.datasetFieldType.allowMultiples}">
+                                                                             id="unique1" required="#{dsf.required and datasetPage}" rendered="#{!dsf.datasetFieldType.allowMultiples}">
                                                                 <f:selectItem itemLabel="#{bundle.select}" itemValue="" noSelectionOption="true"/>
                                                                 <f:selectItems value="#{dsf.datasetFieldType.controlledVocabularyValues}" var="cvv" itemLabel="#{cvv.getLocaleStrValue(mdLangCode)}" itemValue="#{cvv}"/>
                                                             </p:selectOneMenu>


### PR DESCRIPTION
**What this PR does / why we need it**: When you create a template that contains a single value controlled vocabulary field that is marked as required it is currently not possible to save the template. You will get a validation error: 

> Required fields were missed or there was a validation error. Please scroll down to see details.

This is resolved by this PR. The solution was found by @qqmyers .

**Which issue(s) this PR closes**:

Closes n/a

**Special notes for your reviewer**: n/a

**Suggestions on how to test this**: 
Create a custom metadata block with a required single value controlled vocabulary field and try to create a template with no values filled in.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: no

**Is there a release notes update needed for this change?**: no

**Additional documentation**: n/a
