### PR TITLE
Fix broken links under "Best Practices" (nav bar) in guides, sync up with dataverse.org

### DIFF
--- a/doc/sphinx-guides/source/_templates/navbar.html
+++ b/doc/sphinx-guides/source/_templates/navbar.html
@@ -39,7 +39,7 @@
                 <li>
                     <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Best Practices <span class="caret"></span></a>
                     <ul class="dropdown-menu">
-                        <li><a target="_blank" href="http://dataverse.org/data-citation">Academic Credit</a></li>
+                        <li><a target="_blank" href="https://dataverse.org/best-practices/data-citation">Academic Credit</a></li>
                         <li><a target="_blank" href="https://support.dataverse.harvard.edu/policies">Harvard Dataverse Policies</a></li>
                         <li><a target="_blank" href="http://dataverse.org/data-management">Data Management</a></li>
                         <li><a target="_blank" href="https://dataverse.org/best-practices/replication-dataset">Replication Dataset Guidelines</a></li>

--- a/doc/sphinx-guides/source/_templates/navbar.html
+++ b/doc/sphinx-guides/source/_templates/navbar.html
@@ -40,7 +40,7 @@
                     <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Best Practices <span class="caret"></span></a>
                     <ul class="dropdown-menu">
                         <li><a target="_blank" href="http://dataverse.org/data-citation">Academic Credit</a></li>
-                        <li><a target="_blank" href="http://dataverse.org/harvard-dataverse-policies">Harvard Dataverse Policies</a></li>
+                        <li><a target="_blank" href="https://support.dataverse.harvard.edu/policies">Harvard Dataverse Policies</a></li>
                         <li><a target="_blank" href="http://dataverse.org/data-management">Data Management</a></li>
                         <li><a target="_blank" href="https://dataverse.org/best-practices/replication-dataset">Replication Dataset Guidelines</a></li>
                     </ul>

--- a/doc/sphinx-guides/source/_templates/navbar.html
+++ b/doc/sphinx-guides/source/_templates/navbar.html
@@ -40,7 +40,6 @@
                     <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Best Practices <span class="caret"></span></a>
                     <ul class="dropdown-menu">
                         <li><a target="_blank" href="https://dataverse.org/best-practices/data-citation">Academic Credit</a></li>
-                        <li><a target="_blank" href="https://support.dataverse.harvard.edu/policies">Harvard Dataverse Policies</a></li>
                         <li><a target="_blank" href="https://dataverse.org/best-practices/data-management">Data Management</a></li>
                         <li><a target="_blank" href="https://dataverse.org/best-practices/replication-dataset">Replication Dataset Guidelines</a></li>
                     </ul>

--- a/doc/sphinx-guides/source/_templates/navbar.html
+++ b/doc/sphinx-guides/source/_templates/navbar.html
@@ -42,7 +42,7 @@
                         <li><a target="_blank" href="http://dataverse.org/data-citation">Academic Credit</a></li>
                         <li><a target="_blank" href="http://dataverse.org/harvard-dataverse-policies">Harvard Dataverse Policies</a></li>
                         <li><a target="_blank" href="http://dataverse.org/data-management">Data Management</a></li>
-                        <li><a target="_blank" href="http://dataverse.org/replication-dataset">Replication Dataset Guidelines</a></li>
+                        <li><a target="_blank" href="https://dataverse.org/best-practices/replication-dataset">Replication Dataset Guidelines</a></li>
                     </ul>
                 </li>
                 <li>

--- a/doc/sphinx-guides/source/_templates/navbar.html
+++ b/doc/sphinx-guides/source/_templates/navbar.html
@@ -39,7 +39,9 @@
                 <li>
                     <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Best Practices <span class="caret"></span></a>
                     <ul class="dropdown-menu">
-                        <li><a target="_blank" href="https://dataverse.org/best-practices/data-citation">Academic Credit</a></li>
+                        <li><a target="_blank" href="https://dataverse.org/best-practices/academic-credit">Academic Credit</a></li>
+                        <li><a target="_blank" href="https://dataverse.org/best-practices/data-citation">Data Citation</a></li>
+                        <li><a target="_blank" href="https://dataverse.org/best-practices/dataverse-community-norms">Dataverse Community Norms</a></li>
                         <li><a target="_blank" href="https://dataverse.org/best-practices/data-management">Data Management</a></li>
                         <li><a target="_blank" href="https://dataverse.org/best-practices/replication-dataset">Replication Dataset Guidelines</a></li>
                     </ul>

--- a/doc/sphinx-guides/source/_templates/navbar.html
+++ b/doc/sphinx-guides/source/_templates/navbar.html
@@ -41,7 +41,7 @@
                     <ul class="dropdown-menu">
                         <li><a target="_blank" href="https://dataverse.org/best-practices/data-citation">Academic Credit</a></li>
                         <li><a target="_blank" href="https://support.dataverse.harvard.edu/policies">Harvard Dataverse Policies</a></li>
-                        <li><a target="_blank" href="http://dataverse.org/data-management">Data Management</a></li>
+                        <li><a target="_blank" href="https://dataverse.org/best-practices/data-management">Data Management</a></li>
                         <li><a target="_blank" href="https://dataverse.org/best-practices/replication-dataset">Replication Dataset Guidelines</a></li>
                     </ul>
                 </li>


### PR DESCRIPTION
**What this PR does / why we need it**:

All the links under "Best Practices" are broken:

![Screen Shot 2022-03-15 at 10 04 36 AM](https://user-images.githubusercontent.com/21006/158400772-2478127e-1049-4f2a-bb62-4d955033a2de.png)


**Which issue(s) this PR closes**:

Closes https://github.com/IQSS/dataverse.harvard.edu/issues/24

**Special notes for your reviewer**:

The impression I get from https://github.com/IQSS/dataverse.harvard.edu/issues/65 is that we're trying to avoid Harvard specific content on dataverse.org so I removed the link to "Harvard Dataverse Policies". To add it back in we can just revert 11d943e 

**Suggestions on how to test this**:

Make sure the links work.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No.

**Is there a release notes update needed for this change?**:

No.

**Additional documentation**:

None.