### PR TITLE
Harvest: support dx.doi.org url and http protocol

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/GlobalId.java
+++ b/src/main/java/edu/harvard/iq/dataverse/GlobalId.java
@@ -28,6 +28,7 @@ public class GlobalId implements java.io.Serializable {
     public static final String HDL_PROTOCOL = "hdl";
     public static final String HDL_RESOLVER_URL = "https://hdl.handle.net/";
     public static final String DOI_RESOLVER_URL = "https://doi.org/";
+    public static final String DXDOI_RESOLVER_URL = "https://dx.doi.org/";
     
     public static Optional<GlobalId> parse(String identifierString) {
         try {

--- a/src/main/java/edu/harvard/iq/dataverse/api/imports/ImportGenericServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/imports/ImportGenericServiceBean.java
@@ -348,7 +348,10 @@ public class ImportGenericServiceBean {
         if (!otherIds.isEmpty()) {
             // We prefer doi or hdl identifiers like "doi:10.7910/DVN/1HE30F"
             for (String otherId : otherIds) {
-                if (otherId.startsWith(GlobalId.DOI_PROTOCOL) || otherId.startsWith(GlobalId.HDL_PROTOCOL) || otherId.startsWith(GlobalId.DOI_RESOLVER_URL) || otherId.startsWith(GlobalId.HDL_RESOLVER_URL)) {
+                if (otherId.startsWith(GlobalId.DOI_PROTOCOL) || otherId.startsWith(GlobalId.HDL_PROTOCOL) ||
+                    otherId.startsWith(GlobalId.DOI_RESOLVER_URL) || otherId.startsWith(GlobalId.HDL_RESOLVER_URL) || otherId.startsWith(GlobalId.DXDOI_RESOLVER_URL) ||
+                    otherId.startsWith(GlobalId.DOI_RESOLVER_URL.replace("https","http")) || otherId.startsWith(GlobalId.HDL_RESOLVER_URL.replace("https","http")) || otherId.startsWith(GlobalId.DXDOI_RESOLVER_URL.replace("https","http"))
+                    ) {
                     return otherId;
                 }
             }
@@ -389,15 +392,32 @@ public class ImportGenericServiceBean {
             
             // We also recognize global identifiers formatted as global resolver URLs:
             
-            if (identifierString.startsWith(GlobalId.HDL_RESOLVER_URL)) {
+            if (identifierString.startsWith(GlobalId.HDL_RESOLVER_URL) || identifierString.startsWith(GlobalId.HDL_RESOLVER_URL.replace("https", "http"))) {
                 logger.fine("Processing Handle identifier formatted as a resolver URL: "+identifierString);
                 protocol = GlobalId.HDL_PROTOCOL;
                 index1 = GlobalId.HDL_RESOLVER_URL.length() - 1;
+                if (!identifierString.startsWith("https")){
+                    // http
+                    index1--;
+                }
                 index2 = identifierString.indexOf("/", index1 + 1);
-            } else if (identifierString.startsWith(GlobalId.DOI_RESOLVER_URL)) {
+            } else if (identifierString.startsWith(GlobalId.DOI_RESOLVER_URL) || identifierString.startsWith(GlobalId.DOI_RESOLVER_URL.replace("https", "http"))) {
                 logger.fine("Processing DOI identifier formatted as a resolver URL: "+identifierString);
                 protocol = GlobalId.DOI_PROTOCOL;
                 index1 = GlobalId.DOI_RESOLVER_URL.length() - 1; 
+                if (!identifierString.startsWith("https")){
+                    // http
+                    index1--;
+                }
+                index2 = identifierString.indexOf("/", index1 + 1);
+            } else if (identifierString.startsWith(GlobalId.DXDOI_RESOLVER_URL) || identifierString.startsWith(GlobalId.DXDOI_RESOLVER_URL.replace("https", "http"))) {
+                logger.fine("Processing DOI identifier formatted as a resolver URL: "+identifierString);
+                protocol = GlobalId.DOI_PROTOCOL;
+                index1 = GlobalId.DXDOI_RESOLVER_URL.length() - 1; 
+                if (!identifierString.startsWith("https")){
+                    // http
+                    index1--;
+                }
                 index2 = identifierString.indexOf("/", index1 + 1);
             } else {
                 logger.warning("HTTP Url in supplied as the identifier is neither a Handle nor DOI resolver: "+identifierString);


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, surported global id formats are:
- doi://AUTHORITY/IDENTIFIER
- hdl://AUTHORITY/IDENTIFIER
- https://hdl.handle.net/AUTHORITY/IDENTIFIER
- https://doi.org/AUTHORITY/IDENTIFIER

This PR add support for:
- http://hdl.handle.net/AUTHORITY/IDENTIFIER
- http://doi.org/AUTHORITY/IDENTIFIER
- https://dx.doi.org/AUTHORITY/IDENTIFIER
- http://dx.doi.org/AUTHORITY/IDENTIFIER

**Which issue(s) this PR closes**:



**Special notes for your reviewer**:

**Suggestions on how to test this**:

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
