### PR TITLE
Initialize transient fields with empty HashMap instead of null

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/authorization/users/AuthenticatedUser.java
+++ b/src/main/java/edu/harvard/iq/dataverse/authorization/users/AuthenticatedUser.java
@@ -18,6 +18,7 @@ import edu.harvard.iq.dataverse.util.json.NullSafeJsonBuilder;
 import java.io.Serializable;
 import java.sql.Timestamp;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -135,10 +136,10 @@ public class AuthenticatedUser implements User, Serializable {
     private String mutedNotifications;
     
     @Transient
-    private Set<Type> mutedEmailsSet;
+    private Set<Type> mutedEmailsSet = new HashSet<>();
     
     @Transient
-    private Set<Type> mutedNotificationsSet;
+    private Set<Type> mutedNotificationsSet = new HashSet<>();
 
     @PrePersist
     void prePersist() {


### PR DESCRIPTION
**What this PR does / why we need it**:
It resolves a bug in the `ShowMuteOptions` feature.

**Which issue(s) this PR closes**:

Closes #9029

**Special notes for your reviewer**:
It seems `edu.harvard.iq.dataverse.authorization.users.AuthenticatedUser#postLoad` is not executed in the scenario described in the issue (user was just created by a first federated login).

**Suggestions on how to test this**:
1.  Log in with an IdP that you haven't used with the Dataverse instance before.
2. Create an account
3. Navigate to "Account Settings"

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
No

**Is there a release notes update needed for this change?**:
No

**Additional documentation**:
N/a