### PR TITLE
5.12 Fix - misplaced paren disabling direct download

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/api/DownloadInstanceWriter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/DownloadInstanceWriter.java
@@ -217,37 +217,37 @@ public class DownloadInstanceWriter implements MessageBodyWriter<DownloadInstanc
                             }
                         }
                     }
-                    if (redirect_url_str!=null) {
+                }
+                if (redirect_url_str != null) {
 
-                        logger.fine("Data Access API: redirect url: " + redirect_url_str);
-                        URI redirect_uri;
+                    logger.fine("Data Access API: redirect url: " + redirect_url_str);
+                    URI redirect_uri;
 
-                        try {
-                            redirect_uri = new URI(redirect_url_str);
-                        } catch (URISyntaxException ex) {
-                            logger.info("Data Access API: failed to create redirect url (" + redirect_url_str + ")");
-                            redirect_uri = null;
-                        }
-                        if (redirect_uri != null) {
-                            // increment the download count, if necessary:
-                            if (di.getGbr() != null && !(isThumbnailDownload(di) || isPreprocessedMetadataDownload(di))) {
-                                try {
-                                    logger.fine("writing guestbook response, for a download redirect.");
-                                    Command<?> cmd = new CreateGuestbookResponseCommand(di.getDataverseRequestService().getDataverseRequest(), di.getGbr(), di.getGbr().getDataFile().getOwner());
-                                    di.getCommand().submit(cmd);
-                                    MakeDataCountEntry entry = new MakeDataCountEntry(di.getRequestUriInfo(), di.getRequestHttpHeaders(), di.getDataverseRequestService(), di.getGbr().getDataFile());
-                                    mdcLogService.logEntry(entry);
-                                } catch (CommandException e) {
-                                }
-                            }
-
-                            // finally, issue the redirect:
-                            Response response = Response.seeOther(redirect_uri).build();
-                            logger.fine("Issuing redirect to the file location.");
-                            throw new RedirectionException(response);
-                        }
-                        throw new ServiceUnavailableException();
+                    try {
+                        redirect_uri = new URI(redirect_url_str);
+                    } catch (URISyntaxException ex) {
+                        logger.info("Data Access API: failed to create redirect url (" + redirect_url_str + ")");
+                        redirect_uri = null;
                     }
+                    if (redirect_uri != null) {
+                        // increment the download count, if necessary:
+                        if (di.getGbr() != null && !(isThumbnailDownload(di) || isPreprocessedMetadataDownload(di))) {
+                            try {
+                                logger.fine("writing guestbook response, for a download redirect.");
+                                Command<?> cmd = new CreateGuestbookResponseCommand(di.getDataverseRequestService().getDataverseRequest(), di.getGbr(), di.getGbr().getDataFile().getOwner());
+                                di.getCommand().submit(cmd);
+                                MakeDataCountEntry entry = new MakeDataCountEntry(di.getRequestUriInfo(), di.getRequestHttpHeaders(), di.getDataverseRequestService(), di.getGbr().getDataFile());
+                                mdcLogService.logEntry(entry);
+                            } catch (CommandException e) {
+                            }
+                        }
+
+                        // finally, issue the redirect:
+                        Response response = Response.seeOther(redirect_uri).build();
+                        logger.fine("Issuing redirect to the file location.");
+                        throw new RedirectionException(response);
+                    }
+                    throw new ServiceUnavailableException();
                 }
 
                 if (di.getConversionParam() != null) {


### PR DESCRIPTION
**What this PR does / why we need it**: As stated, a misplaced paren I introduced in the Globus PR caused direct download to only be done in the Globus case and disabled it for normal S3 stores.

**Which issue(s) this PR closes**:

Closes #

**Special notes for your reviewer**: This is only a paren relocation - the rest of the block is just moved one indent level out.

**Suggestions on how to test this**:

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
