### PR TITLE
BagIt Support - Improved ignored files for BagIt handler

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/util/file/BagItFileHandlerPostProcessor.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/file/BagItFileHandlerPostProcessor.java
@@ -15,7 +15,7 @@ public class BagItFileHandlerPostProcessor {
 
     private static final Logger logger = Logger.getLogger(BagItFileHandlerPostProcessor.class.getCanonicalName());
 
-    public static final List<String> FILES_TO_IGNORE = Arrays.asList("__", "._", ".DS_Store", "._.DS_Store");
+    public static final List<String> FILES_TO_IGNORE = Arrays.asList("__", "._", ".DS_Store");
 
     public List<DataFile> process(List<DataFile> items) {
         if(items == null) {
@@ -26,7 +26,11 @@ public class BagItFileHandlerPostProcessor {
 
         for(DataFile item: items) {
             String fileName = item.getCurrentName();
-            if(FILES_TO_IGNORE.contains(fileName)) {
+            if(fileName == null || fileName.isEmpty()) {
+                continue;
+            }
+
+            if(FILES_TO_IGNORE.stream().anyMatch(prefix -> fileName.startsWith(prefix))) {
                 logger.fine(String.format("action=BagItFileHandlerPostProcessor result=ignore-entry file=%s", fileName));
                 continue;
             }

--- a/src/test/java/edu/harvard/iq/dataverse/util/file/BagItFileHandlerPostProcessorTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/util/file/BagItFileHandlerPostProcessorTest.java
@@ -29,11 +29,43 @@ public class BagItFileHandlerPostProcessorTest {
     @Test
     public void should_ignore_mac_control_files() throws Exception {
         String bagEntry = UUID.randomUUID().toString();
-        String macFile01 = "__";
-        String macFile02 = "._";
         String macFile03 = ".DS_Store";
         String macFile04 = "._.DS_Store";
-        List<DataFile> dataFiles = createDataFiles(bagEntry, macFile01, macFile02, macFile03, macFile04);
+        List<DataFile> dataFiles = createDataFiles(bagEntry, macFile03, macFile04);
+
+        List<DataFile> result = target.process(dataFiles);
+        MatcherAssert.assertThat(result.size(), Matchers.is(1));
+        MatcherAssert.assertThat(result.get(0).getCurrentName(), Matchers.is(bagEntry));
+    }
+
+    @Test
+    public void should_ignore_empty_files() throws Exception {
+        String bagEntry = UUID.randomUUID().toString();
+        String fileToIgnore = "";
+        List<DataFile> dataFiles = createDataFiles(bagEntry, fileToIgnore);
+
+        List<DataFile> result = target.process(dataFiles);
+        MatcherAssert.assertThat(result.size(), Matchers.is(1));
+        MatcherAssert.assertThat(result.get(0).getCurrentName(), Matchers.is(bagEntry));
+    }
+
+    @Test
+    public void should_ignore_files_that_start_with_dot_underscore() throws Exception {
+        String bagEntry = UUID.randomUUID().toString();
+        String fileToIgnore = "._FileNameToIgnore";
+        List<DataFile> dataFiles = createDataFiles(bagEntry, fileToIgnore);
+
+        List<DataFile> result = target.process(dataFiles);
+        MatcherAssert.assertThat(result.size(), Matchers.is(1));
+        MatcherAssert.assertThat(result.get(0).getCurrentName(), Matchers.is(bagEntry));
+    }
+
+    @Test
+    public void should_ignore_files_that_start_with_double_underscore() throws Exception {
+        String bagEntry = UUID.randomUUID().toString();
+        String fileToIgnore = "__FileNameToIgnore";
+        String validFile = "validName";
+        List<DataFile> dataFiles = createDataFiles(bagEntry, fileToIgnore);
 
         List<DataFile> result = target.process(dataFiles);
         MatcherAssert.assertThat(result.size(), Matchers.is(1));


### PR DESCRIPTION
**What this PR does / why we need it**:
Improved the ignored files for the BagIt file handler. Ignores the control files added automatically by MacOS when creating Zip files.

**Which issue(s) this PR closes**:

Closes:  https://github.com/IQSS/dataverse/issues/8754

**Special notes for your reviewer**:
N/A

**Suggestions on how to test this**:
Enable the feature: curl -X PUT -d 'true' http://localhost:8080/api/admin/settings/:BagItHandlerEnabled

Upload a BagIt package as a Zip file created in a MacOS machine.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
No

**Is there a release notes update needed for this change?**:
No

**Additional documentation**:
N/A
