### PR TITLE
DOCS: add link to development documentation build

### DIFF
--- a/doc/sphinx-guides/source/developers/documentation.rst
+++ b/doc/sphinx-guides/source/developers/documentation.rst
@@ -22,6 +22,8 @@ That's it! Thank you for your contribution! Your pull request will be added manu
 
 Please see https://github.com/IQSS/dataverse/pull/5857 for an example of a quick fix that was merged (the "Files changed" tab shows how a typo was fixed).
 
+Preview your documentation changes which will be built automatically as part of your pull request in Github.  It will show up as a check entitled: `docs/readthedocs.org:dataverse-guide — Read the Docs build succeeded!`.  For example, this PR built to https://dataverse-guide--9249.org.readthedocs.build/en/9249/.
+
 If you would like to read more about the Dataverse Project's use of GitHub, please see the :doc:`version-control` section. For bug fixes and features we request that you create an issue before making a pull request but this is not at all necessary for quick fixes to the documentation.
 
 .. _admin: https://github.com/IQSS/dataverse/tree/develop/doc/sphinx-guides/source/admin

--- a/doc/sphinx-guides/source/index.rst
+++ b/doc/sphinx-guides/source/index.rst
@@ -6,7 +6,7 @@
 Dataverse Documentation v. |version|
 ====================================
 
-These documentation guides are for the |version| version of Dataverse. To find guides belonging to previous versions, :ref:`guides_versions` has a list of all available versions.
+These documentation guides are for the |version| version of Dataverse. To find guides belonging to previous or future versions, :ref:`guides_versions` has a list of all available versions.
 
 .. toctree::
   :glob:

--- a/doc/sphinx-guides/source/versions.rst
+++ b/doc/sphinx-guides/source/versions.rst
@@ -4,8 +4,9 @@
 Dataverse Software Documentation Versions
 =========================================
 
-This list provides a way to refer to the documentation for previous versions of the Dataverse Software. In order to learn more about the updates delivered from one version to another, visit the `Releases <https://github.com/IQSS/dataverse/releases>`__ page in our GitHub repo.
+This list provides a way to refer to the documentation for previous and future versions of the Dataverse Software. In order to learn more about the updates delivered from one version to another, visit the `Releases <https://github.com/IQSS/dataverse/releases>`__ page in our GitHub repo.
 
+- `develop Git branch <http://preview.guides.gdcc.io/en/develop/>`__
 - 5.12.1
 - `5.12 </en/5.12/>`__
 - `5.11.1 </en/5.11.1/>`__


### PR DESCRIPTION
**What this PR does / why we need it**:

I couldn't find where the development builds of the documentation were.  This adds a link.

**Which issue(s) this PR closes**:

Closes #

**Special notes for your reviewer**:

**Suggestions on how to test this**: N/A

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**: No?

**Additional documentation**:
