### PR TITLE
Iqss/8553 fixrequest access to files in datasets with custom terms

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/util/FileUtil.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/FileUtil.java
@@ -1523,9 +1523,8 @@ public class FileUtil implements java.io.Serializable  {
                 logger.fine("Popup required because of terms of access.");
                 answer = true;
             }
-            return answer;
-
         }
+        return answer;
     }
 
     /**

--- a/src/main/java/edu/harvard/iq/dataverse/util/FileUtil.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/FileUtil.java
@@ -1495,17 +1495,22 @@ public class FileUtil implements java.io.Serializable  {
         return false;
     }
     
+    /* Code shared by isDownloadPopupRequired and isRequestAccessPopupRequired.
+     * 
+     * Returns Boolean to allow null = no decision. This allows the isDownloadPopupRequired method to then add another check w.r.t. guestbooks before returning its value.
+     * 
+     */
     private static Boolean popupDueToStateOrTerms(DatasetVersion datasetVersion) {
 
         // Each of these conditions is sufficient reason to have to
         // present the user with the popup:
         if (datasetVersion == null) {
-            logger.fine("Popup required because datasetVersion is null.");
+            logger.fine("Popup not required because datasetVersion is null.");
             return false;
         }
         // 0. if version is draft then Popup "not required"
         if (!datasetVersion.isReleased()) {
-            logger.fine("Popup required because datasetVersion has not been released.");
+            logger.fine("Popup not required because datasetVersion has not been released.");
             return false;
         }
         // 1. License and Terms of Use:
@@ -1513,7 +1518,7 @@ public class FileUtil implements java.io.Serializable  {
             License license = datasetVersion.getTermsOfUseAndAccess().getLicense();
             if ((license == null && StringUtils.isNotBlank(datasetVersion.getTermsOfUseAndAccess().getTermsOfUse()))
                     || (license != null && !license.isDefault())) {
-                logger.fine("Download popup required because of license or terms of use.");
+                logger.fine("Popup required because of license or terms of use.");
                 return true;
             }
 
@@ -1523,6 +1528,7 @@ public class FileUtil implements java.io.Serializable  {
                 return true;
             }
         }
+        //No decision based on the criteria above
         return null;
     }
 

--- a/src/main/java/edu/harvard/iq/dataverse/util/FileUtil.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/FileUtil.java
@@ -1496,35 +1496,34 @@ public class FileUtil implements java.io.Serializable  {
     }
     
     private static Boolean popupDueToStateOrTerms(DatasetVersion datasetVersion) {
-        Boolean answer = null;
+
         // Each of these conditions is sufficient reason to have to
         // present the user with the popup:
         if (datasetVersion == null) {
             logger.fine("Popup required because datasetVersion is null.");
-            answer = false;
+            return false;
         }
         // 0. if version is draft then Popup "not required"
         if (!datasetVersion.isReleased()) {
             logger.fine("Popup required because datasetVersion has not been released.");
-            answer = false;
+            return false;
         }
         // 1. License and Terms of Use:
         if (datasetVersion.getTermsOfUseAndAccess() != null) {
             License license = datasetVersion.getTermsOfUseAndAccess().getLicense();
-            if ((license != null && !license.isDefault())
-                    && !(datasetVersion.getTermsOfUseAndAccess().getTermsOfUse() == null
-                            || datasetVersion.getTermsOfUseAndAccess().getTermsOfUse().equals(""))) {
-                logger.fine("{opup required because of license or terms of use.");
-                answer = true;
+            if ((license == null && StringUtils.isNotBlank(datasetVersion.getTermsOfUseAndAccess().getTermsOfUse()))
+                    || (license != null && !license.isDefault())) {
+                logger.fine("Download popup required because of license or terms of use.");
+                return true;
             }
 
             // 2. Terms of Access:
             if (!(datasetVersion.getTermsOfUseAndAccess().getTermsOfAccess() == null) && !datasetVersion.getTermsOfUseAndAccess().getTermsOfAccess().equals("")) {
                 logger.fine("Popup required because of terms of access.");
-                answer = true;
+                return true;
             }
         }
-        return answer;
+        return null;
     }
 
     /**

--- a/src/main/java/edu/harvard/iq/dataverse/util/FileUtil.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/FileUtil.java
@@ -1471,73 +1471,61 @@ public class FileUtil implements java.io.Serializable  {
      * elaborate on the text "This file cannot be downloaded publicly."
      */
     public static boolean isDownloadPopupRequired(DatasetVersion datasetVersion) {
-        // Each of these conditions is sufficient reason to have to 
-        // present the user with the popup: 
-        if (datasetVersion == null) {
-            logger.fine("Download popup required because datasetVersion is null.");
-            return false;
+        logger.fine("Checking if download popup is required.");
+        Boolean answer = popupDueToStateOrTerms(datasetVersion);
+        if (answer != null) {
+            return answer;
         }
-        //0. if version is draft then Popup "not required"
-        if (!datasetVersion.isReleased()) {
-            logger.fine("Download popup required because datasetVersion has not been released.");
-            return false;
-        }
-        // 1. License and Terms of Use:
-        if (datasetVersion.getTermsOfUseAndAccess() != null) {
-            License license = datasetVersion.getTermsOfUseAndAccess().getLicense();
-            if ((license == null && StringUtils.isNotBlank(datasetVersion.getTermsOfUseAndAccess().getTermsOfUse()))
-                    || (license != null && !license.isDefault())) {
-                logger.fine("Download popup required because of license or terms of use.");
-                return true;
-            }
-
-            // 2. Terms of Access:
-            if (!(datasetVersion.getTermsOfUseAndAccess().getTermsOfAccess() == null) && !datasetVersion.getTermsOfUseAndAccess().getTermsOfAccess().equals("")) {
-                logger.fine("Download popup required because of terms of access.");
-                return true;
-            }
-        }
-
         // 3. Guest Book:
         if (datasetVersion.getDataset() != null && datasetVersion.getDataset().getGuestbook() != null && datasetVersion.getDataset().getGuestbook().isEnabled() && datasetVersion.getDataset().getGuestbook().getDataverse() != null) {
             logger.fine("Download popup required because of guestbook.");
             return true;
         }
-
         logger.fine("Download popup is not required.");
         return false;
     }
     
-    public static boolean isRequestAccessPopupRequired(DatasetVersion datasetVersion){
-        // Each of these conditions is sufficient reason to have to 
-        // present the user with the popup: 
-        if (datasetVersion == null) {
-            logger.fine("Download popup required because datasetVersion is null.");
-            return false;
+    public static boolean isRequestAccessPopupRequired(DatasetVersion datasetVersion) {
+        
+        Boolean answer = popupDueToStateOrTerms(datasetVersion);
+        if (answer != null) {
+            return answer;
         }
-        //0. if version is draft then Popup "not required"
+        logger.fine("Request access popup is not required.");
+        return false;
+    }
+    
+    private static Boolean popupDueToStateOrTerms(DatasetVersion datasetVersion) {
+        Boolean answer = null;
+        // Each of these conditions is sufficient reason to have to
+        // present the user with the popup:
+        if (datasetVersion == null) {
+            logger.fine("Popup required because datasetVersion is null.");
+            answer = false;
+        }
+        // 0. if version is draft then Popup "not required"
         if (!datasetVersion.isReleased()) {
-            logger.fine("Download popup required because datasetVersion has not been released.");
-            return false;
+            logger.fine("Popup required because datasetVersion has not been released.");
+            answer = false;
         }
         // 1. License and Terms of Use:
         if (datasetVersion.getTermsOfUseAndAccess() != null) {
-            if (!datasetVersion.getTermsOfUseAndAccess().getLicense().isDefault()
+            License license = datasetVersion.getTermsOfUseAndAccess().getLicense();
+            if ((license != null && !license.isDefault())
                     && !(datasetVersion.getTermsOfUseAndAccess().getTermsOfUse() == null
-                    || datasetVersion.getTermsOfUseAndAccess().getTermsOfUse().equals(""))) {
-                logger.fine("Download popup required because of license or terms of use.");
-                return true;
+                            || datasetVersion.getTermsOfUseAndAccess().getTermsOfUse().equals(""))) {
+                logger.fine("{opup required because of license or terms of use.");
+                answer = true;
             }
 
             // 2. Terms of Access:
             if (!(datasetVersion.getTermsOfUseAndAccess().getTermsOfAccess() == null) && !datasetVersion.getTermsOfUseAndAccess().getTermsOfAccess().equals("")) {
-                logger.fine("Download popup required because of terms of access.");
-                return true;
+                logger.fine("Popup required because of terms of access.");
+                answer = true;
             }
-        }
+            return answer;
 
-        logger.fine("Download popup is not required.");
-        return false;
+        }
     }
 
     /**


### PR DESCRIPTION
**What this PR does / why we need it**: The request access popup logic failed with a null pointer if license=null-> custom terms were used. This issue was caught/fixed for the download popup but missed here. The PR includes a refactor so that both methods now use common code.

**Which issue(s) this PR closes**:

Closes #8553

**Special notes for your reviewer**: As far as I could tell, prior to the multi-license code, the isDownloadPopupRequired and isRequestAccessPopupRequired methods used the same code except for isDownload doing a final check for guestbooks. With multi-license it looks like they were changed independently at different times (with isRequestAccess being broken). They are now the same again (except the final guestbook check). If there was some other intended change between the two of them, this PR would be removing it.

Is this a basic enough issue to push a 5.10.1 or 5.11 in the short term?

**Suggestions on how to test this**: Use custom terms on some dataset, add a restricted file(s), publish, login as someone else and verify that you get the request access popup. Could also check for regression (does the download popup appear as before), does everything still work with a standard license, ...). FWIW: There are tests in FileUtil for isDownloadPopupRequired that are passing as before.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
