### PR TITLE
Iqss/7394 1 truncate description

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DatasetVersion.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetVersion.java
@@ -852,7 +852,7 @@ public class DatasetVersion implements Serializable {
         for (String htmlDescription : getDescriptions()) {
             plainTextDescriptions.add(MarkupChecker.stripAllTags(htmlDescription));
         }
-        String description = String.join("\\n", plainTextDescriptions);
+        String description = String.join("\n", plainTextDescriptions);
         if(description.length()>=5000) {
             description = description.substring(0, (description.substring(0,4997).lastIndexOf(" "))) + "...";
         }

--- a/src/main/java/edu/harvard/iq/dataverse/DatasetVersion.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetVersion.java
@@ -842,12 +842,21 @@ public class DatasetVersion implements Serializable {
         return MarkupChecker.stripAllTags(getDescription());
     }
 
-    public List<String> getDescriptionsPlainText() {
-        List<String> plainTextDescriptions = new ArrayList<>();
+    /* This method is (only) used in creating schema.org json-jd where Google requires a text description <5000 chars.
+     * 
+     * @returns - a single string composed of all descriptions (joined with \n if more than one) truncated with a trailing '...' if >=5000 chars
+     */
+    public String getDescriptionsPlainTextTruncated() {
+        List<String> plainTextDescriptions = new ArrayList<String>();
+        
         for (String htmlDescription : getDescriptions()) {
             plainTextDescriptions.add(MarkupChecker.stripAllTags(htmlDescription));
         }
-        return plainTextDescriptions;
+        String description = String.join("\\n", plainTextDescriptions);
+        if(description.length()>=5000) {
+            description = description.substring(0, (description.substring(0,4997).lastIndexOf(" "))) + "...";
+        }
+        return description;
     }
 
     /**
@@ -1859,16 +1868,8 @@ public class DatasetVersion implements Serializable {
         job.add("dateModified", this.getPublicationDateAsString());
         job.add("version", this.getVersionNumber().toString());
 
-        JsonArrayBuilder descriptionsArray = Json.createArrayBuilder();
-        List<String> descriptions = this.getDescriptionsPlainText();
-        for (String description : descriptions) {
-            descriptionsArray.add(description);
-        }
-        /**
-         * In Dataverse 4.8.4 "description" was a single string but now it's an
-         * array.
-         */
-        job.add("description", descriptionsArray);
+        String description = this.getDescriptionsPlainTextTruncated();
+        job.add("description", description);
 
         /**
          * "keywords" - contains subject(s), datasetkeyword(s) and topicclassification(s)

--- a/src/test/java/edu/harvard/iq/dataverse/export/SchemaDotOrgExporterTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/export/SchemaDotOrgExporterTest.java
@@ -147,9 +147,7 @@ public class SchemaDotOrgExporterTest {
         assertEquals("1955-11-05", json2.getString("datePublished"));
         assertEquals("1955-11-05", json2.getString("dateModified"));
         assertEquals("1", json2.getString("version"));
-        assertEquals("Darwin's finches (also known as the Galápagos finches) are a group of about fifteen species of passerine birds.", json2.getString("description"));
-        assertEquals("Bird is the word.", json2.getJsonArray("description").getString(1));
-        assertEquals(2, json2.getJsonArray("description").size());
+        assertEquals("Darwin's finches (also known as the Galápagos finches) are a group of about fifteen species of passerine birds.\\nBird is the word.", json2.getString("description"));
         assertEquals("Medicine, Health and Life Sciences", json2.getJsonArray("keywords").getString(0));
         assertEquals("tcTerm1", json2.getJsonArray("keywords").getString(1));
         assertEquals("KeywordTerm1", json2.getJsonArray("keywords").getString(2));

--- a/src/test/java/edu/harvard/iq/dataverse/export/SchemaDotOrgExporterTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/export/SchemaDotOrgExporterTest.java
@@ -147,7 +147,7 @@ public class SchemaDotOrgExporterTest {
         assertEquals("1955-11-05", json2.getString("datePublished"));
         assertEquals("1955-11-05", json2.getString("dateModified"));
         assertEquals("1", json2.getString("version"));
-        assertEquals("Darwin's finches (also known as the Galápagos finches) are a group of about fifteen species of passerine birds.\\nBird is the word.", json2.getString("description"));
+        assertEquals("Darwin's finches (also known as the Galápagos finches) are a group of about fifteen species of passerine birds.\nBird is the word.", json2.getString("description"));
         assertEquals("Medicine, Health and Life Sciences", json2.getJsonArray("keywords").getString(0));
         assertEquals("tcTerm1", json2.getJsonArray("keywords").getString(1));
         assertEquals("KeywordTerm1", json2.getJsonArray("keywords").getString(2));

--- a/src/test/java/edu/harvard/iq/dataverse/export/SchemaDotOrgExporterTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/export/SchemaDotOrgExporterTest.java
@@ -147,7 +147,7 @@ public class SchemaDotOrgExporterTest {
         assertEquals("1955-11-05", json2.getString("datePublished"));
         assertEquals("1955-11-05", json2.getString("dateModified"));
         assertEquals("1", json2.getString("version"));
-        assertEquals("Darwin's finches (also known as the Galápagos finches) are a group of about fifteen species of passerine birds.", json2.getJsonArray("description").getString(0));
+        assertEquals("Darwin's finches (also known as the Galápagos finches) are a group of about fifteen species of passerine birds.", json2.getString("description"));
         assertEquals("Bird is the word.", json2.getJsonArray("description").getString(1));
         assertEquals(2, json2.getJsonArray("description").size());
         assertEquals("Medicine, Health and Life Sciences", json2.getJsonArray("keywords").getString(0));


### PR DESCRIPTION
**What this PR does / why we need it**: Per issue #7349, Google rejects descriptions in the schema.org page metadata. Further, it expects description to be a string rather than a JsonArray which we were sending. This PR joins descriptions with a linefeed and then truncates the result to <5000 characters, sending the description up to the last word boundary before 4997 characters and appending a '...' to indicate there's more content.

**Which issue(s) this PR closes**:

Closes #7349

**Special notes for your reviewer**: This is one of ~3 PRs to close the issue

**Suggestions on how to test this**: Just verify the unit tests run. Can confirm manually by adding a long description and verifying it is truncated as described above (and that shorter ones aren't, and that two descriptions that total more than 5K chars are truncated together, etc.). That said, the unit tests do verify that two descriptions are joined, and there's a separate test for truncation.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:  included

**Additional documentation**:
