### PR TITLE
switch to our regular createDataverseRequest pattern #8992

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/api/EditDDI.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/EditDDI.java
@@ -35,7 +35,6 @@ import javax.ejb.Stateless;
 import javax.inject.Inject;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
-import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.Path;
@@ -91,9 +90,6 @@ public class EditDDI  extends AbstractApiBean {
     DataverseSession session;
 
     private List<FileMetadata> filesToBeDeleted = new ArrayList<>();
-
-    @Context
-    protected HttpServletRequest httpRequest;
 
     private VariableMetadataUtil variableMetadataUtil;
 
@@ -193,7 +189,7 @@ public class EditDDI  extends AbstractApiBean {
         Command<Dataset> cmd;
         try {
 
-            DataverseRequest dr = new DataverseRequest(apiTokenUser, httpRequest);
+            DataverseRequest dr = createDataverseRequest(apiTokenUser);
             cmd = new UpdateDatasetVersionCommand(dataset, dr, fm);
             ((UpdateDatasetVersionCommand) cmd).setValidateLenient(true);
             dataset = commandEngine.submit(cmd);
@@ -335,7 +331,7 @@ public class EditDDI  extends AbstractApiBean {
         }
         Command<Dataset> cmd;
         try {
-            DataverseRequest dr = new DataverseRequest(apiTokenUser, httpRequest);
+            DataverseRequest dr = createDataverseRequest(apiTokenUser);
             cmd = new UpdateDatasetVersionCommand(dataset, dr);
             ((UpdateDatasetVersionCommand) cmd).setValidateLenient(true);
             commandEngine.submit(cmd);


### PR DESCRIPTION
**What this PR does / why we need it**:

put("/api/edit/" + fileId) is failing

Which issue(s) this PR closes**:

Closes #8992

**Special notes for your reviewer**:

I'm putting in our usual pattern for getting a request. I'm not sure why this fixes it on my machine, honestly, but it does. Hopefully Jenkins agrees. The test was failing very consistently for me on my laptop.

@qqmyers suggested it might be a timing issue and I agree it's possible. I didn't add a sleep.

I'm not sure what changed. No recent PRs that were merged seem to have to do with editing DDI.

**Suggestions on how to test this**:

Make sure tests pass.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No.

**Is there a release notes update needed for this change?**:

No.

**Additional documentation**:

None.