### PR TITLE
Extend 'metadatablocks/{block_id}' endpoint JSON output

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
@@ -551,6 +551,14 @@ public class JsonPrinter {
         fieldsBld.add("watermark", fld.getWatermark());
         fieldsBld.add("description", fld.getDescription());
         fieldsBld.add("multiple", fld.isAllowMultiples());
+        fieldsBld.add("isControlledVocabulary", fld.isControlledVocabulary());
+        if (fld.isControlledVocabulary()) {
+            // If the field has a controlled vocabulary,
+            // add all values to the resulting JSON
+            fieldsBld.add(
+                    "controlledVocabularyValues",
+                    fld.getControlledVocabularyValues().toArray().toString());
+        }
         if (!fld.getChildDatasetFieldTypes().isEmpty()) {
             JsonObjectBuilder subFieldsBld = jsonObjectBuilder();
             for (DatasetFieldType subFld : fld.getChildDatasetFieldTypes()) {

--- a/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
@@ -550,6 +550,7 @@ public class JsonPrinter {
         fieldsBld.add("type", fld.getFieldType().toString());
         fieldsBld.add("watermark", fld.getWatermark());
         fieldsBld.add("description", fld.getDescription());
+        fieldsBld.add("multiple", fld.isAllowMultiples());
         if (!fld.getChildDatasetFieldTypes().isEmpty()) {
             JsonObjectBuilder subFieldsBld = jsonObjectBuilder();
             for (DatasetFieldType subFld : fld.getChildDatasetFieldTypes()) {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR extends the API endpoint ```/api/metadatablocks/{block_id}``` to include the following fields:

- ```multiple```: Whether or not multiple instances of this field can exist
- ```isControlledVocabulary```:  Whether or not this field has a controlled vocabulary. Important to derive the ```typeClass``` later on
- ```controlledVocabularyValues ``` - If a vocabulary is given, includes all possible values.

With this extension it is possible to build compatible Dataverse JSON files for upload and download from any installation without having access to the TSV files. EasyDataverse would greatly benefit from this and allow users to "connect" to a Dataverse installation without the need of generating specific code.

**Which issue(s) this PR closes**:

Closes #8944

**Special notes for your reviewer**:

None

**Suggestions on how to test this**:

Add or extend a fixture to test if the new fields are given upon execution.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No.

**Is there a release notes update needed for this change?**:

The API endpoint ```/api/metadatablocks/{block_id}``` has been extended to include the following fields:

- ```multiple```: Whether or not multiple instances of this field can exist
- ```isControlledVocabulary```:  Whether or not this field has a controlled vocabulary. Important to derive the ```typeClass``` later on
- ```controlledVocabularyValues ``` - If a vocabulary is given, includes all possible values.

**Additional documentation**:

 None