### PR TITLE
remove session.setUser(pre-save user) on email change #8643

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/authorization/providers/builtin/DataverseUserPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/authorization/providers/builtin/DataverseUserPage.java
@@ -384,7 +384,6 @@ public class DataverseUserPage implements java.io.Serializable {
                 } catch (ConfirmEmailException ex) {
                     logger.log(Level.INFO, "Unable to send email confirmation link to user id {0}", savedUser.getId());
                 }
-                session.setUser(currentUser);
                 JsfHelper.addSuccessMessage(BundleUtil.getStringFromBundle("confirmEmail.changed", args));
             } else {
                 JsfHelper.addFlashMessage(msg.toString());


### PR DESCRIPTION
**What this PR does / why we need it**:

When you change your email, the tabs on the user page are blank.

**Which issue(s) this PR closes**:

- Closes #8643

**Special notes for your reviewer**:

I'm not sure why `session.setUser(currentUser)` is here (it was added in b13f9be) and removing it seems to help.

There are still weird messages in server.log but fewer than the stacktrace seen in #8643.

When you click "Save Changes":

[2022-04-22T14:40:23.267-0400] [Payara 5.2021.5] [WARNING] [jsf.externalcontext.flash.response.already.committed] [javax.enterprise.resource.webcontainer.jsf.flash] [tid: _ThreadID=116 _ThreadName=http-thread-pool::http-listener-1(1)] [timeMillis: 1650652823267] [levelValue: 900] [[
  JSF1095: The response was already committed by the time we tried to set the outgoing cookie for the flash.  Any values stored to the flash will not be available on the next request.]]

When you click another tab and then go back to "Account Information":

[2022-04-22T14:40:46.258-0400] [Payara 5.2021.5] [WARNING] [] [] [tid: _ThreadID=116 _ThreadName=http-thread-pool::http-listener-1(1)] [timeMillis: 1650652846258] [levelValue: 900] [[
  Response has already been committed, and further write operations are not permitted. This may result in an IllegalStateException being triggered by the underlying application. To avoid this situation, consider adding a Rule `.when(Direction.isInbound().and(Response.isCommitted())).perform(Lifecycle.abort())`, or figure out where the response is being incorrectly committed and correct the bug in the offending code.]]

**Suggestions on how to test this**:

#8643 contains steps.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

Yes, instead of going to "My Data"on email change, you stay on "Account Information" which looks like this:

![Screen Shot 2022-04-22 at 2 45 03 PM](https://user-images.githubusercontent.com/21006/164775934-bf53d322-41d5-48c9-ab91-80ce5d1e8538.png)

**Is there a release notes update needed for this change?**:

No.

**Additional documentation**:

None.