### PR TITLE
standardize license configuration

### DIFF
--- a/scripts/api/data/licenses/licenseAGPL-3.0-or-later.json
+++ b/scripts/api/data/licenses/licenseAGPL-3.0-or-later.json
@@ -1,0 +1,10 @@
+{
+  "rightsName": "AGPL 3.0 or later",
+  "rightsURI": "https://www.gnu.org/licenses/agpl.txt",
+  "rightsIdentifier": "AGPL-3.0-or-later",
+  "rightsIdentifierScheme": "SPDX",
+  "schemeURI": "https://spdx.org/licenses/",
+  "rightsShortDescription": "GNU Affero General Public License v3.0 or later.",
+  "rightsActive": "true",
+  "sortOrder": 20
+}

--- a/scripts/api/data/licenses/licenseApache-2.0.json
+++ b/scripts/api/data/licenses/licenseApache-2.0.json
@@ -1,0 +1,10 @@
+{
+  "rightsName": "Apache 2.0",
+  "rightsURI": "https://www.apache.org/licenses/LICENSE-2.0",
+  "rightsIdentifier": "Apache-2.0",
+  "rightsIdentifierScheme": "SPDX",
+  "schemeURI": "https://spdx.org/licenses/",
+  "rightsShortDescription": "Apache License 2.0.",
+  "rightsActive": "true",
+  "sortOrder": 8
+}

--- a/scripts/api/data/licenses/licenseBSD-2-Clause.json
+++ b/scripts/api/data/licenses/licenseBSD-2-Clause.json
@@ -1,0 +1,10 @@
+{
+  "rightsName": "BSD 2-Clause",
+  "rightsURI": "https://spdx.org/licenses/BSD-2-Clause.html",
+  "rightsIdentifier": "BSD-2-Clause",
+  "rightsIdentifierScheme": "SPDX",
+  "schemeURI": "https://spdx.org/licenses/",
+  "rightsShortDescription": "BSD 2-Clause "Simplified" License.",
+  "rightsActive": "true",
+  "sortOrder": 9
+}

--- a/scripts/api/data/licenses/licenseBSD-3-Clause.json
+++ b/scripts/api/data/licenses/licenseBSD-3-Clause.json
@@ -1,0 +1,10 @@
+{
+  "rightsName": "BSD 3-Clause",
+  "rightsURI": "https://spdx.org/licenses/BSD-3-Clause.html",
+  "rightsIdentifier": "BSD-3-Clause",
+  "rightsIdentifierScheme": "SPDX",
+  "schemeURI": "https://spdx.org/licenses/",
+  "rightsShortDescription": "BSD 3-Clause "New" or "Revised" License.",
+  "rightsActive": "true",
+  "sortOrder": 10
+}

--- a/scripts/api/data/licenses/licenseCC-BY-3.0.json
+++ b/scripts/api/data/licenses/licenseCC-BY-3.0.json
@@ -1,0 +1,11 @@
+{
+  "rightsName": "CC BY 3.0",
+  "rightsURI": "https://creativecommons.org/licenses/by/3.0/",
+  "rightsIdentifier": "CC-BY-3.0",
+  "rightsIdentifierScheme": "SPDX",
+  "schemeURI": "https://spdx.org/licenses/",
+  "rightsShortDescription": "Creative Commons Attribution 3.0 Unported.",
+  "rightsIconUrl": "https://licensebuttons.net/l/by/3.0/88x31.png",
+  "rightsActive": "true",
+  "sortOrder": 21
+}

--- a/scripts/api/data/licenses/licenseCC-BY-4.0.json
+++ b/scripts/api/data/licenses/licenseCC-BY-4.0.json
@@ -1,8 +1,11 @@
 {
-  "name": "CC BY 4.0",
-  "uri": "http://creativecommons.org/licenses/by/4.0",
-  "shortDescription": "Creative Commons Attribution 4.0 International License.",
-  "iconUrl": "https://licensebuttons.net/l/by/4.0/88x31.png",
-  "active": true,
+  "rightsName": "CC BY 4.0",
+  "rightsURI": "https://creativecommons.org/licenses/by/4.0/",
+  "rightsIdentifier": "CC-BY-4.0",
+  "rightsIdentifierScheme": "SPDX",
+  "schemeURI": "https://spdx.org/licenses/",
+  "rightsShortDescription": "Creative Commons Attribution 4.0 International.",
+  "rightsIconUrl": "https://licensebuttons.net/l/by/4.0/88x31.png",
+  "rightsActive": "true",
   "sortOrder": 2
 }

--- a/scripts/api/data/licenses/licenseCC-BY-NC-3.0.json
+++ b/scripts/api/data/licenses/licenseCC-BY-NC-3.0.json
@@ -1,0 +1,11 @@
+{
+  "rightsName": "CC BY NC 3.0",
+  "rightsURI": "https://creativecommons.org/licenses/by-nc/3.0/",
+  "rightsIdentifier": "CC-BY-NC-3.0",
+  "rightsIdentifierScheme": "SPDX",
+  "schemeURI": "https://spdx.org/licenses/",
+  "rightsShortDescription": "Creative Commons Attribution Non Commercial 3.0 Unported.",
+  "rightsIconUrl": "https://licensebuttons.net/l/by-nc/3.0/88x31.png",
+  "rightsActive": "true",
+  "sortOrder": 22
+}

--- a/scripts/api/data/licenses/licenseCC-BY-NC-4.0.json
+++ b/scripts/api/data/licenses/licenseCC-BY-NC-4.0.json
@@ -1,8 +1,11 @@
 {
-  "name": "CC BY-NC 4.0",
-  "uri": "http://creativecommons.org/licenses/by-nc/4.0",
-  "shortDescription": "Creative Commons Attribution-NonCommercial 4.0 International License.",
-  "iconUrl": "https://licensebuttons.net/l/by-nc/4.0/88x31.png",
-  "active": true,
-  "sortOrder": 4
+  "rightsName": "CC BY-NC 4.0",
+  "rightsURI": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "rightsIdentifier": "CC-BY-NC-4.0",
+  "rightsIdentifierScheme": "SPDX",
+  "schemeURI": "https://spdx.org/licenses/",
+  "rightsShortDescription": "Creative Commons Attribution Non Commercial 4.0 International.",
+  "rightsIconUrl": "https://licensebuttons.net/l/by-nc/4.0/88x31.png",
+  "rightsActive": "true",
+  "sortOrder": 3
 }

--- a/scripts/api/data/licenses/licenseCC-BY-NC-ND-4.0.json
+++ b/scripts/api/data/licenses/licenseCC-BY-NC-ND-4.0.json
@@ -1,8 +1,11 @@
 {
-  "name": "CC BY-NC-ND 4.0",
-  "uri": "http://creativecommons.org/licenses/by-nc-nd/4.0",
-  "shortDescription": "Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International License.",
-  "iconUrl": "https://licensebuttons.net/l/by-nc-nd/4.0/88x31.png",
-  "active": true,
-  "sortOrder": 7
+  "rightsName": "CC BY-NC-ND 4.0",
+  "rightsURI": "https://creativecommons.org/licenses/by-nc-nd/4.0/",
+  "rightsIdentifier": "CC-BY-NC-ND-4.0",
+  "rightsIdentifierScheme": "SPDX",
+  "schemeURI": "https://spdx.org/licenses/",
+  "rightsShortDescription": "Creative Commons Attribution Non Commercial No Derivatives 4.0 International.",
+  "rightsIconUrl": "https://licensebuttons.net/l/by-nc-nd/4.0/88x31.png",
+  "rightsActive": "true",
+  "sortOrder": 4
 }

--- a/scripts/api/data/licenses/licenseCC-BY-NC-SA-3.0.json
+++ b/scripts/api/data/licenses/licenseCC-BY-NC-SA-3.0.json
@@ -1,0 +1,11 @@
+{
+  "rightsName": "CC BY NC SA 3.0",
+  "rightsURI": "https://creativecommons.org/licenses/by-nc-sa/3.0/",
+  "rightsIdentifier": "CC-BY-NC-SA-3.0",
+  "rightsIdentifierScheme": "SPDX",
+  "schemeURI": "https://spdx.org/licenses/",
+  "rightsShortDescription": "Creative Commons Attribution Non Commercial Share Alike 3.0 Unported.",
+  "rightsIconUrl": "https://licensebuttons.net/l/by-nc-sa/3.0/88x31.png",
+  "rightsActive": "true",
+  "sortOrder": 23
+}

--- a/scripts/api/data/licenses/licenseCC-BY-NC-SA-4.0.json
+++ b/scripts/api/data/licenses/licenseCC-BY-NC-SA-4.0.json
@@ -1,8 +1,11 @@
 {
-  "name": "CC BY-NC-SA 4.0",
-  "uri": "http://creativecommons.org/licenses/by-nc-sa/4.0",
-  "shortDescription": "Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License.",
-  "iconUrl": "https://licensebuttons.net/l/by-nc-sa/4.0/88x31.png",
-  "active": true,
-  "sortOrder": 3
+  "rightsName": "CC BY-NC-SA 4.0",
+  "rightsURI": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+  "rightsIdentifier": "CC-BY-NC-SA-4.0",
+  "rightsIdentifierScheme": "SPDX",
+  "schemeURI": "https://spdx.org/licenses/",
+  "rightsShortDescription": "Creative Commons Attribution Non Commercial Share Alike 4.0 International.",
+  "rightsIconUrl": "https://licensebuttons.net/l/by-nc-sa/4.0/88x31.png",
+  "rightsActive": "true",
+  "sortOrder": 5
 }

--- a/scripts/api/data/licenses/licenseCC-BY-ND-4.0.json
+++ b/scripts/api/data/licenses/licenseCC-BY-ND-4.0.json
@@ -1,8 +1,11 @@
 {
-  "name": "CC BY-ND 4.0",
-  "uri": "http://creativecommons.org/licenses/by-nd/4.0",
-  "shortDescription": "Creative Commons Attribution-NoDerivatives 4.0 International License.",
-  "iconUrl": "https://licensebuttons.net/l/by-nd/4.0/88x31.png",
-  "active": true,
+  "rightsName": "CC BY-ND 4.0",
+  "rightsURI": "https://creativecommons.org/licenses/by-nd/4.0/",
+  "rightsIdentifier": "CC-BY-ND-4.0",
+  "rightsIdentifierScheme": "SPDX",
+  "schemeURI": "https://spdx.org/licenses/",
+  "rightsShortDescription": "Creative Commons Attribution No Derivatives 4.0 International.",
+  "rightsIconUrl": "https://licensebuttons.net/l/by-sa/4.0/88x31.png",
+  "rightsActive": "true",
   "sortOrder": 6
 }

--- a/scripts/api/data/licenses/licenseCC-BY-SA-3.0.json
+++ b/scripts/api/data/licenses/licenseCC-BY-SA-3.0.json
@@ -1,0 +1,11 @@
+{
+  "rightsName": "CC BY SA 3.0",
+  "rightsURI": "https://creativecommons.org/licenses/by-sa/3.0/",
+  "rightsIdentifier": "CC-BY-SA-3.0",
+  "rightsIdentifierScheme": "SPDX",
+  "schemeURI": "https://spdx.org/licenses/",
+  "rightsShortDescription": "Creative Commons Attribution Share Alike 3.0 Unported.",
+  "rightsIconUrl": "https://licensebuttons.net/l/by-sa/3.0/88x31.png",
+  "rightsActive": "true",
+  "sortOrder": 24
+}

--- a/scripts/api/data/licenses/licenseCC-BY-SA-4.0.json
+++ b/scripts/api/data/licenses/licenseCC-BY-SA-4.0.json
@@ -1,8 +1,11 @@
 {
-  "name": "CC BY-SA 4.0",
-  "uri": "http://creativecommons.org/licenses/by-sa/4.0",
-  "shortDescription": "Creative Commons Attribution-ShareAlike 4.0 International License.",
-  "iconUrl": "https://licensebuttons.net/l/by-sa/4.0/88x31.png",
-  "active": true,
-  "sortOrder": 5
+  "rightsName": "CC BY-SA 4.0",
+  "rightsURI": "https://creativecommons.org/licenses/by-sa/4.0/",
+  "rightsIdentifier": "CC-BY-SA-4.0",
+  "rightsIdentifierScheme": "SPDX",
+  "schemeURI": "https://spdx.org/licenses/",
+  "rightsShortDescription": "Creative Commons Attribution Share Alike 4.0 International.",
+  "rightsIconUrl": "https://licensebuttons.net/l/by/4.0/88x31.png",
+  "rightsActive": "true",
+  "sortOrder": 7
 }

--- a/scripts/api/data/licenses/licenseCC0-1.0.json
+++ b/scripts/api/data/licenses/licenseCC0-1.0.json
@@ -1,8 +1,11 @@
 {
-  "name": "CC0 1.0",
-  "uri": "http://creativecommons.org/publicdomain/zero/1.0",
-  "shortDescription": "Creative Commons CC0 1.0 Universal Public Domain Dedication.",
-  "iconUrl": "https://licensebuttons.net/p/zero/1.0/88x31.png",
-  "active": true,
+  "rightsName": "CC0 1.0",
+  "rightsURI": "https://creativecommons.org/publicdomain/zero/1.0/",
+  "rightsIdentifier": "CC0-1.0",
+  "rightsIdentifierScheme": "SPDX",
+  "schemeURI": "https://spdx.org/licenses/",
+  "rightsShortDescription": "Creative Commons Zero v1.0 Universal.",
+  "rightsIconUrl": "https://licensebuttons.net/p/zero/1.0/88x31.png",
+  "rightsActive": "true",
   "sortOrder": 1
 }

--- a/scripts/api/data/licenses/licenseCECILL-2.0.json
+++ b/scripts/api/data/licenses/licenseCECILL-2.0.json
@@ -1,0 +1,10 @@
+{
+  "rightsName": "CECILL 2.0",
+  "rightsURI": "http://www.cecill.info/licences/Licence_CeCILL_V2-en.html",
+  "rightsIdentifier": "CECILL-2.0",
+  "rightsIdentifierScheme": "SPDX",
+  "schemeURI": "https://spdx.org/licenses/",
+  "rightsShortDescription": "CeCILL Free Software License Agreement v2.0.",
+  "rightsActive": "true",
+  "sortOrder": 25
+}

--- a/scripts/api/data/licenses/licenseCECILL-B.json
+++ b/scripts/api/data/licenses/licenseCECILL-B.json
@@ -1,0 +1,10 @@
+{
+  "rightsName": "CECILL B",
+  "rightsURI": "http://www.cecill.info/licences/Licence_CeCILL-B_V1-en.html",
+  "rightsIdentifier": "CECILL-B",
+  "rightsIdentifierScheme": "SPDX",
+  "schemeURI": "https://spdx.org/licenses/",
+  "rightsShortDescription": "CeCILL-B Free Software License Agreement.",
+  "rightsActive": "true",
+  "sortOrder": 26
+}

--- a/scripts/api/data/licenses/licenseCERN-OHL-1.1.json
+++ b/scripts/api/data/licenses/licenseCERN-OHL-1.1.json
@@ -1,0 +1,10 @@
+{
+  "rightsName": "CERN OHL 1.1",
+  "rightsURI": "https://spdx.org/licenses/CERN-OHL-1.1.html",
+  "rightsIdentifier": "CERN-OHL-1.1",
+  "rightsIdentifierScheme": "SPDX",
+  "schemeURI": "https://spdx.org/licenses/",
+  "rightsShortDescription": "CERN Open Hardware Licence v1.1.",
+  "rightsActive": "true",
+  "sortOrder": 27
+}

--- a/scripts/api/data/licenses/licenseCERN-OHL-1.2.json
+++ b/scripts/api/data/licenses/licenseCERN-OHL-1.2.json
@@ -1,0 +1,10 @@
+{
+  "rightsName": "CERN OHL 1.2",
+  "rightsURI": "https://spdx.org/licenses/CERN-OHL-1.2.html",
+  "rightsIdentifier": "CERN-OHL-1.2",
+  "rightsIdentifierScheme": "SPDX",
+  "schemeURI": "https://spdx.org/licenses/",
+  "rightsShortDescription": "CERN Open Hardware Licence v1.2.",
+  "rightsActive": "true",
+  "sortOrder": 28
+}

--- a/scripts/api/data/licenses/licenseGPL-2.0-only.json
+++ b/scripts/api/data/licenses/licenseGPL-2.0-only.json
@@ -1,0 +1,11 @@
+{
+  "rightsName": "GPL 2.0 only",
+  "rightsURI": "https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
+  "rightsIdentifier": "GPL-2.0-only",
+  "rightsIdentifierScheme": "SPDX",
+  "schemeURI": "https://spdx.org/licenses/",
+  "rightsShortDescription": "GNU General Public License v2.0 only.",
+  "rightsIconUrl": "https://licensebuttons.net/l/GPL/2.0/88x62.png",
+  "rightsActive": "true",
+  "sortOrder": 11
+}

--- a/scripts/api/data/licenses/licenseGPL-3.0-only.json
+++ b/scripts/api/data/licenses/licenseGPL-3.0-only.json
@@ -1,0 +1,10 @@
+{
+  "rightsName": "GPL 3.0 only",
+  "rightsURI": "https://www.gnu.org/licenses/gpl-3.0-standalone.html",
+  "rightsIdentifier": "GPL-3.0-only",
+  "rightsIdentifierScheme": "SPDX",
+  "schemeURI": "https://spdx.org/licenses/",
+  "rightsShortDescription": "GNU General Public License v3.0 only.",
+  "rightsActive": "true",
+  "sortOrder": 12
+}

--- a/scripts/api/data/licenses/licenseGPL-3.0-or-later.json
+++ b/scripts/api/data/licenses/licenseGPL-3.0-or-later.json
@@ -1,0 +1,10 @@
+{
+  "rightsName": "GPL 3.0 or later",
+  "rightsURI": "https://www.gnu.org/licenses/gpl-3.0-standalone.html",
+  "rightsIdentifier": "GPL-3.0-or-later",
+  "rightsIdentifierScheme": "SPDX",
+  "schemeURI": "https://spdx.org/licenses/",
+  "rightsShortDescription": "GNU General Public License v3.0 or later.",
+  "rightsActive": "true",
+  "sortOrder": 13
+}

--- a/scripts/api/data/licenses/licenseLGPL-3.0-only.json
+++ b/scripts/api/data/licenses/licenseLGPL-3.0-only.json
@@ -1,0 +1,10 @@
+{
+  "rightsName": "LGPL 3.0 only",
+  "rightsURI": "https://www.gnu.org/licenses/lgpl-3.0-standalone.html",
+  "rightsIdentifier": "LGPL-3.0-only",
+  "rightsIdentifierScheme": "SPDX",
+  "schemeURI": "https://spdx.org/licenses/",
+  "rightsShortDescription": "GNU Lesser General Public License v3.0 only.",
+  "rightsActive": "true",
+  "sortOrder": 14
+}

--- a/scripts/api/data/licenses/licenseLGPL-3.0-or-later.json
+++ b/scripts/api/data/licenses/licenseLGPL-3.0-or-later.json
@@ -1,0 +1,10 @@
+{
+  "rightsName": "LGPL 3.0 or later",
+  "rightsURI": "https://www.gnu.org/licenses/lgpl-3.0-standalone.html",
+  "rightsIdentifier": "LGPL-3.0-or-later",
+  "rightsIdentifierScheme": "SPDX",
+  "schemeURI": "https://spdx.org/licenses/",
+  "rightsShortDescription": "GNU Lesser General Public License v3.0 or later.",
+  "rightsActive": "true",
+  "sortOrder": 15
+}

--- a/scripts/api/data/licenses/licenseMIT.json
+++ b/scripts/api/data/licenses/licenseMIT.json
@@ -1,0 +1,10 @@
+{
+  "rightsName": "MIT License",
+  "rightsURI": "https://spdx.org/licenses/MIT.html",
+  "rightsIdentifier": "MIT",
+  "rightsIdentifierScheme": "SPDX",
+  "schemeURI": "https://spdx.org/licenses/",
+  "rightsShortDescription": "MIT License.",
+  "rightsActive": "true",
+  "sortOrder": 16
+}

--- a/scripts/api/data/licenses/licenseMPL-2.0.json
+++ b/scripts/api/data/licenses/licenseMPL-2.0.json
@@ -1,0 +1,10 @@
+{
+  "rightsName": "MPL 2.0",
+  "rightsURI": "https://www.mozilla.org/en-US/MPL/2.0/",
+  "rightsIdentifier": "MPL-2.0",
+  "rightsIdentifierScheme": "SPDX",
+  "schemeURI": "https://spdx.org/licenses/",
+  "rightsShortDescription": "Mozilla Public License 2.0.",
+  "rightsActive": "true",
+  "sortOrder": 17
+}

--- a/scripts/api/data/licenses/licenseODC-By-1.0.json
+++ b/scripts/api/data/licenses/licenseODC-By-1.0.json
@@ -1,0 +1,10 @@
+{
+  "rightsName": "ODC-By 1.0",
+  "rightsURI": "https://opendatacommons.org/licenses/by/1.0/",
+  "rightsIdentifier": "ODC-By-1.0",
+  "rightsIdentifierScheme": "SPDX",
+  "schemeURI": "https://spdx.org/licenses/",
+  "rightsShortDescription": "Open Data Commons Attribution License v1.0.",
+  "rightsActive": "true",
+  "sortOrder": 19
+}

--- a/scripts/api/data/licenses/licenseODbL-1.0.json
+++ b/scripts/api/data/licenses/licenseODbL-1.0.json
@@ -1,0 +1,10 @@
+{
+  "rightsName": "ODbL 1.0",
+  "rightsURI": "https://opendatacommons.org/licenses/odbl/1-0/",
+  "rightsIdentifier": "ODbL-1.0",
+  "rightsIdentifierScheme": "SPDX",
+  "schemeURI": "https://spdx.org/licenses/",
+  "rightsShortDescription": "Open Data Commons Open Database License v1.0.",
+  "rightsActive": "true",
+  "sortOrder": 18
+}

--- a/scripts/api/data/licenses/licenseTAPR-OHL-1.0.json
+++ b/scripts/api/data/licenses/licenseTAPR-OHL-1.0.json
@@ -1,0 +1,10 @@
+{
+  "rightsName": "TAPR OHL 1.0",
+  "rightsURI": "https://spdx.org/licenses/TAPR-OHL-1.0.html",
+  "rightsIdentifier": "TAPR-OHL-1.0",
+  "rightsIdentifierScheme": "SPDX",
+  "schemeURI": "https://spdx.org/licenses/",
+  "rightsShortDescription": "TAPR Open Hardware License v1.0.",
+  "rightsActive": "true",
+  "sortOrder": 30
+}

--- a/scripts/api/data/licenses/licenseetalab-2.0.json
+++ b/scripts/api/data/licenses/licenseetalab-2.0.json
@@ -1,6 +1,6 @@
 {
   "rightsName": "Etalab 2.0",
-  "rightsURI": "https://github.com/DISIC/politique-de-contribution-open-source/blob/master/LICENSE.pdf",
+  "rightsURI": "https://spdx.org/licenses/etalab-2.0.html",
   "rightsIdentifier": "etalab-2.0",
   "rightsIdentifierScheme": "SPDX",
   "schemeURI": "https://spdx.org/licenses/",

--- a/scripts/api/data/licenses/licenseetalab-2.0.json
+++ b/scripts/api/data/licenses/licenseetalab-2.0.json
@@ -1,0 +1,10 @@
+{
+  "rightsName": "Etalab 2.0",
+  "rightsURI": "https://github.com/DISIC/politique-de-contribution-open-source/blob/master/LICENSE.pdf",
+  "rightsIdentifier": "etalab-2.0",
+  "rightsIdentifierScheme": "SPDX",
+  "schemeURI": "https://spdx.org/licenses/",
+  "rightsShortDescription": "Etalab Open License 2.0.",
+  "rightsActive": "true",
+  "sortOrder": 29
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is part of the work to make license information from Dataverse installations harvestable in a way that complies with DataCite recommendations as described in issue #8512 Standardize standard license configuration.

**Which issue(s) this PR closes**:
Together with other PRs, this PR closes #8512.

**Special notes for your reviewer**:
See my comment from January 5, 2023 to issue #8512.

**Suggestions on how to test this**:
In a test environmen:
1. Install the JSON license files.
2. Create a dataset.
3. Select a standard license.
4. Export DataCite metadata.
5. Verify that the license information is as recommended by DataCite.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
No.

**Is there a release notes update needed for this change?**:
Yes. See my comment from January 5, 2023 to issue #8512.

**Additional documentation**:
The longer we wait implementing this change, the more installations will have to do clean-ups. Therefore, I hope this PR can be prioritized.