### PR TITLE
Dashboard > Harvesting Server links to unexisting section of the User Guide

### DIFF
--- a/src/main/java/propertyFiles/Bundle.properties
+++ b/src/main/java/propertyFiles/Bundle.properties
@@ -467,7 +467,7 @@ harvestclients.noClients.why.reason2=Harvested metadata records are searchable b
 harvestclients.noClients.how.header=How To Use Harvesting
 harvestclients.noClients.how.tip1=To harvest metadata, a <i>Harvesting Client</i> is created and configured for each remote repository. Note that when creating a client you will need to select an existing local dataverse to host harvested datasets.
 harvestclients.noClients.how.tip2=Harvested records can be kept in sync with the original repository through scheduled incremental updates, for example, daily or weekly. Alternatively, harvests can be run on demand, from this page or via the REST API.
-harvestclients.noClients.getStarted=To get started, click on the Add Client button above. To learn more about Harvesting, visit the <a href="{0}/{1}/user/index.html#index" title="Harvesting - Dataverse User Guide" target="_blank">Harvesting</a> section of the User Guide.
+harvestclients.noClients.getStarted=To get started, click on the Add Client button above. To learn more about Harvesting, visit the <a href="{0}/{1}/admin/dashboard.html#harvesting" title="Harvesting - Dataverse Admin Guide" target="_blank">Harvesting</a> section on the Dashboard page of the Admin Guide.
 harvestclients.btn.add=Add Client
 harvestclients.tab.header.name=Nickname
 harvestclients.tab.header.url=URL
@@ -562,7 +562,7 @@ harvestserver.noSets.why.reason2=Only the published, unrestricted datasets in yo
 harvestserver.noSets.how.header=How to run a Harvesting Server?
 harvestserver.noSets.how.tip1=Harvesting server can be enabled or disabled on this page. 
 harvestserver.noSets.how.tip2=Once the service is enabled, you can define collections of local datasets that will be available to remote harvesters as <i>OAI Sets</i>. Sets are defined by search queries (for example, authorName:king; or parentId:1234 - to select all the datasets that belong to the dataverse specified; or dsPersistentId:"doi:1234/" to select all the datasets with the persistent identifier authority specified). Consult the Search API section of the Dataverse User Guide for more information on the search queries.  
-harvestserver.noSets.getStarted=To get started, enable the OAI server and click on the Add Set button. To learn more about Harvesting, visit the <a href="{0}/{1}/user/index.html#index" title="Harvesting - Dataverse User Guide" target="_blank">Harvesting</a> section of the User Guide.
+harvestserver.noSets.getStarted=To get started, enable the OAI server and click on the Add Set button. To learn more about Harvesting, visit the <a href="{0}/{1}/admin/dashboard.html#harvesting" title="Harvesting - Dataverse Admin Guide" target="_blank">Harvesting</a> section on the Dashboard page of the Admin Guide.
 harvestserver.btn.add=Add Set
 harvestserver.tab.header.spec=OAI setSpec
 harvestserver.tab.col.spec.default=DEFAULT


### PR DESCRIPTION
**What this PR does / why we need it**:
The _Harvesting_ link under section _Dashboard > Harvesting Server > Manage Server > How to run a Harvesting Server?_ redirects to the User Guide index page, but the Harvesting documentation is in Admin Guide

**Which issue(s) this PR closes**:

Closes #8640

**Special notes for your reviewer**:

**Suggestions on how to test this**:

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
