### PR TITLE
IQSS/8587-fix footer position

### DIFF
--- a/src/main/webapp/resources/css/structure.css
+++ b/src/main/webapp/resources/css/structure.css
@@ -49,7 +49,8 @@ body .ui-widget {font-size: inherit;}
 #status-alert {margin-top:0; margin-bottom:0;}
 #status-alert div.alert {border:0; box-shadow:none;}
 
-footer {position:absolute; bottom:0; width:100%; height:60px; padding-bottom:100px; color:#767676;}
+footer {height:0px; color:#767676;}
+#dvfooter {padding-top:60px;}
 #dvfooter.widget-view {position:fixed; left:0; bottom:0; margin:0; padding:4px 0 0 0; min-height:44p; height:auto; background:#fff;}
 #dvfooter .poweredbylogo {text-align:right;}
 #dvfooter .poweredbylogo span {font-size:.85em;margin-right:.3em;}


### PR DESCRIPTION
**What this PR does / why we need it**: This should be a fix for the problem of the footer appearing mid-page when a custom footer is used. It should maintain the previous spacing other page content.

**Which issue(s) this PR closes**:

Closes #8587 

**Special notes for your reviewer**: FWIW: The main issue is that position:absolute on the footer element appears to work with no custom footer but causes problems when a custom footer exists. To maintain spacing when the footer is not absolute, a padding-top on the #dvfooter element is needed. The other deletions in the code either have no effect or (for footer:height just remove blank space at the bottom of the page.)

**Suggestions on how to test this**: Should look at positioning of footer in both default and with custom-footer cases on multiple pages (e.g. the main dataverse/dataset list page and the login page.)

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: only fixes a regression

**Is there a release notes update needed for this change?**:

**Additional documentation**:
