### PR TITLE
#8919: removing an extra space from an API message

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/api/Users.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Users.java
@@ -83,7 +83,7 @@ public class Users extends AbstractApiBean {
             return error(Response.Status.BAD_REQUEST, "Error calling ChangeUserIdentifierCommand: " + e.getLocalizedMessage());
         }
 
-        return ok("All account data for " + consumedIdentifier + " has been merged into " + baseIdentifier + " .");
+        return ok(String.format("All account data for %s has been merged into %s.", consumedIdentifier, baseIdentifier));
     }
 
     @POST


### PR DESCRIPTION
**What this PR does / why we need it**: removes an extra space from an API message

**Which issue(s) this PR closes**:

Closes #8919 

**Special notes for your reviewer**: In the future it would be possible to use a resource string in the message, but in other messages in the same class no resources are used, so I kept this change minimalistic.

**Suggestions on how to test this**: 
1. create two users
2. use the API call I mentioned in the ticket
3. check if the extra space is still there

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: no

**Is there a release notes update needed for this change?**: no

**Additional documentation**: no
