### PR TITLE
IQSS/9471- support delayed setting of :DoiProvider

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/AbstractGlobalIdServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/AbstractGlobalIdServiceBean.java
@@ -30,7 +30,7 @@ public abstract class AbstractGlobalIdServiceBean implements GlobalIdServiceBean
     @Inject
     SystemConfig systemConfig;
 
-    protected boolean configured = false;
+    protected Boolean configured = null;
     
     public static String UNAVAILABLE = ":unav";
 
@@ -684,6 +684,10 @@ public abstract class AbstractGlobalIdServiceBean implements GlobalIdServiceBean
     
     @Override
     public boolean isConfigured() {
-        return configured;
+        if(configured==null) {
+            return false;
+        } else {
+            return configured.booleanValue();
+        }
     }
 }

--- a/src/main/java/edu/harvard/iq/dataverse/AbstractGlobalIdServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/AbstractGlobalIdServiceBean.java
@@ -217,7 +217,7 @@ public abstract class AbstractGlobalIdServiceBean implements GlobalIdServiceBean
      */
     @Override
     public GlobalId parsePersistentId(String fullIdentifierString) {
-        if(!configured) {
+        if(!isConfigured()) {
             return null;
         }
         int index1 = fullIdentifierString.indexOf(':');
@@ -231,7 +231,7 @@ public abstract class AbstractGlobalIdServiceBean implements GlobalIdServiceBean
     }
 
     protected GlobalId parsePersistentId(String protocol, String identifierString) {
-        if(!configured) {
+        if(!isConfigured()) {
             return null;
         }
         String authority;
@@ -262,7 +262,7 @@ public abstract class AbstractGlobalIdServiceBean implements GlobalIdServiceBean
     }
     
     public GlobalId parsePersistentId(String protocol, String authority, String identifier) {
-        if(!configured) {
+        if(!isConfigured()) {
             return null;
         }
         logger.fine("Parsing: " + protocol + ":" + authority + getSeparator() + identifier + " in " + getProviderInformation().get(0));

--- a/src/main/java/edu/harvard/iq/dataverse/DOIDataCiteServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DOIDataCiteServiceBean.java
@@ -11,14 +11,11 @@ import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import javax.annotation.PostConstruct;
 import javax.ejb.EJB;
 import javax.ejb.Stateless;
 
 import org.apache.commons.httpclient.HttpException;
 import org.apache.commons.httpclient.HttpStatus;
-
-import edu.harvard.iq.dataverse.settings.SettingsServiceBean.Key;
 
 
 /**
@@ -37,14 +34,6 @@ public class DOIDataCiteServiceBean extends DOIServiceBean {
 
     @EJB
     DOIDataCiteRegisterService doiDataCiteRegisterService;
-
-    @PostConstruct
-    private void init() {
-        String doiProvider = settingsService.getValueForKey(Key.DoiProvider, "");
-        if("DataCite".equals(doiProvider)) {
-            configured=true;
-        }
-    }
 
     @Override
     public boolean registerWhenPublished() {
@@ -256,7 +245,10 @@ public class DOIDataCiteServiceBean extends DOIServiceBean {
         return providerInfo;
     }
 
-    //PID recognition
 
 
+    @Override
+    protected String getProviderKeyName() {
+        return "DataCite";
+    }
 }

--- a/src/main/java/edu/harvard/iq/dataverse/DOIEZIdServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DOIEZIdServiceBean.java
@@ -1,6 +1,5 @@
 package edu.harvard.iq.dataverse;
 
-import edu.harvard.iq.dataverse.settings.SettingsServiceBean.Key;
 import edu.ucsb.nceas.ezid.EZIDException;
 import edu.ucsb.nceas.ezid.EZIDService;
 import edu.ucsb.nceas.ezid.EZIDServiceRequest;
@@ -283,6 +282,11 @@ public class DOIEZIdServiceBean extends DOIServiceBean {
      */
     private <T> HashMap<T,T> asHashMap(Map<T,T> map) {
         return (map instanceof HashMap) ? (HashMap)map : new HashMap<>(map);
+    }
+
+    @Override
+    protected String getProviderKeyName() {
+        return "EZID";
     }
 
 }

--- a/src/main/java/edu/harvard/iq/dataverse/DOIServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DOIServiceBean.java
@@ -1,5 +1,7 @@
 package edu.harvard.iq.dataverse;
 
+import edu.harvard.iq.dataverse.settings.SettingsServiceBean.Key;
+
 public abstract class DOIServiceBean extends AbstractGlobalIdServiceBean {
 
     public static final String DOI_PROTOCOL = "doi";
@@ -51,6 +53,27 @@ public abstract class DOIServiceBean extends AbstractGlobalIdServiceBean {
 
     public String getUrlPrefix() {
         return DOI_RESOLVER_URL;
+    }
+
+    @Override
+    public boolean isConfigured() {
+        if (configured == null) {
+            if (getProviderKeyName() == null) {
+                configured = false;
+            } else {
+                String doiProvider = settingsService.getValueForKey(Key.DoiProvider, "");
+                if (getProviderKeyName().equals(doiProvider)) {
+                    configured = true;
+                } else if (!doiProvider.isEmpty()) {
+                    configured = false;
+                }
+            }
+        }
+        return super.isConfigured();
+    }
+
+    protected String getProviderKeyName() {
+        return null;
     }
     
 }

--- a/src/main/java/edu/harvard/iq/dataverse/pidproviders/FakePidProviderServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/pidproviders/FakePidProviderServiceBean.java
@@ -3,15 +3,12 @@ package edu.harvard.iq.dataverse.pidproviders;
 import edu.harvard.iq.dataverse.DOIServiceBean;
 import edu.harvard.iq.dataverse.DvObject;
 import edu.harvard.iq.dataverse.GlobalId;
-import edu.harvard.iq.dataverse.settings.SettingsServiceBean.Key;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
 
-import javax.annotation.PostConstruct;
 import javax.ejb.Stateless;
 
 @Stateless
@@ -19,13 +16,6 @@ public class FakePidProviderServiceBean extends DOIServiceBean {
 
     private static final Logger logger = Logger.getLogger(FakePidProviderServiceBean.class.getCanonicalName());
 
-    @PostConstruct
-    private void init() {
-        String doiProvider = settingsService.getValueForKey(Key.DoiProvider, "");
-        if("FAKE".equals(doiProvider)) {
-            configured=true;
-        }
-    }
     
     //Only need to check locally
     public boolean isGlobalIdUnique(GlobalId globalId) {
@@ -81,6 +71,11 @@ public class FakePidProviderServiceBean extends DOIServiceBean {
     @Override
     public boolean publicizeIdentifier(DvObject studyIn) {
         return true;
+    }
+    
+    @Override
+    protected String getProviderKeyName() {
+        return "FAKE";
     }
 
 }

--- a/src/main/java/edu/harvard/iq/dataverse/pidproviders/UnmanagedDOIServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/pidproviders/UnmanagedDOIServiceBean.java
@@ -82,6 +82,7 @@ public class UnmanagedDOIServiceBean extends DOIServiceBean {
         return providerInfo;
     }
 
+
     // PID recognition
     // Done by DOIServiceBean
 

--- a/src/test/java/edu/harvard/iq/dataverse/PersistentIdentifierServiceBeanTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/PersistentIdentifierServiceBeanTest.java
@@ -12,17 +12,30 @@ import edu.harvard.iq.dataverse.pidproviders.PermaLinkPidProviderServiceBean;
 import edu.harvard.iq.dataverse.settings.SettingsServiceBean;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnitRunner;
+
 import static org.junit.Assert.*;
 
 /**
  *
  * @author michael
  */
+@RunWith(MockitoJUnitRunner.class)
 public class PersistentIdentifierServiceBeanTest {
     
-    
+    @Mock
+    private SettingsServiceBean settingsServiceBean;
+
+    @InjectMocks
     DOIEZIdServiceBean ezidServiceBean = new DOIEZIdServiceBean();
+    @InjectMocks
     DOIDataCiteServiceBean dataCiteServiceBean = new DOIDataCiteServiceBean();
+    @InjectMocks
     FakePidProviderServiceBean fakePidProviderServiceBean = new FakePidProviderServiceBean();
     HandlenetServiceBean hdlServiceBean = new HandlenetServiceBean();
     PermaLinkPidProviderServiceBean permaLinkServiceBean = new PermaLinkPidProviderServiceBean(); 
@@ -31,6 +44,7 @@ public class PersistentIdentifierServiceBeanTest {
     
     @Before
     public void setup() {
+        MockitoAnnotations.initMocks(this);
         ctxt = new TestCommandContext(){
             @Override
             public HandlenetServiceBean handleNet() {
@@ -66,14 +80,20 @@ public class PersistentIdentifierServiceBeanTest {
     @Test
     public void testGetBean_String_CommandContext_OK() {
         ctxt.settings().setValueForKey( SettingsServiceBean.Key.DoiProvider, "EZID");
+        Mockito.when(settingsServiceBean.getValueForKey(SettingsServiceBean.Key.DoiProvider, "")).thenReturn("EZID");
+        
         assertEquals(ezidServiceBean, 
                      GlobalIdServiceBean.getBean("doi", ctxt));
         
         ctxt.settings().setValueForKey( SettingsServiceBean.Key.DoiProvider, "DataCite");
+        Mockito.when(settingsServiceBean.getValueForKey(SettingsServiceBean.Key.DoiProvider, "")).thenReturn("DataCite");
+
         assertEquals(dataCiteServiceBean, 
                      GlobalIdServiceBean.getBean("doi", ctxt));
 
         ctxt.settings().setValueForKey(SettingsServiceBean.Key.DoiProvider, "FAKE");
+        Mockito.when(settingsServiceBean.getValueForKey(SettingsServiceBean.Key.DoiProvider, "")).thenReturn("FAKE");
+
         assertEquals(fakePidProviderServiceBean,
                 GlobalIdServiceBean.getBean("doi", ctxt));
 
@@ -100,6 +120,7 @@ public class PersistentIdentifierServiceBeanTest {
     public void testGetBean_CommandContext() {
         ctxt.settings().setValueForKey( SettingsServiceBean.Key.Protocol, "doi");
         ctxt.settings().setValueForKey( SettingsServiceBean.Key.DoiProvider, "EZID");
+        Mockito.when(settingsServiceBean.getValueForKey(SettingsServiceBean.Key.DoiProvider, "")).thenReturn("EZID");
         
         assertEquals(ezidServiceBean, 
                      GlobalIdServiceBean.getBean("doi", ctxt));


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR creates a fix that is expected to change further with the work to support multiple providers at once is done. The fix for DOI providers to allow new installs (with no settings to start) to avoid deciding which bean is configured until the :DoiProvider setting exists works by moving the code that previously ran (in #8674) in @PostConstruct methods to determine if a give Provider was the active one to an isConfigured() method that will return true for the one bean configured once the :DoiProvider setting exists.

**Which issue(s) this PR closes**:

Closes #9471 

**Special notes for your reviewer**:
Lots of discussion at https://iqss.slack.com/archives/C010LA04BCG/p1679663888250749. Nominally the ~root cause here was the use of a Setting rather than jvm-option to decide which bean is active combined with a new check to determine if a provider is allowed to mint new DOIs. The latter isn't technically needed yet as only one PidProvider can run at present but the code was added in anticipation of upcoming work to allow multiple providers. As more discussion is needed (probably a tech hour) for that (including how everything moves to microprofile config options, whether PidProviders can mint new PIDs or just maintain existing ones, etc.) the fix here is a relatively simple one to restore the previous capability to allow the :DoiProvider setting to be set after Payara is up and running.

**Suggestions on how to test this**:
Either start a new instance from scratch (clean database) and confirm that dataset creation/publication works, and/or delete the :DoiProvider setting, restart Payara, and verify that after setting the :DoiProvider again, that dataset creation/publication works. 

The fix is generic to all DOI PIDProviders and affects whether the configured one is active or not, so exhaustive testing beyond smoke tests that PermaLinks and Handles, and DataCite, EZID, and FAKE all work, and that File PIDs work for all providers also, may not be useful.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:
Doesn't really change anything not covered in #8674 already.

**Additional documentation**:
