### PR TITLE
Fixes in Solr docs

### DIFF
--- a/doc/sphinx-guides/source/admin/harvestserver.rst
+++ b/doc/sphinx-guides/source/admin/harvestserver.rst
@@ -115,10 +115,10 @@ Some useful examples of search queries to define OAI sets:
 
   ``keywordValue:censorship``
 
-Important: New SOLR schema required!
+Important: New Solr schema required!
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-In order to be able to define OAI sets, your SOLR server must be upgraded with the search schema that came with release 4.5 (or later), and all your local datasets must be re-indexed, once the new schema is installed. 
+In order to be able to define OAI sets, your Solr server must be upgraded with the search schema that came with release 4.5 (or later), and all your local datasets must be re-indexed, once the new schema is installed. 
 
 OAI Set updates
 ---------------

--- a/doc/sphinx-guides/source/admin/solr-search-index.rst
+++ b/doc/sphinx-guides/source/admin/solr-search-index.rst
@@ -22,7 +22,7 @@ Get a list of all database objects that are missing in Solr, and Solr documents 
 
 ``curl http://localhost:8080/api/admin/index/status``
 
-Remove all Solr documents that are orphaned (ie not associated with objects in the database):
+Remove all Solr documents that are orphaned (i.e. not associated with objects in the database):
 
 ``curl http://localhost:8080/api/admin/index/clear-orphans``
 

--- a/doc/sphinx-guides/source/admin/solr-search-index.rst
+++ b/doc/sphinx-guides/source/admin/solr-search-index.rst
@@ -36,7 +36,7 @@ Please note that the moment you issue this command, it will appear to end users 
 Start Async Reindex
 ~~~~~~~~~~~~~~~~~~~
 
-Please note that this operation may take hours depending on the amount of data in your system. This known issue is being tracked at https://github.com/IQSS/dataverse/issues/50
+Please note that this operation may take hours depending on the amount of data in your system.
 
 ``curl http://localhost:8080/api/admin/index``
 

--- a/doc/sphinx-guides/source/admin/solr-search-index.rst
+++ b/doc/sphinx-guides/source/admin/solr-search-index.rst
@@ -60,7 +60,7 @@ If indexing stops, this command should pick up where it left off based on which 
 Manual Reindexing
 -----------------
 
-If you have made manual changes to a dataset in the database or wish to reindex a dataset that solr didn't want to index properly, it is possible to manually reindex Dataverse collections and datasets.
+If you have made manual changes to a dataset in the database or wish to reindex a dataset that Solr didn't want to index properly, it is possible to manually reindex Dataverse collections and datasets.
 
 Reindexing Dataverse Collections
 ++++++++++++++++++++++++++++++++
@@ -89,7 +89,7 @@ To re-index a dataset by its database ID:
 Manually Querying Solr
 ----------------------
 
-If you suspect something isn't indexed properly in solr, you may bypass the Dataverse installation's web interface and query the command line directly to verify what solr returns:
+If you suspect something isn't indexed properly in Solr, you may bypass the Dataverse installation's web interface and query the command line directly to verify what Solr returns:
 
 ``curl "http://localhost:8983/solr/collection1/select?q=dsPersistentId:doi:10.15139/S3/HFV0AO"``
 

--- a/doc/sphinx-guides/source/admin/solr-search-index.rst
+++ b/doc/sphinx-guides/source/admin/solr-search-index.rst
@@ -69,7 +69,7 @@ Dataverse collections must be referenced by database object ID. If you have dire
 
 ``select id from dataverse where alias='dataversealias';``
 
-should work, or you may click the Dataverse Software's "Edit" menu and look for dataverseId= in the URLs produced by the drop-down. Then, to re-index:
+should work, or you may click the Dataverse Software's "Edit" menu and look for *dataverseId=* in the URLs produced by the drop-down. Then, to re-index:
 
 ``curl http://localhost:8080/api/admin/index/dataverses/135``
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes a link to a long-resolved issue associated with Solr reindexing. It keeps the important information in place (that reindexing takes some time).

Further, this PR add some minor style fixes:
- Consistency of Solr casing (Solr with a capital S seems to be the right version.)
- Minor typographic fixes

Possible additional work:
- Extend section on reindexing to explain what a "completely clean index" means

**Is there a release notes update needed for this change?**: No
