### PR TITLE
IQSS/#8430 - errors with missing i18n files

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/util/BundleUtil.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/BundleUtil.java
@@ -93,14 +93,15 @@ public class BundleUtil {
         }
 
         if (filesRootDirectory == null || filesRootDirectory.isEmpty()) {
-            bundle = ResourceBundle.getBundle("propertyFiles/" +propertyFileName, currentLocale);
+            bundle = ResourceBundle.getBundle("propertyFiles/" + propertyFileName, currentLocale);
         } else {
             try {
-            ClassLoader loader = getClassLoader(filesRootDirectory);
-            bundle = ResourceBundle.getBundle(propertyFileName, currentLocale, loader);
+                ClassLoader loader = getClassLoader(filesRootDirectory);
+                bundle = ResourceBundle.getBundle(propertyFileName, currentLocale, loader);
             } catch (MissingResourceException mre) {
-                logger.warning("No property file named " + propertyFileName+"_" + currentLocale.getLanguage() + " found in " + filesRootDirectory +", using untranslated values");
-                bundle = ResourceBundle.getBundle("propertyFiles/" +propertyFileName, currentLocale);
+                logger.warning("No property file named " + propertyFileName + "_" + currentLocale.getLanguage()
+                        + " found in " + filesRootDirectory + ", using untranslated values");
+                bundle = ResourceBundle.getBundle("propertyFiles/" + propertyFileName, currentLocale);
             }
         }
 

--- a/src/main/java/edu/harvard/iq/dataverse/util/BundleUtil.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/BundleUtil.java
@@ -95,8 +95,13 @@ public class BundleUtil {
         if (filesRootDirectory == null || filesRootDirectory.isEmpty()) {
             bundle = ResourceBundle.getBundle("propertyFiles/" +propertyFileName, currentLocale);
         } else {
+            try {
             ClassLoader loader = getClassLoader(filesRootDirectory);
             bundle = ResourceBundle.getBundle(propertyFileName, currentLocale, loader);
+            } catch (MissingResourceException mre) {
+                logger.warning("No property file named " + propertyFileName+"_" + currentLocale.getLanguage() + " found in " + filesRootDirectory +", using untranslated values");
+                bundle = ResourceBundle.getBundle("propertyFiles/" +propertyFileName, currentLocale);
+            }
         }
 
         return bundle ;


### PR DESCRIPTION
**What this PR does / why we need it**:  If the language dir (-Ddataverse.lang.directory) is set and not yet populated with the files for the default language, Dataverse will fail to deploy/start. Since default values do exist, that seems like bad behavior (i.e. versus warning about the missing file(s) in the log). Further, since the API to add language bundles requires that the language dir is set (to know where to drop the files), it's a bit of a catch-22 (as found in dataverse-ansible work.) This PR just adds a try/catch block around the attempts to read language-specific files so that Dataverse will launch and presumably the API can then be used to add bundles (have not tried the latter, but did confirm Dataverse can start).

**Which issue(s) this PR closes**:

Closes #8430

**Special notes for your reviewer**:

**Suggestions on how to test this**: Set the dataverse.lang.directory jvm option to point to an empty dir and confirm that Dataverse can launch (and won't with the prior code). Could also try running the add language bundle API call to confirm that it will work and populate the empty dir you set up.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: no

**Is there a release notes update needed for this change?**:

**Additional documentation**:
