### PR TITLE
Opens Payara Admin Console port in the containerized setup

### DIFF
--- a/doc/sphinx-guides/source/container/dev-usage.rst
+++ b/doc/sphinx-guides/source/container/dev-usage.rst
@@ -45,5 +45,7 @@ In the future, we are planning on running this script within a container as part
 
 Check that you can log in to http://localhost:8080 using user ``dataverseAdmin`` and password ``admin1``.
 
+You can also access the Payara Admin Console if needed, which is available at http://localhost:4848. To log in, use user ``admin`` and password ``admin``.
+
 Note that data is persisted in ``./docker-dev-volumes`` in the root of the Git repo. For a clean start, you should
 remove this directory before running the ``mvn`` commands above.

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -13,7 +13,8 @@ services:
       - DATAVERSE_DB_PASSWORD=secret
       - DATAVERSE_DB_USER=${DATAVERSE_DB_USER}
     ports:
-      - "8080:8080" # HTTP
+      - "8080:8080" # HTTP (Dataverse Application)
+      - "4848:4848" # HTTP (Payara Admin Console)
       - "9009:9009" # JDWP
       - "8686:8686" # JMX
     networks:


### PR DESCRIPTION
**What this PR does / why we need it**:
Opens port 4848 of the dev_dataverse service, inside the docker-compose-dev file, to make the Payara Admin Console accessible in the containerized setup.

**Which issue(s) this PR closes**:
- Closes #9476

**Special notes for your reviewer**:
N/A

**Suggestions on how to test this**:
- Follow the existing guide to initialize the containers. After setting up the environment, check that Payara Admin Console is accessible on port 4848.
- Check that you can login with username `admin` and password `admin`

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
No

**Is there a release notes update needed for this change?**:
No

**Additional documentation**:
N/A