### PR TITLE
9224 - revert workflow metadata block in Solr schema

### DIFF
--- a/conf/solr/8.11.1/schema.xml
+++ b/conf/solr/8.11.1/schema.xml
@@ -266,9 +266,6 @@
     <field name="cleaningOperations" type="text_en" multiValued="false" stored="true" indexed="true"/>
     <field name="collectionMode" type="text_en" multiValued="true" stored="true" indexed="true"/>
     <field name="collectorTraining" type="text_en" multiValued="false" stored="true" indexed="true"/>
-    <field name="workflowType" type="text_en" multiValued="true" stored="true" indexed="true"/>
-    <field name="workflowCodeRepository" type="text_en" multiValued="true" stored="true" indexed="true"/>
-    <field name="workflowDocumentation" type="text_en" multiValued="true" stored="true" indexed="true"/>
     <field name="contributor" type="text_en" multiValued="true" stored="true" indexed="true"/>
     <field name="contributorName" type="text_en" multiValued="true" stored="true" indexed="true"/>
     <field name="contributorType" type="text_en" multiValued="true" stored="true" indexed="true"/>
@@ -506,9 +503,6 @@
     <copyField source="cleaningOperations" dest="_text_" maxChars="3000"/>
     <copyField source="collectionMode" dest="_text_" maxChars="3000"/>
     <copyField source="collectorTraining" dest="_text_" maxChars="3000"/>
-    <copyField source="workflowType" dest="_text_" maxChars="3000"/>
-    <copyField source="workflowCodeRepository" dest="_text_" maxChars="3000"/>
-    <copyField source="workflowDocumentation" dest="_text_" maxChars="3000"/>
     <copyField source="contributor" dest="_text_" maxChars="3000"/>
     <copyField source="contributorName" dest="_text_" maxChars="3000"/>
     <copyField source="contributorType" dest="_text_" maxChars="3000"/>

--- a/doc/release-notes/9224-remove-workflow-fields-from-index.md
+++ b/doc/release-notes/9224-remove-workflow-fields-from-index.md
@@ -1,0 +1,12 @@
+# Optional: remove Workflow Schema fields from Solr index
+
+In Dataverse 5.12 we added a new experimental metadata schema block for workflow deposition.
+We included the fields within the standard Solr schema we provide. With this version, we
+removed it from the schema. If you are deploying the block to your installation, make sure to
+update your index.
+
+If you already added these fields, you can delete them from your index when not using the schema.
+Make sure to [reindex after changing the schema](https://guides.dataverse.org/en/latest/admin/solr-search-index.html?highlight=reindex#reindex-in-place.
+
+Remember: depending on the size of your installation, reindexing may take serious time to complete.
+You should do this in off-hours.

--- a/doc/sphinx-guides/source/user/appendix.rst
+++ b/doc/sphinx-guides/source/user/appendix.rst
@@ -38,6 +38,9 @@ Unlike supported metadata, experimental metadata is not enabled by default in a 
 
 - `Computational Workflow Metadata <https://docs.google.com/spreadsheets/d/13HP-jI_cwLDHBetn9UKTREPJ_F4iHdAvhjmlvmYdSSw/edit#gid=447508596>`__ (`see .tsv version <https://github.com/IQSS/dataverse/blob/master/scripts/api/data/metadatablocks/computationalworkflow.tsv>`__): adapted from `Bioschemas Computational Workflow Profile, version 1.0 <https://bioschemas.org/profiles/ComputationalWorkflow/1.0-RELEASE>`__ and `Codemeta <https://codemeta.github.io/terms/>`__.
 
+Please note: these custom metadata schemas are not included in the Solr schema for indexation by default, you will need
+to add them as necessary for your custom metadata blocks. See "Update the Solr Schema" in :doc:`../admin/metadatacustomization`.
+
 See Also
 ~~~~~~~~
 

--- a/doc/sphinx-guides/source/user/appendix.rst
+++ b/doc/sphinx-guides/source/user/appendix.rst
@@ -38,7 +38,7 @@ Unlike supported metadata, experimental metadata is not enabled by default in a 
 
 - `Computational Workflow Metadata <https://docs.google.com/spreadsheets/d/13HP-jI_cwLDHBetn9UKTREPJ_F4iHdAvhjmlvmYdSSw/edit#gid=447508596>`__ (`see .tsv version <https://github.com/IQSS/dataverse/blob/master/scripts/api/data/metadatablocks/computationalworkflow.tsv>`__): adapted from `Bioschemas Computational Workflow Profile, version 1.0 <https://bioschemas.org/profiles/ComputationalWorkflow/1.0-RELEASE>`__ and `Codemeta <https://codemeta.github.io/terms/>`__.
 
-Please note: these custom metadata schemas are not included in the Solr schema for indexation by default, you will need
+Please note: these custom metadata schemas are not included in the Solr schema for indexing by default, you will need
 to add them as necessary for your custom metadata blocks. See "Update the Solr Schema" in :doc:`../admin/metadatacustomization`.
 
 See Also


### PR DESCRIPTION
**What this PR does / why we need it**:

As discussed for #7877, we don't want experimental metadata block fields in the out-of-the-box `schema.xml`, but introduced them for the workflow schema in #8812.

**Which issue(s) this PR closes**:

Closes #9224

**Special notes for your reviewer**:
Please review the docs changes to give people a heads up.

See https://dataverse-guide--9225.org.readthedocs.build/en/9225/user/appendix.html#experimental-metadata for preview.

**Suggestions on how to test this**:
Delete the fields, reindex, you're done.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
Nope.

**Is there a release notes update needed for this change?**:
:battery: included

**Additional documentation**:
:battery: included
