### PR TITLE
#8351 fixing inconsistency in admin's Troubleshouting page

### DIFF
--- a/doc/sphinx-guides/source/_static/util/clear_timer.sh
+++ b/doc/sphinx-guides/source/_static/util/clear_timer.sh
@@ -17,7 +17,7 @@ DV_DIR=${PAYARA_DIR}/glassfish/domains/domain1
 ${PAYARA_DIR}/bin/asadmin stop-domain
 
 rm -rf ${PAYARA_DIR}/${DV_DIR}/generated/
-rm -rf ${PAYARA_DIR}/${DV_DIR}/osgi-cache/felix
+rm -rf ${PAYARA_DIR}/${DV_DIR}/osgi-cache/
 
 # restart the domain (also generates a warning if app server is stopped)
 ${PAYARA_DIR}/bin/asadmin start-domain

--- a/doc/sphinx-guides/source/admin/troubleshooting.rst
+++ b/doc/sphinx-guides/source/admin/troubleshooting.rst
@@ -57,7 +57,7 @@ Ingest is both CPU- and memory-intensive, and depending on your system resources
 
 ``/usr/local/payara5/mq/bin/imqcmd -u admin purge dst -t q -n DataverseIngest`` will purge the DataverseIngest queue, and prompt for your confirmation.
 
-Finally, list destinations to verify that the purge was successful::
+Finally, list destinations to verify that the purge was successful:
 
 ``/usr/local/payara5/mq/bin/imqcmd -u admin list dst``
 


### PR DESCRIPTION
**What this PR does / why we need it**:

There is an inconsistency between text and code snippet in admin guide's troubleshooting section.

I also found an extra colon in another part of the document, which makes a wrong formatting of another code snippets.

**Which issue(s) this PR closes**:

Closes #8351 

**Special notes for your reviewer**:

You should build the documentation.

**Suggestions on how to test this**:

```
cd doc/sphinx-guides/
make clean
make html
firefox build/html/admin/troubleshooting.html
```

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

It changes only the Admin guide of the manual.

**Is there a release notes update needed for this change?**:

No.

**Additional documentation**:

the code snippet mentioned in the issue should look like this:
![dataverse-8351-1-fixed](https://user-images.githubusercontent.com/218218/194582176-1f8bcec5-1649-48dc-b857-c0bb5daa5a31.png)

The other formatting issue looks like this now:
![dataverse-8351-2-wrong](https://user-images.githubusercontent.com/218218/194582527-07168628-c668-4f84-b967-418a36bc3bf6.png)

After applying this PR, it will look like this:
![dataverse-8351-2-fixed](https://user-images.githubusercontent.com/218218/194582607-fa3e2482-125f-4ac7-acd7-08de4c11989a.png)

