### PR TITLE
QDR/9172-fix messages

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/util/MailUtil.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/MailUtil.java
@@ -34,8 +34,12 @@ public class MailUtil {
         List<String> rootDvNameAsList = Arrays.asList(BrandingUtil.getInstallationBrandName());
         String datasetDisplayName = "";
 
-        if (objectOfNotification != null && (objectOfNotification instanceof Dataset)  ) {
-            datasetDisplayName = ((Dataset)objectOfNotification).getDisplayName();
+        if (objectOfNotification != null) {
+            if (objectOfNotification instanceof Dataset) {
+                datasetDisplayName = ((Dataset) objectOfNotification).getDisplayName();
+            } else if (objectOfNotification instanceof DatasetVersion) {
+                datasetDisplayName = ((DatasetVersion) objectOfNotification).getDataset().getDisplayName();
+            }
         }
 
         switch (userNotification.getType()) {


### PR DESCRIPTION
**What this PR does / why we need it**: #9056 added the dataset displayname to some messages but a bug/partial fix introduced in review led to some messages display an empty `""`. This PR fixes that.

**Which issue(s) this PR closes**:

- Closes #9172 

**Special notes for your reviewer**:

**Suggestions on how to test this**:  Do what's needed to generate messages of any/all types below and verify that the message includes the dataset displayname. If one works, they all should.

```
CREATEDS:
SUBMITTEDDS:
PUBLISHEDDS:
PUBLISHFAILED_PIDREG:
RETURNEDDS:
WORKFLOW_SUCCESS:
WORKFLOW_FAILURE:
STATUSUPDATED:
```

Regression testing: The message to users when a dataset is created should also show the dataset display name. No other messages (such as REQUESTFILEACCESS) should be broken.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**: no? relatively minor message display bug

**Additional documentation**: