### PR TITLE
9434 app container

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,16 +1,46 @@
-version: "3.9"
+version: "2.4"
 
 services:
 
+  dev_dataverse:
+    hostname: dataverse
+    image: gdcc/dataverse:unstable
+    restart: on-failure
+    user: payara
+    environment:
+      - DATAVERSE_DB_HOST=postgres
+      - DATAVERSE_DB_PASSWORD=secret
+    ports:
+      - "8080:8080" # HTTP
+      - "9009:9009" # JDWP
+      - "8686:8686" # JMX
+    networks:
+      - dataverse
+    depends_on:
+      - dev_postgres
+      - dev_solr
+    volumes:
+      - ./docker-dev-volumes/app/data:/dv
+      - ./docker-dev-volumes/app/secrets:/secrets
+    tmpfs:
+      - /dumps:mode=770,size=2052M,uid=1000,gid=1000
+      - /tmp:mode=770,size=2052M,uid=1000,gid=1000
+    mem_limit: 2147483648 # 2 GiB
+    mem_reservation: 1024m
+    privileged: false
+
   dev_postgres:
     container_name: "dev_postgres"
+    hostname: postgres
     image: postgres:${POSTGRES_VERSION}
     restart: on-failure
     environment:
-      - POSTGRES_USER=postgres
+      - POSTGRES_USER=dataverse
       - POSTGRES_PASSWORD=secret
     ports:
       - "5432:5432"
+    networks:
+      - dataverse
     volumes:
       - ./docker-dev-volumes/postgresql/data:/var/lib/postgresql/data
 
@@ -21,20 +51,24 @@ services:
     command:
       - sh
       - -c
-      - "chown 8983:8983 /conf && cp *.xml /conf"
+      - "chown 8983:8983 /conf /var/solr && cp *.xml /conf"
     volumes:
+      - ./docker-dev-volumes/solr/data:/var/solr
       - ./docker-dev-volumes/solr/conf:/conf
       - ./conf/solr/8.11.1/schema.xml:/schema.xml
       - ./conf/solr/8.11.1/solrconfig.xml:/solrconfig.xml
 
   dev_solr:
     container_name: "dev_solr"
+    hostname: "solr"
     image: solr:${SOLR_VERSION}
     depends_on:
       - dev_solr_initializer
     restart: on-failure
     ports:
       - "8983:8983"
+    networks:
+      - dataverse
     command:
       - bash
       - -c
@@ -45,10 +79,17 @@ services:
 
   dev_smtp:
     container_name: "dev_smtp"
+    hostname: "postfix"
     image: maildev/maildev:2.0.5
     restart: on-failure
     ports:
       - "25:1025" # smtp server
       - "1080:1080" # web ui
+    networks:
+      - dataverse
     volumes:
       - ./docker-dev-volumes/smtp/data:/tmp/maildev-1
+
+networks:
+  dataverse:
+    driver: bridge

--- a/modules/container-base/src/main/docker/Dockerfile
+++ b/modules/container-base/src/main/docker/Dockerfile
@@ -190,6 +190,9 @@ RUN <<EOF
     ### DATAVERSE APPLICATION SPECIFICS
     # Configure the MicroProfile directory config source to point to /secrets
     ${ASADMIN} set-config-dir --directory="${SECRETS_DIR}"
+    # Password alias store = 105, default = 100 - lets sort between those to enable overriding from all of the others
+    # except alias config source and microprofile-config.properties
+    ${ASADMIN} set-config-ordinal --ordinal=104 --source=secrets
     # Make request timeouts configurable via MPCONFIG (default to 900 secs = 15 min)
     ${ASADMIN} set 'server-config.network-config.protocols.protocol.http-listener-1.http.request-timeout-seconds=${MPCONFIG=dataverse.http.timeout:900}'
     # TODO: what of the below 3 items can be deleted for container usage?

--- a/modules/dataverse-parent/pom.xml
+++ b/modules/dataverse-parent/pom.xml
@@ -189,7 +189,7 @@
         <maven-checkstyle-plugin.version>3.1.2</maven-checkstyle-plugin.version>
         
         <!-- Container related -->
-        <fabric8-dmp.version>0.40.2</fabric8-dmp.version>
+        <fabric8-dmp.version>0.42.0</fabric8-dmp.version>
     </properties>
     
     <pluginRepositories>

--- a/pom.xml
+++ b/pom.xml
@@ -15,10 +15,14 @@
     doc/sphinx-guides/source/developers/dependencies.rst
     -->
     <artifactId>dataverse</artifactId>
-    <packaging>war</packaging>
+    <packaging>${packaging.type}</packaging>
     <name>dataverse</name>
     <properties>
         <skipUnitTests>false</skipUnitTests>
+        <!-- By default, this module will produce a WAR file. -->
+        <!-- This will be switched within the container profile! -->
+        <packaging.type>war</packaging.type>
+        
         <reload4j.version>1.2.18.4</reload4j.version>
         <flyway.version>8.5.10</flyway.version>
         <jhove.version>1.20.1</jhove.version>
@@ -754,13 +758,99 @@
         </profile>
         <!-- TODO: Add a profile to run API tests (integration tests that end in IT.java. See conf/docker-aio/run-test-suite.sh -->
         <profile>
-            <id>tc</id>
+            <id>ct</id>
             <properties>
+                <!-- Let's go FAST here - building the image should be quick to do by default. -->
                 <skipUnitTests>true</skipUnitTests>
-                <postgresql.server.version>9.6</postgresql.server.version>
+                <!-- Once we truly run tests with Testcontainers, this should be switch to "docker", activating ITs -->
+                <packaging.type>docker-build</packaging.type>
+                <postgresql.server.version>13</postgresql.server.version>
+            
+                <app.image>gdcc/dataverse:${app.image.tag}</app.image>
+                <app.image.tag>unstable</app.image.tag>
+                <base.image>gdcc/base:${base.image.tag}</base.image>
+                <base.image.tag>unstable</base.image.tag>
+    
+                <docker.platforms></docker.platforms>
+            
+                <!-- Variables as used in docker-compose.yml -->
+                <POSTGRES_VERSION>${postgresql.server.version}</POSTGRES_VERSION>
+                <SOLR_VERSION>${solr.version}</SOLR_VERSION>
             </properties>
+        
             <build>
                 <plugins>
+                    <!-- Build the exploded WAR target directory -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-war-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <phase>prepare-package</phase>
+                                <goals>
+                                    <goal>exploded</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                        </configuration>
+                    </plugin>
+                
+                    <!-- Build image via Docker Maven Plugin -->
+                    <plugin>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>docker-maven-plugin</artifactId>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <images>
+                                <!-- Dataverse Application image -->
+                                <image>
+                                    <alias>dev_dataverse</alias>
+                                    <name>${app.image}</name>
+                                    <build>
+                                        <buildx>
+                                            <platforms>
+                                                <platform>${docker.platforms}</platform>
+                                            </platforms>
+                                        </buildx>
+                                        <dockerFile>Dockerfile</dockerFile>
+                                        <args>
+                                            <BASE_IMAGE>${base.image}</BASE_IMAGE>
+                                        </args>
+                                        <filter>@</filter>
+                                        <assembly>
+                                            <descriptor>assembly.xml</descriptor>
+                                        </assembly>
+                                    </build>
+                                
+                                    <run>
+                                        <!-- <autoRemove>true</autoRemove> -->
+                                        <!--
+                                        <wait>
+                                            <http>
+                                                <url>http://localhost:8080/robots.txt</url>
+                                                <method>GET</method>
+                                                <status>200..399</status>
+                                            </http>
+                                            <log>dataverse was successfully deployed</log>
+                                            <time>${ct.run.wait}</time>
+                                            <exec>
+                                                <postStart>/opt/payara/scripts/bootstrap-job.sh</postStart>
+                                            </exec>
+                                        </wait>
+                                        -->
+                                    </run>
+                                    
+                                    <external>
+                                        <type>compose</type>
+                                        <basedir>${project.basedir}</basedir>
+                                        <composeFile>docker-compose-dev.yml</composeFile>
+                                    </external>
+                                </image>
+                            </images>
+                            <autoCreateCustomNetworks>true</autoCreateCustomNetworks>
+                        </configuration>
+                    </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-failsafe-plugin</artifactId>

--- a/scripts/dev/dev-rebuild-docker.sh
+++ b/scripts/dev/dev-rebuild-docker.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+set -euo pipefail
+
+echo "Running setup-all.sh (INSECURE MODE)..."
+cd scripts/api || exit
+./setup-all.sh --insecure -p=admin1 | tee /tmp/setup-all.sh.out
+cd ../..
+
+echo "Setting DOI provider to \"FAKE\"..."
+curl "http://localhost:8080/api/admin/settings/:DoiProvider" -X PUT -d FAKE
+
+API_TOKEN=$(grep apiToken "/tmp/setup-all.sh.out" | jq ".data.apiToken" | tr -d \")
+export API_TOKEN
+
+echo "Publishing root dataverse..."
+curl -H "X-Dataverse-key:$API_TOKEN" -X POST "http://localhost:8080/api/dataverses/:root/actions/:publish"
+
+echo "Allowing users to create dataverses and datasets in root..."
+curl -H "X-Dataverse-key:$API_TOKEN" -X POST -H "Content-type:application/json" -d "{\"assignee\": \":authenticated-users\",\"role\": \"fullContributor\"}" "http://localhost:8080/api/dataverses/:root/assignments"
+
+echo "Checking Dataverse version..."
+curl "http://localhost:8080/api/info/version"

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -1,0 +1,54 @@
+# Copyright 2023 Forschungszentrum Jülich GmbH
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+################################################################################################################
+#
+# THIS FILE IS TO BE USED WITH MAVEN DOCKER BUILD:
+# mvn -Pct clean package
+#
+################################################################################################################
+#
+# Some commands used are inspired by https://github.com/payara/Payara/tree/master/appserver/extras/docker-images.
+# Most parts origin from older versions of https://github.com/gdcc/dataverse-kubernetes.
+#
+# We are not using upstream Payara images because:
+#  - Their image is less optimised for production usage and Dataverse by design choices
+#  - We provide multi-arch images
+#  - We provide some tweaks for development and monitoring
+#
+
+# Make the Java base image and version configurable (useful for trying newer Java versions and flavors)
+ARG BASE_IMAGE="gdcc/base:unstable"
+FROM $BASE_IMAGE
+
+# Make Payara use the "ct" profile for MicroProfile Config. Will switch various defaults for the application
+# setup in META-INF/microprofile-config.properties.
+# See also https://download.eclipse.org/microprofile/microprofile-config-3.0/microprofile-config-spec-3.0.html#configprofile
+ENV MP_CONFIG_PROFILE=ct
+
+# Copy app and deps from assembly in proper layers
+COPY --chown=payara:payara maven/deps ${DEPLOY_DIR}/dataverse/WEB-INF/lib/
+COPY --chown=payara:payara maven/app ${DEPLOY_DIR}/dataverse/
+COPY --chown=payara:payara maven/supplements ${DEPLOY_DIR}/dataverse/supplements/
+COPY --chown=payara:payara maven/scripts ${SCRIPT_DIR}/
+RUN chmod +x "${SCRIPT_DIR}"/*
+
+# Create symlinks for jHove
+RUN ln -s "${DEPLOY_DIR}/dataverse/supplements/jhove.conf" "${PAYARA_DIR}/glassfish/domains/${DOMAIN_NAME}/config/jhove.conf" && \
+    ln -s "${DEPLOY_DIR}/dataverse/supplements/jhoveConfig.xsd" "${PAYARA_DIR}/glassfish/domains/${DOMAIN_NAME}/config/jhoveConfig.xsd" && \
+    sed -i "${PAYARA_DIR}/glassfish/domains/${DOMAIN_NAME}/config/jhove.conf" -e "s:/usr/local/payara./glassfish/domains/domain1:${PAYARA_DIR}/glassfish/domains/${DOMAIN_NAME}:g"
+
+LABEL org.opencontainers.image.created="@git.build.time@" \
+      org.opencontainers.image.authors="Research Data Management at FZJ <forschungsdaten@fz-juelich.de>" \
+      org.opencontainers.image.url="https://guides.dataverse.org/en/latest/container/" \
+      org.opencontainers.image.documentation="https://guides.dataverse.org/en/latest/container/" \
+      org.opencontainers.image.source="https://github.com/IQSS/dataverse" \
+      org.opencontainers.image.version="@project.version@" \
+      org.opencontainers.image.revision="@git.commit.id.abbrev@" \
+      org.opencontainers.image.vendor="Global Dataverse Community Consortium" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.title="Dataverse Application Image" \
+      org.opencontainers.image.description="This container image provides the research data repository software Dataverse in a box."

--- a/src/main/docker/assembly.xml
+++ b/src/main/docker/assembly.xml
@@ -1,0 +1,28 @@
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.0.0 http://maven.apache.org/xsd/assembly-2.0.0.xsd">
+    <fileSets>
+        <!-- Get our app, but exclude deps -->
+        <fileSet>
+            <directory>target/${project.artifactId}-${project.version}</directory>
+            <outputDirectory>app</outputDirectory>
+            <excludes>
+                <exclude>WEB-INF/lib/**/*</exclude>
+            </excludes>
+        </fileSet>
+        <!-- Get our dependencies in a seperate folder (image layer cache!) -->
+        <fileSet>
+            <directory>target/${project.artifactId}-${project.version}/WEB-INF/lib</directory>
+            <outputDirectory>deps</outputDirectory>
+        </fileSet>
+        <!-- Supplemental data (configs, metadata, ...) -->
+        <fileSet>
+            <directory>conf/jhove</directory>
+            <outputDirectory>supplements</outputDirectory>
+        </fileSet>
+        <!-- Init scripts and usage scripts (bootstrapping, configuration, ...) -->
+        <fileSet>
+            <directory>src/main/docker/scripts</directory>
+            <outputDirectory>scripts</outputDirectory>
+        </fileSet>
+    </fileSets>
+</assembly>

--- a/src/main/docker/scripts/init_2_configure.sh
+++ b/src/main/docker/scripts/init_2_configure.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+################################################################################
+# Configure Payara
+#
+# BEWARE: As this is done for Kubernetes, we will ALWAYS start with a fresh container!
+#         When moving to Payara 5+ the option commands are idempotent.
+#         The resources are to be created by the application on deployment,
+#         once Dataverse has proper refactoring, etc.
+################################################################################
+
+# Fail on any error
+set -euo pipefail
+
+# Include some sane defaults (which are currently not settable via MicroProfile Config).
+# This is an ugly hack and shall be removed once #7000 is resolved.
+export dataverse_auth_password__reset__timeout__in__minutes="${dataverse_auth_password__reset__timeout__in__minutes:-60}"
+export dataverse_timerServer="${dataverse_timerServer:-true}"
+export dataverse_files_storage__driver__id="${dataverse_files_storage__driver__id:-local}"
+if [ "${dataverse_files_storage__driver__id}" = "local" ]; then
+  export dataverse_files_local_type="${dataverse_files_local_type:-file}"
+  export dataverse_files_local_label="${dataverse_files_local_label:-Local}"
+  export dataverse_files_local_directory="${dataverse_files_local_directory:-${STORAGE_DIR}/store}"
+fi
+
+# 0. Define postboot commands file to be read by Payara and clear it
+DV_POSTBOOT=${PAYARA_DIR}/dataverse_postboot
+echo "# Dataverse postboot configuration for Payara" > "${DV_POSTBOOT}"
+
+# 1. Password aliases from secrets
+# TODO: This is ugly and dirty. It leaves leftovers on the filesystem.
+#       It should be replaced by using proper config mechanisms sooner than later,
+#       like MicroProfile Config API.
+if [ -f "${SECRETS_DIR}"/doi.password ]; then
+  echo "INFO: Defining password alias for DOI"
+  PASSTMP=$(mktemp)
+  sed -e "s#^#AS_ADMIN_ALIASPASSWORD=#" < "${SECRETS_DIR}"/doi.password > "${PASSTMP}"
+  echo "create-password-alias doi_password_alias --passwordfile ${PASSTMP}" >> "${DV_POSTBOOT}"
+  # Magic var to be picked up further down
+  export doi_password="\${ALIAS=doi_password_alias}"
+else
+  echo "WARNING: Could not find password secret for DOI in '${SECRETS_DIR}/doi.password'. Ignore when using FAKE provider."
+fi
+
+# 2. Domain-spaced resources (JDBC, JMS, ...)
+# TODO: This is ugly and dirty. It should be replaced with resources from
+#       EE 8 code annotations or at least glassfish-resources.xml
+# NOTE: postboot commands is not multi-line capable, thus spaghetti needed.
+
+# JavaMail
+echo "INFO: Defining JavaMail."
+echo "create-javamail-resource --mailhost=${DATAVERSE_MAIL_HOST:-postfix} --mailuser=${DATAVERSE_MAIL_USER:-dataversenotify} --fromaddress=${DATAVERSE_MAIL_FROM:-dataverse@localhost} mail/notifyMailSession" >> "${DV_POSTBOOT}"
+
+# 3. Domain based configuration options
+# Set Dataverse environment variables
+echo "INFO: Defining system properties for Dataverse configuration options."
+#env | grep -Ee "^(dataverse|doi)_" | sort -fd
+env -0 | grep -z -Ee "^(dataverse|doi)_" | while IFS='=' read -r -d '' k v; do
+    # transform __ to -
+    # shellcheck disable=SC2001
+    KEY=$(echo "${k}" | sed -e "s#__#-#g")
+    # transform remaining single _ to .
+    KEY=$(echo "${KEY}" | tr '_' '.')
+
+    # escape colons in values
+    # shellcheck disable=SC2001
+    v=$(echo "${v}" | sed -e 's/:/\\\:/g')
+
+    echo "DEBUG: Handling ${KEY}=${v}."
+    echo "create-system-properties ${KEY}=${v}" >> "${DV_POSTBOOT}"
+done
+
+# 4. Add the commands to the existing postboot file, but insert BEFORE deployment
+TMPFILE=$(mktemp)
+cat "${DV_POSTBOOT}" "${POSTBOOT_COMMANDS}" > "${TMPFILE}" && mv "${TMPFILE}" "${POSTBOOT_COMMANDS}"
+echo "DEBUG: postboot contains the following commands:"
+echo "--------------------------------------------------"
+cat "${POSTBOOT_COMMANDS}"
+echo "--------------------------------------------------"
+

--- a/src/main/resources/META-INF/microprofile-config.properties
+++ b/src/main/resources/META-INF/microprofile-config.properties
@@ -10,6 +10,9 @@ dataverse.build=
 
 # FILES
 dataverse.files.directory=/tmp/dataverse
+# The variables are replaced with the environment variables from our base image, but still easy to override
+%ct.dataverse.files.directory=${STORAGE_DIR}
+%ct.dataverse.files.uploads=${STORAGE_DIR}/uploads
 
 # SEARCH INDEX
 dataverse.solr.host=localhost


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request will add capabilities to create a Dataverse application image and run it along all necessary dependencies.

**Which issue(s) this PR closes**:

Closes #9434

**Special notes for your reviewer**:
There are some TODOs:
- [ ] Check if Dataverse communicates with maildev properly
- [ ] Maybe add some more ressource limitations. Maybe tweak Dataverse container to fit into less than 2 GiB of RAM
- [ ] Add docs (can be copied from #9424 and extend from there)

**Suggestions on how to test this**:
Clone/switch. Ensure to have Docker running. Execute `mvn -Pct clean package docker:run`, then bootstrap when startup is done with `./scripts/dev/dev-rebuild-docker.sh` and go to localhost:8080.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
Nope.

**Is there a release notes update needed for this change?**:
Yes, there should be one. TODO.

**Additional documentation**:
None yet.
