### PR TITLE
Prevent non-widgets from being embedded in iframes

### DIFF
--- a/doc/release-notes/ds54-csp.md
+++ b/doc/release-notes/ds54-csp.md
@@ -1,0 +1,1 @@
+As always, widgets can be embedded in the `<iframe>` HTML tag, but the HTTP header "Content-Security-Policy" is now being sent on non-widget pages to prevent them from being embedded.

--- a/src/main/java/edu/harvard/iq/dataverse/WidgetWrapper.java
+++ b/src/main/java/edu/harvard/iq/dataverse/WidgetWrapper.java
@@ -8,6 +8,7 @@ package edu.harvard.iq.dataverse;
 import javax.faces.context.FacesContext;
 import javax.faces.view.ViewScoped;
 import javax.inject.Named;
+import javax.servlet.http.HttpServletResponse;
 
 /**
  *
@@ -35,6 +36,11 @@ public class WidgetWrapper implements java.io.Serializable {
                 widgetScope = widgetParam.substring(0, widgetParam.indexOf(WIDGET_SEPARATOR));
                 widgetHome = widgetParam.substring(widgetParam.indexOf(WIDGET_SEPARATOR) + 1);
             }
+        }
+        if (!widgetView) {
+            // Prevent non-widgets from being embedded in iframes.
+            HttpServletResponse response = (HttpServletResponse) FacesContext.getCurrentInstance().getExternalContext().getResponse();
+            response.setHeader("Content-Security-Policy", "frame-ancestors 'none'");
         }
         return widgetView;
     }

--- a/src/main/webapp/dataverse_template.xhtml
+++ b/src/main/webapp/dataverse_template.xhtml
@@ -39,12 +39,6 @@
         <link type="text/css" rel="stylesheet" href="#{resource['css/fontcustom.css']}?version=#{settingsWrapper.appVersion}" />
         <link type="text/css" rel="stylesheet" href="#{resource['css/socicon.css']}?version=#{settingsWrapper.appVersion}" />
         <link type="text/css" rel="stylesheet" href="#{resource['css/structure.css']}?version=#{settingsWrapper.appVersion}" />
-        <ui:fragment rendered="#{!widgetWrapper.widgetView}">
-            <script>
-                // Break out of iframe
-                if (window !== top) top.location = window.location;
-            </script>
-        </ui:fragment>
 	<ui:fragment rendered="#{!empty settingsWrapper.get(':StyleCustomizationFile')}">
             <style>
                 /* Custom CSS */


### PR DESCRIPTION
**What this PR does / why we need it**:

Prevents non-widgets from being embedded in iframes.

**Which issue(s) this PR closes**:

- Closes https://github.com/IQSS/dataverse-security/issues/54

**Special notes for your reviewer**:

**Suggestions on how to test this**:

I'd suggest setting up two servers that are using the same port. Probably 443 (HTTPS) would be used in production. One one server, deploy this branch. On the other server, all you need is Apache or any web server to server a static HTML file. In the static HTML file, I'd suggest coping and pasting code from the widgets tabs. Widgets should still work. You should also try including non-widget pages (e.g. the homepage) in an `<iframe>`. This should fail.

I didn't set up two servers. Instead I used the "logos" directory in docroot to host the static HTML file. That is, I placed the following in `/usr/local/payara5/glassfish/domains/domain1/docroot/logos/42/index.html`

```
<html>
<body>
<p>Homepage example:</p>
<iframe id="homepage"
    title="Homepage"
    width="800"
    height="480"
    src="http://localhost:8080">
</iframe>
<p>Widget example:</p>
<iframe id="widget"
    title="Widget"
    width="800"
    height="480"
    src="http://localhost:8080/dataverse/root?widget=dataverse@root">
</iframe>
</body>
</html>
```

Then I navigated to http://localhost:8080/logos/42/index.html in Firefox, Chrome, and Safari. I'll post screenshots of each below. In each, a widget is displayed.

## Firefox.

![Screen Shot 2022-04-28 at 3 26 24 PM](https://user-images.githubusercontent.com/21006/165834655-4494b494-2914-48e6-8ba2-eddbac5dea45.png)

## Chrome (you have to hover your mouse to see the message)

![Screen Shot 2022-04-28 at 3 26 50 PM](https://user-images.githubusercontent.com/21006/165834854-c1ea799a-2645-439c-aa74-9ac22226d3f3.png)

## Safari

![Screen Shot 2022-04-28 at 3 27 22 PM](https://user-images.githubusercontent.com/21006/165834879-c90c3e98-aed5-4de0-a0fc-d4ecfeeaee3e.png)

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

Not really. Screenshots are above under "testing".

**Is there a release notes update needed for this change?**:

Probably. Included.

**Additional documentation**:

None.