### PR TITLE
show alert to enable popups for external tools #8766

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
@@ -5630,9 +5630,7 @@ public class DatasetPage implements java.io.Serializable {
             apiToken.setTokenString(privUrl.getToken());
         }
         ExternalToolHandler externalToolHandler = new ExternalToolHandler(externalTool, dataset, apiToken, session.getLocaleCode());
-        String toolUrl = externalToolHandler.getToolUrlWithQueryParams();
-        logger.fine("Exploring with " + toolUrl);
-        PrimeFaces.current().executeScript("window.open('"+toolUrl + "', target='_blank');");
+        PrimeFaces.current().executeScript(externalToolHandler.getExploreScript());
     }
 
     private FileMetadata fileMetadataForAction;

--- a/src/main/java/edu/harvard/iq/dataverse/FileDownloadServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/FileDownloadServiceBean.java
@@ -18,6 +18,7 @@ import edu.harvard.iq.dataverse.makedatacount.MakeDataCountLoggingServiceBean.Ma
 import edu.harvard.iq.dataverse.privateurl.PrivateUrl;
 import edu.harvard.iq.dataverse.privateurl.PrivateUrlServiceBean;
 import edu.harvard.iq.dataverse.settings.SettingsServiceBean;
+import edu.harvard.iq.dataverse.util.BundleUtil;
 import edu.harvard.iq.dataverse.util.FileUtil;
 import edu.harvard.iq.dataverse.util.StringUtil;
 import java.io.IOException;
@@ -313,9 +314,7 @@ public class FileDownloadServiceBean implements java.io.Serializable {
         ExternalToolHandler externalToolHandler = new ExternalToolHandler(externalTool, dataFile, apiToken, fmd, localeCode);
         // Persist the name of the tool (i.e. "Data Explorer", etc.)
         guestbookResponse.setDownloadtype(externalTool.getDisplayName());
-        String toolUrl = externalToolHandler.getToolUrlWithQueryParams();
-        logger.fine("Exploring with " + toolUrl);
-        PrimeFaces.current().executeScript("window.open('"+toolUrl + "', target='_blank');");
+        PrimeFaces.current().executeScript(externalToolHandler.getExploreScript());
         // This is the old logic from TwoRavens, null checks and all.
         if (guestbookResponse != null && guestbookResponse.isWriteResponse()
                 && ((fmd != null && fmd.getDataFile() != null) || guestbookResponse.getDataFile() != null)) {

--- a/src/main/java/edu/harvard/iq/dataverse/externaltools/ExternalToolHandler.java
+++ b/src/main/java/edu/harvard/iq/dataverse/externaltools/ExternalToolHandler.java
@@ -7,6 +7,7 @@ import edu.harvard.iq.dataverse.FileMetadata;
 import edu.harvard.iq.dataverse.GlobalId;
 import edu.harvard.iq.dataverse.authorization.users.ApiToken;
 import edu.harvard.iq.dataverse.externaltools.ExternalTool.ReservedWord;
+import edu.harvard.iq.dataverse.util.BundleUtil;
 import edu.harvard.iq.dataverse.util.SystemConfig;
 import java.io.StringReader;
 import java.util.ArrayList;
@@ -200,4 +201,16 @@ public class ExternalToolHandler {
         this.apiToken = apiToken;
     }
 
+    /**
+     * @return Returns Javascript that opens the explore tool in a new browser
+     * tab if the browser allows it.If not, it shows an alert that popups must
+     * be enabled in the browser.
+     */
+    public String getExploreScript() {
+        String toolUrl = this.getToolUrlWithQueryParams();
+        logger.info("Exploring with " + toolUrl);
+        String msg = BundleUtil.getStringFromBundle("externaltools.enable.browser.popups");
+        String script = "const newWin = window.open('" + toolUrl + "', target='_blank'); if (!newWin || newWin.closed || typeof newWin.closed == \"undefined\") {alert(\"" + msg + "\");}";
+        return script;
+    }
 }

--- a/src/main/java/edu/harvard/iq/dataverse/externaltools/ExternalToolHandler.java
+++ b/src/main/java/edu/harvard/iq/dataverse/externaltools/ExternalToolHandler.java
@@ -208,7 +208,7 @@ public class ExternalToolHandler {
      */
     public String getExploreScript() {
         String toolUrl = this.getToolUrlWithQueryParams();
-        logger.info("Exploring with " + toolUrl);
+        logger.fine("Exploring with " + toolUrl);
         String msg = BundleUtil.getStringFromBundle("externaltools.enable.browser.popups");
         String script = "const newWin = window.open('" + toolUrl + "', target='_blank'); if (!newWin || newWin.closed || typeof newWin.closed == \"undefined\") {alert(\"" + msg + "\");}";
         return script;

--- a/src/main/java/propertyFiles/Bundle.properties
+++ b/src/main/java/propertyFiles/Bundle.properties
@@ -2198,6 +2198,8 @@ dataset.AddReplication=Add "Replication Data for" to Title
 dataset.replicationDataFor=Replication Data for:
 dataset.additionalEntry=Additional Entry
 
+#externaltools
+externaltools.enable.browser.popups=You must enable popups in your browser to open external tools in a new window or tab.
 
 #mydata_fragment.xhtml
 mydataFragment.infoAccess=Here are all the dataverses, datasets, and files you have access to. You can filter through them by publication status and roles.


### PR DESCRIPTION
**What this PR does / why we need it**:

When users click a button in Dataverse to open an external tool in a new window tell their browsers to allow pop-up windows. This message from the browser can be somewhat subtle. Here's an example from Firefox:

![Screen Shot 2022-07-26 at 4 23 46 PM](https://user-images.githubusercontent.com/21006/181105408-e2270f0f-b748-4dde-9f67-e11778da053c.png)

This pull request puts up an alert to let the user know that they have to pay attention to what their browser is telling them, that they should allow pop-ups.

**Which issue(s) this PR closes**:

- Closes #8766

**Special notes for your reviewer**:

None.

**Suggestions on how to test this**:

I tested using a private (Firefox) and incognito (Chrome) window.

Preview-only tools do not open in a new window so I changed the "Read Text" previewer to be both a preview and an explore tool like this:

```
curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \
'{
  "displayName":"Read Text",
  "description":"Read the text file.",
  "toolName":"textPreviewer",
  "scope":"file",
  "types":["preview", "explore"],
  "toolUrl":"https://gdcc.github.io/dataverse-previewers/previewers/v1.3/TextPreview.html",
  "toolParameters": {
      "queryParameters":[
        {"fileid":"{fileId}"},
        {"siteUrl":"{siteUrl}"},
        {"key":"{apiToken}"},
        {"datasetid":"{datasetId}"},
        {"datasetversion":"{datasetVersion}"},
        {"locale":"{localeCode}"}
      ]
    },
  "contentType":"text/plain"
}'
```

Given a preview/explore tool like this, there are three places to test (for a .txt file):

- On the dataset page, click "Access File" then "Read Text"
- On the file page, click "Access File" then "Read Text"
- On the file page, click "Explore on Read Text"

In my testing, the alert only appears once unless you refresh the page.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

Yes, two examples below.

## Dataset page

![Screen Shot 2022-07-26 at 4 20 02 PM](https://user-images.githubusercontent.com/21006/181106517-8d199823-5bf7-4ed3-9334-a0e1b0e11eb3.png)

![Screen Shot 2022-07-26 at 4 20 08 PM](https://user-images.githubusercontent.com/21006/181106551-831dbcd0-7ef0-4b18-b5ec-720f36e7dae7.png)

## File page (dropdown shown but "Explore on Read Text" is similar)

![Screen Shot 2022-07-26 at 4 20 27 PM](https://user-images.githubusercontent.com/21006/181106586-4ab1cce9-4316-4794-84a8-7b0c1b0e4fd7.png)

![Screen Shot 2022-07-26 at 4 20 33 PM](https://user-images.githubusercontent.com/21006/181106659-02644f5d-fed1-4471-9499-09daf7d62bf8.png)

**Is there a release notes update needed for this change?**:

No.

**Additional documentation**:

None.