### PR TITLE
8094 test reports

### DIFF
--- a/.github/workflows/maven_unit_test.yml
+++ b/.github/workflows/maven_unit_test.yml
@@ -43,3 +43,7 @@ jobs:
                 CI_NAME: github
                 COVERALLS_SECRET: ${{ secrets.GITHUB_TOKEN }}
             run: mvn -V -B jacoco:report coveralls:report -DrepoToken=${COVERALLS_SECRET} -DpullRequest=${{ github.event.number }}
+          - name: Publish Test Report
+            uses: scacap/action-surefire-report@v1
+            with:
+                check_name: JDK ${{ matrix.jdk }} Test Report

--- a/src/main/java/edu/harvard/iq/dataverse/authorization/groups/impl/maildomain/MailDomainGroupServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/authorization/groups/impl/maildomain/MailDomainGroupServiceBean.java
@@ -37,9 +37,9 @@ public class MailDomainGroupServiceBean {
     ConfirmEmailServiceBean confirmEmailSvc;
     @Inject
     ActionLogServiceBean actionLogSvc;
-	
+    
     MailDomainGroupProvider provider;
-    List<MailDomainGroup> simpleGroups = Collections.EMPTY_LIST;
+    List<MailDomainGroup> simpleGroups = Collections.emptyList();
     Map<MailDomainGroup, Pattern> regexGroups = new HashMap<>();
     
     @PostConstruct
@@ -78,7 +78,9 @@ public class MailDomainGroupServiceBean {
     public Set<MailDomainGroup> findAllWithDomain(AuthenticatedUser user) {
         
         // if the mail address is not verified, escape...
-        if (!confirmEmailSvc.hasVerifiedEmail(user)) { return Collections.emptySet(); }
+        if (!confirmEmailSvc.hasVerifiedEmail(user)) {
+            return Collections.emptySet();
+        }
         
         // otherwise start to bisect the mail and lookup groups.
         // NOTE: the email from the user has been validated via {@link EMailValidator} when persisted.
@@ -192,7 +194,9 @@ public class MailDomainGroupServiceBean {
      */
     static Optional<String> getDomainFromMail(String email) {
         String[] parts = email.split("@");
-        if (parts.length < 2) { return Optional.empty(); }
+        if (parts.length < 2) {
+            return Optional.empty();
+        }
         return Optional.of(parts[parts.length-1]);
     }
     


### PR DESCRIPTION
**What this PR does / why we need it**:
After adding experimental JDK 17 build support, it would be nice to have a easier to read test report than filtering build log output. This PR aims to add them.

**Which issue(s) this PR closes**:

Relates to #8094 

**Special notes for your reviewer**:
I edited a single Java file to trigger the build in a commit that would still be useful...

**Suggestions on how to test this**:
Take a look at the failing tests for JDK 17

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
Nope.

**Is there a release notes update needed for this change?**:
Nope.

**Additional documentation**:
None.
