### PR TITLE
link to guides when creating, editing, selecting guestbooks #8244

### DIFF
--- a/src/main/java/propertyFiles/Bundle.properties
+++ b/src/main/java/propertyFiles/Bundle.properties
@@ -1222,7 +1222,8 @@ dataset.manageGuestbooks.noGuestbooks.why.reason2=You can download the data coll
 dataset.manageGuestbooks.noGuestbooks.how.header=How To Use Guestbooks
 dataset.manageGuestbooks.noGuestbooks.how.tip1=A guestbook can be used for multiple datasets but only one guestbook can be used for a dataset.
 dataset.manageGuestbooks.noGuestbooks.how.tip2=Custom questions can have free form text answers or have a user select an answer from several options.
-dataset.manageGuestbooks.noGuestbooks.getStarted=To get started, click on the Create Dataset Guestbook button above. To learn more about Guestbooks, visit the <a href="{0}/{1}/user/dataverse-management.html#dataset-guestbooks" title="Dataset Guestbook - Dataverse User Guide" target="_blank">Dataset Guestbook</a> section of the User Guide.
+dataset.manageGuestbooks.noGuestbooks.getStarted=To get started, click on the Create Dataset Guestbook button above.
+dataset.manageGuestbooks.noGuestbooks.learnMore=To learn more about Guestbooks, visit the <a href="{0}/{1}/user/dataverse-management.html#dataset-guestbooks" title="Dataset Guestbook - Dataverse User Guide" target="_blank">Dataset Guestbook</a> section of the User Guide.
 dataset.manageGuestbooks.tab.header.name=Guestbook Name
 dataset.manageGuestbooks.tab.header.date=Date Created
 dataset.manageGuestbooks.tab.header.usage=Usage

--- a/src/main/webapp/dataset-license-terms.xhtml
+++ b/src/main/webapp/dataset-license-terms.xhtml
@@ -464,7 +464,13 @@
                                                         and ((!dataverseSession.user.authenticated or !permissionsWrapper.canIssueUpdateDatasetCommand(DatasetPage.dataset))
                                                         or ((dataverseSession.user.authenticated and permissionsWrapper.canIssueUpdateDatasetCommand(DatasetPage.dataset) 
                                                            and !empty DatasetPage.dataset.dataverseContext.availableGuestbooks)))}">
-                                   <p>#{bundle['file.dataFilesTab.terms.list.guestbook.noSelected.tip']}</p>
+                                   <p class="help-block">
+                                       #{bundle['file.dataFilesTab.terms.list.guestbook.noSelected.tip']}
+                                       <h:outputFormat value="#{bundle['dataset.manageGuestbooks.noGuestbooks.learnMore']}" escape="false">
+                                           <f:param value="#{systemConfig.guidesBaseUrl}"/>
+                                           <f:param value="#{systemConfig.guidesVersion}"/>
+                                       </h:outputFormat>
+                                   </p>
                                </ui:fragment>
                                <ui:fragment rendered="#{empty DatasetPage.dataset.guestbook 
                                                  and (dataverseSession.user.authenticated and permissionsWrapper.canIssueUpdateDatasetCommand(DatasetPage.dataset))
@@ -490,7 +496,13 @@
                                </ui:fragment>
                            </ui:fragment>
                            <ui:fragment rendered="#{!empty editMode and datasetPage}">
-                               <p class="help-block">#{bundle['file.dataFilesTab.terms.list.guestbook.select.tip']}</p>
+                               <p class="help-block">
+                                   #{bundle['file.dataFilesTab.terms.list.guestbook.select.tip']}
+                                       <h:outputFormat value=" #{bundle['dataset.manageGuestbooks.noGuestbooks.learnMore']}" escape="false">
+                                            <f:param value="#{systemConfig.guidesBaseUrl}"/>
+                                            <f:param value="#{systemConfig.guidesVersion}"/>
+                                        </h:outputFormat>
+                               </p>
 
                                <ui:fragment rendered="#{empty DatasetPage.dataset.dataverseContext.availableGuestbooks}">
                                    <p class="help-block">

--- a/src/main/webapp/guestbook.xhtml
+++ b/src/main/webapp/guestbook.xhtml
@@ -44,6 +44,14 @@
                         </div>
                     </ui:fragment>
 
+                    <div class="alert alert-info">
+                        <span class="glyphicon glyphicon-info-sign"></span>
+                        <h:outputFormat value=" #{bundle['dataset.manageGuestbooks.noGuestbooks.learnMore']}" escape="false">
+                            <f:param value="#{systemConfig.guidesBaseUrl}"/>
+                            <f:param value="#{systemConfig.guidesVersion}"/>
+                        </h:outputFormat>
+                    </div>
+
                     <!-- Tabs -->
                     <div class="form-horizontal" jsf:rendered="#{!empty GuestbookPage.editMode}">
                         <div class="form-group">

--- a/src/main/webapp/manage-guestbooks.xhtml
+++ b/src/main/webapp/manage-guestbooks.xhtml
@@ -67,7 +67,8 @@
                                     </li>
                                 </ul>
                                 <p>
-                                    <h:outputFormat value="#{bundle['dataset.manageGuestbooks.noGuestbooks.getStarted']}" escape="false">
+                                    <h:outputText value="#{bundle['dataset.manageGuestbooks.noGuestbooks.getStarted']} "/>
+                                    <h:outputFormat value="#{bundle['dataset.manageGuestbooks.noGuestbooks.learnMore']}" escape="false">
                                         <f:param value="#{systemConfig.guidesBaseUrl}"/>
                                         <f:param value="#{systemConfig.guidesVersion}"/>
                                     </h:outputFormat>


### PR DESCRIPTION
**What this PR does / why we need it**:

Users could use some help understanding how guestbooks work by reading the guides. We provide a link to the guides in a few more places.

**Which issue(s) this PR closes**:

Closes #8244

**Special notes for your reviewer**:

**Suggestions on how to test this**:

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

Yes. The "To learn more about" line was added in several places.

## create guestbook

<img width="1007" alt="Screen Shot 2022-02-04 at 2 31 42 PM" src="https://user-images.githubusercontent.com/21006/152596195-a0ae812d-c944-4e1b-8ac7-dbca438188f1.png">

## edit guestbook

<img width="1007" alt="Screen Shot 2022-02-04 at 2 32 52 PM" src="https://user-images.githubusercontent.com/21006/152596187-b3005904-4c03-4740-978a-4f37a1a68372.png">

## view terms while no guestbook is selected

(Note that the "help-block" CSS class was added to make the text grey.)

<img width="1007" alt="Screen Shot 2022-02-04 at 2 35 15 PM" src="https://user-images.githubusercontent.com/21006/152596192-4c33b0c2-6011-4e7d-8691-08adc34d5212.png">

## select a guestbook

<img width="1007" alt="Screen Shot 2022-02-04 at 2 36 13 PM" src="https://user-images.githubusercontent.com/21006/152596188-345e673a-5db4-4253-9842-8c46511af1a9.png">


**Is there a release notes update needed for this change?**:

**Additional documentation**:
