### PR TITLE
9376 - Fix the order of metadatablocks in templates

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/Template.java
+++ b/src/main/java/edu/harvard/iq/dataverse/Template.java
@@ -9,6 +9,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 import java.util.stream.Collectors;
 
 import javax.json.Json;
@@ -139,9 +140,9 @@ public class Template implements Serializable {
     private Map<String, String> instructionsMap = null;
     
     @Transient
-    private Map<MetadataBlock, List<DatasetField>> metadataBlocksForView = new HashMap<>();
+    private TreeMap<MetadataBlock, List<DatasetField>> metadataBlocksForView = new TreeMap<>();
     @Transient
-    private Map<MetadataBlock, List<DatasetField>> metadataBlocksForEdit = new HashMap<>();
+    private TreeMap<MetadataBlock, List<DatasetField>> metadataBlocksForEdit = new TreeMap<>();
     
     @Transient
     private boolean isDefaultForDataverse;
@@ -166,19 +167,19 @@ public class Template implements Serializable {
     }
     
 
-    public Map<MetadataBlock, List<DatasetField>> getMetadataBlocksForView() {
+    public TreeMap<MetadataBlock, List<DatasetField>> getMetadataBlocksForView() {
         return metadataBlocksForView;
     }
 
-    public void setMetadataBlocksForView(Map<MetadataBlock, List<DatasetField>> metadataBlocksForView) {
+    public void setMetadataBlocksForView(TreeMap<MetadataBlock, List<DatasetField>> metadataBlocksForView) {
         this.metadataBlocksForView = metadataBlocksForView;
     }
 
-    public Map<MetadataBlock, List<DatasetField>> getMetadataBlocksForEdit() {
+    public TreeMap<MetadataBlock, List<DatasetField>> getMetadataBlocksForEdit() {
         return metadataBlocksForEdit;
     }
 
-    public void setMetadataBlocksForEdit(Map<MetadataBlock, List<DatasetField>> metadataBlocksForEdit) {
+    public void setMetadataBlocksForEdit(TreeMap<MetadataBlock, List<DatasetField>> metadataBlocksForEdit) {
         this.metadataBlocksForEdit = metadataBlocksForEdit;
     }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This fixes the order of the metadata blocks when viewing or editing templates.

**Which issue(s) this PR closes**:

Closes #9376 

**Special notes for your reviewer**:

The changes made here were parallel to the changes made in https://github.com/IQSS/dataverse/pull/8772 .  

So now, the Maps for metadata blocks in Template.java are TreeMaps. (note: metadata blocks were already made Comparable in that PR, so that change did not need to be carried over)

**Suggestions on how to test this**:

Create or edit or  a template in a dataverse collection for a dataverse that has a custom block. Confirm that the order of the blocks is the same as they appear on the dataset page. (namely that Citation block is first)

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

Technically, yes, in that it changes the order the blocks are displayed. But I wouldn't consider that a UI/UX change.

**Is there a release notes update needed for this change?**:

No

**Additional documentation**:
