### PR TITLE
pom file update to build XOAI-5.0.0 #9339

### DIFF
--- a/modules/dataverse-parent/pom.xml
+++ b/modules/dataverse-parent/pom.xml
@@ -164,8 +164,7 @@
         <apache.httpcomponents.core.version>4.4.14</apache.httpcomponents.core.version>
         
         <!-- NEW gdcc XOAI library implementation -->
-        <!-- gdcc.xoai.version>5.0.0-RC2</gdcc.xoai.version -->
-	<gdcc.xoai.version>5.0.0-SNAPSHOT</gdcc.xoai.version>
+        <gdcc.xoai.version>5.0.0</gdcc.xoai.version>
     
         <!-- Testing dependencies -->
         <testcontainers.version>1.15.0</testcontainers.version>
@@ -325,7 +324,7 @@
             <name>Local repository for hosting jars not available from network repositories.</name>
             <url>file://${project.basedir}/local_lib</url>
         </repository>
-        <!-- Uncomment when using snapshot releases from Maven Central -->
+        <!-- Uncomment when using snapshot releases from Maven Central 
         <repository>
             <id>oss-sonatype</id>
             <name>oss-sonatype</name>
@@ -336,7 +335,7 @@
                 <enabled>true</enabled>
             </snapshots>
         </repository>
-        <!-- -->
+        -->
     </repositories>
     
     <profiles>

--- a/src/main/java/edu/harvard/iq/dataverse/harvest/server/web/servlet/OAIServlet.java
+++ b/src/main/java/edu/harvard/iq/dataverse/harvest/server/web/servlet/OAIServlet.java
@@ -205,7 +205,7 @@ public class OAIServlet extends HttpServlet {
                 .withAdminEmail(systemEmailLabel)
                 .withCompression("gzip")
                 .withCompression("deflate")
-                .withGranularity(Granularity.Second)
+                .withGranularity(Granularity.Lenient)
                 .withResumptionTokenFormat(new SimpleResumptionTokenFormat().withGranularity(Granularity.Second))
                 .withRepositoryName(repositoryName)
                 .withBaseUrl(systemConfig.getDataverseSiteUrl()+"/oai")


### PR DESCRIPTION
**What this PR does / why we need it**:

As described in the linked issue, switching the application to the long-awaited final version of the XOAI v.5.0.0 that has just been released. 

**Which issue(s) this PR closes**:

Closes #9339

**Special notes for your reviewer**:

This uses the final, mature version of XOAI 5.0.0. It contains the latest changes, that were added to accommodate the PR #9310. Those were tested as part of the QA on that PR (built with the final release candidate version, essentially the same jars but packaged as dev. snapshots. The original plan was to wait for the 5.0.0 to be packaged before merging it, but then we merged it anyway; kind of by accident, but in retrospect, it would look bad for that PR to sit in QA all this time). 

The XOAI release in question is the mature version, and the culmination of all the work done to improve, update and modernize the library since it was forked off DSpace/xoai and moved into its new home at https://github.com/gdcc/xoai. Massive credit goes to @poikilotherm for making it happen and all the work he's done there. 



**Suggestions on how to test this**:
Functionality-wise, almost everything in this PR has gone through our QA process already. So it may only need a quick glance, confirming that nothing is visibly broken and the integration tests are passing. 
*The only small change/improvement you will notice* is the treatment of `yyyy-mm-dd` dates (the thing you noticed during QA of #9316)

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
