### PR TITLE
use nonstopmode to build guides PDF, link to preview #9277

### DIFF
--- a/doc/release-notes/9277-nonstopmode-pdf-guides.md
+++ b/doc/release-notes/9277-nonstopmode-pdf-guides.md
@@ -1,0 +1,3 @@
+An experimental version of the guides in PDF format is available at <http://preview.guides.gdcc.io/_/downloads/en/develop/pdf/>
+
+Advice for contributors to documentation who want to help improve the PDF is available at http://preview.guides.gdcc.io/en/develop/developers/documentation.html#pdf-version-of-the-guides

--- a/doc/sphinx-guides/source/developers/documentation.rst
+++ b/doc/sphinx-guides/source/developers/documentation.rst
@@ -141,6 +141,25 @@ In order to make it clear to the crawlers that we only want the latest version d
         Allow: /en/latest/
         Disallow: /en/
 
+PDF Version of the Guides
+-------------------------
+
+The HTML version of the guides is the official one. Any other formats are maintained on a best effort basis.
+
+If you would like to build a PDF version of the guides and have Docker installed, please try the command below from the root of the git repo:
+
+``docker run -it --rm -v $(pwd):/docs sphinxdoc/sphinx-latexpdf:3.5.4 bash -c "cd doc/sphinx-guides && pip3 install -r requirements.txt && make latexpdf LATEXMKOPTS=\"-interaction=nonstopmode\"; cd ../.. && ls -1 doc/sphinx-guides/build/latex/Dataverse.pdf"``
+
+A few notes about the command above:
+
+- Hopefully the PDF was created at ``doc/sphinx-guides/build/latex/Dataverse.pdf``.
+- For now, we are using "nonstopmode" but this masks some errors.
+- See requirements.txt for a note regarding the version of Sphinx we are using.
+
+Also, as of this writing we have enabled PDF builds from the "develop" branch. You download the PDF from http://preview.guides.gdcc.io/_/downloads/en/develop/pdf/
+
+If you would like to help improve the PDF version of the guides, please get in touch! Please see :ref:`getting-help-developers` for ways to contact the developer community.
+
 ----
 
 Previous: :doc:`testing` | Next: :doc:`dependencies`

--- a/doc/sphinx-guides/source/versions.rst
+++ b/doc/sphinx-guides/source/versions.rst
@@ -6,7 +6,7 @@ Dataverse Software Documentation Versions
 
 This list provides a way to refer to the documentation for previous and future versions of the Dataverse Software. In order to learn more about the updates delivered from one version to another, visit the `Releases <https://github.com/IQSS/dataverse/releases>`__ page in our GitHub repo.
 
-- `develop Git branch <http://preview.guides.gdcc.io/en/develop/>`__
+- pre-release `HTML (not final!) <http://preview.guides.gdcc.io/en/develop/>`__ and `PDF (experimental!) <http://preview.guides.gdcc.io/_/downloads/en/develop/pdf/>`__ built from the :doc:`develop </developers/version-control>` branch :doc:`(how to contribute!) </developers/documentation>`
 - 5.13
 - `5.12.1 </en/5.12.1/>`__
 - `5.12 </en/5.12/>`__


### PR DESCRIPTION
**What this PR does / why we need it**:

There is interest in a PDF version of the guides.

In this pull request we advertise the fact that we (as of today) are building a PDF at http://preview.guides.gdcc.io/_/downloads/en/develop/pdf/

We set expectations that this is highly experimental.

It's the same job that builds the regular HTML preview at http://preview.guides.gdcc.io/en/develop/

That is to say, the build happens when we merge a pull request.

In addition, with an eye toward improving the PDF, a Docker command has been added to the "writing docs" section of the dev guide. Again, expectations are set that these are early days.

The key to getting to getting the PDF to build at all is "nonstopmode". Perhaps some day we can remove this as we clean up the guides. I think we should do this in small chunks, which is our usual practice.

**Which issue(s) this PR closes**:

- Closes #9277

**Special notes for your reviewer**:

Not really.

**Suggestions on how to test this**:

Try the Docker command.

Uncomment the PDF building code at https://jenkins.dataverse.org/job/guides.dataverse.org/ and the the nonstopmode from the Docker command to see if a PDF can be build. If so, at release time, consider building the PDF and having it be available at http://guides.dataverse.org/en/latest/Dataverse.pdf (where it has lived off and on over the years).

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No.

**Is there a release notes update needed for this change?**:

Yes, included.

**Additional documentation**:

Included.