### PR TITLE
Validate URLs before saving as metadata

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DatasetFieldValueValidator.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetFieldValueValidator.java
@@ -19,6 +19,7 @@ import java.util.regex.Pattern;
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.validator.routines.UrlValidator;
 
 /**
  *
@@ -168,7 +169,20 @@ public class DatasetFieldValueValidator implements ConstraintValidator<ValidateD
 
         if (fieldType.equals(FieldType.URL) && !lengthOnly) {
             try {
-                URL url = new URL(value.getValue());
+                
+                String[] schemes = {"http","https"};
+                UrlValidator urlValidator = new UrlValidator(schemes);
+                
+                String urlString = value.getValue();
+                URL url = new URL(urlString);
+                
+                if (urlValidator.isValid(urlString)) {
+                    return true;
+                } else {
+                    context.buildConstraintViolationWithTemplate(dsfType.getDisplayName() + " " + value.getValue() + "  is not a valid URL.").addConstraintViolation();
+                    return false;
+                }
+                
             } catch (MalformedURLException e) {
                 try {
                     context.buildConstraintViolationWithTemplate(dsfType.getDisplayName() + " " + value.getValue() + "  is not a valid URL.").addConstraintViolation();

--- a/src/main/java/edu/harvard/iq/dataverse/DatasetFieldValueValidator.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetFieldValueValidator.java
@@ -168,30 +168,17 @@ public class DatasetFieldValueValidator implements ConstraintValidator<ValidateD
         // Note, length validation for FieldType.TEXT was removed to accommodate migrated data that is greater than 255 chars.
 
         if (fieldType.equals(FieldType.URL) && !lengthOnly) {
-            try {
-                
-                String[] schemes = {"http","https"};
-                UrlValidator urlValidator = new UrlValidator(schemes);
-                
-                String urlString = value.getValue();
-                URL url = new URL(urlString);
-                
-                if (urlValidator.isValid(urlString)) {
-                    return true;
-                } else {
-                    context.buildConstraintViolationWithTemplate(dsfType.getDisplayName() + " " + value.getValue() + "  is not a valid URL.").addConstraintViolation();
-                    return false;
-                }
-                
-            } catch (MalformedURLException e) {
-                try {
-                    context.buildConstraintViolationWithTemplate(dsfType.getDisplayName() + " " + value.getValue() + "  is not a valid URL.").addConstraintViolation();
-                } catch (NullPointerException npe) {
+            
+            String[] schemes = {"http","https", "ftp"};
+            UrlValidator urlValidator = new UrlValidator(schemes);
 
-                }
-
+            if (urlValidator.isValid(value.getValue())) {
+                return true;
+            } else {
+                context.buildConstraintViolationWithTemplate(dsfType.getDisplayName() + " " + value.getValue() + "  is not a valid URL.").addConstraintViolation();
                 return false;
             }
+            
         }
 
         if (fieldType.equals(FieldType.EMAIL) && !lengthOnly) {

--- a/src/main/java/edu/harvard/iq/dataverse/DatasetFieldValueValidator.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetFieldValueValidator.java
@@ -171,11 +171,14 @@ public class DatasetFieldValueValidator implements ConstraintValidator<ValidateD
             
             String[] schemes = {"http","https", "ftp"};
             UrlValidator urlValidator = new UrlValidator(schemes);
-
-            if (urlValidator.isValid(value.getValue())) {
-                return true;
-            } else {
-                context.buildConstraintViolationWithTemplate(dsfType.getDisplayName() + " " + value.getValue() + "  is not a valid URL.").addConstraintViolation();
+            
+            try {
+                if (urlValidator.isValid(value.getValue())) {
+                } else {
+                    context.buildConstraintViolationWithTemplate(dsfType.getDisplayName() + " " + value.getValue() + "  is not a valid URL.").addConstraintViolation();
+                    return false;
+                }
+            } catch (NullPointerException npe) {
                 return false;
             }
             

--- a/src/main/java/edu/harvard/iq/dataverse/DatasetFieldValueValidator.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetFieldValueValidator.java
@@ -6,15 +6,12 @@
 package edu.harvard.iq.dataverse;
 
 import edu.harvard.iq.dataverse.DatasetFieldType.FieldType;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.logging.Logger;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;

--- a/src/main/java/edu/harvard/iq/dataverse/URLValidator.java
+++ b/src/main/java/edu/harvard/iq/dataverse/URLValidator.java
@@ -1,10 +1,8 @@
 package edu.harvard.iq.dataverse;
-
 import edu.harvard.iq.dataverse.util.BundleUtil;
-import java.net.MalformedURLException;
-import java.net.URL;
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
+import org.apache.commons.validator.routines.UrlValidator;
 
 /**
  *
@@ -31,12 +29,22 @@ public class URLValidator implements ConstraintValidator<ValidateURL, String> {
         if (value == null || value.isEmpty()) {
             return true;
         }
+        
+        String[] schemes = {"http","https", "ftp"};
+        UrlValidator urlValidator = new UrlValidator(schemes);
+            
         try {
-            URL url = new URL(value);
-        } catch (MalformedURLException e) {
+            if (urlValidator.isValid(value)) {
+            } else {
+                return false;
+            }
+        } catch (NullPointerException npe) {
             return false;
         }
+        
         return true;
+        
     }
+
 
 }

--- a/src/test/java/edu/harvard/iq/dataverse/DatasetFieldValueValidatorTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/DatasetFieldValueValidatorTest.java
@@ -127,15 +127,30 @@ public class DatasetFieldValueValidatorTest {
         
         //URL
         dft.setFieldType(DatasetFieldType.FieldType.URL); 
-        value.setValue("http://cnn.com");
+        value.setValue("https://www.google.com");
         result = instance.isValid(value, ctx);
         assertEquals(true, result);
+
+        value.setValue("http://google.com");
+        result = instance.isValid(value, ctx);
+        assertEquals(true, result);
+
+        value.setValue("https://do-not-exist-123-123.com/"); // does not exist
+        result = instance.isValid(value, ctx);
+        assertEquals(true, result);   
         
+        value.setValue("ftp://somesite.com");
+        result = instance.isValid(value, ctx);
+        assertEquals(true, result);   
         
-        value.setValue("espn.com");
+        value.setValue("google.com");
         result = instance.isValid(value, ctx);
         assertEquals(false, result);
         
+        value.setValue("git@github.com:IQSS/dataverse.git");
+        result = instance.isValid(value, ctx);
+        assertEquals(false, result);
+
     }
 
     @Test


### PR DESCRIPTION
**What this PR does / why we need it**:
Validate URLs before saving as metadata.

**Which issue(s) this PR closes**:
NA

**Special notes for your reviewer**:
None

**Suggestions on how to test this**:
Add `http://google.com test` to Alternative URL when editing metadata. It should not work.
Only https://, http:// and ftp:// allowed.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
No

**Is there a release notes update needed for this change?**:
No

**Additional documentation**:
None