### PR TITLE
fix 404 to Renku docs

### DIFF
--- a/doc/sphinx-guides/source/admin/integrations.rst
+++ b/doc/sphinx-guides/source/admin/integrations.rst
@@ -57,7 +57,7 @@ their research results and retain links to imported and exported data. Users
 can organize their data in "Datasets", which can be exported to a Dataverse installation via
 the command-line interface (CLI).
 
-Renku dataset documentation: https://renku-python.readthedocs.io/en/latest/commands.html#module-renku.cli.dataset
+Renku dataset documentation: https://renku-python.readthedocs.io/en/latest/reference/commands.html#module-renku.cli.dataset
 
 Flagship deployment of the Renku platform: https://renkulab.io
 


### PR DESCRIPTION
https://renku-python.readthedocs.io/en/latest/commands.html#module-renku.cli.dataset is a 404.

This pull request fixes it.