### PR TITLE
Update 5.10-release-notes.md database query regarding multiple license change

### DIFF
--- a/doc/release-notes/5.10-release-notes.md
+++ b/doc/release-notes/5.10-release-notes.md
@@ -140,7 +140,7 @@ or
 To find datasets with a without a CC0 license and with empty terms:
 
 ```
-select CONCAT('doi:', dvo.authority, '/', dvo.identifier), v.alias as dataverse_alias, case when versionstate='RELEASED' then concat(dv.versionnumber, '.', dv.minorversionnumber) else versionstate END  as version, dv.id as datasetversion_id, t.id as termsofuseandaccess_id, t.termsofuse, t.confidentialitydeclaration, t.specialpermissions, t.restrictions, t.citationrequirements, t.depositorrequirements, t.conditions, t.disclaimer from dvobject dvo, termsofuseandaccess t, datasetversion dv, dataverse v where dv.dataset_id=dvo.id and dv.termsofuseandaccess_id=t.id and dvo.owner_id=v.id and t.license='NONE' and t.termsofuse is null;
+select CONCAT('doi:', dvo.authority, '/', dvo.identifier), v.alias as dataverse_alias, case when versionstate='RELEASED' then concat(dv.versionnumber, '.', dv.minorversionnumber) else versionstate END  as version, dv.id as datasetversion_id, t.id as termsofuseandaccess_id, t.termsofuse, t.confidentialitydeclaration, t.specialpermissions, t.restrictions, t.citationrequirements, t.depositorrequirements, t.conditions, t.disclaimer from dvobject dvo, termsofuseandaccess t, datasetversion dv, dataverse v where dv.dataset_id=dvo.id and dv.termsofuseandaccess_id=t.id and dvo.owner_id=v.id and (t.license='NONE' or t.license is null) and t.termsofuse is null;
 ```
 
 As before, there are a couple options.


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR closes**:

Closes #8544 

**Special notes for your reviewer**:

**Suggestions on how to test this**:
Check that one of the queries in the release notes has its where clause adjusted.

I've confirmed that before it was changed by the 5.10 update, the license column of the termsofuseandaccess table in the Harvard repo's database had null values in addition to "NONE" strings to indicate when dataset versions didn't have a CC0 waiver. Not sure if that needs to be confirmed by anyone else.

I'm also not sure if someone else needs to confirm the possibility that other repositories, maybe the older ones like UNC's, have null values in the license columns of their termsofuseandaccess tables. That is, was this adjustment necessary only for Harvard's repo? In any case, I think the adjusted query should still work for all repositories, whether or not the license columns of their termsofuseandaccess tables have null values in addition to "NONE" strings.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
No change to software's user interface

**Is there a release notes update needed for this change?**:
I'm not sure. The change seems pretty small.
