### PR TITLE
Add Pooch to the list of Python clients

### DIFF
--- a/doc/sphinx-guides/source/api/client-libraries.rst
+++ b/doc/sphinx-guides/source/api/client-libraries.rst
@@ -44,11 +44,13 @@ There is no official PHP library for Dataverse APIs (please :ref:`get in touch <
 Python
 ------
 
-There are two Python modules for interacting with Dataverse APIs.
+There are three Python packages for interacting with Dataverse APIs.
 
 `pyDataverse <https://github.com/gdcc/pyDataverse>`_ primarily allows developers to manage Dataverse collections, datasets and datafiles. Its intention is to help with data migrations and DevOps activities such as testing and configuration management. The module is developed by `Stefan Kasberger <http://stefankasberger.at>`_ from `AUSSDA - The Austrian Social Science Data Archive <https://aussda.at>`_.  
 
 `dataverse-client-python <https://github.com/IQSS/dataverse-client-python>`_ had its initial release in 2015. `Robert Liebowitz <https://github.com/rliebz>`_ created this library while at the `Center for Open Science (COS) <https://centerforopenscience.org>`_ and the COS uses it to integrate the `Open Science Framework (OSF) <https://osf.io>`_ with Dataverse installations via an add-on which itself is open source and listed on the :doc:`/api/apps` page.
+
+`Pooch <https://github.com/fatiando/pooch>`_ is a Python library that allows library and application developers to download data. Among other features, it takes care of various protocols, caching in OS-specific locations, checksum verification and adds optional features like progressbars or log messages. Among other popular repositorise, Pooch supports DataVerse in the sense that you can reference DataVerse-hosted datasets by just a DOI and Pooch will determine the data repository type, query the DataVerse API for contained files and checksums, giving you an easy interface to download them.
 
 R
 -


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds Pooch to the list of Python clients.

**Which issue(s) this PR closes**:

Closes #9433 

**Additional documentation**:

I changed `modules` -> `packages` in the introduction bit, as it is the more apt term IMO.