### PR TITLE
GDCC/8924 - Check archival status

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/api/Datasets.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Datasets.java
@@ -82,6 +82,7 @@ import edu.harvard.iq.dataverse.util.ArchiverUtil;
 import edu.harvard.iq.dataverse.util.BundleUtil;
 import edu.harvard.iq.dataverse.util.EjbUtil;
 import edu.harvard.iq.dataverse.util.FileUtil;
+import edu.harvard.iq.dataverse.util.MarkupChecker;
 import edu.harvard.iq.dataverse.util.SystemConfig;
 import edu.harvard.iq.dataverse.util.bagit.OREMap;
 import edu.harvard.iq.dataverse.util.json.JSONLDUtil;
@@ -3333,7 +3334,10 @@ public Response completeMPUpload(String partETagBody, @QueryParam("globalid") St
             if (!au.isSuperuser()) {
                 return error(Response.Status.FORBIDDEN, "Superusers only.");
             }
-
+            
+            //Verify we have valid json after removing any HTML tags (the status gets displayed in the UI, so we want plain text).
+            update= JsonUtil.getJsonObject(MarkupChecker.stripAllTags(JsonUtil.prettyPrint(update)));
+            
             if (update.containsKey(DatasetVersion.ARCHIVAL_STATUS) && update.containsKey(DatasetVersion.ARCHIVAL_STATUS_MESSAGE)) {
                 String status = update.getString(DatasetVersion.ARCHIVAL_STATUS);
                 if (status.equals(DatasetVersion.ARCHIVAL_STATUS_PENDING) || status.equals(DatasetVersion.ARCHIVAL_STATUS_FAILURE)

--- a/src/main/java/edu/harvard/iq/dataverse/api/Datasets.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Datasets.java
@@ -3324,10 +3324,10 @@ public Response completeMPUpload(String partETagBody, @QueryParam("globalid") St
     @Consumes(MediaType.APPLICATION_JSON)
     @Path("/{id}/{version}/archivalStatus")
     public Response setDatasetVersionArchivalStatus(@PathParam("id") String datasetId,
-            @PathParam("version") String versionNumber, JsonObject update, @Context UriInfo uriInfo,
+            @PathParam("version") String versionNumber, String newStatus, @Context UriInfo uriInfo,
             @Context HttpHeaders headers) {
 
-        logger.fine(JsonUtil.prettyPrint(update));
+        logger.fine(newStatus);
         try {
             AuthenticatedUser au = findAuthenticatedUserOrDie();
 
@@ -3336,7 +3336,7 @@ public Response completeMPUpload(String partETagBody, @QueryParam("globalid") St
             }
             
             //Verify we have valid json after removing any HTML tags (the status gets displayed in the UI, so we want plain text).
-            update= JsonUtil.getJsonObject(MarkupChecker.stripAllTags(JsonUtil.prettyPrint(update)));
+            JsonObject update= JsonUtil.getJsonObject(MarkupChecker.stripAllTags(newStatus));
             
             if (update.containsKey(DatasetVersion.ARCHIVAL_STATUS) && update.containsKey(DatasetVersion.ARCHIVAL_STATUS_MESSAGE)) {
                 String status = update.getString(DatasetVersion.ARCHIVAL_STATUS);
@@ -3368,8 +3368,9 @@ public Response completeMPUpload(String partETagBody, @QueryParam("globalid") St
             }
         } catch (WrappedResponse wr) {
             return wr.getResponse();
+        } catch (JsonException| IllegalStateException ex) {
+            return error(Status.BAD_REQUEST, "Unable to parse provided JSON");
         }
-
         return error(Status.BAD_REQUEST, "Unacceptable status format");
     }
     

--- a/src/main/java/edu/harvard/iq/dataverse/util/MarkupChecker.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/MarkupChecker.java
@@ -7,7 +7,7 @@ package edu.harvard.iq.dataverse.util;
 
 import org.apache.commons.text.StringEscapeUtils;
 import org.jsoup.Jsoup;
-import org.jsoup.safety.Whitelist;
+import org.jsoup.safety.Safelist;
 import org.jsoup.parser.Parser;
 
 /**
@@ -20,8 +20,8 @@ public class MarkupChecker {
     
     
     /**
-     * Wrapper around Jsoup clean method with the basic White list
-     *   http://jsoup.org/cookbook/cleaning-html/whitelist-sanitizer
+     * Wrapper around Jsoup clean method with the basic Safe list
+     *   http://jsoup.org/cookbook/cleaning-html/safelist-sanitizer
      * @param unsafe
      * @return 
      */
@@ -33,18 +33,18 @@ public class MarkupChecker {
         // basic includes: a, b, blockquote, br, cite, code, dd, dl, dt, em, i, li, ol, p, pre, q, small, span, strike, strong, sub, sup, u, ul
         //Whitelist wl = Whitelist.basic().addTags("img", "h1", "h2", "h3", "kbd", "hr", "s", "del");  
 
-        Whitelist wl = Whitelist.basicWithImages().addTags("h1", "h2", "h3", "kbd", "hr", "s", "del", "map", "area").addAttributes("img", "usemap")
+        Safelist sl = Safelist.basicWithImages().addTags("h1", "h2", "h3", "kbd", "hr", "s", "del", "map", "area").addAttributes("img", "usemap")
                 .addAttributes("map", "name").addAttributes("area", "shape", "coords", "href", "title", "alt")
                 .addEnforcedAttribute("a", "target", "_blank");
 
-        return Jsoup.clean(unsafe, wl);
+        return Jsoup.clean(unsafe, sl);
 
     }
         
     /**
      * Strip all HTMl tags
      * 
-     * http://jsoup.org/apidocs/org/jsoup/safety/Whitelist.html#none%28%29
+     * http://jsoup.org/apidocs/org/jsoup/safety/Safelist.html#none
      * 
      * @param unsafe
      * @return 
@@ -55,7 +55,7 @@ public class MarkupChecker {
             return null;
         }
 
-        return Parser.unescapeEntities(Jsoup.clean(unsafe, Whitelist.none()), true);
+        return Parser.unescapeEntities(Jsoup.clean(unsafe, Safelist.none()), true);
 
     }
     


### PR DESCRIPTION
**What this PR does / why we need it**: Remove any html tags from supplied archival status (new APIs being added in 5.12). Also updates the Jsoup class we use in general.

**Which issue(s) this PR closes**:

Closes #8924

**Special notes for your reviewer**: 

FWIW: The Jsoup update appears to just be a classname change but the docs do say the old class will be retired soon.


**Suggestions on how to test this**: Use the archival status API (must be superuser) to put an HTML message and confirm the result from doing a get (or what's displayed) does not include html.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
