### PR TITLE
DDI import, fix for collectionMode

### DIFF
--- a/scripts/api/data/dataset-create-new-all-default-fields.json
+++ b/scripts/api/data/dataset-create-new-all-default-fields.json
@@ -1026,9 +1026,9 @@
           },
           {
             "typeName": "collectionMode",
-            "multiple": false,
+            "multiple": true,
             "typeClass": "primitive",
-            "value": "CollectionMode"
+            "value": ["CollectionMode"]
           },
           {
             "typeName": "researchInstrument",

--- a/src/main/java/edu/harvard/iq/dataverse/api/imports/ImportDDIServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/imports/ImportDDIServiceBean.java
@@ -997,7 +997,7 @@ public class ImportDDIServiceBean {
     private void processDataColl(XMLStreamReader xmlr, DatasetVersionDTO dvDTO) throws XMLStreamException {
         MetadataBlockDTO socialScience =getSocialScience(dvDTO);
         
-        String collMode = "";
+        List<String> collMode = new ArrayList<>();
         String timeMeth = "";
         String weight = "";
         String dataCollector = "";
@@ -1035,16 +1035,12 @@ public class ImportDDIServiceBean {
                     //devationsFromSamplingDesign
                 } else if (xmlr.getLocalName().equals("deviat")) {
                    socialScience.getFields().add(FieldDTO.createPrimitiveFieldDTO("deviationsFromSampleDesign", parseText( xmlr, "deviat" )));
-                 // collectionMode
+                // collectionMode - allows multiple values, as of 5.10
                 } else if (xmlr.getLocalName().equals("collMode")) {
                     String thisValue = parseText( xmlr, "collMode" );
                     if (!StringUtil.isEmpty(thisValue)) {
-                        if (!"".equals(collMode)) {
-                            collMode = collMode.concat(", ");
-                        }
-                        collMode = collMode.concat(thisValue);
+                        collMode.add(thisValue);
                     }
-                  //socialScience.getFields().add(FieldDTO.createPrimitiveFieldDTO("collectionMode", parseText( xmlr, "collMode" )));                      
                 //researchInstrument
                 } else if (xmlr.getLocalName().equals("resInstru")) {
                    socialScience.getFields().add(FieldDTO.createPrimitiveFieldDTO("researchInstrument", parseText( xmlr, "resInstru" )));
@@ -1075,8 +1071,8 @@ public class ImportDDIServiceBean {
                     if (!StringUtil.isEmpty(timeMeth)) {
                         socialScience.getFields().add(FieldDTO.createPrimitiveFieldDTO("timeMethod", timeMeth));
                     }
-                    if (!StringUtil.isEmpty(collMode)) {
-                        socialScience.getFields().add(FieldDTO.createPrimitiveFieldDTO("collectionMode", collMode));
+                    if (collMode.size() > 0) {
+                        socialScience.getFields().add(FieldDTO.createMultiplePrimitiveFieldDTO("collectionMode", collMode));
                     }
                     if (!StringUtil.isEmpty(weight)) {
                         socialScience.getFields().add(FieldDTO.createPrimitiveFieldDTO("weighting", weight));


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a followup PR for #8473 where collectionMode was made a multiples-allowed field. There was still a place in the code, in the DDI import, where the field was treated as a single-primitive. 

Please note that the DDI import overall is still broken (#8210), and will still be broken after this PR! However, this PR will make it possible to fix it (as part of Victoiria's #8483). 

The PR also includes an updated example json file (`dataset-create-new-all-default-fields.json`) reflecting the change in #8473.

**Which issue(s) this PR closes**:

Closes #8489

**Special notes for your reviewer**:

Please note that the DDI import overall is still broken (#8210), and will still be broken after this PR! However, this PR will make it possible to fix it (as part of Victoiria's #8483).


**Suggestions on how to test this**:

See the above, about ddi import still being broken, for reasons outside of this issue/this PR. 
You can kinda test it, by attempting to import the example ddi (see attached, as a .txt file): 

`curl -H "X-Dataverse-key:xyz" -X POST http://localhost:8080/api/dataverses/root/datasets/:importddi --upload-file ddi_dataset.txt`

*before* this PR, it'll be failing with 

`Error parsing data as Json: incorrect multiple   for field collectionMode`

*after* this PR, it'll be failing with the expected

`Validation Failed: Subject is required. (Invalid value:edu.harvard.iq.dataverse.DatasetField...`

[ddi_dataset.txt](https://github.com/IQSS/dataverse/files/8256057/ddi_dataset.txt)


**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
