### PR TITLE
8932 - fix pushing to Docker Hub

### DIFF
--- a/.github/workflows/container_base_push.yml
+++ b/.github/workflows/container_base_push.yml
@@ -21,7 +21,6 @@ on:
 
 env:
     IMAGE_TAG: unstable
-    REGISTRY: docker.io
 
 jobs:
     build:
@@ -83,4 +82,4 @@ jobs:
               run: echo "IMAGE_TAG=stable"
             - if: ${{ github.event_name != 'pull_request' }}
               name: Deploy multi-arch base container image to Docker Hub
-              run: mvn -f modules/container-base -Pct deploy -Dbase.image.tag=${{ env.IMAGE_TAG }} -Ddocker.registry=${{ env.REGISTRY }}
+              run: mvn -f modules/container-base -Pct deploy -Dbase.image.tag=${{ env.IMAGE_TAG }}


### PR DESCRIPTION
**What this PR does / why we need it**:

The Docker Login Actions do not enable logging in to docker.io, but a standard registry. By not overriding the registry, Docker Maven Plugin will use the one supplied by Docker context.

This is basically a typo and was tested with https://github.com/poikilotherm/dataverse/tree/test-8933 to identify the causing issue.

**Which issue(s) this PR closes**:

Closes #8932

**Special notes for your reviewer**:
This is a "typo" and took some debugging. Not sure this needs deeper reviewing.

**Suggestions on how to test this**:
Was tested with a feature branch, as mentioned above. The [failing action](https://github.com/IQSS/dataverse/actions/runs/3716132790/jobs/6320191106) could be reproduced to fail in [the feature branch action](https://github.com/poikilotherm/dataverse/actions/runs/3726689008/jobs/6320297280) and the ONLY difference is the additional option.
Not sure what else should be tested.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
Nope.

**Is there a release notes update needed for this change?**:
Nope, this is a type, the main PR had a release note.

**Additional documentation**:
None.
