### PR TITLE
Define/use an additional secret key, Refactor token replacement for signed urls

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/api/AbstractApiBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/AbstractApiBean.java
@@ -440,7 +440,7 @@ public abstract class AbstractApiBean {
         //ToDo - add null checks/ verify that calling methods catch things.
         String user = httpRequest.getParameter("user");
         AuthenticatedUser targetUser = authSvc.getAuthenticatedUser(user);
-        String key = authSvc.findApiTokenByUser(targetUser).getTokenString();
+        String key = System.getProperty(SystemConfig.API_SIGNING_SECRET,"") + authSvc.findApiTokenByUser(targetUser).getTokenString();
         String signedUrl = httpRequest.getRequestURL().toString();
         String method = httpRequest.getMethod();
         

--- a/src/main/java/edu/harvard/iq/dataverse/api/Admin.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Admin.java
@@ -2088,7 +2088,7 @@ public class Admin extends AbstractApiBean {
             userId=superuser.getIdentifier();
             //We ~know this exists - the superuser just used it and it was unexpired/not disabled. (ToDo - if we want this to work with workflow tokens (or as a signed URL, we should do more checking as for the user above))
         }
-            key =  authSvc.findApiTokenByUser(superuser).getTokenString();
+            key =  System.getProperty(SystemConfig.API_SIGNING_SECRET,"") + authSvc.findApiTokenByUser(superuser).getTokenString();
         }
         if(key==null) {
             return error(Response.Status.CONFLICT, "Do not have a valid user with apiToken");

--- a/src/main/java/edu/harvard/iq/dataverse/externaltools/ExternalTool.java
+++ b/src/main/java/edu/harvard/iq/dataverse/externaltools/ExternalTool.java
@@ -299,64 +299,6 @@ public class ExternalTool implements Serializable {
         return jab;
     }
 
-    public enum ReservedWord {
-
-        // TODO: Research if a format like "{reservedWord}" is easily parse-able or if another format would be
-        // better. The choice of curly braces is somewhat arbitrary, but has been observed in documenation for
-        // various REST APIs. For example, "Variable substitutions will be made when a variable is named in {brackets}."
-        // from https://swagger.io/specification/#fixed-fields-29 but that's for URLs.
-        FILE_ID("fileId"),
-        FILE_PID("filePid"),
-        SITE_URL("siteUrl"),
-        API_TOKEN("apiToken"),
-        // datasetId is the database id
-        DATASET_ID("datasetId"),
-        // datasetPid is the DOI or Handle
-        DATASET_PID("datasetPid"),
-        DATASET_VERSION("datasetVersion"),
-        FILE_METADATA_ID("fileMetadataId"),
-        LOCALE_CODE("localeCode"),
-        ALLOWED_URLS("allowedUrls");
-
-        private final String text;
-        private final String START = "{";
-        private final String END = "}";
-
-        private ReservedWord(final String text) {
-            this.text = START + text + END;
-        }
-
-        /**
-         * This is a centralized method that enforces that only reserved words
-         * are allowed to be used by external tools. External tool authors
-         * cannot pass their own query parameters through Dataverse such as
-         * "mode=mode1".
-         *
-         * @throws IllegalArgumentException
-         */
-        public static ReservedWord fromString(String text) throws IllegalArgumentException {
-            if (text != null) {
-                for (ReservedWord reservedWord : ReservedWord.values()) {
-                    if (text.equals(reservedWord.text)) {
-                        return reservedWord;
-                    }
-                }
-            }
-            // TODO: Consider switching to a more informative message that enumerates the valid reserved words.
-            boolean moreInformativeMessage = false;
-            if (moreInformativeMessage) {
-                throw new IllegalArgumentException("Unknown reserved word: " + text + ". A reserved word must be one of these values: " + Arrays.asList(ReservedWord.values()) + ".");
-            } else {
-                throw new IllegalArgumentException("Unknown reserved word: " + text);
-            }
-        }
-
-        @Override
-        public String toString() {
-            return text;
-        }
-    }
-
     public String getDescriptionLang() {
         String description = "";
         if (this.toolName != null) {

--- a/src/main/java/edu/harvard/iq/dataverse/externaltools/ExternalToolHandler.java
+++ b/src/main/java/edu/harvard/iq/dataverse/externaltools/ExternalToolHandler.java
@@ -3,10 +3,9 @@ package edu.harvard.iq.dataverse.externaltools;
 import edu.harvard.iq.dataverse.DataFile;
 import edu.harvard.iq.dataverse.Dataset;
 import edu.harvard.iq.dataverse.FileMetadata;
-import edu.harvard.iq.dataverse.GlobalId;
 import edu.harvard.iq.dataverse.authorization.users.ApiToken;
-import edu.harvard.iq.dataverse.externaltools.ExternalTool.ReservedWord;
-import edu.harvard.iq.dataverse.util.SystemConfig;
+import edu.harvard.iq.dataverse.util.URLTokenUtil;
+
 import edu.harvard.iq.dataverse.util.UrlSignerUtil;
 import java.io.IOException;
 import java.io.StringReader;
@@ -19,6 +18,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
 import javax.json.Json;
 import javax.json.JsonArray;
 import javax.json.JsonObject;
@@ -31,8 +31,7 @@ import javax.ws.rs.HttpMethod;
  * instantiated. Applies logic based on an {@link ExternalTool} specification,
  * such as constructing a URL to access that file.
  */
-public class ExternalToolHandler {
-
+public class ExternalToolHandler extends URLTokenUtil {
     /**
      * @return the allowedUrls
      */
@@ -54,15 +53,8 @@ public class ExternalToolHandler {
         this.user = user;
     }
 
-    private static final Logger logger = Logger.getLogger(ExternalToolHandler.class.getCanonicalName());
-
     private final ExternalTool externalTool;
-    private final DataFile dataFile;
-    private final Dataset dataset;
-    private final FileMetadata fileMetadata;
 
-    private ApiToken apiToken;
-    private String localeCode;
     private String requestMethod;
     private String toolContext;
     private String user;
@@ -78,23 +70,9 @@ public class ExternalToolHandler {
      * used anonymously.
      */
     public ExternalToolHandler(ExternalTool externalTool, DataFile dataFile, ApiToken apiToken, FileMetadata fileMetadata, String localeCode) {
+        super(dataFile, apiToken, fileMetadata, localeCode);
         this.externalTool = externalTool;
         toolContext = externalTool.getToolUrl();
-        if (dataFile == null) {
-            String error = "A DataFile is required.";
-            logger.warning("Error in ExternalToolHandler constructor: " + error);
-            throw new IllegalArgumentException(error);
-        }
-        if (fileMetadata == null) {
-            String error = "A FileMetadata is required.";
-            logger.warning("Error in ExternalToolHandler constructor: " + error);
-            throw new IllegalArgumentException(error);
-        }
-        this.dataFile = dataFile;
-        this.apiToken = apiToken;
-        this.fileMetadata = fileMetadata;
-        dataset = fileMetadata.getDatasetVersion().getDataset();
-        this.localeCode = localeCode;
     }
 
     /**
@@ -106,33 +84,8 @@ public class ExternalToolHandler {
      * used anonymously.
      */
     public ExternalToolHandler(ExternalTool externalTool, Dataset dataset, ApiToken apiToken, String localeCode) {
+        super(dataset, apiToken, localeCode);
         this.externalTool = externalTool;
-        if (dataset == null) {
-            String error = "A Dataset is required.";
-            logger.warning("Error in ExternalToolHandler constructor: " + error);
-            throw new IllegalArgumentException(error);
-        }
-        this.dataset = dataset;
-        this.apiToken = apiToken;
-        this.dataFile = null;
-        this.fileMetadata = null;
-        this.localeCode = localeCode;
-    }
-
-    public DataFile getDataFile() {
-        return dataFile;
-    }
-
-    public FileMetadata getFileMetadata() {
-        return fileMetadata;
-    }
-
-    public ApiToken getApiToken() {
-        return apiToken;
-    }
-
-    public String getLocaleCode() {
-        return localeCode;
     }
 
     // TODO: rename to handleRequest() to someday handle sending headers as well as query parameters.
@@ -175,63 +128,6 @@ public class ExternalToolHandler {
         }
     }
 
-    private String getQueryParam(String key, String value) {
-        ReservedWord reservedWord = ReservedWord.fromString(value);
-        switch (reservedWord) {
-            case FILE_ID:
-                // getDataFile is never null for file tools because of the constructor
-                return key + "=" + getDataFile().getId();
-            case FILE_PID:
-                GlobalId filePid = getDataFile().getGlobalId();
-                if (filePid != null) {
-                    return key + "=" + getDataFile().getGlobalId();
-                }
-                break;
-            case SITE_URL:
-                siteUrl = SystemConfig.getDataverseSiteUrlStatic();
-                return key + "=" + siteUrl;
-            case API_TOKEN:
-                String apiTokenString = null;
-                ApiToken theApiToken = getApiToken();
-                if (theApiToken != null) {
-                    apiTokenString = theApiToken.getTokenString();
-                    return key + "=" + apiTokenString;
-                }
-                break;
-            case DATASET_ID:
-                return key + "=" + dataset.getId();
-            case DATASET_PID:
-                return key + "=" + dataset.getGlobalId().asString();
-            case DATASET_VERSION:
-                String versionString = null;
-                if(fileMetadata!=null) { //true for file case
-                    versionString = fileMetadata.getDatasetVersion().getFriendlyVersionNumber();
-                } else { //Dataset case - return the latest visible version (unless/until the dataset case allows specifying a version)
-                    if (getApiToken() != null) {
-                        versionString = dataset.getLatestVersion().getFriendlyVersionNumber();
-                    } else {
-                        versionString = dataset.getLatestVersionForCopy().getFriendlyVersionNumber();
-                    }
-                }
-                if (("DRAFT").equals(versionString)) {
-                    versionString = ":draft"; // send the token needed in api calls that can be substituted for a numeric
-                                              // version.
-                }
-                return key + "=" + versionString;
-            case FILE_METADATA_ID:
-                if(fileMetadata!=null) { //true for file case
-                    return key + "=" + fileMetadata.getId();
-                }
-            case LOCALE_CODE:
-                return key + "=" + getLocaleCode();
-            case ALLOWED_URLS:
-                return key + "=" + getAllowedUrls();                    
-            default:
-                break;
-        }
-        return null;
-    }
-    
     
     private String postFormData(Integer timeout,List<String> params ) throws IOException, InterruptedException{
         String url = "";

--- a/src/main/java/edu/harvard/iq/dataverse/externaltools/ExternalToolServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/externaltools/ExternalToolServiceBean.java
@@ -3,8 +3,9 @@ package edu.harvard.iq.dataverse.externaltools;
 import edu.harvard.iq.dataverse.DataFile;
 import edu.harvard.iq.dataverse.DataFileServiceBean;
 import edu.harvard.iq.dataverse.authorization.users.ApiToken;
-import edu.harvard.iq.dataverse.externaltools.ExternalTool.ReservedWord;
 import edu.harvard.iq.dataverse.externaltools.ExternalTool.Type;
+import edu.harvard.iq.dataverse.util.URLTokenUtil;
+import edu.harvard.iq.dataverse.util.URLTokenUtil.ReservedWord;
 import edu.harvard.iq.dataverse.externaltools.ExternalTool.Scope;
 
 import java.io.StringReader;

--- a/src/main/java/edu/harvard/iq/dataverse/util/SystemConfig.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/SystemConfig.java
@@ -124,6 +124,11 @@ public class SystemConfig {
     public final static String DEFAULTCURATIONLABELSET = "DEFAULT";
     public final static String CURATIONLABELSDISABLED = "DISABLED";
     
+    // A secret used in signing URLs - individual urls are signed using this and the
+    // intended user's apiKey, creating an aggregate key that is unique to the user
+    // but not known to the user (as their apiKey is)
+    public final static String API_SIGNING_SECRET = "dataverse.api-signing-secret;";
+    
     public String getVersion() {
         return getVersion(false);
     }

--- a/src/main/java/edu/harvard/iq/dataverse/util/URLTokenUtil.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/URLTokenUtil.java
@@ -1,0 +1,231 @@
+package edu.harvard.iq.dataverse.util;
+
+import java.util.Arrays;
+import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import edu.harvard.iq.dataverse.DataFile;
+import edu.harvard.iq.dataverse.Dataset;
+import edu.harvard.iq.dataverse.FileMetadata;
+import edu.harvard.iq.dataverse.GlobalId;
+import edu.harvard.iq.dataverse.authorization.users.ApiToken;
+
+public class URLTokenUtil {
+
+    protected static final Logger logger = Logger.getLogger(URLTokenUtil.class.getCanonicalName());
+    protected final DataFile dataFile;
+    protected final Dataset dataset;
+    protected final FileMetadata fileMetadata;
+    protected ApiToken apiToken;
+    protected String localeCode;
+
+    /**
+     * File level
+     *
+     * @param dataFile     Required.
+     * @param apiToken     The apiToken can be null
+     * @param fileMetadata Required.
+     * @param localeCode   optional.
+     * 
+     */
+    public URLTokenUtil(DataFile dataFile, ApiToken apiToken, FileMetadata fileMetadata, String localeCode)
+            throws IllegalArgumentException {
+        if (dataFile == null) {
+            String error = "A DataFile is required.";
+            logger.warning("Error in URLTokenUtil constructor: " + error);
+            throw new IllegalArgumentException(error);
+        }
+        if (fileMetadata == null) {
+            String error = "A FileMetadata is required.";
+            logger.warning("Error in URLTokenUtil constructor: " + error);
+            throw new IllegalArgumentException(error);
+        }
+        this.dataFile = dataFile;
+        this.dataset = fileMetadata.getDatasetVersion().getDataset();
+        this.fileMetadata = fileMetadata;
+        this.apiToken = apiToken;
+        this.localeCode = localeCode;
+    }
+
+    /**
+     * Dataset level
+     *
+     * @param dataset  Required.
+     * @param apiToken The apiToken can be null
+     */
+    public URLTokenUtil(Dataset dataset, ApiToken apiToken, String localeCode) {
+        if (dataset == null) {
+            String error = "A Dataset is required.";
+            logger.warning("Error in URLTokenUtil constructor: " + error);
+            throw new IllegalArgumentException(error);
+        }
+        this.dataset = dataset;
+        this.dataFile = null;
+        this.fileMetadata = null;
+        this.apiToken = apiToken;
+        this.localeCode = localeCode;
+    }
+
+    public DataFile getDataFile() {
+        return dataFile;
+    }
+
+    public FileMetadata getFileMetadata() {
+        return fileMetadata;
+    }
+
+    public ApiToken getApiToken() {
+        return apiToken;
+    }
+
+    public String getLocaleCode() {
+        return localeCode;
+    }
+
+    public String getQueryParam(String key, String value) {
+        String tokenValue = null;
+        tokenValue = getTokenValue(value);
+        if (tokenValue != null) {
+            return key + '=' + tokenValue;
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Tries to replace all occurrences of {<text>} with the value for the
+     * corresponding ReservedWord
+     * 
+     * @param url - the input string in which to replace tokens, normally a url
+     * @throws IllegalArgumentException if there is no matching ReservedWord or if
+     *                                  the configuation of this instance doesn't
+     *                                  have values for this ReservedWord (e.g.
+     *                                  asking for FILE_PID when using the dataset
+     *                                  constructor, etc.)
+     */
+    public String replaceTokensWithValues(String url) {
+        String newUrl = url;
+        Pattern pattern = Pattern.compile("(\\{.*?\\})");
+        Matcher matcher = pattern.matcher(url);
+        while(matcher.find()) {
+            String token = matcher.group(1);
+            ReservedWord reservedWord = ReservedWord.fromString(token);
+            String tValue = getTokenValue(token);
+            logger.info("Replacing " + reservedWord.toString() + " with " + tValue + " in " + newUrl);
+            newUrl = newUrl.replace(reservedWord.toString(), tValue);
+        }
+        return newUrl;
+    }
+
+    private String getTokenValue(String value) {
+        ReservedWord reservedWord = ReservedWord.fromString(value);
+        switch (reservedWord) {
+        case FILE_ID:
+            // getDataFile is never null for file tools because of the constructor
+            return getDataFile().getId().toString();
+        case FILE_PID:
+            GlobalId filePid = getDataFile().getGlobalId();
+            if (filePid != null) {
+                return getDataFile().getGlobalId().asString();
+            }
+            break;
+        case SITE_URL:
+            return SystemConfig.getDataverseSiteUrlStatic();
+        case API_TOKEN:
+            String apiTokenString = null;
+            ApiToken theApiToken = getApiToken();
+            if (theApiToken != null) {
+                apiTokenString = theApiToken.getTokenString();
+            }
+            return apiTokenString;
+        case DATASET_ID:
+            return dataset.getId().toString();
+        case DATASET_PID:
+            return dataset.getGlobalId().asString();
+        case DATASET_VERSION:
+            String versionString = null;
+            if (fileMetadata != null) { // true for file case
+                versionString = fileMetadata.getDatasetVersion().getFriendlyVersionNumber();
+            } else { // Dataset case - return the latest visible version (unless/until the dataset
+                     // case allows specifying a version)
+                if (getApiToken() != null) {
+                    versionString = dataset.getLatestVersion().getFriendlyVersionNumber();
+                } else {
+                    versionString = dataset.getLatestVersionForCopy().getFriendlyVersionNumber();
+                }
+            }
+            if (("DRAFT").equals(versionString)) {
+                versionString = ":draft"; // send the token needed in api calls that can be substituted for a numeric
+                                          // version.
+            }
+            return versionString;
+        case FILE_METADATA_ID:
+            if (fileMetadata != null) { // true for file case
+                return fileMetadata.getId().toString();
+            }
+        case LOCALE_CODE:
+            return getLocaleCode();
+        default:
+            break;
+        }
+        throw new IllegalArgumentException("Cannot replace reserved word: " + value);
+    }
+
+    public enum ReservedWord {
+
+        // TODO: Research if a format like "{reservedWord}" is easily parse-able or if
+        // another format would be
+        // better. The choice of curly braces is somewhat arbitrary, but has been
+        // observed in documentation for
+        // various REST APIs. For example, "Variable substitutions will be made when a
+        // variable is named in {brackets}."
+        // from https://swagger.io/specification/#fixed-fields-29 but that's for URLs.
+        FILE_ID("fileId"), FILE_PID("filePid"), SITE_URL("siteUrl"), API_TOKEN("apiToken"),
+        // datasetId is the database id
+        DATASET_ID("datasetId"),
+        // datasetPid is the DOI or Handle
+        DATASET_PID("datasetPid"), DATASET_VERSION("datasetVersion"), FILE_METADATA_ID("fileMetadataId"),
+        LOCALE_CODE("localeCode");
+
+        private final String text;
+        private final String START = "{";
+        private final String END = "}";
+
+        private ReservedWord(final String text) {
+            this.text = START + text + END;
+        }
+
+        /**
+         * This is a centralized method that enforces that only reserved words are
+         * allowed to be used by external tools. External tool authors cannot pass their
+         * own query parameters through Dataverse such as "mode=mode1".
+         *
+         * @throws IllegalArgumentException
+         */
+        public static ReservedWord fromString(String text) throws IllegalArgumentException {
+            if (text != null) {
+                for (ReservedWord reservedWord : ReservedWord.values()) {
+                    if (text.equals(reservedWord.text)) {
+                        return reservedWord;
+                    }
+                }
+            }
+            // TODO: Consider switching to a more informative message that enumerates the
+            // valid reserved words.
+            boolean moreInformativeMessage = false;
+            if (moreInformativeMessage) {
+                throw new IllegalArgumentException(
+                        "Unknown reserved word: " + text + ". A reserved word must be one of these values: "
+                                + Arrays.asList(ReservedWord.values()) + ".");
+            } else {
+                throw new IllegalArgumentException("Unknown reserved word: " + text);
+            }
+        }
+
+        @Override
+        public String toString() {
+            return text;
+        }
+    }
+}

--- a/src/test/java/edu/harvard/iq/dataverse/util/UrlTokenUtilTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/util/UrlTokenUtilTest.java
@@ -1,0 +1,50 @@
+package edu.harvard.iq.dataverse.util;
+
+import edu.harvard.iq.dataverse.DataFile;
+import edu.harvard.iq.dataverse.Dataset;
+import edu.harvard.iq.dataverse.DatasetVersion;
+import edu.harvard.iq.dataverse.FileMetadata;
+import edu.harvard.iq.dataverse.GlobalId;
+import edu.harvard.iq.dataverse.authorization.users.ApiToken;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+public class UrlTokenUtilTest {
+
+    @Test
+    public void testGetToolUrlWithOptionalQueryParameters() {
+
+        DataFile dataFile = new DataFile();
+        dataFile.setId(42l);
+        FileMetadata fmd = new FileMetadata();
+        DatasetVersion dv = new DatasetVersion();
+        Dataset ds = new Dataset();
+        ds.setId(50L);
+        ds.setGlobalId(new GlobalId("doi:10.5072/FK2ABCDEF"));
+        dv.setDataset(ds);
+        fmd.setDatasetVersion(dv);
+        List<FileMetadata> fmdl = new ArrayList<FileMetadata>();
+        fmdl.add(fmd);
+        dataFile.setFileMetadatas(fmdl);
+        ApiToken apiToken = new ApiToken();
+        apiToken.setTokenString("7196b5ce-f200-4286-8809-03ffdbc255d7");
+        URLTokenUtil urlTokenUtil = new URLTokenUtil(dataFile, apiToken, fmd, "en");
+        assertEquals("en", urlTokenUtil.replaceTokensWithValues("{localeCode}"));
+        assertEquals("42 test en", urlTokenUtil.replaceTokensWithValues("{fileId} test {localeCode}"));
+        assertEquals("42 test en", urlTokenUtil.replaceTokensWithValues("{fileId} test {localeCode}"));
+        
+        assertEquals("https://librascholar.org/api/files/42/metadata?key=" + apiToken.getTokenString(), urlTokenUtil.replaceTokensWithValues("{siteUrl}/api/files/{fileId}/metadata?key={apiToken}"));
+        
+        URLTokenUtil urlTokenUtil2 = new URLTokenUtil(ds, apiToken, "en");
+        assertEquals("https://librascholar.org/api/datasets/50?key=" + apiToken.getTokenString(), urlTokenUtil2.replaceTokensWithValues("{siteUrl}/api/datasets/{datasetId}?key={apiToken}"));
+        assertEquals("https://librascholar.org/api/datasets/:persistentId/?persistentId=doi:10.5072/FK2ABCDEF&key=" + apiToken.getTokenString(), urlTokenUtil2.replaceTokensWithValues("{siteUrl}/api/datasets/:persistentId/?persistentId={datasetPid}&key={apiToken}"));
+    }
+}


### PR DESCRIPTION
**What this PR does / why we need it**: The two commits in this PR do two different things:

1. The initial use case for signed URLs used a secret shared between Dataverse and the remote store to create/validate signed urls. In the initial dev for signed URLs for external tools, we swapped to using the apiKey of the intended user which has value in avoiding a single key across a whole Dataverse instance. However, the apiKey is relatively short and is known to the user (making it possible for the user or someone who gains that apiKey) to sign URLs associated with their account. This PR adds a dataverse.api-signing-secret jvm option that is prepended with the user's apiKey when signing, which then a) provides a longer, more secure signing/validation key, and b) maintains a one-key-per-user model (that can be changed by the user by invalidating/recreating their apiKey) while avoiding using something the user can access/obtain.

The external tools signing will also have to use the same aggregate key (global secret + user api key) when creating signedUrls when launching external tools. (Perhaps a util method to get the key that gets used in all these places?).

2. The original code to replace ReservedWord tokens was limited to use as part of the external tools framework and only handled creating query parameters. For openDP/signedURLs, we also want to replace tokens in URLs (i.e. path parameters). For HDC Objective 1/Globus integration, it is also useful to be able to replace tokens rather than having to write custom code to do so. The second commit here refactors the externalTools framework to pull the reserved words and the basic token replacement into a new URLTokenUtil class and adds, in that class, a new method to substitute tokens in a string/URL to handle the case where path parameters need to be entered.