### PR TITLE
8663 create ds json fails

### DIFF
--- a/doc/release-notes/8663-update-create-ds-doc.md
+++ b/doc/release-notes/8663-update-create-ds-doc.md
@@ -1,0 +1,5 @@
+## Release Highlights
+
+### Documentation of Create Dataset API has been Updated
+
+Previous versions of the guides omitted the content header in the example API call for creating a datset. Due to a code change introduced in Dataverse version 5.6 calls without the content header will fail.

--- a/doc/sphinx-guides/source/api/native-api.rst
+++ b/doc/sphinx-guides/source/api/native-api.rst
@@ -473,13 +473,13 @@ Next you need to figure out the alias or database id of the "parent" Dataverse c
   export PARENT=root
   export SERVER_URL=https://demo.dataverse.org
 
-  curl -H X-Dataverse-key:$API_TOKEN -X POST "$SERVER_URL/api/dataverses/$PARENT/datasets" --upload-file dataset-finch1.json
+  curl -H X-Dataverse-key:$API_TOKEN -X POST "$SERVER_URL/api/dataverses/$PARENT/datasets" --upload-file dataset-finch1.json -H 'Content-type:application/json'
 
 The fully expanded example above (without the environment variables) looks like this:
 
 .. code-block:: bash
 
-  curl -H "X-Dataverse-key:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" -X POST "https://demo.dataverse.org/api/dataverses/root/datasets" --upload-file "dataset-finch1.json"
+  curl -H "X-Dataverse-key:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" -X POST "https://demo.dataverse.org/api/dataverses/root/datasets" --upload-file "dataset-finch1.json" -H 'Content-type:application/json'
 
 You should expect an HTTP 200 ("OK") response and JSON indicating the database ID and Persistent ID (PID such as DOI or Handle) that has been assigned to your newly created dataset.
 


### PR DESCRIPTION
**What this PR does / why we need it**:  The documented api for creating a dataset via the api is failing. Due to a coding change the api requires a content header. This PR updates the doc and adds a release note.

**Which issue(s) this PR closes**:

Closes #8663 Cannot create dataset on demo using json example 

**Special notes for your reviewer**: no code - just doc and release note

**Suggestions on how to test this**: verify that the example for [Create a Dataset in a Dataverse Collection](https://guides.dataverse.org/en/5.10.1/api/native-api.html#id40) works.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: no

**Is there a release notes update needed for this change?**: included

**Additional documentation**:
