### PR TITLE
3621 update metadata namespace

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/harvest/server/web/servlet/OAIServlet.java
+++ b/src/main/java/edu/harvard/iq/dataverse/harvest/server/web/servlet/OAIServlet.java
@@ -96,9 +96,15 @@ public class OAIServlet extends HttpServlet {
     // be calling ListIdentifiers, and then making direct calls to the export 
     // API of the remote Dataverse, to obtain the records in native json. This 
     // is how we should have implemented this in the first place, really. 
+    /*
+    SEK
+     per #3621 we are adding urls to the namespace and schema
+     These will not resolve presently. the change is so that the
+     xml produced by  https://demo.dataverse.org/oai?verb=ListMetadataFormats will validate
+    */
     private static final String DATAVERSE_EXTENDED_METADATA_FORMAT = "dataverse_json";
-    private static final String DATAVERSE_EXTENDED_METADATA_NAMESPACE = "Custom Dataverse metadata in JSON format (Dataverse4 to Dataverse4 harvesting only)";
-    private static final String DATAVERSE_EXTENDED_METADATA_SCHEMA = "JSON schema pending";     
+    private static final String DATAVERSE_EXTENDED_METADATA_NAMESPACE = "https://dataverse.org/schema/core#";
+    private static final String DATAVERSE_EXTENDED_METADATA_SCHEMA = "https://dataverse.org/schema/core.xsd";     
     
     private Context xoaiContext;
     private SetRepository setRepository;

--- a/src/main/java/edu/harvard/iq/dataverse/harvest/server/web/servlet/OAIServlet.java
+++ b/src/main/java/edu/harvard/iq/dataverse/harvest/server/web/servlet/OAIServlet.java
@@ -103,7 +103,7 @@ public class OAIServlet extends HttpServlet {
      xml produced by  https://demo.dataverse.org/oai?verb=ListMetadataFormats will validate
     */
     private static final String DATAVERSE_EXTENDED_METADATA_FORMAT = "dataverse_json";
-    private static final String DATAVERSE_EXTENDED_METADATA_NAMESPACE = "https://dataverse.org/schema/core#";
+    private static final String DATAVERSE_EXTENDED_METADATA_NAMESPACE = "https://dataverse.org/schema/core";
     private static final String DATAVERSE_EXTENDED_METADATA_SCHEMA = "https://dataverse.org/schema/core.xsd";     
     
     private Context xoaiContext;


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates the metadatanamespace and schema in the ListMetadataFormats response 

**Which issue(s) this PR closes**:

Closes #3621 invalid schema and metadataNamespace fields in OAI-PMH ListMetadataFormats response 

**Special notes for your reviewer**:
This just updates the response so that the format fits what is expected. It does not create an actual landing page depicting the json schema.There is a ticket tracking it https://github.com/IQSS/dataverse/issues/7173

**Suggestions on how to test this**:
I used https://validator.oaipmh.com/#ListMetadataFormats to check the xml response. We still get an error for the landing page not being found, as is the case with oai_ddi and datacite

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
No
**Is there a release notes update needed for this change?**:
no
**Additional documentation**:
None 