### PR TITLE
IQSS/9486- fix EZID NPE when doi.baseurlstring is not defined

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DOIEZIdServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DOIEZIdServiceBean.java
@@ -29,7 +29,10 @@ public class DOIEZIdServiceBean extends DOIServiceBean {
         try {
             // Guessing these are System.getProperty rather than using settingsService
             // because this is a constructor rather than a @PostConstruct method
-            baseURLString = System.getProperty("doi.baseurlstring");
+            String urlFromProperty = System.getProperty("doi.baseurlstring");
+            if(urlFromProperty!=null) {
+                baseURLString = urlFromProperty;
+            }
             logger.log(Level.FINE, "Using baseURLString {0}", baseURLString);
             ezidService = new EZIDService(baseURLString);
             USERNAME = System.getProperty("doi.username");


### PR DESCRIPTION
**What this PR does / why we need it**: See issue - fixes a fatal NPE in the current dev branch when doi.baseurlstring is not defined

**Which issue(s) this PR closes**:

Closes #9486 

**Special notes for your reviewer**:

**Suggestions on how to test this**: Unset doi.baseurlstring and verify that publication fails on dev now and succeeds after this PR.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
No

**Is there a release notes update needed for this change?**:
No

**Additional documentation**:
None