### PR TITLE
By default Feide authentication service returns two values in Norwegi…

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/Shib.java
+++ b/src/main/java/edu/harvard/iq/dataverse/Shib.java
@@ -218,7 +218,13 @@ public class Shib implements java.io.Serializable {
             ? getValueFromAssertion(shibAffiliationAttribute)
             : shibService.getAffiliation(shibIdp, shibService.getDevShibAccountType());
 
+
         if (affiliation != null) {
+            boolean defaultShibAffiliationFeide = false;
+            boolean ShibAffiliationFeide = settingsService.isTrueForKey(SettingsServiceBean.Key.ShibAffiliationFeide, defaultShibAffiliationFeide);
+            if (ShibAffiliationFeide != false) {
+                 affiliation = affiliation.substring(affiliation.lastIndexOf(';') + 1); //patch for FEIDE returning an array
+            }
             affiliationToDisplayAtConfirmation = affiliation;
             friendlyNameForInstitution = affiliation;
         }

--- a/src/main/java/edu/harvard/iq/dataverse/settings/SettingsServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/settings/SettingsServiceBean.java
@@ -426,6 +426,10 @@ public class SettingsServiceBean {
          */
         ShibAttributeCharacterSetConversionEnabled,
         /**
+         *Return the last value of the array of affiliations names returned by FEIDE
+         */
+        ShibAffiliationFeide,
+        /**
          * Validate physical files for all the datafiles in the dataset when publishing
          */
         FileValidationOnPublishEnabled,


### PR DESCRIPTION
…an and English. Split and use only English affiliation.

**What this PR does / why we need it**: Feide authentication service returns an array of values. The affiliation in English is expected to be the last element in the array. This modification adds an option to only return the last element of said array.

**Which issue(s) this PR closes**: 

Closes #

**Special notes for your reviewer**:

**Suggestions on how to test this**:  the array is comma separated for example : 
"UiT Norges Arktiske Universitet ; UiT The Arctic University of Norway"
Using the following curl command 
_curl -X PUT -d true http://localhost:8080/api/admin/settings/:ShibAffiliationFeide_ 
will make it so the affiliation is only "UiT The Arctic University of Norway" and not an array

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: NO

**Is there a release notes update needed for this change?**: YES 
New parameter in configuration : :ShibAffiliationFeide

**Additional documentation**:
under database settings
:ShibAffiliationFeide
Returns the last value of an array in affiliations list.
The array is separated using ";"
curl -X PUT -d true http://localhost:8080/api/admin/settings/:ShibAffiliationFeide_
