### PR TITLE
BagIt Support - Improve error messages for BagIt handler

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/EditDataFilesPageHelper.java
+++ b/src/main/java/edu/harvard/iq/dataverse/EditDataFilesPageHelper.java
@@ -2,9 +2,11 @@ package edu.harvard.iq.dataverse;
 
 import edu.harvard.iq.dataverse.util.BundleUtil;
 import edu.harvard.iq.dataverse.util.file.CreateDataFileResult;
+import org.apache.commons.text.StringEscapeUtils;
 
 import javax.ejb.Stateless;
 import javax.inject.Inject;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -22,6 +24,14 @@ public class EditDataFilesPageHelper {
     @Inject
     private SettingsWrapper settingsWrapper;
 
+    public String consolidateHtmlErrorMessages(List<String> errorMessages) {
+        if(errorMessages == null || errorMessages.isEmpty()) {
+            return null;
+        }
+
+        return String.join("</br>", errorMessages);
+    }
+
     public String getHtmlErrorMessage(CreateDataFileResult createDataFileResult) {
         List<String> errors = createDataFileResult.getErrors();
         if(errors == null || errors.isEmpty()) {
@@ -33,8 +43,8 @@ public class EditDataFilesPageHelper {
             return null;
         }
 
-        String typeMessage = Optional.ofNullable(BundleUtil.getStringFromBundle(createDataFileResult.getBundleKey())).orElse("Error processing file");
-        String errorsMessage = errors.stream().limit(maxErrorsToShow).map(text -> String.format("<li>%s</li>", text)).collect(Collectors.joining());
-        return String.format("%s:<br /><ul>%s</ul>", typeMessage, errorsMessage);
+        String typeMessage = Optional.ofNullable(BundleUtil.getStringFromBundle(createDataFileResult.getBundleKey(), Arrays.asList(createDataFileResult.getFilename()))).orElse("Error processing file");
+        String errorsMessage = errors.stream().limit(maxErrorsToShow).map(text -> String.format("<li>%s</li>", StringEscapeUtils.escapeHtml4(text))).collect(Collectors.joining());
+        return String.format("%s<br /><ul>%s</ul>", typeMessage, errorsMessage);
     }
 }

--- a/src/main/java/edu/harvard/iq/dataverse/EditDatafilesPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/EditDatafilesPage.java
@@ -51,6 +51,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.logging.Logger;
 import javax.ejb.EJB;
 import javax.ejb.EJBException;
@@ -1491,7 +1492,7 @@ public class EditDatafilesPage implements java.io.Serializable {
                 //datafiles = ingestService.createDataFiles(workingVersion, dropBoxStream, fileName, "application/octet-stream");
                 CreateDataFileResult createDataFilesResult = FileUtil.createDataFiles(workingVersion, dropBoxStream, fileName, "application/octet-stream", null, null, systemConfig);
                 datafiles = createDataFilesResult.getDataFiles();
-                errorMessage = editDataFilesPageHelper.getHtmlErrorMessage(createDataFilesResult);
+                Optional.ofNullable(editDataFilesPageHelper.getHtmlErrorMessage(createDataFilesResult)).ifPresent(errorMessage -> errorMessages.add(errorMessage));
 
             } catch (IOException ex) {
                 this.logger.log(Level.SEVERE, "Error during ingest of DropBox file {0} from link {1}", new Object[]{fileName, fileLink});
@@ -1745,12 +1746,13 @@ public class EditDatafilesPage implements java.io.Serializable {
             uploadedFiles.clear();
             uploadInProgress.setValue(false);
         }
-        if(errorMessage != null) {
-            FacesContext.getCurrentInstance().addMessage(null, new FacesMessage(FacesMessage.SEVERITY_ERROR, BundleUtil.getStringFromBundle("dataset.file.uploadFailure"), errorMessage));
-            PrimeFaces.current().ajax().update(":messagePanel");
-        }
+
         // refresh the warning message below the upload component, if exists:
         if (uploadComponentId != null) {
+            if(!errorMessages.isEmpty()) {
+                FacesContext.getCurrentInstance().addMessage(uploadComponentId, new FacesMessage(FacesMessage.SEVERITY_ERROR,  BundleUtil.getStringFromBundle("dataset.file.uploadFailure"), editDataFilesPageHelper.consolidateHtmlErrorMessages(errorMessages)));
+            }
+
             if (uploadWarningMessage != null) {
                 if (existingFilesWithDupeContent != null || newlyUploadedFilesWithDupeContent != null) {
                     setWarningMessageForAlreadyExistsPopUp(uploadWarningMessage);
@@ -1797,7 +1799,7 @@ public class EditDatafilesPage implements java.io.Serializable {
         multipleDupesNew = false;
         uploadWarningMessage = null;
         uploadSuccessMessage = null;
-        errorMessage = null;
+        errorMessages = new ArrayList<>();
     }
 
     private String warningMessageForFileTypeDifferentPopUp;
@@ -1948,7 +1950,7 @@ public class EditDatafilesPage implements java.io.Serializable {
     }
 
     private String uploadWarningMessage = null;
-    private String errorMessage = null;
+    private List<String> errorMessages = new ArrayList<>();
     private String uploadSuccessMessage = null;
     private String uploadComponentId = null;
 
@@ -2020,7 +2022,11 @@ public class EditDatafilesPage implements java.io.Serializable {
             // zip file.
             CreateDataFileResult createDataFilesResult = FileUtil.createDataFiles(workingVersion, uFile.getInputStream(), uFile.getFileName(), uFile.getContentType(), null, null, systemConfig);
             dFileList = createDataFilesResult.getDataFiles();
-            errorMessage = editDataFilesPageHelper.getHtmlErrorMessage(createDataFilesResult);
+            String createDataFilesError = editDataFilesPageHelper.getHtmlErrorMessage(createDataFilesResult);
+            if(createDataFilesError != null) {
+                errorMessages.add(createDataFilesError);
+                uploadComponentId = event.getComponent().getClientId();
+            }
 
         } catch (IOException ioex) {
             logger.warning("Failed to process and/or save the file " + uFile.getFileName() + "; " + ioex.getMessage());
@@ -2127,7 +2133,7 @@ public class EditDatafilesPage implements java.io.Serializable {
                     //datafiles = ingestService.createDataFiles(workingVersion, dropBoxStream, fileName, "application/octet-stream");
                     CreateDataFileResult createDataFilesResult = FileUtil.createDataFiles(workingVersion, null, fileName, contentType, fullStorageIdentifier, checksumValue, checksumType, systemConfig);
                     datafiles = createDataFilesResult.getDataFiles();
-                    errorMessage = editDataFilesPageHelper.getHtmlErrorMessage(createDataFilesResult);
+                    Optional.ofNullable(editDataFilesPageHelper.getHtmlErrorMessage(createDataFilesResult)).ifPresent(errorMessage -> errorMessages.add(errorMessage));
                 } catch (IOException ex) {
                     logger.log(Level.SEVERE, "Error during ingest of file {0}", new Object[]{fileName});
                 }

--- a/src/main/java/edu/harvard/iq/dataverse/util/FileUtil.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/FileUtil.java
@@ -876,7 +876,7 @@ public class FileUtil implements java.io.Serializable  {
                     }
 
                     datafiles.add(datafile);
-                    return CreateDataFileResult.success(finalType, datafiles);
+                    return CreateDataFileResult.success(fileName, finalType, datafiles);
                 }
 
                 // If it's a ZIP file, we are going to unpack it and create multiple
@@ -1052,7 +1052,7 @@ public class FileUtil implements java.io.Serializable  {
                         logger.warning("Could not remove temp file " + tempFile.getFileName().toString());
                     }
                     // and return:
-                    return CreateDataFileResult.success(finalType, datafiles);
+                    return CreateDataFileResult.success(fileName, finalType, datafiles);
                 }
 
             } else if (finalType.equalsIgnoreCase(ShapefileHandler.SHAPEFILE_FILE_TYPE)) {
@@ -1068,7 +1068,7 @@ public class FileUtil implements java.io.Serializable  {
                 boolean didProcessWork = shpIngestHelper.processFile();
                 if (!(didProcessWork)) {
                     logger.severe("Processing of zipped shapefile failed.");
-                    return CreateDataFileResult.error(finalType);
+                    return CreateDataFileResult.error(fileName, finalType);
                 }
 
                 try {
@@ -1129,11 +1129,11 @@ public class FileUtil implements java.io.Serializable  {
                         logger.warning("Unable to delete: " + tempFile.toString() + "due to Security Exception: "
                                 + se.getMessage());
                     }
-                    return CreateDataFileResult.success(finalType, datafiles);
+                    return CreateDataFileResult.success(fileName, finalType, datafiles);
                 } else {
                     logger.severe("No files added from directory of rezipped shapefiles");
                 }
-                return CreateDataFileResult.error(finalType);
+                return CreateDataFileResult.error(fileName, finalType);
 
             } else if (finalType.equalsIgnoreCase(BagItFileHandler.FILE_TYPE)) {
                 Optional<BagItFileHandler> bagItFileHandler = CDI.current().select(BagItFileHandlerFactory.class).get().getBagItFileHandler();
@@ -1176,10 +1176,10 @@ public class FileUtil implements java.io.Serializable  {
             }
             datafiles.add(datafile);
 
-            return CreateDataFileResult.success(finalType, datafiles);
+            return CreateDataFileResult.success(fileName, finalType, datafiles);
         }
 
-        return CreateDataFileResult.error(finalType);
+        return CreateDataFileResult.error(fileName, finalType);
     }   // end createDataFiles
     
 

--- a/src/main/java/edu/harvard/iq/dataverse/util/bagit/BagValidation.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/bagit/BagValidation.java
@@ -3,8 +3,11 @@ package edu.harvard.iq.dataverse.util.bagit;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  *
@@ -16,7 +19,7 @@ public class BagValidation {
     private final Map<Path, FileValidationResult> fileResults;
 
     public BagValidation(Optional<String> errorMessage) {
-        this.errorMessage = errorMessage;
+        this.errorMessage = errorMessage == null ? Optional.empty() : errorMessage;
         this.fileResults = new LinkedHashMap<>();
     }
 
@@ -32,6 +35,12 @@ public class BagValidation {
 
     public Map<Path, FileValidationResult> getFileResults() {
         return Collections.unmodifiableMap(fileResults);
+    }
+
+    public List<String> getAllErrors() {
+        Stream<String> mainError = getErrorMessage().stream();
+        Stream<String> fileErrors = getFileResults().values().stream().filter(result -> result.isError()).map(result -> result.getMessage());
+        return Stream.concat(mainError, fileErrors).collect(Collectors.toList());
     }
 
     public long errors() {
@@ -76,8 +85,9 @@ public class BagValidation {
             this.status = Status.SUCCESS;
         }
 
-        public void setError() {
+        public void setError(String message) {
             this.status = Status.ERROR;
+            this.message = message;
         }
 
         public boolean isPending() {
@@ -90,10 +100,6 @@ public class BagValidation {
 
         public boolean isError() {
             return status.equals(Status.ERROR);
-        }
-
-        public void setMessage(String message) {
-            this.message = message;
         }
 
         public String getMessage() {

--- a/src/main/java/edu/harvard/iq/dataverse/util/bagit/BagValidator.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/bagit/BagValidator.java
@@ -118,8 +118,7 @@ public class BagValidator {
                 FileChecksumValidationJob validationJob = new FileChecksumValidationJob(inputStreamProvider.get(), filePath, fileChecksum, manifestChecksums.getType(), fileValidationResult);
                 executor.execute(validationJob);
             } else {
-                fileValidationResult.setError();
-                fileValidationResult.setMessage(getMessage("bagit.validation.file.not.found", filePath, fileDataProvider.getName()));
+                fileValidationResult.setError(getMessage("bagit.validation.file.not.found", filePath, fileDataProvider.getName()));
             }
 
         }
@@ -148,7 +147,8 @@ public class BagValidator {
         return Executors.newFixedThreadPool(validatorJobPoolSize);
     }
 
-    private String getMessage(String propertyKey, Object... parameters){
+    // Visible for testing
+    String getMessage(String propertyKey, Object... parameters){
         List<String> parameterList = Arrays.stream(parameters).map(param -> param.toString()).collect(Collectors.toList());
         return BundleUtil.getStringFromBundle(propertyKey, parameterList);
     }

--- a/src/main/java/edu/harvard/iq/dataverse/util/bagit/FileChecksumValidationJob.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/bagit/FileChecksumValidationJob.java
@@ -43,12 +43,10 @@ public class FileChecksumValidationJob implements Runnable {
             if (fileChecksum.equals(calculatedChecksum)) {
                 result.setSuccess();
             } else {
-                result.setError();
-                result.setMessage(getMessage("bagit.checksum.validation.error", filePath, bagChecksumType, fileChecksum, calculatedChecksum));
+                result.setError(getMessage("bagit.checksum.validation.error", filePath, bagChecksumType, fileChecksum, calculatedChecksum));
             }
         } catch (Exception e) {
-            result.setError();
-            result.setMessage(getMessage("bagit.checksum.validation.exception", filePath, bagChecksumType, e.getMessage()));
+            result.setError(getMessage("bagit.checksum.validation.exception", filePath, bagChecksumType, e.getMessage()));
             logger.log(Level.WARNING, String.format("action=validate-checksum result=error filePath=%s type=%s", filePath, bagChecksumType), e);
         } finally {
             IOUtils.closeQuietly(inputStream);

--- a/src/main/java/edu/harvard/iq/dataverse/util/file/CreateDataFileResult.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/file/CreateDataFileResult.java
@@ -13,26 +13,32 @@ public class CreateDataFileResult {
 
     private static final String BUNDLE_KEY_PREFIX = "dataset.file.error";
 
+    private final String filename;
     private final String type;
     private final List<DataFile> dataFiles;
     private final List<String> errors;
 
-    public CreateDataFileResult(String type, List<DataFile> dataFiles, List<String> errors) {
+    public CreateDataFileResult(String filename, String type, List<DataFile> dataFiles, List<String> errors) {
+        this.filename = filename;
         this.type = type;
         this.dataFiles = dataFiles == null ? null : Collections.unmodifiableList(dataFiles);
         this.errors = errors == null ? Collections.emptyList() : Collections.unmodifiableList(errors);
     }
 
-    public static CreateDataFileResult success(String type, List<DataFile> dataFiles) {
-        return new CreateDataFileResult(type, dataFiles, null);
+    public static CreateDataFileResult success(String filename, String type, List<DataFile> dataFiles) {
+        return new CreateDataFileResult(filename, type, dataFiles, null);
     }
 
-    public static CreateDataFileResult error(String type) {
-        return new CreateDataFileResult(type, null, Collections.emptyList());
+    public static CreateDataFileResult error(String filename, String type) {
+        return new CreateDataFileResult(filename, type, null, Collections.emptyList());
     }
 
-    public static CreateDataFileResult error(String type, List<String> errors) {
-        return new CreateDataFileResult(type, null, errors);
+    public static CreateDataFileResult error(String filename, String type, List<String> errors) {
+        return new CreateDataFileResult(filename, type, null, errors);
+    }
+
+    public String getFilename() {
+        return filename;
     }
 
     public String getType() {

--- a/src/main/java/propertyFiles/Bundle.properties
+++ b/src/main/java/propertyFiles/Bundle.properties
@@ -2270,12 +2270,12 @@ bagit.sourceOrganization=Dataverse Installation (<Site Url>)
 bagit.sourceOrganizationAddress=<Full address>
 bagit.sourceOrganizationEmail=<Email address>
 
-bagit.checksum.validation.error=Invalid checksum. filePath={0} type={1} fileChecksum={2} calculatedChecksum={3}
-bagit.checksum.validation.exception=Error while calculating checksum. filePath={0} type={1} error={2}
-bagit.validation.bag.file.not.found=Invalid bag file: {0}
-bagit.validation.manifest.not.supported=No supported manifest found in: {0} supportedTypes: {1}
-bagit.validation.file.not.found=Manifest declared file: {0} not-found in data provider: {1}
-bagit.validation.exception=Unable to complete checksums for: {0}
+bagit.checksum.validation.error=Invalid checksum for file "{0}". Manifest checksum={2}, calculated checksum={3}, type={1}
+bagit.checksum.validation.exception=Error while calculating checksum for file "{0}". Checksum type={1}, error={2}
+bagit.validation.bag.file.not.found=Invalid BagIt package: "{0}"
+bagit.validation.manifest.not.supported=No supported manifest found in BagIt package. Supported types are: {1}
+bagit.validation.file.not.found=The manifest declared a file, "{0}", that is not found in the BagIt package
+bagit.validation.exception=Unable to complete checksums for BagIt package
 
 #Permission.java
 permission.addDataverseDataverse=Add a dataverse within another dataverse
@@ -2348,7 +2348,7 @@ dataset.file.uploadWarning=upload warning
 dataset.file.uploadWorked=upload worked
 dataset.file.upload.popup.explanation.tip=For more information, please refer to the <a href="{0}/{1}/user/dataset-management.html#duplicate-files" title="Duplicate Files - Dataverse User Guide" target="_blank" rel="noopener">Duplicate Files section of the User Guide</a>.
 
-dataset.file.error.application/zipped-bagit=BagIt package detected, but errors found. These are the errors found until processing stopped
+dataset.file.error.application/zipped-bagit=BagIt package, "{0}", detected but errors found. These are the errors found until processing stopped:
 
 #HarvestingClientsPage.java
 harvest.start.error=Sorry, harvest could not be started for the selected harvesting client configuration (unknown server error).

--- a/src/main/webapp/editFilesFragment.xhtml
+++ b/src/main/webapp/editFilesFragment.xhtml
@@ -294,7 +294,7 @@
                         </div>
                     </div>               
                     
-                    <p:message for="fileUpload" id="uploadMessage" display="text" />
+                    <p:message for="fileUpload" id="uploadMessage" display="text" escape="false"/>
                     
                     <p:commandButton id="updateEditDataFilesButtonsForUpload" action="#{EditDatafilesPage.uploadFinished()}" update="datasetForm:editDataFilesButtons" rendered="#{showFileButtonUpdate}" style="display:none"/>
                     <p:commandButton id="updateEditDataFilesButtonsForDelete" action="#{EditDatafilesPage.deleteFilesCompleted()}" update="datasetForm:editDataFilesButtons" rendered="#{showFileButtonUpdate}" style="display:none"/>

--- a/src/test/java/edu/harvard/iq/dataverse/EditDataFilesPageHelperTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/EditDataFilesPageHelperTest.java
@@ -12,6 +12,8 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
 
 /**
  *
@@ -19,6 +21,9 @@ import java.util.Collections;
  */
 @RunWith(MockitoJUnitRunner.class)
 public class EditDataFilesPageHelperTest {
+
+    private static final String FILENAME = UUID.randomUUID().toString();
+    private static final String TYPE = UUID.randomUUID().toString();
 
     @Mock
     private SettingsWrapper settingsWrapper;
@@ -28,7 +33,7 @@ public class EditDataFilesPageHelperTest {
 
     @Test
     public void getHtmlErrorMessage_should_return_null_when_no_error_messages() {
-        CreateDataFileResult createDataFileResult = new CreateDataFileResult("test_type", Collections.emptyList(), Collections.emptyList());
+        CreateDataFileResult createDataFileResult = new CreateDataFileResult(FILENAME, TYPE, Collections.emptyList(), Collections.emptyList());
 
         MatcherAssert.assertThat(target.getHtmlErrorMessage(createDataFileResult), Matchers.nullValue());
     }
@@ -36,7 +41,7 @@ public class EditDataFilesPageHelperTest {
     @Test
     public void getHtmlErrorMessage_should_return_null_when_max_errors_is_0() {
         Mockito.when(settingsWrapper.getInteger(EditDataFilesPageHelper.MAX_ERRORS_TO_DISPLAY_SETTING, EditDataFilesPageHelper.MAX_ERRORS_TO_DISPLAY)).thenReturn(0);
-        CreateDataFileResult createDataFileResult = CreateDataFileResult.error("test_type", Arrays.asList("error1"));
+        CreateDataFileResult createDataFileResult = CreateDataFileResult.error(FILENAME, TYPE, Arrays.asList("error1"));
 
         MatcherAssert.assertThat(target.getHtmlErrorMessage(createDataFileResult), Matchers.nullValue());
     }
@@ -44,7 +49,7 @@ public class EditDataFilesPageHelperTest {
     @Test
     public void getHtmlErrorMessage_should_return_message_when_there_are_errors() {
         Mockito.when(settingsWrapper.getInteger(EditDataFilesPageHelper.MAX_ERRORS_TO_DISPLAY_SETTING, EditDataFilesPageHelper.MAX_ERRORS_TO_DISPLAY)).thenReturn(10);
-        CreateDataFileResult createDataFileResult = CreateDataFileResult.error("test_type", Arrays.asList("error1"));
+        CreateDataFileResult createDataFileResult = CreateDataFileResult.error(FILENAME, TYPE, Arrays.asList("error1"));
 
         MatcherAssert.assertThat(target.getHtmlErrorMessage(createDataFileResult), Matchers.notNullValue());
         MatcherAssert.assertThat(target.getHtmlErrorMessage(createDataFileResult), Matchers.containsString("error1"));
@@ -53,13 +58,51 @@ public class EditDataFilesPageHelperTest {
     @Test
     public void getHtmlErrorMessage_should_return_message_with_MAX_ERRORS_TO_DISPLAY_when_there_are_more_errors() {
         Mockito.when(settingsWrapper.getInteger(EditDataFilesPageHelper.MAX_ERRORS_TO_DISPLAY_SETTING, EditDataFilesPageHelper.MAX_ERRORS_TO_DISPLAY)).thenReturn(2);
-        CreateDataFileResult createDataFileResult = CreateDataFileResult.error("test_type", Arrays.asList("error1", "error2", "error3", "error4"));
+        CreateDataFileResult createDataFileResult = CreateDataFileResult.error(FILENAME, TYPE, Arrays.asList("error1", "error2", "error3", "error4"));
 
         MatcherAssert.assertThat(target.getHtmlErrorMessage(createDataFileResult), Matchers.notNullValue());
         MatcherAssert.assertThat(target.getHtmlErrorMessage(createDataFileResult), Matchers.containsString("error1"));
         MatcherAssert.assertThat(target.getHtmlErrorMessage(createDataFileResult), Matchers.containsString("error2"));
         MatcherAssert.assertThat(target.getHtmlErrorMessage(createDataFileResult), Matchers.not(Matchers.containsString("error3")));
         MatcherAssert.assertThat(target.getHtmlErrorMessage(createDataFileResult), Matchers.not(Matchers.containsString("error4")));
+    }
+
+    @Test
+    public void getHtmlErrorMessage_should_escape_html_from_error_messages() {
+        Mockito.when(settingsWrapper.getInteger(EditDataFilesPageHelper.MAX_ERRORS_TO_DISPLAY_SETTING, EditDataFilesPageHelper.MAX_ERRORS_TO_DISPLAY)).thenReturn(5);
+        CreateDataFileResult createDataFileResult = CreateDataFileResult.error(FILENAME, TYPE, Arrays.asList("<script>alert('hello');</script>"));
+
+        MatcherAssert.assertThat(target.getHtmlErrorMessage(createDataFileResult), Matchers.notNullValue());
+        MatcherAssert.assertThat(target.getHtmlErrorMessage(createDataFileResult), Matchers.not(Matchers.containsString("<script>")));
+        MatcherAssert.assertThat(target.getHtmlErrorMessage(createDataFileResult), Matchers.not(Matchers.containsString("</script>")));
+        MatcherAssert.assertThat(target.getHtmlErrorMessage(createDataFileResult), Matchers.containsString("&lt;script&gt;"));
+        MatcherAssert.assertThat(target.getHtmlErrorMessage(createDataFileResult), Matchers.containsString("&lt;/script&gt;"));
+    }
+
+    @Test
+    public void consolidateHtmlErrorMessages_should_return_null_when_null_or_no_errors() {
+        MatcherAssert.assertThat(target.consolidateHtmlErrorMessages(null), Matchers.nullValue());
+        MatcherAssert.assertThat(target.consolidateHtmlErrorMessages(Collections.emptyList()), Matchers.nullValue());
+    }
+
+    @Test
+    public void consolidateHtmlErrorMessages_should_not_add_anything_when_only_one_error() {
+        List<String> errorMessages = Arrays.asList("error1");
+
+        String result = target.consolidateHtmlErrorMessages(errorMessages);
+
+        MatcherAssert.assertThat(result, Matchers.notNullValue());
+        MatcherAssert.assertThat(result, Matchers.containsString("error1"));
+    }
+
+    @Test
+    public void consolidateHtmlErrorMessages_should_add_HTML_break_line_between_errors() {
+        List<String> errorMessages = Arrays.asList("error1", "error2");
+
+        String result = target.consolidateHtmlErrorMessages(errorMessages);
+
+        MatcherAssert.assertThat(result, Matchers.notNullValue());
+        MatcherAssert.assertThat(result, Matchers.containsString("error1</br>error2"));
     }
 
 }

--- a/src/test/java/edu/harvard/iq/dataverse/util/bagit/BagValidationTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/util/bagit/BagValidationTest.java
@@ -18,6 +18,15 @@ public class BagValidationTest {
     private static final Path FILE_PATH = Path.of(UUID.randomUUID().toString());
 
     @Test
+    public void BagValidation_should_handle_null_messages() {
+        BagValidation target = new BagValidation(null);
+
+        MatcherAssert.assertThat(target.success(), Matchers.is(true));
+        MatcherAssert.assertThat(target.getErrorMessage().isPresent(), Matchers.is(false));
+        MatcherAssert.assertThat(target.getFileResults().isEmpty(), Matchers.is(true));
+    }
+
+    @Test
     public void success_should_be_true_when_no_error_message() {
         BagValidation target = new BagValidation(Optional.empty());
 
@@ -50,7 +59,7 @@ public class BagValidationTest {
     public void success_should_be_false_when_no_error_message_but_has_file_validation_errors() {
         BagValidation target = new BagValidation(Optional.empty());
         FileValidationResult result = target.addFileResult(FILE_PATH);
-        result.setError();
+        result.setError("Error Message");
 
         MatcherAssert.assertThat(target.success(), Matchers.is(false));
         MatcherAssert.assertThat(target.getErrorMessage().isPresent(), Matchers.is(false));
@@ -61,11 +70,53 @@ public class BagValidationTest {
     public void report_should_return_total_file_validation_and_total_success_validations() {
         BagValidation target = new BagValidation(Optional.empty());
         target.addFileResult(Path.of(UUID.randomUUID().toString())).setSuccess();
-        target.addFileResult(Path.of(UUID.randomUUID().toString())).setError();
+        target.addFileResult(Path.of(UUID.randomUUID().toString())).setError("Error Message");
 
         MatcherAssert.assertThat(target.report(), Matchers.containsString("success=false"));
         MatcherAssert.assertThat(target.report(), Matchers.containsString("fileResultsItems=2"));
         MatcherAssert.assertThat(target.report(), Matchers.containsString("fileResultsSuccess=1"));
+    }
+
+    @Test
+    public void errors_should_only_count_file_errors() {
+        BagValidation target = new BagValidation(Optional.of("main error"));
+        target.addFileResult(Path.of(UUID.randomUUID().toString())).setSuccess();
+        target.addFileResult(Path.of(UUID.randomUUID().toString())).setError("Error Message");
+
+        MatcherAssert.assertThat(target.errors(), Matchers.is(1l));
+    }
+
+    @Test
+    public void errors_should_not_count_main_errors() {
+        BagValidation target = new BagValidation(Optional.of("main error"));
+
+        MatcherAssert.assertThat(target.errors(), Matchers.is(0l));
+    }
+
+    @Test
+    public void getAllErrors_should_return_main_validation_error_and_file_errors() {
+        BagValidation target = new BagValidation(Optional.of("main error"));
+        target.addFileResult(Path.of(UUID.randomUUID().toString())).setError("Error Message");
+
+        MatcherAssert.assertThat(target.getAllErrors().size(), Matchers.is(2));
+        MatcherAssert.assertThat(target.getAllErrors().get(0), Matchers.is("main error"));
+        MatcherAssert.assertThat(target.getAllErrors().get(1), Matchers.is("Error Message"));
+    }
+
+    @Test
+    public void getAllErrors_should_return_main_validation_error_when_no_file_errors() {
+        BagValidation target = new BagValidation(Optional.of("main error"));
+
+        MatcherAssert.assertThat(target.getAllErrors().size(), Matchers.is(1));
+        MatcherAssert.assertThat(target.getAllErrors().get(0), Matchers.is("main error"));
+    }
+
+    @Test
+    public void getAllErrors_should_return_empty_when_success() {
+        BagValidation target = new BagValidation(Optional.empty());
+        target.addFileResult(Path.of(UUID.randomUUID().toString())).setSuccess();
+
+        MatcherAssert.assertThat(target.getAllErrors().size(), Matchers.is(0));
     }
 
 }

--- a/src/test/java/edu/harvard/iq/dataverse/util/bagit/BagValidatorTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/util/bagit/BagValidatorTest.java
@@ -36,7 +36,7 @@ public class BagValidatorTest {
     @Before
     public void beforeEachTest() {
         manifestReader = Mockito.mock(ManifestReader.class);
-        target = new BagValidator(manifestReader);
+        target = Mockito.spy(new BagValidator(manifestReader));
     }
 
     @Test
@@ -93,7 +93,7 @@ public class BagValidatorTest {
 
         MatcherAssert.assertThat(result.success(), Matchers.is(false));
         MatcherAssert.assertThat(result.getErrorMessage().isEmpty(), Matchers.is(false));
-        MatcherAssert.assertThat(result.getErrorMessage().get(), Matchers.containsString("Invalid bag file"));
+        Mockito.verify(target).getMessage(Mockito.eq("bagit.validation.bag.file.not.found"), Mockito.any());
 
         Mockito.verifyZeroInteractions(manifestReader);
     }
@@ -119,7 +119,7 @@ public class BagValidatorTest {
 
         MatcherAssert.assertThat(result.success(), Matchers.is(false));
         MatcherAssert.assertThat(result.getErrorMessage().isEmpty(), Matchers.is(false));
-        MatcherAssert.assertThat(result.getErrorMessage().get(), Matchers.containsString("No supported manifest found"));
+        Mockito.verify(target).getMessage(Mockito.eq("bagit.validation.manifest.not.supported"), Mockito.any());
 
         Mockito.verify(manifestReader).getManifestChecksums(fileDataProvider, expectedBagRoot);
     }
@@ -139,8 +139,8 @@ public class BagValidatorTest {
         MatcherAssert.assertThat(result.getFileResults().size(), Matchers.is(checksums.getFileChecksums().size()));
         for(Path filePath: checksums.getFileChecksums().keySet()) {
             MatcherAssert.assertThat(result.getFileResults().get(filePath).isError(), Matchers.is(true));
-            MatcherAssert.assertThat(result.getFileResults().get(filePath).getMessage(), Matchers.containsString("Manifest declared file"));
         }
+        Mockito.verify(target, Mockito.times(checksums.getFileChecksums().size())).getMessage(Mockito.eq("bagit.validation.file.not.found"), Mockito.any());
 
         Mockito.verify(manifestReader).getManifestChecksums(fileDataProvider, expectedBagRoot);
         Mockito.verify(fileDataProvider).getFilePaths();
@@ -226,7 +226,7 @@ public class BagValidatorTest {
 
         MatcherAssert.assertThat(result.success(), Matchers.is(false));
         MatcherAssert.assertThat(result.getErrorMessage().isEmpty(), Matchers.is(false));
-        MatcherAssert.assertThat(result.getErrorMessage().get(), Matchers.containsString("Unable to complete checksums"));
+        Mockito.verify(target).getMessage(Mockito.eq("bagit.validation.exception"), Mockito.any());
     }
 
     private FileDataProvider createDataProviderWithRandomFiles(String... filePathItems) {

--- a/src/test/java/edu/harvard/iq/dataverse/util/file/BagItFileHandlerTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/util/file/BagItFileHandlerTest.java
@@ -96,6 +96,7 @@ public class BagItFileHandlerTest {
 
         CreateDataFileResult result = target.handleBagItPackage(SYSTEM_CONFIG, DATASET_VERSION, FILE.getName(), FILE);
         MatcherAssert.assertThat(result.success(), Matchers.is(false));
+        createDataFileResultAsserts(result);
 
         handleBagItPackageAsserts(fileDataProvider);
         Mockito.verifyZeroInteractions(postProcessor);
@@ -113,6 +114,7 @@ public class BagItFileHandlerTest {
 
         CreateDataFileResult result = target.handleBagItPackage(SYSTEM_CONFIG, DATASET_VERSION, FILE.getName(), FILE);
         MatcherAssert.assertThat(result.success(), Matchers.is(true));
+        createDataFileResultAsserts(result);
         for(DataFile expectedDataFile: dataProviderWithDataFiles.dataFiles) {
             MatcherAssert.assertThat(result.getDataFiles(), Matchers.hasItems(expectedDataFile));
         }
@@ -133,6 +135,7 @@ public class BagItFileHandlerTest {
 
         CreateDataFileResult result = target.handleBagItPackage(SYSTEM_CONFIG, DATASET_VERSION, FILE.getName(), FILE);
         MatcherAssert.assertThat(result.success(), Matchers.is(true));
+        createDataFileResultAsserts(result);
         Mockito.verify(postProcessor).process(Mockito.any());
         handleBagItPackageAsserts(dataProviderSpy);
         createDataFileAsserts(dataProviderWithDataFiles.dataProvider.getFilePaths());
@@ -151,6 +154,7 @@ public class BagItFileHandlerTest {
 
         CreateDataFileResult result = target.handleBagItPackage(SYSTEM_CONFIG, DATASET_VERSION, FILE.getName(), FILE);
         MatcherAssert.assertThat(result.success(), Matchers.is(true));
+        createDataFileResultAsserts(result);
         MatcherAssert.assertThat(result.getDataFiles().size(), Matchers.is(1));
         MatcherAssert.assertThat(result.getDataFiles().get(0), Matchers.is(dataProviderWithDataFiles.dataFiles.get(0)));
         MatcherAssert.assertThat(result.getDataFiles().get(0).getDirectoryLabel(), Matchers.is("dir/path"));
@@ -173,6 +177,7 @@ public class BagItFileHandlerTest {
 
         CreateDataFileResult result = target.handleBagItPackage(SYSTEM_CONFIG, DATASET_VERSION, FILE.getName(), FILE);
         MatcherAssert.assertThat(result.success(), Matchers.is(true));
+        createDataFileResultAsserts(result);
         MatcherAssert.assertThat(result.getDataFiles().size(), Matchers.is(1));
         MatcherAssert.assertThat(result.getDataFiles().get(0), Matchers.is(dataProviderWithDataFiles.dataFiles.get(0)));
         MatcherAssert.assertThat(result.getDataFiles().get(0).getContentType(), Matchers.nullValue());
@@ -194,6 +199,7 @@ public class BagItFileHandlerTest {
 
         CreateDataFileResult result = target.handleBagItPackage(SYSTEM_CONFIG, DATASET_VERSION, FILE.getName(), FILE);
         MatcherAssert.assertThat(result.success(), Matchers.is(true));
+        createDataFileResultAsserts(result);
 
         DataFile expectedDataFile = dataProviderWithDataFiles.dataFiles.stream().filter(dataFile -> dataFile.getCurrentName().equals(bagEntry)).findFirst().get();
         MatcherAssert.assertThat(result.getDataFiles().size(), Matchers.is(1));
@@ -220,9 +226,8 @@ public class BagItFileHandlerTest {
 
         CreateDataFileResult result = target.handleBagItPackage(SYSTEM_CONFIG, DATASET_VERSION, FILE.getName(), FILE);
         MatcherAssert.assertThat(result.success(), Matchers.is(false));
+        createDataFileResultAsserts(result);
         MatcherAssert.assertThat(result.getErrors().size(), Matchers.is(1));
-        MatcherAssert.assertThat(result.getErrors().get(0), Matchers.containsString(exceptionDataFile));
-        MatcherAssert.assertThat(result.getErrors().get(0), Matchers.containsString("exceeds the size limit"));
 
         handleBagItPackageAsserts(dataProviderSpy);
         createDataFileAsserts(Arrays.asList(Path.of(bagEntry)), 2);
@@ -240,9 +245,8 @@ public class BagItFileHandlerTest {
 
         CreateDataFileResult result = target.handleBagItPackage(SYSTEM_CONFIG, DATASET_VERSION, FILE.getName(), FILE);
         MatcherAssert.assertThat(result.success(), Matchers.is(false));
+        createDataFileResultAsserts(result);
         MatcherAssert.assertThat(result.getErrors().size(), Matchers.is(1));
-        MatcherAssert.assertThat(result.getErrors().get(0), Matchers.containsString(FILE.getName()));
-        MatcherAssert.assertThat(result.getErrors().get(0), Matchers.containsString("exceeds the number of files limit"));
 
         handleBagItPackageAsserts(dataProviderSpy);
         Mockito.verifyZeroInteractions(postProcessor);
@@ -258,10 +262,16 @@ public class BagItFileHandlerTest {
 
         CreateDataFileResult result = target.handleBagItPackage(SYSTEM_CONFIG, DATASET_VERSION, FILE.getName(), FILE);
         MatcherAssert.assertThat(result.success(), Matchers.is(false));
+        createDataFileResultAsserts(result);
 
         handleBagItPackageAsserts(dataProviderSpy);
         createDataFileAsserts(dataProviderWithDataFiles.dataProvider.getFilePaths());
         Mockito.verifyZeroInteractions(postProcessor);
+    }
+
+    private void createDataFileResultAsserts(CreateDataFileResult result) {
+        MatcherAssert.assertThat(result.getFilename(), Matchers.is(FILE.getName()));
+        MatcherAssert.assertThat(result.getType(), Matchers.is(BagItFileHandler.FILE_TYPE));
     }
 
     private void handleBagItPackageAsserts(FileDataProvider dataProviderMock) throws IOException{

--- a/src/test/java/edu/harvard/iq/dataverse/util/file/CreateDataFileResultTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/util/file/CreateDataFileResultTest.java
@@ -17,9 +17,10 @@ public class CreateDataFileResultTest {
 
     @Test
     public void error_static_initializer_should_return_error_result() {
-        CreateDataFileResult target = CreateDataFileResult.error("test_type");
+        CreateDataFileResult target = CreateDataFileResult.error("filename", "test_type");
 
         MatcherAssert.assertThat(target.success(), Matchers.is(false));
+        MatcherAssert.assertThat(target.getFilename(), Matchers.is("filename"));
         MatcherAssert.assertThat(target.getType(), Matchers.is("test_type"));
         MatcherAssert.assertThat(target.getErrors(), Matchers.is(Collections.emptyList()));
         MatcherAssert.assertThat(target.getDataFiles(), Matchers.nullValue());
@@ -27,9 +28,10 @@ public class CreateDataFileResultTest {
 
     @Test
     public void error_static_initializer_with_messages_should_return_error_result() {
-        CreateDataFileResult target = CreateDataFileResult.error("test_type", Arrays.asList("error1", "error2"));
+        CreateDataFileResult target = CreateDataFileResult.error("filename", "test_type", Arrays.asList("error1", "error2"));
 
         MatcherAssert.assertThat(target.success(), Matchers.is(false));
+        MatcherAssert.assertThat(target.getFilename(), Matchers.is("filename"));
         MatcherAssert.assertThat(target.getType(), Matchers.is("test_type"));
         MatcherAssert.assertThat(target.getErrors(), Matchers.is(Arrays.asList("error1", "error2")));
         MatcherAssert.assertThat(target.getDataFiles(), Matchers.nullValue());
@@ -38,9 +40,10 @@ public class CreateDataFileResultTest {
     @Test
     public void success_static_initializer_should_return_success_result() {
         List<DataFile> dataFiles = Arrays.asList(new DataFile(), new DataFile());
-        CreateDataFileResult target = CreateDataFileResult.success("test_type", dataFiles);
+        CreateDataFileResult target = CreateDataFileResult.success("filename", "test_type", dataFiles);
 
         MatcherAssert.assertThat(target.success(), Matchers.is(true));
+        MatcherAssert.assertThat(target.getFilename(), Matchers.is("filename"));
         MatcherAssert.assertThat(target.getType(), Matchers.is("test_type"));
         MatcherAssert.assertThat(target.getErrors(), Matchers.is(Collections.emptyList()));
         MatcherAssert.assertThat(target.getDataFiles(), Matchers.is(dataFiles));
@@ -48,7 +51,7 @@ public class CreateDataFileResultTest {
 
     @Test
     public void getBundleKey_should_return_string_based_on_type() {
-        CreateDataFileResult target = new CreateDataFileResult("test_type", Collections.emptyList(), Collections.emptyList());
+        CreateDataFileResult target = new CreateDataFileResult("filename", "test_type", Collections.emptyList(), Collections.emptyList());
 
         MatcherAssert.assertThat(target.getBundleKey(), Matchers.is("dataset.file.error.test_type"));
     }


### PR DESCRIPTION
**What this PR does / why we need it**:
Improvements to the error messages for the BagIt file handler. The message location has changed from the top of the page to just underneath the file upload widget.

The message text has been updated following a review from our user testing.

**Which issue(s) this PR closes**:
Closes #8787

**Special notes for your reviewer**:
None

**Suggestions on how to test this**:
As only the error messages has ben updated, we need to enable the `:BagItHandlerEnabled` feature and use invalid BagIt packages.

To enable the feature: curl -X PUT -d 'true' http://localhost:8080/api/admin/settings/:BagItHandlerEnabled

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
No UI changes. The error messages section where the errors are displayed was already in the system.

**Is there a release notes update needed for this change?**:
No

**Additional documentation**:
None
