### PR TITLE
IQSS/8845 - Avoid creation of extra version in TOA check

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
@@ -410,7 +410,7 @@ public class DatasetPage implements java.io.Serializable {
                hasValidTermsOfAccess = true;
                return hasValidTermsOfAccess;
             } else {
-                hasValidTermsOfAccess = TermsOfUseAndAccessValidator.isTOUAValid(dataset.getEditVersion().getTermsOfUseAndAccess(), null);
+                hasValidTermsOfAccess = TermsOfUseAndAccessValidator.isTOUAValid(dataset.getLatestVersion().getTermsOfUseAndAccess(), null);
                 return hasValidTermsOfAccess;
             }
         }    


### PR DESCRIPTION
**What this PR does / why we need it**: As of 5.11 a new dataset version was appearing when viewing the DatasetPage for datasets with no draft version. This has various effects from turning on the Delete Draft Dataset menu item to showing the 'ghost' draft in the version table. It may also relate to #8867, #8742. 

**Which issue(s) this PR closes**:

Closes #8845

**Special notes for your reviewer**: This removes the ghost version creation. I was able to create datasets (some by editing the db) that display this issue while not showing #8867, even if they had fileaccessrequest false and no TofA. So - while this is pretty clearly a bug, I don't know that other issues should be closed without further investigation. (I think it should stop the route we know if that might cause delete from a different version though.) 

**Suggestions on how to test this**: Create a dataset, publish one or more versions, verify that as a logged in user you don't see a ghost draft version in the versions table, don't see a Delete Draft Dataset item in the Edit menu.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
