### PR TITLE
add sleep in FilesIT, clean up assertions #6846

### DIFF
--- a/src/test/java/edu/harvard/iq/dataverse/api/FilesIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/FilesIT.java
@@ -650,14 +650,18 @@ public class FilesIT {
         //"junk" passed below is to test that it is discarded
         String updateJsonString = "{\"description\":\""+updateDescription+"\",\"categories\":[\""+updateCategory+"\"],\"forceReplace\":false ,\"junk\":\"junk\"}";
         Response updateMetadataFailResponse = UtilIT.updateFileMetadata(origFileId.toString(), updateJsonString, apiToken);
-        assertEquals(BAD_REQUEST.getStatusCode(), updateMetadataFailResponse.getStatusCode());  
-        
+        updateMetadataFailResponse.prettyPrint();
+        updateMetadataFailResponse.then().assertThat().statusCode(BAD_REQUEST.getStatusCode());
+
+        UtilIT.sleepForLock(datasetId, null, apiToken, UtilIT.MAXIMUM_INGEST_LOCK_DURATION);
+
         //Adding an additional fileMetadata update tests after this to ensure updating replaced files works
         msg("Update file metadata for new file");
         //"junk" passed below is to test that it is discarded
         System.out.print("params: " +  String.valueOf(newDfId) + " " + updateJsonString + " " + apiToken);
         Response updateMetadataResponse = UtilIT.updateFileMetadata(String.valueOf(newDfId), updateJsonString, apiToken);
-        assertEquals(OK.getStatusCode(), updateMetadataResponse.getStatusCode());  
+        updateMetadataResponse.prettyPrint();
+        updateMetadataResponse.then().assertThat().statusCode(OK.getStatusCode());
         //String updateMetadataResponseString = updateMetadataResponse.body().asString();
         Response getUpdatedMetadataResponse = UtilIT.getDataFileMetadataDraft(newDfId, apiToken);
         String getUpMetadataResponseString = getUpdatedMetadataResponse.body().asString();


### PR DESCRIPTION
**What this PR does / why we need it**:

FilesIT.testForceReplaceAndUpdate has been failing randomly.

**Which issue(s) this PR closes**:

- Closes #6846

**Special notes for your reviewer**:

If you look at https://github.com/IQSS/dataverse/issues/6846#issuecomment-1136097242 you'll see that back in May I identified the line that was failing with a 500 error. In this PR, I added the sleepForLock just before this line.

I also did a tiny bit of clean up of the assertions.

**Suggestions on how to test this**:

This is a hard one to test since it's so intermittent. Assuming Jenkins is happy with the PR (the tests pass), I vote for merging it and seeing if the intermittent test failures go away, which we'll only know over time.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No.

**Is there a release notes update needed for this change?**:

No.

**Additional documentation**:

None.