### PR TITLE
Revert "class field can be replaced by local variable"

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/api/datadeposit/SWORDv2ContainerServlet.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/datadeposit/SWORDv2ContainerServlet.java
@@ -17,9 +17,9 @@ public class SWORDv2ContainerServlet extends SwordServlet {
     ContainerManagerImpl containerManagerImpl;
     @Inject
     StatementManagerImpl statementManagerImpl;
-//    private ContainerManager cm; this field can be replaced by local variable
+    private ContainerManager cm;
     private ContainerAPI api;
-//    private StatementManager sm; this field can be replaced by local variable
+    private StatementManager sm;
     private final ReentrantLock lock = new ReentrantLock();
     
     
@@ -28,16 +28,13 @@ public class SWORDv2ContainerServlet extends SwordServlet {
         super.init();
 
         // load the container manager implementation
-//        this.cm = containerManagerImpl;
-        ContainerManager cm = containerManagerImpl;
+        this.cm = containerManagerImpl;
 
         // load the statement manager implementation
-//        this.sm = statementManagerImpl;
-        StatementManager sm = statementManagerImpl;
+        this.sm = statementManagerImpl;
 
         // initialise the underlying servlet processor
-//        this.api = new ContainerAPI(this.cm, this.sm, this.config);
-        this.api = new ContainerAPI(cm, sm, this.config);
+        this.api = new ContainerAPI(this.cm, this.sm, this.config);
     }
 
     @Override


### PR DESCRIPTION
Reverts IQSS/dataverse#8809

Whoops! PR #8809 was targeting the "master" branch rather than "develop" and I didn't notice before merging it.

I clicked the "Revert" button...

![Screen Shot 2022-09-08 at 3 57 42 PM](https://user-images.githubusercontent.com/21006/189215155-cfff906c-0a3e-4ede-bb14-63a8fa73bde0.png)

... to create this pull request, which I'll merge to revert PR #8809.

Docs on this process: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/reverting-a-pull-request

(Seems less scary than force pushing and other alternatives offered at https://stackoverflow.com/questions/6481575/undo-a-merge-by-pull-request .)