### PR TITLE
fix npes on template page

### DIFF
--- a/src/main/webapp/dataset-license-terms.xhtml
+++ b/src/main/webapp/dataset-license-terms.xhtml
@@ -248,7 +248,7 @@
            <div id="panelCollapseTOA" jsf:class="#{!datasetPage.hasValidTermsOfAccess ? 'collapse' : ''}">
                <div class="panel-body">
                    <ui:fragment rendered="#{empty editMode}">
-                       <div class="form-group" jsf:rendered="#{!settingsWrapper.publicInstall and DatasetPage.hasRestrictedFiles}">
+                       <div class="form-group" jsf:rendered="#{!settingsWrapper.publicInstall and datasetPage and DatasetPage.hasRestrictedFiles}">
                            <label for="datasetForm:tabView:metadata_RestrictedFiles" class="col-sm-3 control-label">
                                #{bundle['file.dataFilesTab.terms.list.termsOfAccess.restrictedFiles']}
                                <span class="glyphicon glyphicon-question-sign tooltip-icon"
@@ -295,19 +295,7 @@
                    <ui:fragment rendered="#{!empty editMode}">
                         <div class="form-group" jsf:rendered="#{!settingsWrapper.publicInstall}"> 
                             <p:fragment id="termsOfAccessHelp">
-                                <ui:remove>
-                                <ui:fragment rendered="#{datasetPage == true and (!DatasetPage.hasRestrictedFiles or !termsOfUseAndAccess.fileAccessRequest)}">
-                                    <p class="help-block">
-                                       
-                                        <h:outputText value=" #{bundle['file.dataFilesTab.terms.list.termsOfAccess.description']}"/>
-                                        <h:outputFormat value=" #{bundle['file.dataFilesTab.terms.list.termsOfAccess.description.line.2']}" escape="false">
-                                            <f:param value="#{systemConfig.guidesBaseUrl}"/>
-                                            <f:param value="#{systemConfig.guidesVersion}"/>
-                                        </h:outputFormat>
-                                    </p>                                    
-                                </ui:fragment>
-                                </ui:remove>
-                                <ui:fragment rendered="#{DatasetPage.hasRestrictedFiles}">
+                                <ui:fragment rendered="#{datasetPage == true and DatasetPage.hasRestrictedFiles}">
                                     <div class="alert alert-info">
                                         <span class="glyphicon glyphicon-info-sign"></span>&#160;<strong>#{bundle['messages.info']}</strong> –
                                         <h:outputText value=" #{bundle['file.dataFilesTab.terms.list.termsOfAccess.description']}"/>

--- a/src/main/webapp/dataset-license-terms.xhtml
+++ b/src/main/webapp/dataset-license-terms.xhtml
@@ -248,7 +248,7 @@
            <div id="panelCollapseTOA" jsf:class="#{!datasetPage.hasValidTermsOfAccess ? 'collapse' : ''}">
                <div class="panel-body">
                    <ui:fragment rendered="#{empty editMode}">
-                       <div class="form-group" jsf:rendered="#{!settingsWrapper.publicInstall and datasetPage and DatasetPage.hasRestrictedFiles}">
+                       <div class="form-group" jsf:rendered="#{!settingsWrapper.publicInstall and datasetPage== true and DatasetPage.hasRestrictedFiles}">
                            <label for="datasetForm:tabView:metadata_RestrictedFiles" class="col-sm-3 control-label">
                                #{bundle['file.dataFilesTab.terms.list.termsOfAccess.restrictedFiles']}
                                <span class="glyphicon glyphicon-question-sign tooltip-icon"


### PR DESCRIPTION
**What this PR does / why we need it**: Fixes NPEs introduced in #8902

**Which issue(s) this PR closes**:

Closes #8916 

**Special notes for your reviewer**: After some investigation, it appears that two of the calls replaced with DatasetPage.hasRestrictedFiles in #8902 were 'working' because nulls in the xhtml logic were being ignored, i.e. in dataset-license-terms.xhtml
line 251: DatasetPage.restrictedFileCount returns 0 if the workingVersion is null (true on the template page, so the count of the # of restricted files HTML is suppressed on the template page.
line 267 - same logic appears to be accidentally suppressing any terms of access in the view mode for a template page. (not fixed in this PR)
line 310 (prior to this PR): DatasetPage.dataset.editVersion.hasRestrictedFile ~worked on the template page because DatasetPage [creates an empty Dataset when initializing the dataset variable](https://github.com/IQSS/dataverse/blob/1e528090e37d0236fcc3c69e041763b56a711834/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java#L255) and editVersion would then create a datasetversion for the empty dataset and its hasRestrictedFile method them reports false, with the net effect of appropriately suppressing the info about needed access requests or ToA.

This PR keeps the changes in #8902 and adds a check of datasetPage (a variable that is only true when this fragment is included from a dataset page) prior to DatasetPage.hasRestrictedFiles which avoids having it called from the template page. This pattern is already done elsewhere in the dataset-license-terms.xhtml file.

In working through this, I did note the line 267 issue above (terms of access set in a template are not show in the template/view mode) as well as other issues (collapse state isn't set correctly due to use of jsf:class instead of class, no display of template fileaccessrequest status) - rather than bloat this PR or potentially miss other related issues, I'll open an issue to review what should be happening in the template view and note these as an initial list.

**Suggestions on how to test this**: Test the scenario in #8916 as well as verifying that there is no null pointer exception when viewing a template with terms of access and/or data place terms added.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: no

**Is there a release notes update needed for this change?**:

**Additional documentation**:
