### PR TITLE
add lip-computing/dataverse to prep.rst

### DIFF
--- a/doc/sphinx-guides/source/installation/prep.rst
+++ b/doc/sphinx-guides/source/installation/prep.rst
@@ -27,6 +27,7 @@ Advanced Installation
 There are some community-lead projects to use configuration management tools such as Ansible and Puppet to automate the installation and configuration of the Dataverse Software, but support for these solutions is limited to what the Dataverse Community can offer as described in each project's webpage:
 
 - https://github.com/GlobalDataverseCommunityConsortium/dataverse-ansible
+- https://gitlab.com/lip-computing/dataverse
 - https://github.com/IQSS/dataverse-puppet
 
 (Please note that the "dataverse-ansible" repo is used in a script that allows the Dataverse Software to be installed on Amazon Web Services (AWS) from arbitrary GitHub branches as described in the :doc:`/developers/deployment` section of the Developer Guide.)


### PR DESCRIPTION
Added LIP's repo with resources for an advanced installation as proposed by Philip Durbin.

**What this PR does / why we need it**:
Added some new installation method to the advanced installation documentation.

**Which issue(s) this PR closes**:
The unavalabilty of a recipe for an advanced installation with all the resources needed to deploy a full functioning dataverse service with a fault tolerant architecture 

Closes #8963

**Special notes for your reviewer**:

**Suggestions on how to test this**:

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
