### PR TITLE
Iqss/8321 accessibility

### DIFF
--- a/src/main/java/propertyFiles/Bundle.properties
+++ b/src/main/java/propertyFiles/Bundle.properties
@@ -1437,6 +1437,7 @@ dataset.compute.computeBatchList=List Batch
 dataset.compute.computeBatchAdd=Add to Batch
 dataset.compute.computeBatchClear=Clear Batch
 dataset.compute.computeBatchRemove=Remove from Batch
+dataset.compute.computeBatchChange=Change Compute Batch
 dataset.compute.computeBatchCompute=Compute Batch
 dataset.compute.computeBatch.success=The list of datasets in your compute batch has been updated.
 dataset.compute.computeBatch.failure=The list of datasets in your compute batch failed to be updated. Please try again.

--- a/src/main/webapp/dataset.xhtml
+++ b/src/main/webapp/dataset.xhtml
@@ -1450,17 +1450,6 @@
                         </div>
                     </p:dialog>
                     <!-- END: Request Access Sign Up/Log In Button -->
-                    <p:dialog id="mapDataDialog" header="#{bundle['file.mapData.unpublished.header']}" widgetVar="mapDataDialog" modal="true">
-                        <p class="help-block">
-                            <span class="text-danger"><span class="glyphicon glyphicon-exclamation-sign"/> #{bundle['file.mapData.unpublished.message']}</span>
-                        </p>
-                        <div class="button-block">
-                            <button type="button" class="btn btn-default" onclick="PF('mapDataDialog').hide();
-                                    PF('blockDatasetForm').hide();">
-                                #{bundle.close}
-                            </button>
-                        </div>
-                    </p:dialog>
                     <p:dialog id="downloadPopup" styleClass="largePopUp" header="#{bundle['file.downloadDialog.header']}" widgetVar="downloadPopup" modal="true">
                         <o:importFunctions type="edu.harvard.iq.dataverse.util.MarkupChecker" />
                         <ui:include src="file-download-popup-fragment.xhtml">

--- a/src/main/webapp/dataset.xhtml
+++ b/src/main/webapp/dataset.xhtml
@@ -656,7 +656,7 @@
                     <ui:fragment rendered="#{DatasetPage.editMode == 'METADATA' or DatasetPage.editMode == 'CREATE'}">
                         <p:focus context="datasetForm"/>
                         <div class="form-group">
-                            <label jsf:for="#{DatasetPage.editMode == 'CREATE' ? 'selectHostDataverse' : 'select_HostDataverse_Static'}" class="col-md-3 control-label">
+                            <label jsf:for="#{DatasetPage.editMode == 'CREATE' ? 'selectHostDataverse_input' : 'select_HostDataverse_Static'}" class="col-md-3 control-label">
                                 #{bundle.hostDataverse}
                                 <span class="glyphicon glyphicon-question-sign tooltip-icon"
                                       data-toggle="tooltip" data-placement="auto right" data-original-title="#{bundle['dataverse.host.title']}"></span>

--- a/src/main/webapp/dataset.xhtml
+++ b/src/main/webapp/dataset.xhtml
@@ -1576,6 +1576,7 @@
                                 <h:outputText value="#{computeCartDatasetList.value}"/>
                             </h:column>
                             <h:column>
+                                <f:facet name="header">#{bundle['dataset.compute.computeBatchChange']}</f:facet>
                                 <p:commandButton value="#{bundle['dataset.compute.computeBatchRemove']}" action="#{DatasetPage.removeCartItem(computeCartDatasetList.key, computeCartDatasetList.value)}" update=":datasetForm,:messagePanel"/>
                             </h:column>
                         </h:dataTable>
@@ -1794,7 +1795,7 @@
                             </button>
                         </div>
                     </p:dialog>
-                    <p:dialog id="maynotPublishParent" header="#{bundle['dataset.publish.header']}" widgetVar="maynotPublishParent" modal="true">
+                    <p:dialog id="maynotPublishParent" header="#{bundle['dataset.publish.header']}" widgetVar="maynotPublishParent" modal="true"  rendered="#{DatasetPage.dataset.owner.owner != null}">
                         <p class="text-danger">
                             <span class="glyphicon glyphicon-exclamation-sign"/>
                             <h:outputFormat value="#{bundle['dataset.mayNotPublish.twoGenerations']}" escape="false">

--- a/src/main/webapp/dataset.xhtml
+++ b/src/main/webapp/dataset.xhtml
@@ -1187,7 +1187,6 @@
                             </button>
                         </div>
                     </p:dialog>
-                    <p:inputText id="hiddenReasonInput" style="display:none" widgetVar="hiddenReasonInput"/>
                     <p:dialog id="compareTwo" header="#{bundle['file.viewDiffDialog.header']}" widgetVar="compareTwo" modal="true">
                         <p class="help-block"><span class="glyphicon glyphicon-exclamation-sign text-danger"/> <span class="text-danger">#{bundle['file.viewDiffDialog.dialog.warning']}</span></p>
                         <div class="button-block">
@@ -1899,9 +1898,6 @@
                     }
                     function updateTemplate() {
                         $('button[id$="updateTemplate"]').trigger('click');
-                    }
-                    function updateHiddenReason(textArea) {
-                        $('input[id$="hiddenReasonInput"]').val(textArea.value);
                     }
                     function updateOwnerDataverse() {
                         $('button[id$="updateOwnerDataverse"]').trigger('click');

--- a/src/main/webapp/datasetFieldForEditFragment.xhtml
+++ b/src/main/webapp/datasetFieldForEditFragment.xhtml
@@ -8,10 +8,10 @@
         xmlns:jsf="http://xmlns.jcp.org/jsf">
 
     <ui:remove>
-        <!-- input text start UPDATE: UI:REMOVE applied due to duplicate ID errors, left code as reference incase test scripts complain -->
+        <!-- input text start UPDATE: UI:REMOVE applied due to duplicate ID errors, left code as reference in case test scripts complain -->
         <span id="pre-input-#{dsf.datasetFieldType.name}" class="pre-input-tag"/></ui:remove>
     <ui:fragment rendered="#{cvoc==null}">
-        <p:inputText value="#{dsfv.valueForEdit}" id="inputText" pt:aria-required="#{dsf.required}"  pt:aria-label="#{dsfvIndex!=0 ? bundle['dataset.additionalEntry']:''}"
+        <p:inputText value="#{dsfv.valueForEdit}" id="inputText" pt:aria-required="#{dsf.required}"
                  styleClass="form-control #{dsfv.datasetField.datasetFieldType.name == 'title' and DatasetPage.editMode == 'CREATE'  ? 'datasetfield-title' : ''}"
                  rendered="#{!dsfv.datasetField.datasetFieldType.controlledVocabulary
                              and (dsfv.datasetField.datasetFieldType.fieldType == 'TEXT'
@@ -20,11 +20,14 @@
                              or dsfv.datasetField.datasetFieldType.fieldType == 'URL'
                              or dsfv.datasetField.datasetFieldType.fieldType == 'DATE'
                              or dsfv.datasetField.datasetFieldType.fieldType == 'EMAIL')}">
+            <c:if test="#{dsfvIndex!=0}">
+                <f:passThroughAttribute name="aria-label" value="#{bundle['dataset.additionalEntry']}" />
+            </c:if>
         </p:inputText>
         <p:watermark for="inputText" value="#{dsfv.datasetField.datasetFieldType.localeWatermark}"></p:watermark>
     </ui:fragment>
     <ui:fragment rendered="#{cvoc!=null and cvoc.getString('term-uri-field').equals(dsfv.datasetField.datasetFieldType.name)}">
-        <p:inputText value="#{dsfv.valueForEdit}" id="cvocInputText" pt:aria-required="#{dsf.required}" pt:aria-label="#{dsfvIndex!=0 ? bundle['dataset.additionalEntry']:''}"
+        <p:inputText value="#{dsfv.valueForEdit}" id="cvocInputText" pt:aria-required="#{dsf.required}"
                  styleClass="form-control #{dsfv.datasetField.datasetFieldType.name == 'title' and DatasetPage.editMode == 'CREATE'  ? 'datasetfield-title' : ''}"
                  rendered="#{!dsfv.datasetField.datasetFieldType.controlledVocabulary
                              and (dsfv.datasetField.datasetFieldType.fieldType == 'TEXT'
@@ -33,6 +36,9 @@
                              or dsfv.datasetField.datasetFieldType.fieldType == 'URL'
                              or dsfv.datasetField.datasetFieldType.fieldType == 'DATE'
                              or dsfv.datasetField.datasetFieldType.fieldType == 'EMAIL')}">
+            <c:if test="#{dsfvIndex!=0}">
+                <f:passThroughAttribute name="aria-label" value="#{bundle['dataset.additionalEntry']}" />
+            </c:if>
             <f:passThroughAttribute name="lang" value="#{DatasetPage.getFieldLanguage(cvoc.getString('languages'))}"/>
             <f:passThroughAttribute name="data-cvoc-service-url" value="#{cvoc.getString('cvoc-url','')}"/>
             <f:passThroughAttribute name="data-cvoc-protocol" value="#{cvoc.getString('protocol','')}"/>
@@ -44,7 +50,7 @@
         </p:inputText>
     </ui:fragment>
     <ui:fragment rendered="#{cvoc!=null and !cvoc.getString('term-uri-field').equals(dsfv.datasetField.datasetFieldType.name)}">
-        <p:inputText value="#{dsfv.valueForEdit}" id="cvocInputText2" pt:aria-required="#{dsf.required}" pt:aria-label="#{dsfvIndex!=0 ? bundle['dataset.additionalEntry']:''}"
+        <p:inputText value="#{dsfv.valueForEdit}" id="cvocInputText2" pt:aria-required="#{dsf.required}"
                  styleClass="form-control #{dsfv.datasetField.datasetFieldType.name == 'title' and DatasetPage.editMode == 'CREATE'  ? 'datasetfield-title' : ''}"
                  rendered="#{!dsfv.datasetField.datasetFieldType.controlledVocabulary
                              and (dsfv.datasetField.datasetFieldType.fieldType == 'TEXT'
@@ -53,13 +59,20 @@
                              or dsfv.datasetField.datasetFieldType.fieldType == 'URL'
                              or dsfv.datasetField.datasetFieldType.fieldType == 'DATE'
                              or dsfv.datasetField.datasetFieldType.fieldType == 'EMAIL')}">
+            <c:if test="#{dsfvIndex!=0}">
+                <f:passThroughAttribute name="aria-label" value="#{bundle['dataset.additionalEntry']}" />
+            </c:if>
             <f:passThroughAttribute name="data-cvoc-managed-field" value="#{dsfv.datasetField.datasetFieldType.name}"/>
         </p:inputText>
     </ui:fragment>
     
-    <p:inputTextarea value="#{dsfv.valueForEdit}" id="description" pt:aria-required="#{dsf.required}" pt:aria-label="#{dsfvIndex!=0 ? bundle['dataset.additionalEntry']:''}"
+    <p:inputTextarea value="#{dsfv.valueForEdit}" id="description" pt:aria-required="#{dsf.required}"
                      rows="5" cols="60" styleClass="form-control"
-                     rendered="#{dsfv.datasetField.datasetFieldType.fieldType == 'TEXTBOX'}"/>
+                     rendered="#{dsfv.datasetField.datasetFieldType.fieldType == 'TEXTBOX'}">
+        <c:if test="#{dsfvIndex!=0}">
+            <f:passThroughAttribute name="aria-label" value="#{bundle['dataset.additionalEntry']}" />
+        </c:if>
+        </p:inputArea>
     <p:watermark for="description" value="#{dsfv.datasetField.datasetFieldType.localeWatermark}"></p:watermark>
 
     <div class="ui-message ui-message-error ui-widget ui-corner-all" aria-live="polite" jsf:rendered="#{dsfvIndex eq 0 and !empty dsfv.datasetField.validationMessage}">

--- a/src/main/webapp/datasetFieldForEditFragment.xhtml
+++ b/src/main/webapp/datasetFieldForEditFragment.xhtml
@@ -72,7 +72,7 @@
         <c:if test="#{dsfvIndex!=0}">
             <f:passThroughAttribute name="aria-label" value="#{bundle['dataset.additionalEntry']}" />
         </c:if>
-        </p:inputArea>
+        </p:inputTextarea>
     <p:watermark for="description" value="#{dsfv.datasetField.datasetFieldType.localeWatermark}"></p:watermark>
 
     <div class="ui-message ui-message-error ui-widget ui-corner-all" aria-live="polite" jsf:rendered="#{dsfvIndex eq 0 and !empty dsfv.datasetField.validationMessage}">

--- a/src/main/webapp/editFilesFragment.xhtml
+++ b/src/main/webapp/editFilesFragment.xhtml
@@ -835,7 +835,7 @@
         <p:focus context="fileSetThumbnail"/>
         <div class="form-horizontal">
             <div class="form-group">
-                <label for="datasetThumbnailImage" class="col-sm-4 control-label">
+                <label jsf:for="datasetThumbnailImage_input" class="col-sm-4 control-label">
                     #{bundle['file.datasetThumbnail']}
                 </label>
                 <div class="col-sm-8">

--- a/src/main/webapp/editFilesFragment.xhtml
+++ b/src/main/webapp/editFilesFragment.xhtml
@@ -615,7 +615,7 @@
         </p>        
         <div class="form-horizontal">
             <div class="form-group">
-                <label for="metadata_TermsAccess" class="col-sm-3 control-label">
+                <label jsf:for="metadata_TermsAccess" class="col-sm-3 control-label">
                     #{bundle['file.dataFilesTab.terms.list.termsOfAccess.termsOfsAccess']}
                     <span class="glyphicon glyphicon-question-sign tooltip-icon"
                           data-toggle="tooltip" data-placement="auto top" data-original-title="#{bundle['file.dataFilesTab.terms.list.termsOfAccess.termsOfsAccess.title']}"></span>
@@ -626,7 +626,7 @@
                 </div>
             </div>
             <div class="form-group">
-                <label for="metadata_RequestAccess" class="col-sm-3 control-label">
+                <label class="col-sm-3 control-label">
                     #{bundle['file.dataFilesTab.terms.list.termsOfAccess.requestAccess']}
                     <span class="glyphicon glyphicon-question-sign tooltip-icon"
                           data-toggle="tooltip" data-placement="auto top" data-original-title="#{bundle['file.dataFilesTab.terms.list.termsOfAccess.requestAccess.title']}"></span>

--- a/src/main/webapp/editFilesFragment.xhtml
+++ b/src/main/webapp/editFilesFragment.xhtml
@@ -155,7 +155,9 @@
                                   fileLimit="#{EditDatafilesPage.getMaxNumberOfFiles()}" 
                                   invalidSizeMessage="#{bundle['file.edit.error.file_exceeds_limit']}" 
                                   sequential="true"
-                                  widgetVar="fileUploadWidget"/>
+                                  widgetVar="fileUploadWidget">
+                        <f:passThroughAttribute name="aria-label" value="#{bundle['file.uploadFiles']}"/>
+                    </p:fileUpload>
                                 
                                 <div jsf:id="dropboxBlock" jsf:rendered="#{settingsWrapper.isHasDropBoxKey() and !lockedFromEdits }"  class="margin-top">
                                     <!-- Dropbox upload widget -->
@@ -615,13 +617,13 @@
         </p>        
         <div class="form-horizontal">
             <div class="form-group">
-                <label jsf:for="metadata_TermsAccess" class="col-sm-3 control-label">
+                <label jsf:for="popup_TermsAccess" class="col-sm-3 control-label">
                     #{bundle['file.dataFilesTab.terms.list.termsOfAccess.termsOfsAccess']}
                     <span class="glyphicon glyphicon-question-sign tooltip-icon"
                           data-toggle="tooltip" data-placement="auto top" data-original-title="#{bundle['file.dataFilesTab.terms.list.termsOfAccess.termsOfsAccess.title']}"></span>
                 </label>
                 <div class="col-sm-9">
-                    <p:inputTextarea styleClass="form-control"
+                    <p:inputTextarea id="popup_TermsAccess" styleClass="form-control"
                                      value="#{EditDatafilesPage.termsOfAccess}" autoResize="false" rows="5"/>
                 </div>
             </div>

--- a/src/main/webapp/file-info-fragment.xhtml
+++ b/src/main/webapp/file-info-fragment.xhtml
@@ -25,7 +25,7 @@
     -->            
     </ui:remove>
     
-    <p:outputPanel id="fileInfoInclude-filesTable" styleClass="media" rendered="#{fileMetadata != null}>
+    <p:outputPanel id="fileInfoInclude-filesTable" styleClass="media" rendered="#{fileMetadata != null}">
         <div class="media-left col-file-thumb" style="padding-top:4px;">
             <div class="media-object thumbnail-block text-center">
                 <span class="icon-#{dataFileServiceBean.getFileThumbnailClass(fileMetadata.dataFile)} file-thumbnail-icon text-muted" jsf:rendered="#{!fileDownloadHelper.canDownloadFile(fileMetadata) or !dataFileServiceBean.isThumbnailAvailable(fileMetadata.dataFile)}"/>

--- a/src/main/webapp/file-info-fragment.xhtml
+++ b/src/main/webapp/file-info-fragment.xhtml
@@ -25,7 +25,7 @@
     -->            
     </ui:remove>
     
-    <p:outputPanel id="fileInfoInclude-filesTable" styleClass="media">
+    <p:outputPanel id="fileInfoInclude-filesTable" styleClass="media" rendered="#{fileMetadata != null}>
         <div class="media-left col-file-thumb" style="padding-top:4px;">
             <div class="media-object thumbnail-block text-center">
                 <span class="icon-#{dataFileServiceBean.getFileThumbnailClass(fileMetadata.dataFile)} file-thumbnail-icon text-muted" jsf:rendered="#{!fileDownloadHelper.canDownloadFile(fileMetadata) or !dataFileServiceBean.isThumbnailAvailable(fileMetadata.dataFile)}"/>

--- a/src/main/webapp/metadataFragment.xhtml
+++ b/src/main/webapp/metadataFragment.xhtml
@@ -206,7 +206,7 @@
                                     <!-- Primitive fields -->
                                     <p:fragment id="editPrimitiveValueFragment" rendered="#{dsf.datasetFieldType.primitive}">
                                         <p:autoUpdate/>
-                                        <h:outputLabel for="fieldvaluelist:0:#{dsf.datasetFieldType.fieldType == 'TEXTBOX' ? 'description' : 'inputText'}" styleClass="col-sm-3 control-label">
+                                        <h:outputLabel for="#{dsf.datasetFieldType.controlledVocabulary ? (!dsf.datasetFieldType.allowMultiples ? 'unique1_focus' : 'unique2_focus') : ('fieldvaluelist:0:'.concat(((dsf.datasetFieldType.fieldType == 'TEXTBOX') ? 'description' : 'inputText')))}" styleClass="col-sm-3 control-label">
                                             #{dsf.datasetFieldType.localeTitle}
                                             <span class="glyphicon glyphicon-asterisk text-danger" jsf:rendered="#{dsf.required}"/>
                                             <span class="glyphicon glyphicon-question-sign tooltip-icon"

--- a/src/main/webapp/provenance-popups-fragment.xhtml
+++ b/src/main/webapp/provenance-popups-fragment.xhtml
@@ -25,7 +25,7 @@
                         
                     </p>
                 </div>
-                <label for="provenanceBundle" class="col-sm-3 control-label">
+                <label jsf:for="provUpload_input" class="col-sm-3 control-label">
                     #{bundle['file.editProvenanceDialog.bundleFile']}
                 </label>
                 <div class="col-sm-9">
@@ -116,7 +116,7 @@
                 </div>
             </div>
             <div class="form-group text-left">
-                <label for="provenanceAddDescription" class="col-sm-3 control-label">
+                <label jsf:for="provenanceFreeform" class="col-sm-3 control-label">
                     #{bundle['file.editProvenanceDialog.description']}
                 </label>
                 <div class="col-sm-9">

--- a/src/main/webapp/resources/css/structure.css
+++ b/src/main/webapp/resources/css/structure.css
@@ -244,7 +244,7 @@ body.widget-view #dataverse-header-block {padding-top:0px;}
 #breadcrumbNavBlock a[id^='breadcrumbLnkTree'] span.glyphicon-chevron-down {vertical-align:middle;padding-bottom:2px;}
 #breadcrumbNavBlock > .ui-panel-content {overflow:hidden;}
 #breadcrumbNavBlock.panelLayoutBlock > .ui-widget-content {border-bottom: 0;}
-#breadcrumbNavBlock .breadcrumbCarrot {float:left; margin:0 .4em; color:#B3B3B3;}
+#breadcrumbNavBlock .breadcrumbCarrot {float:left; margin:0 .4em; color:#757575;}
 #breadcrumbNavBlock div.dropdown-menu {padding-right:.5em; min-width:280px;}
 #breadcrumbNavBlock .ui-tree {width: auto;}
 #breadcrumbNavBlock div.ui-tree.ui-widget-content {border:0;}

--- a/src/main/webapp/search-include-fragment.xhtml
+++ b/src/main/webapp/search-include-fragment.xhtml
@@ -196,9 +196,11 @@
                     <p:dataList value="#{facetCategory.facetLabel}" var="facetLabel" rows="#{DataversePage.getNumberOfFacets(facetCategory.name,5)}">
                         <h:outputLink value="#{widgetWrapper.wrapURL(page)}" rendered="#{!DataversePage.filterQueries.contains(facetLabel.filterQuery)}" styleClass="facetLink">
                             <h:outputText value="#{facetLabel.name}">
-                                <f:passThroughAttribute name="lang" value="#{DatasetPage.getFieldLanguage(cvocConf.get(facetCategory.datasetFieldTypeId).getString('languages'))}" />
-                                <f:passThroughAttribute name="data-cvoc-service-url" value="#{cvocConf.get(facetCategory.datasetFieldTypeId).getString('cvoc-url','')}" />
-                                <f:passThroughAttribute name="data-cvoc-protocol" value="#{cvocConf.get(facetCategory.datasetFieldTypeId).getString('protocol','')}" />
+                                <c:if test="#{!cvocConf.isEmpty()}">
+                                    <f:passThroughAttribute name="lang" value="#{DatasetPage.getFieldLanguage(cvocConf.get(facetCategory.datasetFieldTypeId).getString('languages'))}" />
+                                    <f:passThroughAttribute name="data-cvoc-service-url" value="#{cvocConf.get(facetCategory.datasetFieldTypeId).getString('cvoc-url','')}" />
+                                    <f:passThroughAttribute name="data-cvoc-protocol" value="#{cvocConf.get(facetCategory.datasetFieldTypeId).getString('protocol','')}" />
+                                </c:if>
                             </h:outputText>
                             <h:outputFormat value=" &#40;{0}&#41;">
                                 <f:param value="#{facetLabel.count}"/>
@@ -215,9 +217,11 @@
 
                         <h:outputLink value="#{widgetWrapper.wrapURL(page)}" rendered="#{DataversePage.filterQueries.contains(facetLabel.filterQuery)}" styleClass="facetLink facetSelected">
                             <h:outputText value="#{facetLabel.name}">
-                                <f:passThroughAttribute name="lang" value="#{DatasetPage.getFieldLanguage(cvocConf.get(facetCategory.datasetFieldTypeId).getString('languages'))}" />
-                                <f:passThroughAttribute name="data-cvoc-service-url" value="#{cvocConf.get(facetCategory.datasetFieldTypeId).getString('cvoc-url','')}" />
-                                <f:passThroughAttribute name="data-cvoc-protocol" value="#{cvocConf.get(facetCategory.datasetFieldTypeId).getString('protocol','')}" />
+                                <c:if test="#{!cvocConf.isEmpty()}">
+                                    <f:passThroughAttribute name="lang" value="#{DatasetPage.getFieldLanguage(cvocConf.get(facetCategory.datasetFieldTypeId).getString('languages'))}" />
+                                    <f:passThroughAttribute name="data-cvoc-service-url" value="#{cvocConf.get(facetCategory.datasetFieldTypeId).getString('cvoc-url','')}" />
+                                    <f:passThroughAttribute name="data-cvoc-protocol" value="#{cvocConf.get(facetCategory.datasetFieldTypeId).getString('protocol','')}" />
+                                </c:if>
                             </h:outputText>
                             <h:outputFormat value=" &#40;{0}&#41;">
                                 <f:param value="#{facetLabel.count}"/>


### PR DESCRIPTION
**What this PR does / why we need it**: Adds additional Accessibility fixes/enhancements from QDR

**Which issue(s) this PR closes**:

Closes #

**Special notes for your reviewer**: There's more discussion in #8321. For this PR, the primary tool to find issues was [WebAIM WaVE](https://addons.mozilla.org/en-US/firefox/addon/wave-accessibility-tool/). As mentioned elsewhere, I'm hopeful that there are few enough issues after this that we can close old accessibility issues and create new ones for any that remain. The main source at this point would be PrimeFaces so the PrimeFaces 11 update could help there.

Also note that this removes an old worldmap dialog and a hidden input related to deaccessioning that appears to have stopped being used 5+ years ago.

**Suggestions on how to test this**: Verify standard Dataverse functionality. Probably worth trying a deaccession since I did remove what I think is an unused hidden input there. Otherwise, the changes should primarily be to labels that don't show in the standard UI. I think there's one minor color change in a breadcrumb caret. It could also be worthwhile to install the Wave tool mentioned above into Firefox and verify before/after that the number of issues descreases.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: ~no - see test note

**Is there a release notes update needed for this change?**:

**Additional documentation**:
