### PR TITLE
add CC BY, improve license config docs #8347

### DIFF
--- a/doc/sphinx-guides/source/api/native-api.rst
+++ b/doc/sphinx-guides/source/api/native-api.rst
@@ -3727,6 +3727,8 @@ Note: setting ``:InheritParentRoleAssignments`` will automatically trigger inher
 Manage Available Standard License Terms
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+For more context about configuring licenses, see :ref:`license-config` in the Installation Guide.
+
 View the list of standard license terms that can be selected for a dataset:
 
 .. code-block:: bash
@@ -3742,7 +3744,7 @@ View the details of the standard license with the database ID specified in ``$ID
   curl $SERVER_URL/api/licenses/$ID
 
 
-Superusers can add a new license by posting a JSON file adapted from this example :download:`add-license.json <../_static/api/add-license.json>`. The ``name`` and ``uri`` of the new license must be unique. :
+Superusers can add a new license by posting a JSON file adapted from this example :download:`add-license.json <../_static/api/add-license.json>`. The ``name`` and ``uri`` of the new license must be unique. If you are interested in adding a Creative Commons license, you are encouarged to use the JSON files under :ref:`adding-creative-commons-licenses`:
 
 .. code-block:: bash
 
@@ -3762,7 +3764,7 @@ Superusers can set which license is the default specified by the license ``$ID``
 
   curl -X PUT -H 'Content-Type: application/json' -H X-Dataverse-key:$API_TOKEN --data-binary @edit-license.json $SERVER_URL/api/licenses/default/$ID
 
-Superusers can delete a license that is not in useby the license ``$ID``:
+Superusers can delete a license that is not in use by the license ``$ID``:
 
 .. code-block:: bash
 

--- a/doc/sphinx-guides/source/installation/advanced.rst
+++ b/doc/sphinx-guides/source/installation/advanced.rst
@@ -39,20 +39,24 @@ Please note that :ref:`network-ports` under the Configuration section has more i
 Licensing
 ---------
 
-Dataverse allows superusers to specify the list of allowed licenses, to define which license is the default, to decide whether users can instead define custom terms, and to mark obsolete licenses as 'inactive' to stop further use of them.
-These can be accomplished using the :ref:`:native API <license-management-api>` and the :ref:`:AllowCustomTermsOfUse <:AllowCustomTermsOfUse>` setting.
+Dataverse allows superusers to specify the list of allowed licenses, to define which license is the default, to decide whether users can instead define custom terms, and to mark obsolete licenses as "inactive" to stop further use of them.
+These can be accomplished using the :ref:`native API <license-management-api>` and the :ref:`:AllowCustomTermsOfUse <:AllowCustomTermsOfUse>` setting. See also :ref:`license-config`.
+
+.. _standardizing-custom-licenses:
 
 Standardizing Custom Licenses
 +++++++++++++++++++++++++++++
 
 In addition, if many datasets use the same set of Custom Terms, it may make sense to create and register a standard license including those terms. Doing this would include:
+
 - Creating and posting an external document that includes the custom terms, i.e. an HTML document with sections corresponding to the terms fields that are used.
-- Defining a name, short description, URL (where it is posted), and optionally an icon URL for this license
-- Using the Dataverse API to register the new license as one of the options available in your installation
-- Using the API to make sure the license is active and deciding whether the license should also be the default
+- Defining a name, short description, URL (where it is posted), and optionally an icon URL for this license.
+- Using the Dataverse API to register the new license as one of the options available in your installation.
+- Using the API to make sure the license is active and deciding whether the license should also be the default.
 - Once the license is registered with Dataverse, making an SQL update to change datasets/versions using that license to reference it instead of having their own copy of those custom terms.
 
 The benefits of this approach are:
+
 - usability: the license can be selected for new datasets without allowing custom terms and without users having to cut/paste terms or collection administrators having to configure templates with those terms
 - efficiency: custom terms are stored per dataset whereas licenses are registered once and all uses of it refer to the same object and external URL
 - security: with the license terms maintained external to Dataverse, users cannot edit specific terms and curators do not need to check for edits

--- a/doc/sphinx-guides/source/installation/config.rst
+++ b/doc/sphinx-guides/source/installation/config.rst
@@ -847,6 +847,65 @@ For Google Analytics, the example script at :download:`analytics-code.html </_st
 
 Once this script is running, you can look in the Google Analytics console (Realtime/Events or Behavior/Events) and view events by type and/or the Dataset or File the event involves.
 
+.. _license-config:
+
+Configuring Licenses
+--------------------
+
+Out of the box, users select from the following licenses or terms:
+
+- CC0 1.0 (default)
+- CC BY 4.0
+- Custom Dataset Terms
+
+You have a lot of control over which licenses and terms are available. You can remove licenses and add new ones. You can decide which license is the default. You can remove "Custom Dataset Terms" as a option. You can remove all licenses and make "Custom Dataset Terms" the only option.
+
+Before making changes, you are encouraged to read the :ref:`license-terms` section of the User Guide about why CC0 is the default and what the "Custom Dataset Terms" option allows.
+
+Setting the Default License
++++++++++++++++++++++++++++
+
+The default license can be set with a curl command as explained in the API Guide under :ref:`license-management-api`.
+
+Note that "Custom Dataset Terms" is not a license and cannot be set to be the default.
+
+Adding Licenses
++++++++++++++++
+
+Licenses are added with curl using JSON file as explained in the API Guide under :ref:`license-management-api`.
+
+.. _adding-creative-commons-licenses:
+
+Adding Creative Common Licenses
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+JSON files for `Creative Commons licenses <https://creativecommons.org/about/cclicenses/>`_ are provided below. Note that a new installation of Dataverse already includes CC0 and CC BY.
+
+- :download:`licenseCC0-1.0.json <../../../../scripts/api/data/licenses/licenseCC0-1.0.json>`
+- :download:`licenseCC-BY-4.0.json <../../../../scripts/api/data/licenses/licenseCC-BY-4.0.json>`
+- :download:`licenseCC-BY-SA-4.0.json <../../../../scripts/api/data/licenses/licenseCC-BY-SA-4.0.json>`
+- :download:`licenseCC-BY-NC-4.0.json <../../../../scripts/api/data/licenses/licenseCC-BY-NC-4.0.json>`
+- :download:`licenseCC-BY-NC-SA-4.0.json <../../../../scripts/api/data/licenses/licenseCC-BY-NC-SA-4.0.json>`
+- :download:`licenseCC-BY-ND-4.0.json <../../../../scripts/api/data/licenses/licenseCC-BY-ND-4.0.json>`
+- :download:`licenseCC-BY-NC-ND-4.0.json <../../../../scripts/api/data/licenses/licenseCC-BY-NC-ND-4.0.json>`
+
+.. _adding-custom-licenses:
+
+Adding Custom Licenses
+^^^^^^^^^^^^^^^^^^^^^^
+
+If you are interested in adding a custom license, you will need to create your own JSON file as explained in  see :ref:`standardizing-custom-licenses`.
+
+Removing Licenses
++++++++++++++++++
+
+Licenses can be removed with a curl command as explained in the API Guide under :ref:`license-management-api`.
+
+Disabling Custom Dataset Terms
+++++++++++++++++++++++++++++++
+
+See :ref:`:AllowCustomTermsOfUse` for how to disable the "Custom Dataset Terms" option.
+
 .. _BagIt Export:
 
 BagIt Export

--- a/doc/sphinx-guides/source/installation/prep.rst
+++ b/doc/sphinx-guides/source/installation/prep.rst
@@ -106,6 +106,7 @@ Here are some questions to keep in the back of your mind as you test and move in
 - Do I want to to run my app server on the standard web ports (80 and 443) or do I want to "front" my app server with a proxy such as Apache or nginx? See "Network Ports" in the :doc:`config` section.
 - How many points of failure am I willing to tolerate? How much complexity do I want?
 - How much does it cost to subscribe to a service to create persistent identifiers such as DOIs or handles?
+- What licenses should I make available to my users?
 
 Next Steps
 ----------

--- a/doc/sphinx-guides/source/user/dataset-management.rst
+++ b/doc/sphinx-guides/source/user/dataset-management.rst
@@ -318,7 +318,7 @@ For example, the `Creative Commons <https://creativecommons.org>`_ organization 
 (These licenses may or may not be available in the Dataverse instance you are using, but we expect them to be common in the community.)
 Each Creative Commons license typically specifies simple terms for how the IP must be used, reused, shared, and attributed and includes language intended to address variations in the laws of different countries.
 
-In addition to these licenses, Creative Commons also the `CC0 1.0 Universal (CC0 1.0) Public Domain Dedication <https://creativecommons.org/share-your-work/public-domain/cc0>`_ which allows you to unambiguously waive all copyright control over your data in all jurisdictions worldwide. 
+In addition to these licenses, Creative Commons also provides the `CC0 1.0 Universal (CC0 1.0) Public Domain Dedication <https://creativecommons.org/share-your-work/public-domain/cc0>`_ which allows you to unambiguously waive all copyright control over your data in all jurisdictions worldwide.
 Data released with CC0 can be freely copied, modified, and distributed (even for commercial purposes) without violating copyright. 
 In most parts of the world, factual data is exempt from copyright anyway, but applying CC0 removes all ambiguity and makes the legal copyright status of the data as clear as possible. 
 
@@ -327,9 +327,9 @@ When available. CC0 can be a good choice for datasets because it facilitates reu
 Data depositors and data users should also understand that while licenses define legal use, they do not exempt a Dataverse installation's users from following ethical and professional norms in scholarly communications.
 For example, though CC0 waives a dataset owner's legal copyright controls over the data, users, as scholarly researchers, are still expected to cite the data they use, giving credit to the data's authors following ethical and professional norms in scholarly communications.
 This is true of other licenses as well - users should cite data as appropriate even if the specified license does not require it. 
-The `Dataverse Community Norms <https://dataverse.org/best-practices/dataverse-community-norms>`_ * details additional areas where data users should follow societal norms and scientific best practices.
+The `Dataverse Community Norms <https://dataverse.org/best-practices/dataverse-community-norms>`_\* detail additional areas where data users should follow societal norms and scientific best practices.
 
-\* **Legal Disclaimer:** these `Community Norms <https://dataverse.org/best-practices/dataverse-community-norms>`_ are not a substitute for the CC0 waiver or custom terms and licenses applicable to each dataset. The Community Norms are not a binding contractual agreement, and that downloading datasets from a Dataverse installation does not create a legal obligation to follow these policies.  
+\* **Legal Disclaimer:** these `Community Norms <https://dataverse.org/best-practices/dataverse-community-norms>`_ are not a substitute for the CC0 waiver or custom terms and licenses applicable to each dataset. The Community Norms are not a binding contractual agreement, and downloading datasets from a Dataverse installation does not create a legal obligation to follow these policies.
 
 Custom Terms of Use for Datasets
 --------------------------------

--- a/scripts/api/data/licenses/licenseCC-BY-NC-ND-4.0.json
+++ b/scripts/api/data/licenses/licenseCC-BY-NC-ND-4.0.json
@@ -1,6 +1,6 @@
 {
   "name": "CC BY-NC-ND 4.0",
-  "uri": "http://creativecommons.org/licenses/b-nc-ndy/4.0",
+  "uri": "http://creativecommons.org/licenses/by-nc-nd/4.0",
   "shortDescription": "Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International License.",
   "iconUrl": "https://licensebuttons.net/l/by-nc-nd/4.0/88x31.png",
   "active": true

--- a/scripts/api/setup-all.sh
+++ b/scripts/api/setup-all.sh
@@ -80,6 +80,11 @@ echo "Set the default facets for Root"
 curl -s -X POST -H "Content-type:application/json" -d "[\"authorName\",\"subject\",\"keywordValue\",\"dateOfDeposit\"]" $SERVER/dataverses/:root/facets/?key=$adminKey
 echo
 
+echo "Set up licenses"
+# Note: CC0 has been added and set as the default license through
+# Flyway script V5.9.0.1__7440-configurable-license-list.sql
+curl -X POST -H 'Content-Type: application/json' -H "X-Dataverse-key:$adminKey" $SERVER/licenses --upload-file data/licenses/licenseCC-BY-4.0.json
+
 # OPTIONAL USERS AND DATAVERSES
 #./setup-optional.sh
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Pull request #7920 added multiple license support but we could take it a bit farther by providing new installations additional licenses beyond CC0 and by providing more documentation on how to manage licenses and add popular licenses such as the ones from Creative Commons.

To this end:

- CC BY is now available for new installations.
- New "Configuring Licenses" section added to Installation Guide.
  - JSON files for all Creative Commons licenses are downloadable.
- URL fixed in licenseCC-BY-NC-ND-4.0.json.
- Various cleanup of typos, formatting, etc.

**Which issue(s) this PR closes**:

Closes #8347

**Special notes for your reviewer**:

I tried to take a relatively light touch on existing docs. I used the new "Configuring Licenses" section as a way to weave them together. However, I was tempted to change the following:

- Move the docs on `/api/licenses` from "Admin" to their own section ("Licenses"). They really aren't part of the Admin API. Let me know and I'll include this change.

Also, I used "CC0 1.0" instead of "CC0" in anticipation of pull request #8413 being merged.

**Suggestions on how to test this**:

Check to make sure of the following:

- CC BY is now available for new installations.
- URL fixed in licenseCC-BY-NC-ND-4.0.json.
- Docs look and make sense.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No.

**Is there a release notes update needed for this change?**:

No. I think we have enough release notes docs for multiple licenses. We can tweak them as needed at release time. The CC BY addition is only for new installations, not upgrades.

**Additional documentation**:

None.