### PR TITLE
document GeoJSON and list file previewers #8984

### DIFF
--- a/doc/sphinx-guides/source/user/dataset-management.rst
+++ b/doc/sphinx-guides/source/user/dataset-management.rst
@@ -191,6 +191,23 @@ File Previews
 
 Dataverse installations can add previewers for common file types uploaded by their research communities. The previews appear on the file page. If a preview tool for a specific file type is available, the preview will be created and will display automatically, after terms have been agreed to or a guestbook entry has been made, if necessary. File previews are not available for restricted files unless they are being accessed using a Private URL. See also :ref:`privateurl`.
 
+Previewers are available for the following file types:
+
+- Text
+- PDF
+- Tabular (CSV, Excel, etc., see :doc:`tabulardataingest/index`)
+- Code (R, etc.)
+- Images (PNG, GIF, JPG)
+- Audio (MP3, MPEG, WAV, OGG, M4A)
+- Video (MP4, OGG, Quicktime)
+- Zip (preview and extract/download)
+- HTML
+- GeoJSON
+- NetCDF/HDF5 (NcML format)
+- Hypothes.is
+
+Additional file types will be added to the `dataverse-previewers <https://github.com/gdcc/dataverse-previewers>`_ repo before they are listed above so please check there for the latest information or to request (or contribute!) an additional file previewer.
+
 Installation of previewers is explained in the :doc:`/admin/external-tools` section of in the Admin Guide.
 
 Tabular Data Files
@@ -309,6 +326,13 @@ Astronomy (FITS)
 ----------------
 
 Metadata found in the header section of `Flexible Image Transport System (FITS) files <http://fits.gsfc.nasa.gov/fits_primer.html>`_ are automatically extracted by the Dataverse Software, aggregated and displayed in the Astronomy Domain-Specific Metadata of the Dataset that the file belongs to. This FITS file metadata, is therefore searchable and browsable (facets) at the Dataset-level.
+
+.. _geojson:
+
+GeoJSON
+-------
+
+A map will be shown as a preview of GeoJSON files when the previewer has been enabled (see :ref:`file-previews`). See also a `video demo <https://www.youtube.com/watch?v=EACJJaV3O1c&t=588s>`_ of the GeoJSON previewer by its author, Kaitlin Newson.
 
 .. _netcdf-and-hdf5:
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Users don't know GeoJSON files can be previewed. Additionally, people generally don't know which files formats have previewers.

**Which issue(s) this PR closes**:

- Closes #8984

**Special notes for your reviewer**:

I didn't list Stata under "Code" because I'm confused how it works. I thought it was a binary format but it uses the text previewer. Also, in addition to R we could list Python and a few other languages but these aren't in the previewer repo (so maybe they should be added there first).

**Suggestions on how to test this**:

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No but here's a preview of what I added

![Screen Shot 2023-02-10 at 9 33 40 AM](https://user-images.githubusercontent.com/21006/218118495-054d18f3-1880-43f9-804a-5c72f704f6a4.png)
![Screen Shot 2023-02-10 at 9 34 43 AM](https://user-images.githubusercontent.com/21006/218118499-4338332a-4f82-4ac4-8c8d-acb2edb4ca6d.png)

**Is there a release notes update needed for this change?**:

I don't think it's worth it. Just a small doc change.

**Additional documentation**:

Nope. It is documentation.