### PR TITLE
IQSS/8219 - only close stream if opened (for S3)

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/api/DownloadInstanceWriter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/DownloadInstanceWriter.java
@@ -179,15 +179,12 @@ public class DownloadInstanceWriter implements MessageBodyWriter<DownloadInstanc
                     }
 
                     if (redirectSupported) {
-                        // definitely close the (still open) S3 input stream, 
-                        // since we are not going to use it. The S3 documentation
+                        // definitely close the (potentially still open) input stream, 
+                        // since we are not going to use it. The S3 documentation in particular
                         // emphasizes that it is very important not to leave these
                         // lying around un-closed, since they are going to fill 
                         // up the S3 connection pool!
-                        try {
-                            storageIO.getInputStream().close();
-                        } catch (IOException ioex) {
-                        }
+                        storageIO.closeInputStream();
                         // [attempt to] redirect: 
                         String redirect_url_str;
                         try {
@@ -370,10 +367,7 @@ public class DownloadInstanceWriter implements MessageBodyWriter<DownloadInstanc
                     }
                 } else if (di.getAuxiliaryFile() != null) {
                     // Make sure to close the InputStream for the main datafile: 
-                    try {
-                        storageIO.getInputStream().close();
-                    } catch (IOException ioex) {
-                    }
+                    storageIO.closeInputStream();
                     String auxTag = di.getAuxiliaryFile().getFormatTag();
                     String auxVersion = di.getAuxiliaryFile().getFormatVersion();
                     if (auxVersion != null) {


### PR DESCRIPTION
**What this PR does / why we need it**: Due to changes over time, the current code ends up needlessly opening a stream with the S3 store just to close it in cases like accessing thumbnails, direct download, etc. This PR uses a smarted existing call that checks to see if the stream was ever opened and only calls close in that case. Aside from efficiency, the main improvement is getting rid of the log messages noted in the issue.

**Which issue(s) this PR closes**:

Closes #8219 

**Special notes for your reviewer**:

**Suggestions on how to test this**: Set up with S3 store and get a test case(s) where you see the `Not all bytes were read from the S3ObjectInputStream` warning. The PR should then stop those warnings. Could also check that file stores aren't affected/no new warnings are appearing.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: no

**Is there a release notes update needed for this change?**:

**Additional documentation**:
