### PR TITLE
Add table of contents to the mail groups docs page

### DIFF
--- a/doc/sphinx-guides/source/admin/mail-groups.rst
+++ b/doc/sphinx-guides/source/admin/mail-groups.rst
@@ -1,18 +1,18 @@
 Mail Domain Groups
 ==================
 
-Groups can be defined based on the domain part of users (verified) email addresses. Email addresses that match
-one or more groups configuration will add the user to them.
+Groups can be defined based on the domain part of users (verified) email addresses. Email addresses that match one or more groups configuration will add the user to them.
 
-Within the scientific community, in many cases users will use a institutional email address for their account in a
-Dataverse installation. This might offer a simple solution for building groups of people, as the domain part can be
-seen as a selector for group membership.
+Within the scientific community, in many cases users will use a institutional email address for their account in a Dataverse installation. This might offer a simple solution for building groups of people, as the domain part can be seen as a selector for group membership.
 
 Some use cases: installations that like to avoid Shibboleth, enable self sign up, offer multi-tenancy or can't use
 :doc:`ip-groups` plus many more.
 
 .. hint:: Please be aware that non-verified mail addresses will exclude the user even if matching. This is to avoid
           privilege escalation.
+
+.. contents:: Contents:
+	:local:
 
 Listing Mail Domain Groups
 --------------------------


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds the contents list to the mail domain groups page under the Admin Guide section in the docs, similar to other pages. This is missing from [the current page](https://guides.dataverse.org/en/latest/admin/mail-groups.html).

**Which issue(s) this PR closes**:

N/A

**Special notes for your reviewer**:

**Suggestions on how to test this**:

Build docs and view the mail domain groups page under the Admin section (`/admin/mail-groups.html`).

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No

**Is there a release notes update needed for this change?**:

No