### PR TITLE
rename getEditVersion to getOrCreateEditVersion, mention getLatestVersion #8930

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/Dataset.java
+++ b/src/main/java/edu/harvard/iq/dataverse/Dataset.java
@@ -391,19 +391,21 @@ public class Dataset extends DvObjectContainer {
 
     /**
      * The "edit version" is the most recent *draft* of a dataset, and if the
-     * latest version of a dataset is published, a new draft will be created.
-     * 
+     * latest version of a dataset is published, a new draft will be created. If
+     * you don't want to create a new version, you should be using
+     * getLatestVersion.
+     *
      * @return The edit version {@code this}.
      */
-    public DatasetVersion getEditVersion() {
-        return getEditVersion(null, null);
+    public DatasetVersion getOrCreateEditVersion() {
+        return getOrCreateEditVersion(null, null);
     }
 
-    public DatasetVersion getEditVersion(FileMetadata fm) {
-        return getEditVersion(null, fm);
+    public DatasetVersion getOrCreateEditVersion(FileMetadata fm) {
+        return getOrCreateEditVersion(null, fm);
     }
 
-    public DatasetVersion getEditVersion(Template template, FileMetadata fm) {
+    public DatasetVersion getOrCreateEditVersion(Template template, FileMetadata fm) {
         DatasetVersion latestVersion = this.getLatestVersion();
         if (!latestVersion.isWorkingCopy() || template != null) {
             // if the latest version is released or archived, create a new version for editing

--- a/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
@@ -2067,7 +2067,7 @@ public class DatasetPage implements java.io.Serializable {
                 }
                 //Initalize with the default if there is one 
                 dataset.setTemplate(selectedTemplate);
-                workingVersion = dataset.getEditVersion(selectedTemplate, null);
+                workingVersion = dataset.getOrCreateEditVersion(selectedTemplate, null);
                 updateDatasetFieldInputLevels();
             } else {
                 workingVersion = dataset.getCreateVersion(licenseServiceBean.getDefault());
@@ -2401,7 +2401,7 @@ public class DatasetPage implements java.io.Serializable {
             AuthenticatedUser au = (AuthenticatedUser) session.getUser();
 
             //On create set pre-populated fields
-            for (DatasetField dsf : dataset.getEditVersion().getDatasetFields()) {
+            for (DatasetField dsf : dataset.getOrCreateEditVersion().getDatasetFields()) {
                 if (dsf.getDatasetFieldType().getName().equals(DatasetFieldConstant.depositor) && dsf.isEmpty()) {
                     dsf.getDatasetFieldValues().get(0).setValue(au.getLastName() + ", " + au.getFirstName());
                 }
@@ -2458,7 +2458,7 @@ public class DatasetPage implements java.io.Serializable {
         }
         String termsOfAccess = workingVersion.getTermsOfUseAndAccess().getTermsOfAccess();
         boolean requestAccess = workingVersion.getTermsOfUseAndAccess().isFileAccessRequest();
-        workingVersion = dataset.getEditVersion();
+        workingVersion = dataset.getOrCreateEditVersion();
         workingVersion.getTermsOfUseAndAccess().setTermsOfAccess(termsOfAccess);
         workingVersion.getTermsOfUseAndAccess().setFileAccessRequest(requestAccess);
         List <FileMetadata> newSelectedFiles = new ArrayList<>();
@@ -2521,7 +2521,7 @@ public class DatasetPage implements java.io.Serializable {
         if (this.readOnly) {
             dataset = datasetService.find(dataset.getId());
         }
-        workingVersion = dataset.getEditVersion();
+        workingVersion = dataset.getOrCreateEditVersion();
         clone = workingVersion.cloneDatasetVersion();
         if (editMode.equals(EditMode.METADATA)) {
             datasetVersionUI = datasetVersionUI.initDatasetVersionUI(workingVersion, true);
@@ -3452,7 +3452,7 @@ public class DatasetPage implements java.io.Serializable {
             if (markedForDelete.getId() != null) {
                 // This FileMetadata has an id, i.e., it exists in the database.
                 // We are going to remove this filemetadata from the version:
-                dataset.getEditVersion().getFileMetadatas().remove(markedForDelete);
+                dataset.getOrCreateEditVersion().getFileMetadatas().remove(markedForDelete);
                 // But the actual delete will be handled inside the UpdateDatasetCommand
                 // (called later on). The list "filesToBeDeleted" is passed to the
                 // command as a parameter:
@@ -3678,7 +3678,7 @@ public class DatasetPage implements java.io.Serializable {
                     // have been created in the dataset.
                     dataset = datasetService.find(dataset.getId());
 
-                    List<DataFile> filesAdded = ingestService.saveAndAddFilesToDataset(dataset.getEditVersion(), newFiles, null, true);
+                    List<DataFile> filesAdded = ingestService.saveAndAddFilesToDataset(dataset.getOrCreateEditVersion(), newFiles, null, true);
                     newFiles.clear();
 
                     // and another update command:

--- a/src/main/java/edu/harvard/iq/dataverse/EditDatafilesPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/EditDatafilesPage.java
@@ -539,7 +539,7 @@ public class EditDatafilesPage implements java.io.Serializable {
             return permissionsWrapper.notFound();
         }
 
-        workingVersion = dataset.getEditVersion();
+        workingVersion = dataset.getOrCreateEditVersion();
 
         //TODO: review if we we need this check; 
         // as getEditVersion should either return the exisiting draft or create a new one      
@@ -890,7 +890,7 @@ public class EditDatafilesPage implements java.io.Serializable {
                 // ToDo - FileMetadataUtil.removeFileMetadataFromList should handle these two
                 // removes so they could be put after this if clause and the else clause could
                 // be removed.
-                dataset.getEditVersion().getFileMetadatas().remove(markedForDelete);
+                dataset.getOrCreateEditVersion().getFileMetadatas().remove(markedForDelete);
                 fileMetadatas.remove(markedForDelete);
 
                 filesToBeDeleted.add(markedForDelete);
@@ -907,7 +907,7 @@ public class EditDatafilesPage implements java.io.Serializable {
                 // 1. delete the filemetadata from the local display list: 
                 FileMetadataUtil.removeFileMetadataFromList(fileMetadatas, markedForDelete);
                 // 2. delete the filemetadata from the version: 
-                FileMetadataUtil.removeFileMetadataFromList(dataset.getEditVersion().getFileMetadatas(), markedForDelete);
+                FileMetadataUtil.removeFileMetadataFromList(dataset.getOrCreateEditVersion().getFileMetadatas(), markedForDelete);
             }
 
             if (markedForDelete.getDataFile().getId() == null) {
@@ -1201,7 +1201,7 @@ public class EditDatafilesPage implements java.io.Serializable {
              */
         }
 
-        workingVersion = dataset.getEditVersion();
+        workingVersion = dataset.getOrCreateEditVersion();
         logger.fine("working version id: " + workingVersion.getId());
 
         if (FileEditMode.EDIT == mode && Referrer.FILE == referrer) {

--- a/src/main/java/edu/harvard/iq/dataverse/FilePage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/FilePage.java
@@ -365,7 +365,7 @@ public class FilePage implements java.io.Serializable {
         file.setProvEntityName(dataFileFromPopup.getProvEntityName()); //passing this value into the file being saved here is pretty hacky.
         Command cmd;
         
-        for (FileMetadata fmw : editDataset.getEditVersion().getFileMetadatas()) {
+        for (FileMetadata fmw : editDataset.getOrCreateEditVersion().getFileMetadatas()) {
             if (fmw.getDataFile().equals(this.fileMetadata.getDataFile())) {
                 cmd = new PersistProvFreeFormCommand(dvRequestService.getDataverseRequest(), file, freeformTextInput);
                 commandEngine.submit(cmd);
@@ -381,15 +381,15 @@ public class FilePage implements java.io.Serializable {
         String fileNames = null;
         editDataset = this.file.getOwner();
         if (restricted) { // get values from access popup
-            editDataset.getEditVersion().getTermsOfUseAndAccess().setTermsOfAccess(termsOfAccess);
-            editDataset.getEditVersion().getTermsOfUseAndAccess().setFileAccessRequest(fileAccessRequest);   
+            editDataset.getOrCreateEditVersion().getTermsOfUseAndAccess().setTermsOfAccess(termsOfAccess);
+            editDataset.getOrCreateEditVersion().getTermsOfUseAndAccess().setFileAccessRequest(fileAccessRequest);   
         }
         //using this method to update the terms for datasets that are out of compliance 
         // with Terms of Access requirement - may get her with a file that is already restricted
         // we'll allow it 
         try {
             Command cmd;
-            for (FileMetadata fmw : editDataset.getEditVersion().getFileMetadatas()) {
+            for (FileMetadata fmw : editDataset.getOrCreateEditVersion().getFileMetadatas()) {
                 if (fmw.getDataFile().equals(this.fileMetadata.getDataFile())) {
                     fileNames += fmw.getLabel();
                     cmd = new RestrictFileCommand(fmw.getDataFile(), dvRequestService.getDataverseRequest(), restricted);
@@ -424,7 +424,7 @@ public class FilePage implements java.io.Serializable {
 
         FileMetadata markedForDelete = null;
 
-        for (FileMetadata fmd : editDataset.getEditVersion().getFileMetadatas()) {
+        for (FileMetadata fmd : editDataset.getOrCreateEditVersion().getFileMetadatas()) {
 
             if (fmd.getDataFile().getId().equals(fileId)) {
                 markedForDelete = fmd;
@@ -435,17 +435,17 @@ public class FilePage implements java.io.Serializable {
             // the file already exists as part of this dataset
             // so all we remove is the file from the fileMetadatas (for display)
             // and let the delete be handled in the command (by adding it to the filesToBeDeleted list
-            editDataset.getEditVersion().getFileMetadatas().remove(markedForDelete);
+            editDataset.getOrCreateEditVersion().getFileMetadatas().remove(markedForDelete);
             filesToBeDeleted.add(markedForDelete);
 
         } else {
             List<FileMetadata> filesToKeep = new ArrayList<>();
-            for (FileMetadata fmo : editDataset.getEditVersion().getFileMetadatas()) {
+            for (FileMetadata fmo : editDataset.getOrCreateEditVersion().getFileMetadatas()) {
                 if (!fmo.getDataFile().getId().equals(this.getFile().getId())) {
                     filesToKeep.add(fmo);
                 }
             }
-            editDataset.getEditVersion().setFileMetadatas(filesToKeep);
+            editDataset.getOrCreateEditVersion().setFileMetadatas(filesToKeep);
         }
 
         fileDeleteInProgress = true;
@@ -612,7 +612,7 @@ public class FilePage implements java.io.Serializable {
 
     public String save() {
         // Validate
-        Set<ConstraintViolation> constraintViolations = editDataset.getEditVersion().validate();
+        Set<ConstraintViolation> constraintViolations = editDataset.getOrCreateEditVersion().validate();
         if (!constraintViolations.isEmpty()) {
              //JsfHelper.addFlashMessage(JH.localize("dataset.message.validationError"));
              fileDeleteInProgress = false;
@@ -629,7 +629,7 @@ public class FilePage implements java.io.Serializable {
 
         if (!filesToBeDeleted.isEmpty()) { 
             // We want to delete the file (there's always only one file with this page)
-            editDataset.getEditVersion().getFileMetadatas().remove(filesToBeDeleted.get(0));
+            editDataset.getOrCreateEditVersion().getFileMetadatas().remove(filesToBeDeleted.get(0));
             deleteFileId = filesToBeDeleted.get(0).getDataFile().getId();
             deleteStorageLocation = datafileService.getPhysicalFileToDelete(filesToBeDeleted.get(0).getDataFile());
         }

--- a/src/main/java/edu/harvard/iq/dataverse/api/Access.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Access.java
@@ -1384,7 +1384,7 @@ public class Access extends AbstractApiBean {
             return error(BAD_REQUEST, BundleUtil.getStringFromBundle("access.api.fileAccess.failure.noUser", args));
         }
 
-        dataset.getEditVersion().getTermsOfUseAndAccess().setFileAccessRequest(allowRequest);
+        dataset.getOrCreateEditVersion().getTermsOfUseAndAccess().setFileAccessRequest(allowRequest);
 
         try {
             engineSvc.submit(new UpdateDatasetVersionCommand(dataset, dataverseRequest));

--- a/src/main/java/edu/harvard/iq/dataverse/api/Datasets.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Datasets.java
@@ -630,7 +630,7 @@ public class Datasets extends AbstractApiBean {
             
             DatasetVersion managedVersion;
             if (updateDraft) {
-                final DatasetVersion editVersion = ds.getEditVersion();
+                final DatasetVersion editVersion = ds.getOrCreateEditVersion();
                 editVersion.setDatasetFields(incomingVersion.getDatasetFields());
                 editVersion.setTermsOfUseAndAccess(incomingVersion.getTermsOfUseAndAccess());
                 editVersion.getTermsOfUseAndAccess().setDatasetVersion(editVersion);
@@ -639,7 +639,7 @@ public class Datasets extends AbstractApiBean {
                     return error(Status.CONFLICT, BundleUtil.getStringFromBundle("dataset.message.toua.invalid"));
                 }
                 Dataset managedDataset = execCommand(new UpdateDatasetVersionCommand(ds, req));
-                managedVersion = managedDataset.getEditVersion();
+                managedVersion = managedDataset.getOrCreateEditVersion();
             } else {
                 boolean hasValidTerms = TermsOfUseAndAccessValidator.isTOUAValid(incomingVersion.getTermsOfUseAndAccess(), null);
                 if (!hasValidTerms) {
@@ -698,7 +698,7 @@ public class Datasets extends AbstractApiBean {
         try {
             Dataset ds = findDatasetOrDie(id);
             DataverseRequest req = createDataverseRequest(findUserOrDie());
-            DatasetVersion dsv = ds.getEditVersion();
+            DatasetVersion dsv = ds.getOrCreateEditVersion();
             boolean updateDraft = ds.getLatestVersion().isDraft();
             dsv = JSONLDUtil.updateDatasetVersionMDFromJsonLD(dsv, jsonLDBody, metadataBlockService, datasetFieldSvc, !replaceTerms, false, licenseSvc);
             dsv.getTermsOfUseAndAccess().setDatasetVersion(dsv);
@@ -709,7 +709,7 @@ public class Datasets extends AbstractApiBean {
             DatasetVersion managedVersion;
             if (updateDraft) {
                 Dataset managedDataset = execCommand(new UpdateDatasetVersionCommand(ds, req));
-                managedVersion = managedDataset.getEditVersion();
+                managedVersion = managedDataset.getOrCreateEditVersion();
             } else {
                 managedVersion = execCommand(new CreateDatasetVersionCommand(req, ds, dsv));
             }
@@ -731,14 +731,14 @@ public class Datasets extends AbstractApiBean {
         try {
             Dataset ds = findDatasetOrDie(id);
             DataverseRequest req = createDataverseRequest(findUserOrDie());
-            DatasetVersion dsv = ds.getEditVersion();
+            DatasetVersion dsv = ds.getOrCreateEditVersion();
             boolean updateDraft = ds.getLatestVersion().isDraft();
             dsv = JSONLDUtil.deleteDatasetVersionMDFromJsonLD(dsv, jsonLDBody, metadataBlockService, licenseSvc);
             dsv.getTermsOfUseAndAccess().setDatasetVersion(dsv);
             DatasetVersion managedVersion;
             if (updateDraft) {
                 Dataset managedDataset = execCommand(new UpdateDatasetVersionCommand(ds, req));
-                managedVersion = managedDataset.getEditVersion();
+                managedVersion = managedDataset.getOrCreateEditVersion();
             } else {
                 managedVersion = execCommand(new CreateDatasetVersionCommand(req, ds, dsv));
             }
@@ -769,7 +769,7 @@ public class Datasets extends AbstractApiBean {
 
             Dataset ds = findDatasetOrDie(id);
             JsonObject json = Json.createReader(rdr).readObject();
-            DatasetVersion dsv = ds.getEditVersion();
+            DatasetVersion dsv = ds.getOrCreateEditVersion();
             dsv.getTermsOfUseAndAccess().setDatasetVersion(dsv);
             List<DatasetField> fields = new LinkedList<>();
             DatasetField singleField = null;
@@ -882,7 +882,7 @@ public class Datasets extends AbstractApiBean {
 
             boolean updateDraft = ds.getLatestVersion().isDraft();
             DatasetVersion managedVersion = updateDraft
-                    ? execCommand(new UpdateDatasetVersionCommand(ds, req)).getEditVersion()
+                    ? execCommand(new UpdateDatasetVersionCommand(ds, req)).getOrCreateEditVersion()
                     : execCommand(new CreateDatasetVersionCommand(req, ds, dsv));
             return ok(json(managedVersion));
 
@@ -932,7 +932,7 @@ public class Datasets extends AbstractApiBean {
            
             Dataset ds = findDatasetOrDie(id);
             JsonObject json = Json.createReader(rdr).readObject();
-            DatasetVersion dsv = ds.getEditVersion();
+            DatasetVersion dsv = ds.getOrCreateEditVersion();
             dsv.getTermsOfUseAndAccess().setDatasetVersion(dsv);
             List<DatasetField> fields = new LinkedList<>();
             DatasetField singleField = null;
@@ -1037,7 +1037,7 @@ public class Datasets extends AbstractApiBean {
             DatasetVersion managedVersion;
 
             if (updateDraft) {
-                managedVersion = execCommand(new UpdateDatasetVersionCommand(ds, req)).getEditVersion();
+                managedVersion = execCommand(new UpdateDatasetVersionCommand(ds, req)).getOrCreateEditVersion();
             } else {
                 managedVersion = execCommand(new CreateDatasetVersionCommand(req, ds, dsv));
             }

--- a/src/main/java/edu/harvard/iq/dataverse/api/Files.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Files.java
@@ -388,7 +388,7 @@ public class Files extends AbstractApiBean {
             }
 
             try {
-                DatasetVersion editVersion = df.getOwner().getEditVersion();
+                DatasetVersion editVersion = df.getOwner().getOrCreateEditVersion();
 
                 //We get the new fileMetadata from the new version
                 //This is because after generating the draft with getEditVersion,

--- a/src/main/java/edu/harvard/iq/dataverse/api/datadeposit/CollectionDepositManagerImpl.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/datadeposit/CollectionDepositManagerImpl.java
@@ -110,7 +110,7 @@ public class CollectionDepositManagerImpl implements CollectionDepositManager {
                         throw new SwordError(UriRegistry.ERROR_BAD_REQUEST, "user " + user.getDisplayInfo().getTitle() + " is not authorized to create a dataset in this dataverse.");
                     }
 
-                    DatasetVersion newDatasetVersion = dataset.getEditVersion();
+                    DatasetVersion newDatasetVersion = dataset.getOrCreateEditVersion();
 
                     String foreignFormat = SwordUtil.DCTERMS;
                     try {

--- a/src/main/java/edu/harvard/iq/dataverse/api/datadeposit/ContainerManagerImpl.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/datadeposit/ContainerManagerImpl.java
@@ -137,7 +137,7 @@ public class ContainerManagerImpl implements ContainerManager {
                     if (!permissionService.isUserAllowedOn(user, updateDatasetCommand, dataset)) {
                         throw new SwordError(UriRegistry.ERROR_BAD_REQUEST, "User " + user.getDisplayInfo().getTitle() + " is not authorized to modify dataverse " + dvThatOwnsDataset.getAlias());
                     }
-                    DatasetVersion datasetVersion = dataset.getEditVersion();
+                    DatasetVersion datasetVersion = dataset.getOrCreateEditVersion();
                     // erase all metadata before creating populating dataset version
                     List<DatasetField> emptyDatasetFields = new ArrayList<>();
                     datasetVersion.setDatasetFields(emptyDatasetFields);

--- a/src/main/java/edu/harvard/iq/dataverse/api/datadeposit/MediaResourceManagerImpl.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/datadeposit/MediaResourceManagerImpl.java
@@ -250,7 +250,7 @@ public class MediaResourceManagerImpl implements MediaResourceManager {
             // Make sure that the upload type is not rsync - handled above for dual mode
             // ------------------------------------- 
 
-            if (dataset.getEditVersion().isHasPackageFile()) {                
+            if (dataset.getOrCreateEditVersion().isHasPackageFile()) {                
                 throw new SwordError(UriRegistry.ERROR_BAD_REQUEST, BundleUtil.getStringFromBundle("file.api.alreadyHasPackageFile"));
             }
             
@@ -276,7 +276,7 @@ public class MediaResourceManagerImpl implements MediaResourceManager {
             }
 
             String uploadedZipFilename = deposit.getFilename();
-            DatasetVersion editVersion = dataset.getEditVersion();
+            DatasetVersion editVersion = dataset.getOrCreateEditVersion();
 
             if (deposit.getInputStream() == null) {
                 throw new SwordError(UriRegistry.ERROR_BAD_REQUEST, "Deposit input stream was null.");

--- a/src/main/java/edu/harvard/iq/dataverse/batch/jobs/importer/filesystem/FileRecordJobListener.java
+++ b/src/main/java/edu/harvard/iq/dataverse/batch/jobs/importer/filesystem/FileRecordJobListener.java
@@ -190,7 +190,7 @@ public class FileRecordJobListener implements ItemReadListener, StepListener, Jo
             // if mode = REPLACE, remove all filemetadata from the dataset version and start fresh
             if (mode.equalsIgnoreCase(ImportMode.REPLACE.name())) {
                 try {
-                    DatasetVersion workingVersion = dataset.getEditVersion();
+                    DatasetVersion workingVersion = dataset.getOrCreateEditVersion();
                     List<FileMetadata> fileMetadataList = workingVersion.getFileMetadatas();
                     jobLogger.log(Level.INFO, "Removing any existing file metadata since mode = REPLACE");
                     for (FileMetadata fmd : fileMetadataList) {

--- a/src/main/java/edu/harvard/iq/dataverse/datasetutility/AddReplaceFileHelper.java
+++ b/src/main/java/edu/harvard/iq/dataverse/datasetutility/AddReplaceFileHelper.java
@@ -1200,7 +1200,7 @@ public class AddReplaceFileHelper{
         }
 
         // Load the working version of the Dataset
-        workingVersion = dataset.getEditVersion();
+        workingVersion = dataset.getOrCreateEditVersion();
         clone =   workingVersion.cloneDatasetVersion();
         try {
             CreateDataFileResult result = FileUtil.createDataFiles(workingVersion,
@@ -1805,7 +1805,7 @@ public class AddReplaceFileHelper{
         newlyAddedFileMetadatas = new ArrayList<>();
         
         // Loop of uglinesss...but expect 1 to 4 files in final file list
-        List<FileMetadata> latestFileMetadatas = dataset.getEditVersion().getFileMetadatas();
+        List<FileMetadata> latestFileMetadatas = dataset.getOrCreateEditVersion().getFileMetadatas();
         
         
         for (DataFile newlyAddedFile : finalFileList){

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/CreateNewDatasetCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/CreateNewDatasetCommand.java
@@ -81,7 +81,7 @@ public class CreateNewDatasetCommand extends AbstractCreateDatasetCommand {
     
     @Override
     protected DatasetVersion getVersionToPersist( Dataset theDataset ) {
-        return theDataset.getEditVersion();
+        return theDataset.getOrCreateEditVersion();
     }
 
     @Override

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/CuratePublishedDatasetVersionCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/CuratePublishedDatasetVersionCommand.java
@@ -56,7 +56,7 @@ public class CuratePublishedDatasetVersionCommand extends AbstractDatasetCommand
         DatasetVersion updateVersion = getDataset().getLatestVersionForCopy();
 
         // Copy metadata from draft version to latest published version
-        updateVersion.setDatasetFields(getDataset().getEditVersion().initDatasetFields());
+        updateVersion.setDatasetFields(getDataset().getOrCreateEditVersion().initDatasetFields());
 
         validateOrDie(updateVersion, isValidateLenient());
 
@@ -68,14 +68,14 @@ public class CuratePublishedDatasetVersionCommand extends AbstractDatasetCommand
 
 
         TermsOfUseAndAccess oldTerms = updateVersion.getTermsOfUseAndAccess();
-        TermsOfUseAndAccess newTerms = getDataset().getEditVersion().getTermsOfUseAndAccess();
+        TermsOfUseAndAccess newTerms = getDataset().getOrCreateEditVersion().getTermsOfUseAndAccess();
         newTerms.setDatasetVersion(updateVersion);
         updateVersion.setTermsOfUseAndAccess(newTerms);
         //Put old terms on version that will be deleted....
-        getDataset().getEditVersion().setTermsOfUseAndAccess(oldTerms);
+        getDataset().getOrCreateEditVersion().setTermsOfUseAndAccess(oldTerms);
         //Also set the fileaccessrequest boolean on the dataset to match the new terms
         getDataset().setFileAccessRequest(updateVersion.getTermsOfUseAndAccess().isFileAccessRequest());
-        List<WorkflowComment> newComments = getDataset().getEditVersion().getWorkflowComments();
+        List<WorkflowComment> newComments = getDataset().getOrCreateEditVersion().getWorkflowComments();
         if (newComments!=null && newComments.size() >0) {
             for(WorkflowComment wfc: newComments) {
                 wfc.setDatasetVersion(updateVersion);
@@ -91,7 +91,7 @@ public class CuratePublishedDatasetVersionCommand extends AbstractDatasetCommand
         // Look for file metadata changes and update published metadata if needed
         List<FileMetadata> pubFmds = updateVersion.getFileMetadatas();
         int pubFileCount = pubFmds.size();
-        int newFileCount = tempDataset.getEditVersion().getFileMetadatas().size();
+        int newFileCount = tempDataset.getOrCreateEditVersion().getFileMetadatas().size();
         /* The policy for this command is that it should only be used when the change is a 'minor update' with no file changes.
          * Nominally we could call .isMinorUpdate() for that but we're making the same checks as we go through the update here. 
          */
@@ -131,7 +131,7 @@ public class CuratePublishedDatasetVersionCommand extends AbstractDatasetCommand
             ctxt.em().remove(mergedFmd);
             // including removing metadata from the list on the datafile
             draftFmd.getDataFile().getFileMetadatas().remove(draftFmd);
-            tempDataset.getEditVersion().getFileMetadatas().remove(draftFmd);
+            tempDataset.getOrCreateEditVersion().getFileMetadatas().remove(draftFmd);
             // And any references in the list held by categories
             for (DataFileCategory cat : tempDataset.getCategories()) {
                 cat.getFileMetadatas().remove(draftFmd);

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/GetDraftDatasetVersionCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/GetDraftDatasetVersionCommand.java
@@ -24,7 +24,7 @@ public class GetDraftDatasetVersionCommand extends AbstractCommand<DatasetVersio
 
     @Override
     public DatasetVersion execute(CommandContext ctxt) throws CommandException {
-        return ds.getEditVersion();
+        return ds.getOrCreateEditVersion();
     }
     
 }

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/PersistProvFreeFormCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/PersistProvFreeFormCommand.java
@@ -36,7 +36,7 @@ public class PersistProvFreeFormCommand extends AbstractCommand<DataFile> {
         }
         else {
             Dataset dataset = dataFile.getOwner();
-            DatasetVersion workingVersion = dataset.getEditVersion();
+            DatasetVersion workingVersion = dataset.getOrCreateEditVersion();
 
             if (workingVersion.isDraft()) { 
                 if (dataset.isReleased()){

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/RestrictFileCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/RestrictFileCommand.java
@@ -63,7 +63,7 @@ public class RestrictFileCommand extends AbstractVoidCommand {
         }
         else {
             Dataset dataset = file.getOwner();
-            DatasetVersion workingVersion = dataset.getEditVersion();
+            DatasetVersion workingVersion = dataset.getOrCreateEditVersion();
             // We need the FileMetadata for the file in the draft dataset version and the
             // file we have may still reference the fmd from the prior released version
             FileMetadata draftFmd = file.getFileMetadata();

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/ReturnDatasetToAuthorCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/ReturnDatasetToAuthorCommand.java
@@ -37,11 +37,11 @@ public class ReturnDatasetToAuthorCommand extends AbstractDatasetCommand<Dataset
             throw new IllegalCommandException(BundleUtil.getStringFromBundle("dataset.reject.datasetNotInReview"), this);
         }
         
-        dataset.getEditVersion().setLastUpdateTime(getTimestamp());
+        dataset.getOrCreateEditVersion().setLastUpdateTime(getTimestamp());
         dataset.setModificationTime(getTimestamp());
         
         ctxt.engine().submit( new RemoveLockCommand(getRequest(), getDataset(), DatasetLock.Reason.InReview) );
-        WorkflowComment workflowComment = new WorkflowComment(dataset.getEditVersion(), WorkflowComment.Type.RETURN_TO_AUTHOR, comment, (AuthenticatedUser) this.getUser());
+        WorkflowComment workflowComment = new WorkflowComment(dataset.getOrCreateEditVersion(), WorkflowComment.Type.RETURN_TO_AUTHOR, comment, (AuthenticatedUser) this.getUser());
         ctxt.datasets().addWorkflowComment(workflowComment);
 
         updateDatasetUser(ctxt);

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/SetCurationStatusCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/SetCurationStatusCommand.java
@@ -77,7 +77,7 @@ public class SetCurationStatusCommand extends AbstractDatasetCommand<Dataset> {
 
     public Dataset save(CommandContext ctxt) throws CommandException {
 
-        getDataset().getEditVersion().setLastUpdateTime(getTimestamp());
+        getDataset().getOrCreateEditVersion().setLastUpdateTime(getTimestamp());
         getDataset().setModificationTime(getTimestamp());
 
         Dataset savedDataset = ctxt.em().merge(getDataset());

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/SubmitDatasetForReviewCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/SubmitDatasetForReviewCommand.java
@@ -51,7 +51,7 @@ public class SubmitDatasetForReviewCommand extends AbstractDatasetCommand<Datase
 
     private Dataset save(CommandContext ctxt) throws CommandException {
 
-        getDataset().getEditVersion().setLastUpdateTime(getTimestamp());
+        getDataset().getOrCreateEditVersion().setLastUpdateTime(getTimestamp());
         getDataset().setModificationTime(getTimestamp());
 
         Dataset savedDataset = ctxt.em().merge(getDataset());

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/UpdateDatasetVersionCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/UpdateDatasetVersionCommand.java
@@ -64,7 +64,7 @@ public class UpdateDatasetVersionCommand extends AbstractDatasetCommand<Dataset>
         this.filesToDelete = new ArrayList<>();
         this.clone = null;
         this.fmVarMet = null;
-        for (FileMetadata fmd : theDataset.getEditVersion().getFileMetadatas()) {
+        for (FileMetadata fmd : theDataset.getOrCreateEditVersion().getFileMetadatas()) {
             if (fmd.getDataFile().equals(fileToDelete)) {
                 filesToDelete.add(fmd);
                 break;
@@ -114,10 +114,10 @@ public class UpdateDatasetVersionCommand extends AbstractDatasetCommand<Dataset>
                 logger.log(Level.WARNING, "Failed to lock the dataset (dataset id={0})", getDataset().getId());
             }
             
-            getDataset().getEditVersion(fmVarMet).setDatasetFields(getDataset().getEditVersion(fmVarMet).initDatasetFields());
-            validateOrDie(getDataset().getEditVersion(fmVarMet), isValidateLenient());
+            getDataset().getOrCreateEditVersion(fmVarMet).setDatasetFields(getDataset().getOrCreateEditVersion(fmVarMet).initDatasetFields());
+            validateOrDie(getDataset().getOrCreateEditVersion(fmVarMet), isValidateLenient());
 
-            final DatasetVersion editVersion = getDataset().getEditVersion(fmVarMet);
+            final DatasetVersion editVersion = getDataset().getOrCreateEditVersion(fmVarMet);
 
             DatasetFieldUtil.tidyUpFields(editVersion.getDatasetFields(), true);
 
@@ -204,10 +204,10 @@ public class UpdateDatasetVersionCommand extends AbstractDatasetCommand<Dataset>
                     // If the datasetversion doesn't match, we have the fmd from a published version
                     // and we need to remove the one for the newly created draft instead, so we find
                     // it here
-                    logger.fine("Edit ver: " + theDataset.getEditVersion().getId());
+                    logger.fine("Edit ver: " + theDataset.getOrCreateEditVersion().getId());
                     logger.fine("fmd ver: " + fmd.getDatasetVersion().getId());
-                    if (!theDataset.getEditVersion().equals(fmd.getDatasetVersion())) {
-                        fmd = FileMetadataUtil.getFmdForFileInEditVersion(fmd, theDataset.getEditVersion());
+                    if (!theDataset.getOrCreateEditVersion().equals(fmd.getDatasetVersion())) {
+                        fmd = FileMetadataUtil.getFmdForFileInEditVersion(fmd, theDataset.getOrCreateEditVersion());
                     }
                 } 
                 fmd = ctxt.em().merge(fmd);
@@ -229,21 +229,21 @@ public class UpdateDatasetVersionCommand extends AbstractDatasetCommand<Dataset>
                 // In either case, to fully remove the fmd, we have to remove any other possible
                 // references
                 // From the datasetversion
-                FileMetadataUtil.removeFileMetadataFromList(theDataset.getEditVersion().getFileMetadatas(), fmd);
+                FileMetadataUtil.removeFileMetadataFromList(theDataset.getOrCreateEditVersion().getFileMetadatas(), fmd);
                 // and from the list associated with each category
                 for (DataFileCategory cat : theDataset.getCategories()) {
                     FileMetadataUtil.removeFileMetadataFromList(cat.getFileMetadatas(), fmd);
                 }
             }
-            for(FileMetadata fmd: theDataset.getEditVersion().getFileMetadatas()) {
+            for(FileMetadata fmd: theDataset.getOrCreateEditVersion().getFileMetadatas()) {
                 logger.fine("FMD: " + fmd.getId() + " for file: " + fmd.getDataFile().getId() + "is in final draft version");    
             }
             
             if (recalculateUNF) {
-                ctxt.ingest().recalculateDatasetVersionUNF(theDataset.getEditVersion());
+                ctxt.ingest().recalculateDatasetVersionUNF(theDataset.getOrCreateEditVersion());
             }
 
-            theDataset.getEditVersion().setLastUpdateTime(getTimestamp());
+            theDataset.getOrCreateEditVersion().setLastUpdateTime(getTimestamp());
             theDataset.setModificationTime(getTimestamp());
 
             savedDataset = ctxt.em().merge(theDataset);

--- a/src/test/java/edu/harvard/iq/dataverse/engine/command/impl/CreateDatasetVersionCommandTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/engine/command/impl/CreateDatasetVersionCommandTest.java
@@ -33,7 +33,7 @@ public class CreateDatasetVersionCommandTest {
         Dataset ds = makeDataset();
         
         // Populate the Initial version
-        DatasetVersion dsvInitial = ds.getEditVersion();
+        DatasetVersion dsvInitial = ds.getOrCreateEditVersion();
         dsvInitial.setCreateTime( dateFmt.parse("20001012") );
         dsvInitial.setLastUpdateTime( dsvInitial.getLastUpdateTime() );
         dsvInitial.setId( MocksFactory.nextId() );
@@ -62,7 +62,7 @@ public class CreateDatasetVersionCommandTest {
         assertEquals( dsvCreationDate, dsvNew.getLastUpdateTime() );
         assertEquals( dsvCreationDate.getTime(), ds.getModificationTime().getTime() );
         assertEquals( ds, dsvNew.getDataset() );
-        assertEquals( dsvNew, ds.getEditVersion() );
+        assertEquals( dsvNew, ds.getOrCreateEditVersion() );
         Map<DvObject, Set<Permission>> expected = new HashMap<>();
         expected.put(ds, Collections.singleton(Permission.AddDataset));
         assertEquals(expected, testEngine.getReqiredPermissionsForObjects() );

--- a/src/test/java/edu/harvard/iq/dataverse/engine/command/impl/RestrictFileCommandTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/engine/command/impl/RestrictFileCommandTest.java
@@ -108,7 +108,7 @@ public class RestrictFileCommandTest {
         //asserts
         assertTrue(!file.isRestricted());
         boolean fileFound = false;
-        for (FileMetadata fmw : dataset.getEditVersion().getFileMetadatas()) {
+        for (FileMetadata fmw : dataset.getOrCreateEditVersion().getFileMetadatas()) {
             if (file.equals(fmw.getDataFile())) {
                 fileFound=true;
                 //If it worked fmw is for the draft version and file.getFileMetadata() is for the published version
@@ -193,7 +193,7 @@ public class RestrictFileCommandTest {
         //asserts
         assertTrue(file.isRestricted());
         boolean fileFound = false;
-        for (FileMetadata fmw : dataset.getEditVersion().getFileMetadatas()) {
+        for (FileMetadata fmw : dataset.getOrCreateEditVersion().getFileMetadatas()) {
             if (file.equals(fmw.getDataFile())) {
                 fileFound = true;
                 assertTrue(!fmw.isRestricted());

--- a/src/test/java/edu/harvard/iq/dataverse/ingest/IngestUtilTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/ingest/IngestUtilTest.java
@@ -42,7 +42,7 @@ public class IngestUtilTest {
         Dataset dataset = makeDataset();
 
         // create dataset version
-        DatasetVersion datasetVersion = dataset.getEditVersion();
+        DatasetVersion datasetVersion = dataset.getOrCreateEditVersion();
         datasetVersion.setCreateTime(dateFmt.parse("20001012"));
         datasetVersion.setLastUpdateTime(datasetVersion.getLastUpdateTime());
         datasetVersion.setId(MocksFactory.nextId());
@@ -146,7 +146,7 @@ public class IngestUtilTest {
         Dataset dataset = makeDataset();
 
         // create dataset version
-        DatasetVersion datasetVersion = dataset.getEditVersion();
+        DatasetVersion datasetVersion = dataset.getOrCreateEditVersion();
         datasetVersion.setCreateTime(dateFmt.parse("20001012"));
         datasetVersion.setLastUpdateTime(datasetVersion.getLastUpdateTime());
         datasetVersion.setId(MocksFactory.nextId());
@@ -251,7 +251,7 @@ public class IngestUtilTest {
         Dataset dataset = makeDataset();
 
         // create dataset version
-        DatasetVersion datasetVersion = dataset.getEditVersion();
+        DatasetVersion datasetVersion = dataset.getOrCreateEditVersion();
         datasetVersion.setCreateTime(dateFmt.parse("20001012"));
         datasetVersion.setLastUpdateTime(datasetVersion.getLastUpdateTime());
         datasetVersion.setId(MocksFactory.nextId());
@@ -389,7 +389,7 @@ public class IngestUtilTest {
         Dataset dataset = makeDataset();
 
         // create dataset version
-        DatasetVersion datasetVersion = dataset.getEditVersion();
+        DatasetVersion datasetVersion = dataset.getOrCreateEditVersion();
         datasetVersion.setCreateTime(dateFmt.parse("20001012"));
         datasetVersion.setLastUpdateTime(datasetVersion.getLastUpdateTime());
         datasetVersion.setId(MocksFactory.nextId());
@@ -475,7 +475,7 @@ public class IngestUtilTest {
         Dataset dataset = makeDataset();
 
         // create dataset version
-        DatasetVersion datasetVersion = dataset.getEditVersion();
+        DatasetVersion datasetVersion = dataset.getOrCreateEditVersion();
         datasetVersion.setCreateTime(dateFmt.parse("20001012"));
         datasetVersion.setLastUpdateTime(datasetVersion.getLastUpdateTime());
         datasetVersion.setId(MocksFactory.nextId());

--- a/src/test/java/edu/harvard/iq/dataverse/util/FileUtilTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/util/FileUtilTest.java
@@ -128,7 +128,7 @@ public class FileUtilTest {
         @Test
         public void testIsDownloadPopupRequiredDraft() {
             Dataset dataset = new Dataset();
-            DatasetVersion dsv1 = dataset.getEditVersion();
+            DatasetVersion dsv1 = dataset.getOrCreateEditVersion();
             assertEquals(DatasetVersion.VersionState.DRAFT, dsv1.getVersionState());
             assertEquals(false, FileUtil.isDownloadPopupRequired(dsv1));
         }


### PR DESCRIPTION
**What this PR does / why we need it**:

In version 5.11 we had some pretty terrible "ghost drafts" problems that were resolved by switching from getEditVersion to getLatestVersion in 3967820 (thank you @qqmyers !).

This pull request does two simple things:

- rename getEditVersion to getOrCreateEditVersion to remind us that a "create" can happen.
- javadoc added to getOrCreateEditVersion: "If you don't want to create a new version, you should be using getLatestVersion."

**Which issue(s) this PR closes**:

Closes #8930

**Special notes for your reviewer**:

25 files were changed but this was an automatic refactor, a rename done in NetBeans. No other changes were made apart from improving the javadoc.

**Suggestions on how to test this**:

Let the API tests run.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No.

**Is there a release notes update needed for this change?**:

No.

**Additional documentation**:

None.