### PR TITLE
8650 ReadTheDocs based HTML guides preview

### DIFF
--- a/.github/workflows/guides_build_sphinx.yml
+++ b/.github/workflows/guides_build_sphinx.yml
@@ -2,7 +2,9 @@ name: "Guides Build Status"
 on: 
   pull_request:
     paths:
-      - 'doc/sphinx-guides/**/*.rst'
+      - "doc/sphinx-guides/**/*.rst"
+      - "doc/sphinx-guides/**/requirements.txt"
+      - "doc/sphinx-guides/**/conf.py"
 
 jobs:
   docs:

--- a/doc/sphinx-guides/requirements.txt
+++ b/doc/sphinx-guides/requirements.txt
@@ -1,2 +1,4 @@
 # current version as of this writing
 Sphinx==3.5.4
+# Necessary workaround for Sphinx 3.x - unnecessary as of Sphinx 4.5+
+Jinja2>=3.0.2,<3.1

--- a/doc/sphinx-guides/requirements.txt
+++ b/doc/sphinx-guides/requirements.txt
@@ -1,4 +1,4 @@
 # current version as of this writing
 Sphinx==3.5.4
-# Necessary workaround for Sphinx 3.x - unnecessary as of Sphinx 4.5+
+# Necessary workaround for ReadTheDocs for Sphinx 3.x - unnecessary as of Sphinx 4.5+
 Jinja2>=3.0.2,<3.1


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix issues with the RTD build (using a newer, incompatible version of Jinja) and make the guide action get triggered by changes to the Sphinx config & Python deps, too.

**Which issue(s) this PR closes**:
Closes #8650

**Special notes for your reviewer**:
None.

**Suggestions on how to test this**:
See if the build at RTD works and enjoy the preview: https://dataverse-guide--8651.org.readthedocs.build/en/8651/

The link was taken from here:
![grafik](https://user-images.githubusercontent.com/5468333/165124558-f3125e23-af78-43ec-bf88-423a78caf460.png)


**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
Nope.

**Is there a release notes update needed for this change?**:
Nope.

**Additional documentation**:
None.
