### PR TITLE
add range headers to S3 CORS example

### DIFF
--- a/doc/sphinx-guides/source/developers/big-data-support.rst
+++ b/doc/sphinx-guides/source/developers/big-data-support.rst
@@ -62,7 +62,7 @@ with the contents of the file cors.json as follows:
                 "AllowedOrigins": ["*"],
                 "AllowedHeaders": ["*"],
                 "AllowedMethods": ["PUT", "GET"],
-                "ExposeHeaders": ["ETag"]
+                "ExposeHeaders": ["ETag", "Accept-Ranges", "Content-Encoding", "Content-Range"]
              }
           ]
         }


### PR DESCRIPTION
**What this PR does / why we need it**:

Per Jim, range requests won't work in S3 if these headers aren't exposed.

**Which issue(s) this PR closes**:

Closes #9473 

**Special notes for your reviewer**:

Adding these specifically per https://github.com/gdcc/dataverse-previewers/wiki/Using-Previewers-with-download-redirects-from-S3

**Suggestions on how to test this**:

I think zipfile-previewers are specifically in mind, at least for now.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

no

**Is there a release notes update needed for this change?**:

no

**Additional documentation**:

none