### PR TITLE
Resolved ClassCastException

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/AbstractDatasetCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/AbstractDatasetCommand.java
@@ -100,6 +100,7 @@ public abstract class AbstractDatasetCommand<T> extends AbstractCommand<T> {
             if (lenient) {
                 // populate invalid fields with N/A
                 constraintViolations.stream()
+                    .filter(cv -> cv.getRootBean() instanceof DatasetField)
                     .map(cv -> ((DatasetField) cv.getRootBean()))
                     .forEach(f -> f.setSingleValue(DatasetField.NA_VALUE));
 


### PR DESCRIPTION
**What this PR does / why we need it**:  A `ClassCastException` was thrown when casting the root bean of a constraint violation to `DatasetField` in cases where the root bean was actually a `FileMetadata` object. This happened in the logical that sets `N/A` as the field value if there are constraint violations for that field. Obviously that logic doesn't make sense for files, so the solution is to only execute it if the root bean of the contraint is an instance of  `DatasetField`.

The `ClassCastException` obscured the problem. The server returned `Failed to add file to dataset.` but no explanation. 

**Which issue(s) this PR closes**: See previous item

Closes N/A

**Special notes for your reviewer**: N/A

**Suggestions on how to test this**: Try to create a file with invalid characters in its name of directoryLabel. This will trigger a constraint violation that has a `FileMetadata` as root bean, which should now be filtered out of above mentioned logic.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: no

**Is there a release notes update needed for this change?**: no

**Additional documentation**: N/A
