### PR TITLE
#165 ensure ordering of MDBs with Citation first

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DatasetVersionUI.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetVersionUI.java
@@ -18,6 +18,8 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
+import static java.util.stream.Collectors.toList;
 import javax.ejb.EJB;
 import javax.faces.view.ViewScoped;
 import javax.inject.Named;
@@ -39,22 +41,22 @@ public class DatasetVersionUI implements Serializable {
     public DatasetVersionUI() {
     }
 
-    private Map<MetadataBlock, List<DatasetField>> metadataBlocksForView = new HashMap<>();
-    private Map<MetadataBlock, List<DatasetField>> metadataBlocksForEdit = new HashMap<>();
+    private TreeMap<MetadataBlock, List<DatasetField>> metadataBlocksForView = new TreeMap<>();
+    private TreeMap<MetadataBlock, List<DatasetField>> metadataBlocksForEdit = new TreeMap<>();
 
-    public Map<MetadataBlock, List<DatasetField>> getMetadataBlocksForView() {
+    public TreeMap<MetadataBlock, List<DatasetField>> getMetadataBlocksForView() {
         return metadataBlocksForView;
     }
 
-    public void setMetadataBlocksForView(Map<MetadataBlock, List<DatasetField>> metadataBlocksForView) {
+    public void setMetadataBlocksForView(TreeMap<MetadataBlock, List<DatasetField>> metadataBlocksForView) {
         this.metadataBlocksForView = metadataBlocksForView;
     }
 
-    public Map<MetadataBlock, List<DatasetField>> getMetadataBlocksForEdit() {
+    public TreeMap<MetadataBlock, List<DatasetField>> getMetadataBlocksForEdit() {
         return metadataBlocksForEdit;
     }
 
-    public void setMetadataBlocksForEdit(Map<MetadataBlock, List<DatasetField>> metadataBlocksForEdit) {
+    public void setMetadataBlocksForEdit(TreeMap<MetadataBlock, List<DatasetField>> metadataBlocksForEdit) {
         this.metadataBlocksForEdit = metadataBlocksForEdit;
     }
     
@@ -417,7 +419,7 @@ public class DatasetVersionUI implements Serializable {
                     actualMDB.add(mdbTest);
                 }
             }
-        }       
+        }
         
         for (MetadataBlock mdb : actualMDB) {
             mdb.setEmpty(true);

--- a/src/main/java/edu/harvard/iq/dataverse/MetadataBlock.java
+++ b/src/main/java/edu/harvard/iq/dataverse/MetadataBlock.java
@@ -35,7 +35,7 @@ import javax.persistence.Transient;
     @NamedQuery( name="MetadataBlock.findByName", query = "SELECT mdb FROM MetadataBlock mdb WHERE mdb.name=:name")
 })
 @Entity
-public class MetadataBlock implements Serializable {
+public class MetadataBlock implements Serializable, Comparable {
 
     private static final long serialVersionUID = 1L;
     
@@ -209,5 +209,13 @@ public class MetadataBlock implements Serializable {
         } catch (MissingResourceException e) {
             return displayName;
         }
+    }
+
+    @Override
+    public int compareTo(Object arg0) {
+        //guaranteeing that citation will be shown first with custom blocks in order of creation
+        MetadataBlock other = (MetadataBlock) arg0;
+        Long t = "citation".equals(name) ? -1 : this.getId();
+        return t.compareTo("citation".equals(other.name) ? -1 : other.getId());
     }
 }

--- a/src/test/java/edu/harvard/iq/dataverse/engine/command/impl/MoveDataverseCommandTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/engine/command/impl/MoveDataverseCommandTest.java
@@ -156,9 +156,11 @@ public class MoveDataverseCommandTest {
         mbA = new MetadataBlock();
         mbA.setOwner(root);
         mbA.setId(1l);
+        mbA.setName("mbA");
         mbB = new MetadataBlock();
         mbB.setOwner(childE);
         mbB.setId(2l);
+        mbB.setName("mbB");
         mbsE.add(mbB);
         mbsEE.add(mbA);
         mbsEE.add(mbB);


### PR DESCRIPTION
**What this PR does / why we need it**: For at least one dataset users are seeing custom metadata blocks appear before the Citation block on dataset view and edit. We always want to display the Citation block first among all mdbs.

**Which issue(s) this PR closes**:

Closes https://github.com/IQSS/dataverse.harvard.edu/issues/165 When creating, editing and viewing datasets in the NegotiationDataRepository collection, its custom metadatablock appears above the Citation metadatablock

**Special notes for your reviewer**: This fix relies on the name of the citation block similar to the "isRequired" on the metadata block object. There is no display order field so the sort for custom mdbs is id.

**Suggestions on how to test this**: verify that the citation block is always rendered first.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: no

**Is there a release notes update needed for this change?**: no

**Additional documentation**: none
