### PR TITLE
IQSS/8422 default to allow dataset level choice of metadatalanguage

### DIFF
--- a/doc/sphinx-guides/source/installation/config.rst
+++ b/doc/sphinx-guides/source/installation/config.rst
@@ -241,7 +241,7 @@ As for the "Remote only" authentication mode, it means that:
 - The "builtin" authentication provider has been disabled (:ref:`api-toggle-auth-provider`). Note that disabling the "builtin" authentication provider means that the API endpoint for converting an account from a remote auth provider will not work. Converting directly from one remote authentication provider to another (i.e. from GitHub to Google) is not supported. Conversion from remote is always to "builtin". Then the user initiates a conversion from "builtin" to remote. Note that longer term, the plan is to permit multiple login options to the same Dataverse installation account per https://github.com/IQSS/dataverse/issues/3487 (so all this talk of conversion will be moot) but for now users can only use a single login option, as explained in the :doc:`/user/account` section of the User Guide. In short, "remote only" might work for you if you only plan to use a single remote authentication provider such that no conversion between remote authentication providers will be necessary.
 
 File Storage: Using a Local Filesystem and/or Swift and/or object stores
----------------------------------------------------------------------------
+------------------------------------------------------------------------
 
 By default, a Dataverse installation stores all data files (files uploaded by end users) on the filesystem at ``/usr/local/payara5/glassfish/domains/domain1/files``. This path can vary based on answers you gave to the installer (see the :ref:`dataverse-installer` section of the Installation Guide) or afterward by reconfiguring the ``dataverse.files.\<id\>.directory`` JVM option described below.
 
@@ -731,7 +731,8 @@ Allowing the Language Used for Dataset Metadata to be Specified
 
 Since dataset metadata can only be entered in one language, and administrators may wish to limit which languages metadata can be entered in, Dataverse also offers a separate setting defining allowed metadata languages.
 The presence of the :ref:`:MetadataLanguages` database setting identifies the available options (which can be different from those in the :Languages setting above, with fewer or more options).
-Dataverse collection admins can select from these options to indicate which language should be used for new Datasets created with that specific collection.
+
+Dataverse collection admins can select from these options to indicate which language should be used for new Datasets created with that specific collection. If they do not, users will be asked when creating a dataset to select the language they want to use when entering metadata. 
 
 When creating or editing a dataset, users will be asked to enter the metadata in that language. The metadata language selected will also be shown when dataset metadata is viewed and will be included in metadata exports (as appropriate for each format) for published datasets:
 

--- a/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
@@ -5618,11 +5618,15 @@ public class DatasetPage implements java.io.Serializable {
     
     public String getLocaleDisplayName(String code) {
         String displayName = settingsWrapper.getBaseMetadataLanguageMap(false).get(code);
-        if(displayName==null) {
+        if(displayName==null && !code.equals(DvObjectContainer.UNDEFINED_METADATA_LANGUAGE_CODE)) {
             //Default (for cases such as :when a Dataset has a metadatalanguage code but :MetadataLanguages is no longer defined).
             displayName = new Locale(code).getDisplayName(); 
         }
         return displayName; 
+    }
+    
+    public Set<Entry<String, String>> getMetadataLanguages() {
+        return settingsWrapper.getBaseMetadataLanguageMap(false).entrySet();
     }
     
     public List<String> getVocabScripts() {

--- a/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
@@ -5609,7 +5609,10 @@ public class DatasetPage implements java.io.Serializable {
     }
     
     public String getEffectiveMetadataLanguage() {
-        String mdLang = dataset.getEffectiveMetadataLanguage();
+        return getEffectiveMetadataLanguage(false);
+    }
+    public String getEffectiveMetadataLanguage(boolean ofParent) {
+        String mdLang = ofParent ? dataset.getOwner().getEffectiveMetadataLanguage() : dataset.getEffectiveMetadataLanguage();
         if (mdLang.equals(DvObjectContainer.UNDEFINED_METADATA_LANGUAGE_CODE)) {
             mdLang = settingsWrapper.getDefaultMetadataLanguage();
         }

--- a/src/main/java/edu/harvard/iq/dataverse/DvObjectContainer.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DvObjectContainer.java
@@ -16,8 +16,6 @@ public abstract class DvObjectContainer extends DvObject {
 	
     
     //Default to "file" is for tests only
-    public static final String DEFAULT_METADATA_LANGUAGE = Locale.getDefault().getDisplayLanguage();
-    public static final String DEFAULT_METADATA_LANGUAGE_CODE = Locale.getDefault().getLanguage();
     public static final String UNDEFINED_METADATA_LANGUAGE_CODE = "undefined"; //Used in dataverse.xhtml as a non-null selection option value (indicating inheriting the default)
     
     

--- a/src/main/java/edu/harvard/iq/dataverse/SettingsWrapper.java
+++ b/src/main/java/edu/harvard/iq/dataverse/SettingsWrapper.java
@@ -488,7 +488,7 @@ public class SettingsWrapper implements java.io.Serializable {
 
     Map<String,String> languageMap = null;
     
-    Map<String, String> getBaseMetadataLanguageMap(boolean refresh) {
+    public Map<String, String> getBaseMetadataLanguageMap(boolean refresh) {
         if (languageMap == null || refresh) {
             languageMap = new HashMap<String, String>();
 
@@ -518,18 +518,13 @@ public class SettingsWrapper implements java.io.Serializable {
     }
     
     private String getDefaultMetadataLanguageLabel(DvObjectContainer target) {
-        String mlLabel = Locale.getDefault().getDisplayLanguage();
-        Dataverse parent = target.getOwner();
-        if (parent != null) {
-            String mlCode = parent.getEffectiveMetadataLanguage();
-            // If it's 'undefined', it's the global default
-            if (mlCode.equals(DvObjectContainer.UNDEFINED_METADATA_LANGUAGE_CODE)) {
-                mlLabel = BundleUtil.getStringFromBundle("dataverse.metadatalanguage.setatdatasetcreation");
-            } else {
-                // Get the label for the language code found
-                mlLabel = getBaseMetadataLanguageMap(false).get(mlCode);
-                mlLabel = mlLabel + " " + BundleUtil.getStringFromBundle("dataverse.inherited");
-            }
+        String mlLabel = BundleUtil.getStringFromBundle("dataverse.metadatalanguage.setatdatasetcreation");
+        String mlCode = target.getEffectiveMetadataLanguage();
+        // If it's 'undefined', it's the global default
+        if (!mlCode.equals(DvObjectContainer.UNDEFINED_METADATA_LANGUAGE_CODE)) {
+            // Get the label for the language code found
+            mlLabel = getBaseMetadataLanguageMap(false).get(mlCode);
+            mlLabel = mlLabel + " " + BundleUtil.getStringFromBundle("dataverse.inherited");
         }
         return mlLabel;
     }

--- a/src/main/java/edu/harvard/iq/dataverse/SettingsWrapper.java
+++ b/src/main/java/edu/harvard/iq/dataverse/SettingsWrapper.java
@@ -520,24 +520,16 @@ public class SettingsWrapper implements java.io.Serializable {
     private String getDefaultMetadataLanguageLabel(DvObjectContainer target) {
         String mlLabel = Locale.getDefault().getDisplayLanguage();
         Dataverse parent = target.getOwner();
-        boolean fromAncestor=false;
         if (parent != null) {
-            fromAncestor=true;
             String mlCode = parent.getEffectiveMetadataLanguage();
             // If it's 'undefined', it's the global default
             if (mlCode.equals(DvObjectContainer.UNDEFINED_METADATA_LANGUAGE_CODE)) {
-                //so it's not from an ancestor
-                fromAncestor=false;
-                //and we need to lookup the global default
-                mlCode = getDefaultMetadataLanguage();
+                mlLabel = BundleUtil.getStringFromBundle("dataverse.metadatalanguage.setatdatasetcreation");
+            } else {
+                // Get the label for the language code found
+                mlLabel = getBaseMetadataLanguageMap(false).get(mlCode);
+                mlLabel = mlLabel + " " + BundleUtil.getStringFromBundle("dataverse.inherited");
             }
-            // Get the label for the language code found
-            mlLabel = getBaseMetadataLanguageMap(false).get(mlCode);
-        }
-        if(fromAncestor) {
-            mlLabel = mlLabel + " " + BundleUtil.getStringFromBundle("dataverse.inherited");
-        } else {
-            mlLabel = mlLabel + " " + BundleUtil.getStringFromBundle("dataverse.default");
         }
         return mlLabel;
     }
@@ -549,8 +541,8 @@ public class SettingsWrapper implements java.io.Serializable {
                 //One entry - it's the default
             return (String) mdMap.keySet().toArray()[0];
             } else {
-                //More than one - :MetadataLanguages is set so we use the default
-                return DvObjectContainer.DEFAULT_METADATA_LANGUAGE_CODE;
+                //More than one - :MetadataLanguages is set and the default is undefined (users must choose if the collection doesn't override the default)
+                return DvObjectContainer.UNDEFINED_METADATA_LANGUAGE_CODE;
             }
         } else {
             // None - :MetadataLanguages is not set so return null to turn off the display (backward compatibility)

--- a/src/main/java/propertyFiles/Bundle.properties
+++ b/src/main/java/propertyFiles/Bundle.properties
@@ -1168,6 +1168,7 @@ dataset.anonymized.withheld=withheld
 
 dataset.metadatalanguage.create.guidance=Please enter metadata in the <b>{0}</b> language, or change the metadata language choice in the parent dataverse before proceeding.
 dataset.metadatalanguage.view.guidance=This dataset has been configured to use <b>{0}</b> as the language for all metadata entries.
+dataset.metadatalanguage.title=Metadata entered for this dataset will be assumed to be in the selected language. Cannot be changed after dataset is created.
 
 # template.xhtml
 dataset.template.name.tip=The name of the dataset template.

--- a/src/main/java/propertyFiles/Bundle.properties
+++ b/src/main/java/propertyFiles/Bundle.properties
@@ -856,6 +856,7 @@ dataverse.datasize=Total size of the files stored in this dataverse: {0} bytes
 dataverse.datasize.ioerror=Fatal IO error while trying to determine the total size of the files stored in the dataverse. Please report this error to the Dataverse administrator.
 dataverse.inherited=(inherited from enclosing Dataverse)
 dataverse.default=(Default)
+dataverse.metadatalanguage.setatdatasetcreation=Chosen at Dataset Creation
 # rolesAndPermissionsFragment.xhtml
 
 # advanced.xhtml

--- a/src/main/java/propertyFiles/Bundle.properties
+++ b/src/main/java/propertyFiles/Bundle.properties
@@ -1169,6 +1169,7 @@ dataset.anonymized.withheld=withheld
 dataset.metadatalanguage.create.guidance=Please enter metadata in the <b>{0}</b> language, or change the metadata language choice in the parent dataverse before proceeding.
 dataset.metadatalanguage.view.guidance=This dataset has been configured to use <b>{0}</b> as the language for all metadata entries.
 dataset.metadatalanguage.title=Metadata entered for this dataset will be assumed to be in the selected language. Cannot be changed after dataset is created.
+dataset.metadatalanguage.tip=Select the language you wish to use when entering metadata.
 
 # template.xhtml
 dataset.template.name.tip=The name of the dataset template.

--- a/src/main/webapp/dataset.xhtml
+++ b/src/main/webapp/dataset.xhtml
@@ -730,9 +730,7 @@
                                 </p:commandButton>
                             </div>
                         </div>
-                        <div class="form-group">
-                            <span class="glyphicon glyphicon-asterisk text-danger"/> <h:outputText value="#{bundle['dataset.asterisk.tip']}"/>
-                        </div>
+
                     </ui:fragment>
                     <ui:fragment rendered="#{DatasetPage.editMode == 'CREATE'}">
                         <ui:include src="metadataFragment.xhtml">
@@ -741,8 +739,8 @@
                             <ui:param name="metadataBlocks" value="#{!empty DatasetPage.editMode ? DatasetPage.datasetVersionUI.metadataBlocksForEdit.entrySet().toArray(): DatasetPage.datasetVersionUI.metadataBlocksForView.entrySet().toArray()}"/>
                             <!-- ui:param name="publicationDate" value="#{DatasetPage.dataset.publicationDateFormattedYYYYMMDD}"/-->
                             <ui:param name="globalId" value="#{DatasetPage.dataset.globalIdString}"/>
-                            <ui:param name="mdLang" value="#{DatasetPage.getLocaleDisplayName(DatasetPage.effectiveMetadataLanguage)}"/>
-                            <ui:param name="mdLangCode" value="#{DatasetPage.effectiveMetadataLanguage}"/>
+                            <ui:param name="mdLang" value="#{DatasetPage.getLocaleDisplayName(DatasetPage.getEffectiveMetadataLanguage(true))}"/>
+                            <ui:param name="mdLangCode" value="#{DatasetPage.getEffectiveMetadataLanguage(true)}"/>
                         </ui:include>
                     </ui:fragment>
                     <!-- Create/Save Dataset Button Panel TOP editMode -->

--- a/src/main/webapp/metadataFragment.xhtml
+++ b/src/main/webapp/metadataFragment.xhtml
@@ -18,9 +18,33 @@
     <div class="panel-group" jsf:rendered="${empty editMode  or managePage}">
         <o:importFunctions type="edu.harvard.iq.dataverse.util.MarkupChecker" />
         <p>
-            <h:outputFormat rendered="#{!(empty mdLang)}" value="#{bundle['dataset.metadatalanguage.view.guidance']}" escape="false">
+            <h:outputFormat rendered="#{!(empty mdLang and mdlangCode!='undefined')}" value="#{bundle['dataset.metadatalanguage.view.guidance']}" escape="false">
                 <f:param value="#{mdLang}"/>
             </h:outputFormat>
+            
+            
+                                                <div class="col-md-6 form-group" jsf:rendered="##{!(empty mdLang and mdlangCode=='undefined')}">
+                                        <h:outputLabel for="dsMetadataLanguage" styleClass="control-label">
+                                            #{bundle.metadataLanguage} 
+                                            <span class="glyphicon glyphicon-question-sign tooltip-icon"
+                                                  data-toggle="tooltip" data-placement="auto right" data-original-title="#{bundle['dataverse.metadatalanguage.title']}"></span>
+                                        </h:outputLabel>
+                                        <div class="form-col-container">
+                                            <h:selectOneMenu id="dsMetadataLanguage" styleClass="form-control" value="#{DatasetPage.dataset.metadataLanguage}">
+                                                <f:selectItems value="#{DatasetPage.getMetadataLanguages()}" var="lang" itemLabel="#{lang.getValue()}" itemValue="#{lang.getKey()}"/>
+                                            </h:selectOneMenu>
+                                            <p:message for="dsMetadataLanguage" display="text"/>
+                                        </div>
+                                    </div>
+            
+            
+            
+            
+            
+            
+            
+            
+            
         </p>
         <ui:repeat value="#{metadataBlocks}"
                    var="metadataBlockVal" varStatus="block">

--- a/src/main/webapp/metadataFragment.xhtml
+++ b/src/main/webapp/metadataFragment.xhtml
@@ -21,30 +21,6 @@
             <h:outputFormat rendered="#{!(empty mdLang and mdlangCode!='undefined')}" value="#{bundle['dataset.metadatalanguage.view.guidance']}" escape="false">
                 <f:param value="#{mdLang}"/>
             </h:outputFormat>
-            
-            
-                                                <div class="col-md-6 form-group" jsf:rendered="##{!(empty mdLang and mdlangCode=='undefined')}">
-                                        <h:outputLabel for="dsMetadataLanguage" styleClass="control-label">
-                                            #{bundle.metadataLanguage} 
-                                            <span class="glyphicon glyphicon-question-sign tooltip-icon"
-                                                  data-toggle="tooltip" data-placement="auto right" data-original-title="#{bundle['dataverse.metadatalanguage.title']}"></span>
-                                        </h:outputLabel>
-                                        <div class="form-col-container">
-                                            <h:selectOneMenu id="dsMetadataLanguage" styleClass="form-control" value="#{DatasetPage.dataset.metadataLanguage}">
-                                                <f:selectItems value="#{DatasetPage.getMetadataLanguages()}" var="lang" itemLabel="#{lang.getValue()}" itemValue="#{lang.getKey()}"/>
-                                            </h:selectOneMenu>
-                                            <p:message for="dsMetadataLanguage" display="text"/>
-                                        </div>
-                                    </div>
-            
-            
-            
-            
-            
-            
-            
-            
-            
         </p>
         <ui:repeat value="#{metadataBlocks}"
                    var="metadataBlockVal" varStatus="block">
@@ -181,9 +157,22 @@
         <o:importFunctions type="java.util.Collections" />
         <div class="panel-group">
             <p>
-                <h:outputFormat rendered="#{(not empty mdLangCode) and ((editMode == 'CREATE') or (editMode == 'METADATA'))}" value="#{bundle['dataset.metadatalanguage.create.guidance']}" escape="false">
+                <h:outputFormat rendered="#{(mdLangCode!='undefined') and ((editMode == 'CREATE') or (editMode == 'METADATA'))}" value="#{bundle['dataset.metadatalanguage.create.guidance']}" escape="false">
                     <f:param value="#{mdLang}"/>
                 </h:outputFormat>
+                <div class="form-group" jsf:rendered="#{(empty mdLang and mdLangCode=='undefined')}">
+                                        <h:outputLabel for="dsMetadataLanguage" styleClass="col-md-3 control-label">
+                                            #{bundle.metadataLanguage}
+                                            <span class="glyphicon glyphicon-question-sign tooltip-icon"
+                                                  data-toggle="tooltip" data-placement="auto right" data-original-title="#{bundle['dataset.metadatalanguage.title']}"></span>
+                                        </h:outputLabel>
+                                        <div class="col-md-3 form-col-container">
+                                            <h:selectOneMenu id="dsMetadataLanguage" styleClass="form-control" value="#{DatasetPage.dataset.metadataLanguage}">
+                                                <f:selectItems value="#{DatasetPage.getMetadataLanguages()}" var="lang" itemLabel="#{lang.getValue()}" itemValue="#{lang.getKey()}"/>
+                                            </h:selectOneMenu>
+                                            <p:message for="dsMetadataLanguage" display="text"/>
+                                        </div>
+                                    </div>
             </p>
             <ui:repeat value="#{metadataBlocks}" var="metadataBlockVal" varStatus="block">
                 <div class="panel panel-default" jsf:rendered="#{(editMode == 'METADATA' or metadataBlockVal.key.displayOnCreate or !metadataBlockVal.key.isEmpty()

--- a/src/main/webapp/metadataFragment.xhtml
+++ b/src/main/webapp/metadataFragment.xhtml
@@ -156,25 +156,40 @@
         <p:fragment id="editMetadataFragement">
         <o:importFunctions type="java.util.Collections" />
         <div class="panel-group">
-            <p>
-                <h:outputFormat rendered="#{(mdLangCode!='undefined') and ((editMode == 'CREATE') or (editMode == 'METADATA'))}" value="#{bundle['dataset.metadatalanguage.create.guidance']}" escape="false">
-                    <f:param value="#{mdLang}"/>
-                </h:outputFormat>
-                <div class="form-group" jsf:rendered="#{(empty mdLang and mdLangCode=='undefined')}">
-                                        <h:outputLabel for="dsMetadataLanguage" styleClass="col-md-3 control-label">
+                <p>
+                    <h:outputFormat
+                        rendered="#{(mdLangCode!='undefined') and ((editMode == 'CREATE') or (editMode == 'METADATA'))}"
+                        value="#{bundle['dataset.metadatalanguage.create.guidance']}"
+                        escape="false">
+                        <f:param value="#{mdLang}" />
+                    </h:outputFormat>
+                </p>
+                <div class="form-group"
+                    jsf:rendered="#{(empty mdLang and mdLangCode=='undefined')}">
+                    <h:outputLabel for="dsMetadataLanguage"
+                        styleClass="col-md-3 control-label">
                                             #{bundle.metadataLanguage}
-                                            <span class="glyphicon glyphicon-question-sign tooltip-icon"
-                                                  data-toggle="tooltip" data-placement="auto right" data-original-title="#{bundle['dataset.metadatalanguage.title']}"></span>
-                                        </h:outputLabel>
-                                        <div class="col-md-3 form-col-container">
-                                            <h:selectOneMenu id="dsMetadataLanguage" styleClass="form-control" value="#{DatasetPage.dataset.metadataLanguage}">
-                                                <f:selectItems value="#{DatasetPage.getMetadataLanguages()}" var="lang" itemLabel="#{lang.getValue()}" itemValue="#{lang.getKey()}"/>
-                                            </h:selectOneMenu>
-                                            <p:message for="dsMetadataLanguage" display="text"/>
-                                        </div>
-                                    </div>
-            </p>
-            <ui:repeat value="#{metadataBlocks}" var="metadataBlockVal" varStatus="block">
+                                            <span
+                            class="glyphicon glyphicon-question-sign tooltip-icon"
+                            data-toggle="tooltip" data-placement="auto right"
+                            data-original-title="#{bundle['dataset.metadatalanguage.title']}"></span>
+                    </h:outputLabel>
+                    <div class="col-md-7 form-col-container">
+                        <p class="help-block">
+                            #{bundle['dataset.metadatalanguage.tip']}</p>
+                        <p:selectOneMenu id="dsMetadataLanguage" styleClass="form-control"
+                            value="#{DatasetPage.dataset.metadataLanguage}">
+                            <f:selectItems value="#{DatasetPage.getMetadataLanguages()}"
+                                var="lang" itemLabel="#{lang.getValue()}"
+                                itemValue="#{lang.getKey()}" />
+                        </p:selectOneMenu>
+                        <p:message for="dsMetadataLanguage" display="text" />
+                    </div>
+                </div>
+                <div class="form-group">
+                    <span class="glyphicon glyphicon-asterisk text-danger"/> <h:outputText value="#{bundle['dataset.asterisk.tip']}"/>
+                </div>
+                <ui:repeat value="#{metadataBlocks}" var="metadataBlockVal" varStatus="block">
                 <div class="panel panel-default" jsf:rendered="#{(editMode == 'METADATA' or metadataBlockVal.key.displayOnCreate or !metadataBlockVal.key.isEmpty()
                                                                  or metadataBlockVal.key.isHasRequired())
                                                                  or (!datasetPage)}">


### PR DESCRIPTION
**What this PR does / why we need it**: Per the issue, the recent enhancement to add a choice of metadata language restricted that choice to collections and, if no collection-level choice was made, the global default option (the machine locale/language) was chosen. This PR changes the default behavior such that, if the metadatalanguage isn't chosen in an ancestor collection, the user is allowed/forced (because there is no 'none' option) to chose a language at dataset creation. (This is only if the metadata language setting is configured in the first place.) Thus, this allows a use case where a collection/repository manager can let users decide which language to use and have collections that include datasets using different metadata languages.

**Which issue(s) this PR closes**:

Closes #8422

**Special notes for your reviewer**:

**Suggestions on how to test this**: Configure metadatalanguages, verify that the dataverse/edit/general entry for metadata language includes the new value 'Chosen at Dataset Creation' and that choosing that on the root or child dataverse triggers a change in the dataset creation page to allow a user to chose the metadata language (versus showing the predefined choice from the collection level) -see image below.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
The change in the dataset page, only if metadatalanguage is enabled and only in collections where a choice hasn't been made is for the metadata language to be a live input:
![image](https://user-images.githubusercontent.com/6731983/154767341-9dba8fc1-a33a-4284-98c8-ee9045104428.png)


**Is there a release notes update needed for this change?**:

**Additional documentation**: Change in default behavior note in the config docs
