### PR TITLE
Validation fix and API call

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/api/AbstractApiBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/AbstractApiBean.java
@@ -432,14 +432,22 @@ public abstract class AbstractApiBean {
     
     private AuthenticatedUser getAuthenticatedUserFromSignedUrl() {
         AuthenticatedUser authUser = null;
-        String signedUrl = httpRequest.getRequestURL().toString();
+        // The signUrl contains a param telling which user this is supposed to be for.
+        // We don't trust this. So we lookup that user, and get their API key, and use
+        // that as a secret in validation the signedURL. If the signature can't be
+        // validating with their key, the user (or their API key) has been changed and
+        // we reject the request.
+        //ToDo - add null checks/ verify that calling methods catch things.
         String user = httpRequest.getParameter("user");
+        AuthenticatedUser targetUser = authSvc.getAuthenticatedUser(user);
+        String key = authSvc.findApiTokenByUser(targetUser).getTokenString();
+        String signedUrl = httpRequest.getRequestURL().toString();
         String method = httpRequest.getMethod();
-        String key = httpRequest.getParameter("token");
+        
         boolean validated = UrlSignerUtil.isValidUrl(signedUrl, method, user, key);
         if (validated){
-            authUser = authSvc.getAuthenticatedUser(user);
-        }     
+            authUser = targetUser;
+        }
         return authUser;
     }    
 

--- a/src/main/java/edu/harvard/iq/dataverse/util/json/JsonUtil.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/json/JsonUtil.java
@@ -3,6 +3,8 @@ package edu.harvard.iq.dataverse.util.json;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonObject;
+
+import java.io.StringReader;
 import java.io.StringWriter;
 import java.util.HashMap;
 import java.util.Map;
@@ -55,5 +57,16 @@ public class JsonUtil {
         }
         return stringWriter.toString();
     }
+    
+    public static javax.json.JsonObject getJsonObject(String serializedJson) {
+        try (StringReader rdr = new StringReader(serializedJson)) {
+            return Json.createReader(rdr).readObject();
+        }
+    }
 
+    public static JsonArray getJsonArray(String serializedJson) {
+        try (StringReader rdr = new StringReader(serializedJson)) {
+            return Json.createReader(rdr).readArray();
+        }
+    }
 }


### PR DESCRIPTION
The two commits fix a misconception in the validation routine and then add an api call to test with. I haven't done more than compile this so there could still be bugs. The api call should allow requests POSTing a json object with
"url" - the unsigned url you want (must be exact with any dataset/file id, etc. 
"method" - optional - GET is assumed
"timeout" - optional - 10 minutes is assumed
"userId" - optional - the user id string - assumes the superuser using this API.