### PR TITLE
IQSS/8407 fix - update CC0 1.0 info in db/align json with other licenses

### DIFF
--- a/scripts/api/data/licenses/licenseCC0-1.0.json
+++ b/scripts/api/data/licenses/licenseCC0-1.0.json
@@ -1,6 +1,6 @@
 {
   "name": "CC0 1.0",
-  "uri": "https://creativecommons.org/publicdomain/zero/1.0/",
+  "uri": "https://creativecommons.org/publicdomain/zero/1.0",
   "shortDescription": "Creative Commons CC0 1.0 Universal Public Domain Dedication.",
   "iconUrl": "https://licensebuttons.net/p/zero/1.0/88x31.png",
   "active": true

--- a/src/main/resources/db/migration/V5.9.0.1__7440-configurable-license-list.sql
+++ b/src/main/resources/db/migration/V5.9.0.1__7440-configurable-license-list.sql
@@ -71,6 +71,12 @@ BEGIN
   EXCEPTION
     WHEN undefined_column THEN RAISE NOTICE 'license is not in table - new instance';
   END;
+  
+  BEGIN
+    UPDATE license SET shortdescription='Creative Commons CC0 1.0 Universal Public Domain Dedication.' WHERE name='CC0';
+    UPDATE license SET iconurl='https://licensebuttons.net/p/zero/1.0/88x31.png' WHERE name='CC0';
+    UPDATE license SET name='CC0 1.0' WHERE name='CC0';
+  END;
 
 END $$;
 ALTER TABLE termsofuseandaccess DROP COLUMN IF EXISTS license;

--- a/src/main/resources/db/migration/V5.9.0.1__7440-configurable-license-list.sql
+++ b/src/main/resources/db/migration/V5.9.0.1__7440-configurable-license-list.sql
@@ -72,6 +72,7 @@ BEGIN
     WHEN undefined_column THEN RAISE NOTICE 'license is not in table - new instance';
   END;
   
+  -- This section updates the db of those who ran the develop branch and does not make changes for new installs or upgrades from v5.9
   BEGIN
     UPDATE license SET shortdescription='Creative Commons CC0 1.0 Universal Public Domain Dedication.' WHERE name='CC0';
     UPDATE license SET iconurl='https://licensebuttons.net/p/zero/1.0/88x31.png' WHERE name='CC0';

--- a/src/main/resources/db/migration/V5.9.0.2__8407-fix-CC0-license.sql
+++ b/src/main/resources/db/migration/V5.9.0.2__8407-fix-CC0-license.sql
@@ -1,0 +1,3 @@
+UPDATE license SET shortdescription='Creative Commons CC0 1.0 Universal Public Domain Dedication.' WHERE name='CC0';
+UPDATE license SET iconurl='https://licensebuttons.net/p/zero/1.0/88x31.png' WHERE name='CC0';
+UPDATE license SET name='CC0 1.0' WHERE name='CC0';

--- a/src/main/resources/db/migration/V5.9.0.2__8407-fix-CC0-license.sql
+++ b/src/main/resources/db/migration/V5.9.0.2__8407-fix-CC0-license.sql
@@ -1,3 +1,0 @@
-UPDATE license SET shortdescription='Creative Commons CC0 1.0 Universal Public Domain Dedication.' WHERE name='CC0';
-UPDATE license SET iconurl='https://licensebuttons.net/p/zero/1.0/88x31.png' WHERE name='CC0';
-UPDATE license SET name='CC0 1.0' WHERE name='CC0';


### PR DESCRIPTION
**What this PR does / why we need it**: This is a minor DB update to align the upgrade changes create by the prior flyway script to match the current CC0 1.0 json file and to align the URl in that file with the other licenses (i.e. no trailing slash).

**Which issue(s) this PR closes**:

Closes #8407

**Special notes for your reviewer**: 

I spent some time today trying to figure out how to handle the conditional logic required to update the prior script and still work on databases that had deployed develop already (i.e. starting from a 5.9 database or from one that already had the multilicense changes applied and only needing the updates to the name/description/icon for CC0 1.0 . I wasn't very successful and started thinking that that approach would be a bear to test (assuming you test new db, 5.9 update and update from develop). Instead I just developed ~option 2 in the issue which results in a 5 line flyway script that can be then be added as a last step in the original script (i.e. relying on the fact that the original is idempotent).

I also saw the suggestion in the issue to not have a flyway script duplicating what is in the json file. As far as I understand, that would involve the upgrade instructions adding two manual steps (deploy CC0 1.0 and then run a manual update sql script) rather than providing a fully automated option (aside from the prior discussion that people may want to do some manual work to change a few corner cases rather than accept the default automated results). Given that, and the fact that we've done db updates to things like external tools before rather than have people re-register them, and wanting to avoid the work to make those changes and update/explain the manual steps, I didn't pursue that option.

**Suggestions on how to test this**:
Edit your db to remove the prior run of the V5.9.0.1 script from the flyway_schema_history table if you've run the develop branch before. Verify that the deployment results in a license with the name 'CC0 1.0', shortdescription 'Creative Commons CC0 1.0 Universal Public Domain Dedication.' and pulling the icon from 'https://licensebuttons.net/p/zero/1.0/88x31.png' exists instead of the 'CC0' license with other values for the shortdescription and icon URL that a) the old script produces, and b) would have already been in the table if you had run develop before. Nominally all of the license info is visible in the UI/browser console, but one could check the db entry in addition/instead.

After merge, let me know so we can alert developers that they will also have to delete the latest flyway entry if they were on develop already.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
