### PR TITLE
document ongoing security and practices #3215

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,7 @@
+# Security
+
+To report a security vulnerability please email security@dataverse.org as explained at https://guides.dataverse.org/en/latest/installation/config.html#reporting-security-issues
+
+Advice on securing your installation can be found at https://guides.dataverse.org/en/latest/installation/config.html#securing-your-installation
+
+Security practices and procedures used by the Dataverse team are described at https://guides.dataverse.org/en/latest/developers/security.html

--- a/doc/sphinx-guides/source/developers/index.rst
+++ b/doc/sphinx-guides/source/developers/index.rst
@@ -19,6 +19,7 @@ Developer Guide
    sql-upgrade-scripts
    testing
    documentation
+   security
    dependencies
    debugging
    coding-style

--- a/doc/sphinx-guides/source/developers/security.rst
+++ b/doc/sphinx-guides/source/developers/security.rst
@@ -1,0 +1,34 @@
+========
+Security
+========
+
+This section describes security practices and procedures for the Dataverse team.
+
+.. contents:: |toctitle|
+	:local:
+
+Intake of Security Issues
+-------------------------
+
+As described under :ref:`reporting-security-issues`, we encourage the community to email security@dataverse.org if they have any security concerns. These emails go into our private ticket tracker (RT_).
+
+.. _RT: https://help.hmdc.harvard.edu
+
+We use a private GitHub issue tracker at https://github.com/IQSS/dataverse-security/issues for security issues.
+
+Sending Security Notices
+------------------------
+
+When drafting the security notice, it might be helpful to look at `previous examples`_.
+
+.. _previous examples: https://drive.google.com/drive/folders/0B_qMYwdHFZghaDZIU2hWQnBDZVE?resourcekey=0-SYjuhCohAIM7_pmysVc3Xg&usp=sharing
+
+Gather email addresses from the following sources (these are also described under :ref:`ongoing-security` in the Installation Guide):
+
+- "contact_email" in the `public installation spreadsheet`_
+- "Other Security Contacts" in the `private installation spreadsheet`_
+
+Once you have the emails, include them as bcc.
+
+.. _public installation spreadsheet: https://docs.google.com/spreadsheets/d/1bfsw7gnHlHerLXuk7YprUT68liHfcaMxs1rFciA-mEo/edit#gid=0
+.. _private installation spreadsheet: https://docs.google.com/spreadsheets/d/1EWDwsj6eptQ7nEr-loLvdU7I6Tm2ljAplfNSVWR42i0/edit?usp=sharing

--- a/doc/sphinx-guides/source/index.rst
+++ b/doc/sphinx-guides/source/index.rst
@@ -70,7 +70,7 @@ The support email address is `support@dataverse.org <mailto:support@dataverse.or
 Report bugs and add feature requests in `GitHub Issues <https://github.com/IQSS/dataverse/issues>`__
 or use `GitHub pull requests <http://guides.dataverse.org/en/latest/developers/version-control.html#how-to-make-a-pull-request>`__,
 if you have some code, scripts or documentation that you'd like to share.
-If you have a **security issue** to report, please email `security@dataverse.org <mailto:security@dataverse.org>`__.
+If you have a **security issue** to report, please email `security@dataverse.org <mailto:security@dataverse.org>`__. See also :ref:`reporting-security-issues`.
 
 
 Indices and Tables

--- a/doc/sphinx-guides/source/installation/config.rst
+++ b/doc/sphinx-guides/source/installation/config.rst
@@ -101,6 +101,31 @@ Password complexity rules for "builtin" accounts can be adjusted with a variety 
 - :ref:`:PVGoodStrength`
 - :ref:`:PVCustomPasswordResetAlertMessage`
 
+.. _ongoing-security:
+
+Ongoing Security of Your Installation
++++++++++++++++++++++++++++++++++++++
+
+Like any application, you should keep up-to-date with patches to both the Dataverse software and the platform (usually Linux) it runs on. Dataverse releases are announced on the dataverse-community_ mailing list, the Dataverse blog_, and in chat.dataverse.org_.
+
+.. _dataverse-community: https://groups.google.com/g/dataverse-community
+.. _blog: https://dataverse.org/blog
+.. _chat.dataverse.org: https://chat.dataverse.org
+
+In addition to these public channels, you can subscribe to receive security notices via email from the Dataverse team. These notices are sent to the ``contact_email`` in the installation spreadsheet_ and you can open an issue in the dataverse-installations_ repo to add or change the contact email. Security notices are also sent to people and organizations that prefer to remain anonymous. To be added to this private list, please email support@dataverse.org.
+
+.. _spreadsheet: https://docs.google.com/spreadsheets/d/1bfsw7gnHlHerLXuk7YprUT68liHfcaMxs1rFciA-mEo/edit#gid=0
+.. _dataverse-installations: https://github.com/IQSS/dataverse-installations
+
+For additional details about security practices by the Dataverse team, see the :doc:`/developers/security` section of the Developer Guide.
+
+.. _reporting-security-issues:
+
+Reporting Security Issues
++++++++++++++++++++++++++
+
+If you have a security issue to report, please email it to security@dataverse.org.
+
 .. _network-ports:
 
 Network Ports


### PR DESCRIPTION
**What this PR does / why we need it**:

- We need to explain to the community how to receive security notices.
- A permalink for "how to report security vulnerabilities" is a good thing.
- It's nice to have have links handy to resources (lists of emails, previous examples, etc.) when sending security notices.

**Which issue(s) this PR closes**:

- Closes #3215

**Special notes for your reviewer**:

Here's a good entry point: https://dataverse-guide--9241.org.readthedocs.build/en/9241/installation/config.html#ongoing-security

Note that I added SECURITY.md: https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository

It's expected that the links in that SECURITY.md file won't work until we make a release (when the new content is in place under "latest").

**Suggestions on how to test this**:

Sanity check on the content. Please see entry point above.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No.

**Is there a release notes update needed for this change?**:

No. I'm happy to add one.

**Additional documentation**:

This PR is only documentation.