### PR TITLE
#8735 fix edit fields

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/Template.java
+++ b/src/main/java/edu/harvard/iq/dataverse/Template.java
@@ -235,10 +235,8 @@ public class Template implements Serializable {
     }
 
     private void initMetadataBlocksForCreate() {
-        metadataBlocksForView.clear();
         metadataBlocksForEdit.clear();
         for (MetadataBlock mdb : this.getDataverse().getMetadataBlocks()) {
-            List<DatasetField> datasetFieldsForView = new ArrayList<>();
             List<DatasetField> datasetFieldsForEdit = new ArrayList<>();
             for (DatasetField dsf : this.getDatasetFields()) {
 
@@ -247,9 +245,6 @@ public class Template implements Serializable {
                 }
             }
 
-            if (!datasetFieldsForView.isEmpty()) {
-                metadataBlocksForView.put(mdb, sortDatasetFields(datasetFieldsForView));
-            }
             if (!datasetFieldsForEdit.isEmpty()) {
                 metadataBlocksForEdit.put(mdb, sortDatasetFields(datasetFieldsForEdit));
             }
@@ -262,25 +257,24 @@ public class Template implements Serializable {
         metadataBlocksForEdit.clear();
         List<DatasetField> filledInFields = this.getDatasetFields(); 
         
-        
-        List <MetadataBlock> actualMDB = new ArrayList<>();
+        List <MetadataBlock> viewMDB = new ArrayList<>();
+        List <MetadataBlock> editMDB=this.getDataverse().getMetadataBlocks(true);
             
-        actualMDB.addAll(this.getDataverse().getMetadataBlocks());
+        viewMDB.addAll(this.getDataverse().getMetadataBlocks(true));
         for (DatasetField dsfv : filledInFields) {
             if (!dsfv.isEmptyForDisplay()) {
                 MetadataBlock mdbTest = dsfv.getDatasetFieldType().getMetadataBlock();
-                if (!actualMDB.contains(mdbTest)) {
-                    actualMDB.add(mdbTest);
+                if (!viewMDB.contains(mdbTest)) {
+                    viewMDB.add(mdbTest);
                 }
             }
         }       
         
-        for (MetadataBlock mdb : actualMDB) {
+        for (MetadataBlock mdb : viewMDB) {
+
             List<DatasetField> datasetFieldsForView = new ArrayList<>();
-            List<DatasetField> datasetFieldsForEdit = new ArrayList<>();
             for (DatasetField dsf : this.getDatasetFields()) {
                 if (dsf.getDatasetFieldType().getMetadataBlock().equals(mdb)) {
-                    datasetFieldsForEdit.add(dsf);
                     if (!dsf.isEmpty()) {
                         datasetFieldsForView.add(dsf);
                     }
@@ -290,10 +284,20 @@ public class Template implements Serializable {
             if (!datasetFieldsForView.isEmpty()) {
                 metadataBlocksForView.put(mdb, sortDatasetFields(datasetFieldsForView));
             }
-            if (!datasetFieldsForEdit.isEmpty()) {
-                metadataBlocksForEdit.put(mdb, sortDatasetFields(datasetFieldsForEdit));
-            }
+
         }
+        
+        for (MetadataBlock mdb : editMDB) {
+            List<DatasetField> datasetFieldsForEdit = new ArrayList<>();
+            this.setDatasetFields(initDatasetFields());
+            for (DatasetField dsf : this.getDatasetFields() ) {
+                if (dsf.getDatasetFieldType().getMetadataBlock().equals(mdb)) { 
+                    datasetFieldsForEdit.add(dsf);
+                }
+            }
+            metadataBlocksForEdit.put(mdb, sortDatasetFields(datasetFieldsForEdit));
+        }
+        
     }
 
     // TODO: clean up init methods and get them to work, cascading all the way down.

--- a/src/main/java/edu/harvard/iq/dataverse/TemplatePage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/TemplatePage.java
@@ -14,6 +14,7 @@ import static edu.harvard.iq.dataverse.util.JsfHelper.JH;
 import java.sql.Timestamp;
 import java.util.Date;
 import java.util.List;
+import java.util.logging.Logger;
 import javax.ejb.EJB;
 import javax.ejb.EJBException;
 import javax.faces.application.FacesMessage;
@@ -52,6 +53,8 @@ public class TemplatePage implements java.io.Serializable {
     
     @Inject
     LicenseServiceBean licenseServiceBean;
+    
+    private static final Logger logger = Logger.getLogger(TemplatePage.class.getCanonicalName());
 
     public enum EditMode {
 
@@ -160,7 +163,7 @@ public class TemplatePage implements java.io.Serializable {
         
         for (DatasetField dsf: template.getFlatDatasetFields()){ 
            DataverseFieldTypeInputLevel dsfIl = dataverseFieldTypeInputLevelService.findByDataverseIdDatasetFieldTypeId(dvIdForInputLevel, dsf.getDatasetFieldType().getId());
-           if (dsfIl != null){              
+           if (dsfIl != null){
                dsf.setInclude(dsfIl.isInclude());
            } else {
                dsf.setInclude(true);
@@ -208,20 +211,13 @@ public class TemplatePage implements java.io.Serializable {
                 error.append(cause).append(" ");
                 error.append(cause.getMessage()).append(" ");
             }
-            //
-            //FacesContext.getCurrentInstance().addMessage(null, new FacesMessage(FacesMessage.SEVERITY_ERROR, "Template Save Failed", " - " + error.toString()));
-            System.out.print("dataverse " + dataverse.getName());
-            System.out.print("Ejb exception");
-            System.out.print(error.toString());
+            logger.warning("Template Save failed - Ejb exception " + error.toString());
             JH.addMessage(FacesMessage.SEVERITY_FATAL, BundleUtil.getStringFromBundle("template.save.fail"));
             return null;
         } catch (CommandException ex) {
-            System.out.print("command exception");
-            System.out.print(ex.toString());
-            //FacesContext.getCurrentInstance().addMessage(null, new FacesMessage(FacesMessage.SEVERITY_ERROR, "Template Save Failed", " - " + ex.toString()));
+            logger.severe("Template Save failed - Ejb exception " + ex.toString());
             JH.addMessage(FacesMessage.SEVERITY_FATAL, BundleUtil.getStringFromBundle("template.save.fail"));
             return null;
-            //logger.severe(ex.getMessage());
         }
         editMode = null;       
         String msg = (create)? BundleUtil.getStringFromBundle("template.create"): BundleUtil.getStringFromBundle("template.save");


### PR DESCRIPTION
**What this PR does / why we need it**: IF you add a custom metadata block to a dataverse that already has a template, when you edit that template the new meatdata block is not available for adding default values. This PR allows you to add default values to the newly added MDB.

**Which issue(s) this PR closes**:

Closes #8735 New Metadata blocks not appearing in previously created templates.

**Special notes for your reviewer**:

**Suggestions on how to test this**:

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: no 

**Is there a release notes update needed for this change?**: no

**Additional documentation**: none
