### PR TITLE
Fix guestbook clear selection button

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
@@ -1400,10 +1400,6 @@ public class DatasetPage implements java.io.Serializable {
         this.selectedGuestbook = selectedGuestbook;
     }
 
-    public void reset() {
-        dataset.setGuestbook(null);
-    }
-
     public int getFilePaginatorPage() {
         return filePaginatorPage;
     }

--- a/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
@@ -1400,6 +1400,10 @@ public class DatasetPage implements java.io.Serializable {
         this.selectedGuestbook = selectedGuestbook;
     }
 
+    public void reset() {
+        dataset.setGuestbook(null);
+    }
+
     public int getFilePaginatorPage() {
         return filePaginatorPage;
     }

--- a/src/main/webapp/dataset-license-terms.xhtml
+++ b/src/main/webapp/dataset-license-terms.xhtml
@@ -504,7 +504,7 @@
                                    <p:commandButton styleClass="btn btn-default"
                                                     value="#{bundle['file.dataFilesTab.terms.list.guestbook.clearBtn']}" 
                                                     rendered="#{!empty DatasetPage.dataset.guestbook}"
-                                                    update="guestbookTable" process="@this" oncomplete="PF('guestbookTable').unselectAllRows();"/>
+                                                    update="guestbookTable" process="@this" oncomplete="PF('guestbookTable').unselectAllRows();" actionListener="#{DatasetPage.reset}"/>
                                    <p:dataTable id="guestbookTable" styleClass="headerless-table margin-top"
                                                 value="#{DatasetPage.dataset.dataverseContext.availableGuestbooks}" var="guestbook" widgetVar="guestbookTable"
                                                 rendered="#{!empty DatasetPage.dataset.dataverseContext.availableGuestbooks}"

--- a/src/main/webapp/dataset-license-terms.xhtml
+++ b/src/main/webapp/dataset-license-terms.xhtml
@@ -504,7 +504,7 @@
                                    <p:commandButton styleClass="btn btn-default"
                                                     value="#{bundle['file.dataFilesTab.terms.list.guestbook.clearBtn']}" 
                                                     rendered="#{!empty DatasetPage.dataset.guestbook}"
-                                                    update="guestbookTable" process="@this" actionListener="#{DatasetPage.reset}"/>
+                                                    update="guestbookTable" process="@this" oncomplete="PF('guestbookTable').unselectAllRows();"/>
                                    <p:dataTable id="guestbookTable" styleClass="headerless-table margin-top"
                                                 value="#{DatasetPage.dataset.dataverseContext.availableGuestbooks}" var="guestbook" widgetVar="guestbookTable"
                                                 rendered="#{!empty DatasetPage.dataset.dataverseContext.availableGuestbooks}"


### PR DESCRIPTION
**What this PR does / why we need it**: Per slack discussions, @pdurbin found that the button to clear the selected guestbook (i.e. to return to no guestbook)_on the dataset page/edit terms tab was broken. etc. This PR fixes that. (After discussion with @kcondon, I took a look to make sure this wasn't related to recent changes to accessibility/multilicenses,)

I did not see an issue yet.

**Which issue(s) this PR closes**:

Closes #2257

**Special notes for your reviewer**: I can't yet understand if/how this worked originally. The main issue is one I saw in some embargo work making controls in a form interact - changing the state in the backing bean doesn't update the state of the UI widget. In this case, the clear button was setting the guestbook to null on the server but the selected radio button remains selected and hence, when you save, it selects the indicated guestbook resulting in no overall change. Changing the 'update' attribute of the button to refresh the set of radio buttons doesn't have the intended effect of making the radio button state reflect the backing bean. (One can confirm that the radio buttons are getting updated by, for example, printing the Guestbook id within the list of guestbooks. That shows that indeed the backing bean has a null guestbook after the clear button is hit. and that the set of radio buttons has just been updated from the server in the response to the actionListener.) 

While there may be a way to force such an update, I took an alternate approach and, rather than have an actionListener to update the backing bean, I just call the widget's unselectAllRows() method (listed in the PrimeFaces client API guide for the DataTable) in an oncomplete call. That appears to work and seems like a reasonable option if not the only/best one. The PR is basically that one line change and removal of the DatasetPage.reset() method which appears to only have been called by this button's actionListener.

**Suggestions on how to test this**: Try to clear the guestbook with the button and verify a) the UI updates to show no radio button selected and that b) after a save that the guestbook is indeed null/no guestbook selected for the dataset.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
