### PR TITLE
Citation download links for the Payara6-ee10 branch (#8305, #9214)

### DIFF
--- a/src/main/webapp/dataset-citation.xhtml
+++ b/src/main/webapp/dataset-citation.xhtml
@@ -33,19 +33,19 @@
                     </button>
                     <ul class="dropdown-menu">
                         <li>
-                            <a jsf:id="endNoteLink" jsf:action="#{DatasetPage.fileDownloadService.downloadDatasetCitationXML(DatasetPage.dataset)}" >
-                                #{bundle['dataset.cite.downloadBtn.xml']}
-                            </a>
+                            <h:commandLink styleClass="btn-download" action="#{fileDownloadServiceBean.downloadDatasetCitationXML(DatasetPage.dataset)}">
+                                <h:outputText value="#{bundle['dataset.cite.downloadBtn.xml']}"/>
+                            </h:commandLink>
                         </li>
                         <li>
-                            <a jsf:id="risLink" jsf:actionListener="#{DatasetPage.fileDownloadService.downloadDatasetCitationRIS(DatasetPage.dataset)}">
-                                #{bundle['dataset.cite.downloadBtn.ris']}
-                            </a>
+                            <h:commandLink styleClass="btn-download" action="#{fileDownloadServiceBean.downloadDatasetCitationRIS(DatasetPage.dataset)}">
+                                <h:outputText value="#{bundle['dataset.cite.downloadBtn.ris']}"/>
+                            </h:commandLink>
                         </li>
                         <li>
-                            <a jsf:id="bibLink" jsf:actionListener="#{DatasetPage.fileDownloadService.downloadDatasetCitationBibtex(DatasetPage.dataset)}" target="_blank">
-                                #{bundle['dataset.cite.downloadBtn.bib']}
-                            </a>
+                            <h:commandLink styleClass="btn-download" action="#{fileDownloadServiceBean.downloadDatasetCitationBibtex(DatasetPage.dataset)}">
+                                <h:outputText value="#{bundle['dataset.cite.downloadBtn.bib']}"/>
+                            </h:commandLink>
                         </li>
                     </ul>
                 </div>

--- a/src/main/webapp/file.xhtml
+++ b/src/main/webapp/file.xhtml
@@ -108,19 +108,19 @@
                                                     </button>
                                                     <ul class="dropdown-menu">
                                                         <li>
-                                                            <a jsf:id="endNoteLink-2" jsf:action="#{FilePage.fileDownloadService.downloadCitationXML(FilePage.fileMetadata, null, FilePage.fileMetadata.dataFile.isIdentifierRegistered())}" >
-                                                                #{bundle['dataset.cite.downloadBtn.xml']}
-                                                            </a>
+                                                            <h:commandLink styleClass="btn-download" action="#{fileDownloadServiceBean.downloadCitationXML(FilePage.fileMetadata, null, FilePage.fileMetadata.dataFile.isIdentifierRegistered())}">
+                                                                <h:outputText value="#{bundle['dataset.cite.downloadBtn.xml']}"/>
+                                                            </h:commandLink>
                                                         </li>
                                                         <li>
-                                                            <a jsf:id="risLink-2" jsf:actionListener="#{FilePage.fileDownloadService.downloadCitationRIS(FilePage.fileMetadata, null, FilePage.fileMetadata.dataFile.isIdentifierRegistered())}">
-                                                                #{bundle['dataset.cite.downloadBtn.ris']}
-                                                            </a>
+                                                            <h:commandLink action="#{fileDownloadServiceBean.downloadCitationRIS(FilePage.fileMetadata, null, FilePage.fileMetadata.dataFile.isIdentifierRegistered())}">
+                                                                <h:outputText value="#{bundle['dataset.cite.downloadBtn.ris']}"/>
+                                                            </h:commandLink>
                                                         </li>
                                                         <li>
-                                                            <a jsf:id="bibLink-2" jsf:actionListener="#{FilePage.fileDownloadService.downloadCitationBibtex(FilePage.fileMetadata, null, FilePage.fileMetadata.dataFile.isIdentifierRegistered())}" target="_blank">
-                                                                #{bundle['dataset.cite.downloadBtn.bib']}
-                                                            </a>
+                                                            <h:commandLink action="#{fileDownloadServiceBean.downloadCitationBibtex(FilePage.fileMetadata, null, FilePage.fileMetadata.dataFile.isIdentifierRegistered())}">
+                                                                <h:outputText value="#{bundle['dataset.cite.downloadBtn.bib']}"/>
+                                                            </h:commandLink>
                                                         </li>
                                                     </ul>
                                                 </div>
@@ -154,19 +154,19 @@
                                                     </button>
                                                     <ul class="dropdown-menu">
                                                         <li>
-                                                            <a jsf:id="endNoteLink" jsf:action="#{FilePage.fileDownloadService.downloadDatasetCitationXML(FilePage.fileMetadata.datasetVersion.dataset)}" >
-                                                                #{bundle['dataset.cite.downloadBtn.xml']}
-                                                            </a>
+                                                            <h:commandLink action="#{fileDownloadServiceBean.downloadDatasetCitationXML(FilePage.fileMetadata.datasetVersion.dataset)}" >
+                                                                <h:outputText value="#{bundle['dataset.cite.downloadBtn.xml']}"/>
+                                                            </h:commandLink>
                                                         </li>
                                                         <li>
-                                                            <a jsf:id="risLink" jsf:actionListener="#{FilePage.fileDownloadService.downloadDatasetCitationRIS(FilePage.fileMetadata.datasetVersion.dataset)}">
-                                                                #{bundle['dataset.cite.downloadBtn.ris']}
-                                                            </a>
+                                                            <h:commandLink action="#{fileDownloadServiceBean.downloadDatasetCitationRIS(FilePage.fileMetadata.datasetVersion.dataset)}">
+                                                                <h:outputText value="#{bundle['dataset.cite.downloadBtn.ris']}"/>
+                                                            </h:commandLink>
                                                         </li>
                                                         <li>
-                                                            <a jsf:id="bibLink" jsf:actionListener="#{FilePage.fileDownloadService.downloadDatasetCitationBibtex(FilePage.fileMetadata.datasetVersion.dataset)}" target="_blank">
-                                                                #{bundle['dataset.cite.downloadBtn.bib']}
-                                                            </a>
+                                                            <h:commandLink action="#{fileDownloadServiceBean.downloadDatasetCitationBibtex(FilePage.fileMetadata.datasetVersion.dataset)}">
+                                                                <h:outputText value="#{bundle['dataset.cite.downloadBtn.bib']}"/>
+                                                            </h:commandLink>
                                                         </li>
                                                     </ul>
                                                 </div>


### PR DESCRIPTION

**What this PR does / why we need it**:
This fixes the 500 on the dataset page (#9214 has more info), and a similar problem on the file page, and restores the citation download functionality. 
An annoying amount of time has been spent on this; especially since I still don't know why the old solution is still working in the main branch, why it stopped working under Jakarta ee10 and why the "fix" I've checked in is still working... 
More time was spent trying to figure how to use the officially supported PrimeFaces dynamic download component (`p:fileDownload`), all in vain. 

On the positive side, I now understand what was done and accomplished in the Payara6-ee10 branch under #8305 which will be useful going forward (and now have even more appreciation for the monumental effort @poikilotherm undertook there). 

**Which issue(s) this PR closes**:


Closes #9214

**Special notes for your reviewer**:

**Suggestions on how to test this**:

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
