### PR TITLE
Iqss/8846 fix popup

### DIFF
--- a/src/main/webapp/resources/js/dv_rebind_bootstrap_ui.js
+++ b/src/main/webapp/resources/js/dv_rebind_bootstrap_ui.js
@@ -35,9 +35,6 @@ function bind_bsui_components(){
     // Sharrre
     sharrre();
     
-    // Custom Popover with HTML content
-    popoverHTML();
-    
     // clipboard.js click to copy
     clickCopyClipboard();
     

--- a/src/main/webapp/template.xhtml
+++ b/src/main/webapp/template.xhtml
@@ -127,6 +127,12 @@
                                          action="#{TemplatePage.deleteTemplate(TemplatePage.templateId)}"    ></p:commandButton>          
                     </div>
                 </h:form>
+                <script>
+                    //<![CDATA[
+                      $(document).ready(function () {
+                        popoverHTML('#{bundle.htmlAllowedTitle}', '#{bundle.htmlAllowedTags}');
+                    //]]>
+                </script>
             </ui:define>
         </ui:composition>
     </h:body>


### PR DESCRIPTION
**What this PR does / why we need it**: Replacement for #8849 that shows the correct difference from develop.

Fixes issue. Also fixes a related issue that the popup was not showing on the Edit Template page (i.e. for the dataset description). That may have been broken longer.

**Which issue(s) this PR closes**:

Closes #8846

Special notes for your reviewer: Looks like the change in how dv_rebind... was called made it's no argument constructor for popoverHTML be the one that initialized the popup. The popup, with the correct title and list of tags is called from the dataset and dataverse pages as well so it looks like just removing the no arg call fixes things.

For the template page, it looks like there hasn't been any call to the popoverHTML function with parameters for a while (the thing that made the dataverse and dataset pages work after removing the line noted above). So - guessing this has been broken earlier.

Suggestions on how to test this:

See issue - 3 places: check the dataset/metadata/description popup and the one in the issue for the dataverse description, and the dataset description in the template edit page. and verify that you see the tags.

Key thing to check is whether the popup is still there after some ajax refresh of the page. (Spot checking by changing the template used for a new dataset (suggested by @scolapasta) suggests it does still work, but perhaps there are other situations where it won't).