### PR TITLE
IQSS/8595 - update existing schema and code to make all cvv files multival in solr

### DIFF
--- a/conf/solr/8.11.1/schema.xml
+++ b/conf/solr/8.11.1/schema.xml
@@ -315,7 +315,7 @@
     <field name="grantNumber" type="text_en" multiValued="true" stored="true" indexed="true"/>
     <field name="grantNumberAgency" type="text_en" multiValued="true" stored="true" indexed="true"/>
     <field name="grantNumberValue" type="text_en" multiValued="true" stored="true" indexed="true"/>
-    <field name="journalArticleType" type="text_en" multiValued="false" stored="true" indexed="true"/>
+    <field name="journalArticleType" type="text_en" multiValued="true" stored="true" indexed="true"/>
     <field name="journalIssue" type="text_en" multiValued="true" stored="true" indexed="true"/>
     <field name="journalPubDate" type="text_en" multiValued="true" stored="true" indexed="true"/>
     <field name="journalVolume" type="text_en" multiValued="true" stored="true" indexed="true"/>

--- a/doc/release-notes/8595-cvv-field-solr-update.md
+++ b/doc/release-notes/8595-cvv-field-solr-update.md
@@ -1,0 +1,3 @@
+Controlled vocabulary fields that do not allow multiple entries are not indexed properly in Dataverse instances configured to support multiple languages. This release fixes the schema.xml file for the one field affected in the standard metadata blocks (journalArticleType) and updates the api/admin/index/solr/schema to provide the correct information for use with the update-fields.sh script described in the [Metadata Customization section of the Admin Guide](https://guides.dataverse.org/en/latest/admin/metadatacustomization.html#updating-the-solr-schema).
+
+The release should include updating the schema.xml file for solr or running the update-fields.sh script and reindexing (whatever standard instructions we give for schema changes.)

--- a/src/main/java/edu/harvard/iq/dataverse/DatasetFieldType.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetFieldType.java
@@ -543,7 +543,7 @@ public class DatasetFieldType implements Serializable, Comparable<DatasetFieldTy
             
             boolean makeSolrFieldMultivalued;
             // http://stackoverflow.com/questions/5800762/what-is-the-use-of-multivalued-field-type-in-solr
-            if (allowMultiples || parentAllowsMultiplesBoolean) {
+            if (allowMultiples || parentAllowsMultiplesBoolean || isControlledVocabulary()) {
                 makeSolrFieldMultivalued = true;
             } else {
                 makeSolrFieldMultivalued = false;

--- a/src/main/java/edu/harvard/iq/dataverse/api/Index.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Index.java
@@ -442,6 +442,7 @@ public class Index extends AbstractApiBean {
         StringBuilder sb = new StringBuilder();
 
         for (DatasetFieldType datasetField : datasetFieldService.findAllOrderedByName()) {
+            //ToDo - getSolrField() creates/returns a new object - just get it once and re-use
             String nameSearchable = datasetField.getSolrField().getNameSearchable();
             SolrField.SolrType solrType = datasetField.getSolrField().getSolrType();
             String type = solrType.getType();
@@ -490,7 +491,7 @@ public class Index extends AbstractApiBean {
         }
 
         sb.append("---\n");
-
+        //ToDo - this is the same for loop as above - could combine into one by using a second string buffer and appending the latter one after the loop. 
         for (DatasetFieldType datasetField : datasetFieldService.findAllOrderedByName()) {
             String nameSearchable = datasetField.getSolrField().getNameSearchable();
             String nameFacetable = datasetField.getSolrField().getNameFacetable();


### PR DESCRIPTION
**What this PR does / why we need it**: The recent PR #8435 indexes the i18n values of a CVV field. Implicit in that is the fact that CVV fields now must be multivalued in solr to support this. Looking through all of the metadata blocks defined in the current codebase, there is only one field that is CVV that does not allow multiple values (i.e. for the user to add multiple values) that is not already multivalued in solr. (Strangely, so CVV fields that do not allow multiple inputs are already multvalued in solr). That field (journalArticleType) is changed in this PR to be mutlivalued in solr. The PR also changes the logic behind the api/admin/index/solr/schema endpoint, which is used by the update-fields.sh script listed in the guides to update the schema for custom blocks.

**Which issue(s) this PR closes**:

Closes #8595

**Special notes for your reviewer**:

**Suggestions on how to test this**: Enable multiple languages, add a journalArticleType and verify that pre-PR a search fails as described in the issue and after the PR it works. Could also verify that the output for that field in the api/admin/index/solr/schema API call switches from single to multivalued.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:  a schema.xml update /reindex is required

**Additional documentation**: Didn't see any place where this would come up in the documentation about metadata customization since it is an internal calculation that you'd just trust when using the update-fields.sh script.
