### PR TITLE
8599 legacy template issue

### DIFF
--- a/doc/release-notes/8599-legacy-templates
+++ b/doc/release-notes/8599-legacy-templates
@@ -1,0 +1,5 @@
+Some older legacy templates did not have an associated termsofuseandaccess linked to them. When custom licenses were added, dataverses that these legacy templates as default would not allow the creation of a new dataset (500 error). 
+
+In this release, we run a script that creates a default empty termsofuseandaccess for each of these templates and links them.
+
+Note the termsofuseandaccess that are created this way default to using the license with id=1 (cc0) and the fileaccessrequest to false. 

--- a/src/main/resources/db/migration/V5.10.1.3__8599-legacy-templates.sql
+++ b/src/main/resources/db/migration/V5.10.1.3__8599-legacy-templates.sql
@@ -1,0 +1,10 @@
+-- this script finds legacy templates that do not hava an associated termsofuseandaccess 
+-- and creates / links a termsofuseandaccess to them
+with  _update as 
+(
+update template set termsofuseandaccess_id =  nextval('termsofuseandaccess_id_seq' )
+where termsofuseandaccess_id is null
+returning termsofuseandaccess_id
+)
+insert into termsofuseandaccess (id, fileaccessrequest, license_id) (select termsofuseandaccess_id, false, 1 from _update)
+


### PR DESCRIPTION
**What this PR does / why we need it**:
adds a flyway script fix some legacy templates

**Which issue(s) this PR closes**:

Closes #8599

**Special notes for your reviewer**:
none

**Suggestions on how to test this**:
find a legacy template (or create one by removing the id in the termsofuseandaccess column), set the default template for the dv to use that template. Verify that trying to create a dataset there causes a 500 error. Then run script (e.g. deploy this branch) and see that the issue is fixed.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
no

**Is there a release notes update needed for this change?**:
yes, included 

**Additional documentation**:
