### PR TITLE
Added <dataverse_home>/scripts/installer/default.config as the template used in documentation

### DIFF
--- a/doc/sphinx-guides/source/installation/installation-main.rst
+++ b/doc/sphinx-guides/source/installation/installation-main.rst
@@ -66,7 +66,7 @@ The script will prompt you for some configuration values. If this is a test/eval
 - Postgres admin password - We'll need it in order to create the database and user for the Dataverse Software installer to use, without having to run the installer as root. If you don't know your Postgres admin password, you may simply set the authorization level for localhost to "trust" in the PostgreSQL ``pg_hba.conf`` file (See the PostgreSQL section in the Prerequisites). If this is a production environment, you may want to change it back to something more secure, such as "password" or "md5", after the installation is complete.
 - Network address of a remote Solr search engine service (if needed) - In most cases, you will be running your Solr server on the same host as the Dataverse Software application (then you will want to leave this set to the default value of ``LOCAL``). But in a serious production environment you may set it up on a dedicated separate server.
 
-If desired, these default values can be configured by creating a ``default.config`` (example :download:`here <../_static/util/default.config>`) file in the installer's working directory with new values (if this file isn't present, the above defaults will be used).
+If desired, these default values can be configured by creating a ``default.config`` (example :download:`here <../../../../scripts/installer/default.config>`) file in the installer's working directory with new values (if this file isn't present, the above defaults will be used).
 
 This allows the installer to be run in non-interactive mode (with ``./install -y -f > install.out 2> install.err``), which can allow for easier interaction with automated provisioning tools.
 


### PR DESCRIPTION
Added <dataverse_home>/scripts/installer/default.config as the template used in documentation

**What this PR does / why we need it**:

_default.config_ sample file available for download in the [installation guide](https://guides.dataverse.org/en/latest/installation/installation-main.html#running-the-dataverse-software-installer) is out of date and uses a differente format from the one available in dvinstall.zip (from the releases page)

**Which issue(s) this PR closes**:

Closes #8481 

**Special notes for your reviewer**:

**Suggestions on how to test this**:
Download the default.config sample file from the i[installation guide](https://guides.dataverse.org/en/latest/installation/installation-main.html#running-the-dataverse-software-installer),
Open the file and check that its contents are the same as <dataverse_home>/scripts/installer/default.config

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
