### PR TITLE
8094 disable 17 ci

### DIFF
--- a/.github/workflows/maven_unit_test.yml
+++ b/.github/workflows/maven_unit_test.yml
@@ -17,10 +17,15 @@ jobs:
                 jdk: [ '11' ]
                 experimental: [false]
                 status:  ["Stable"]
-                include:
-                    - jdk: '17'
-                      experimental: true
-                      status: "Experimental"
+                #
+                # JDK 17 builds disabled due to non-essential fails marking CI jobs as completely failed within
+                # Github Projects, PR lists etc. This was consensus on Slack #dv-tech. See issue #8094
+                # (This is a limitation of how Github is currently handling these things.)
+                #
+                #include:
+                #    - jdk: '17'
+                #      experimental: true
+                #      status: "Experimental"
         continue-on-error: ${{ matrix.experimental }}
         runs-on: ubuntu-latest
         steps:

--- a/src/main/java/edu/harvard/iq/dataverse/authorization/groups/impl/maildomain/MailDomainGroupServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/authorization/groups/impl/maildomain/MailDomainGroupServiceBean.java
@@ -37,7 +37,7 @@ public class MailDomainGroupServiceBean {
     ConfirmEmailServiceBean confirmEmailSvc;
     @Inject
     ActionLogServiceBean actionLogSvc;
-	
+    
     MailDomainGroupProvider provider;
     List<MailDomainGroup> simpleGroups = Collections.EMPTY_LIST;
     Map<MailDomainGroup, Pattern> regexGroups = new HashMap<>();
@@ -78,7 +78,9 @@ public class MailDomainGroupServiceBean {
     public Set<MailDomainGroup> findAllWithDomain(AuthenticatedUser user) {
         
         // if the mail address is not verified, escape...
-        if (!confirmEmailSvc.hasVerifiedEmail(user)) { return Collections.emptySet(); }
+        if (!confirmEmailSvc.hasVerifiedEmail(user)) {
+            return Collections.emptySet();
+        }
         
         // otherwise start to bisect the mail and lookup groups.
         // NOTE: the email from the user has been validated via {@link EMailValidator} when persisted.
@@ -192,7 +194,9 @@ public class MailDomainGroupServiceBean {
      */
     static Optional<String> getDomainFromMail(String email) {
         String[] parts = email.split("@");
-        if (parts.length < 2) { return Optional.empty(); }
+        if (parts.length < 2) {
+            return Optional.empty();
+        }
         return Optional.of(parts[parts.length-1]);
     }
     


### PR DESCRIPTION
**What this PR does / why we need it**:
Disabling the Java 17 experimental builds to make cleaner views on PR status within Github Project Cards etc. 

**Which issue(s) this PR closes**:

Related to #8094

**Special notes for your reviewer**:
None. (Besides: added a useful  commit to trigger CI that's just a style fix)

**Suggestions on how to test this**:
Well let's watch the PR CI status, shall we?

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
Nope

**Is there a release notes update needed for this change?**:
Nope

**Additional documentation**:
None