### PR TITLE
IQSS/9496: restore legacy behavior including an empty persistentID

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
@@ -627,7 +627,8 @@ public class JsonPrinter {
         fileName = fileMetadata.getLabel();
         GlobalId filePid = df.getGlobalId();
         String pidURL = (filePid!=null)? filePid.asURL(): null;
-        String pidString = (filePid!=null)? filePid.asString(): null;
+        //For backward compatibility - prior to #8674, asString() returned "" for the value when no PID exists.
+        String pidString = (filePid!=null)? filePid.asString(): "";
 
         JsonObjectBuilder embargo = df.getEmbargo() != null ? JsonPrinter.json(df.getEmbargo()) : null;
 


### PR DESCRIPTION
**What this PR does / why we need it**: Restores pre #8674 behavior in JSON file metadata - see issue

**Which issue(s) this PR closes**:

Closes #9496

**Special notes for your reviewer**: Slack discussion at https://iqss.slack.com/archives/C010LA04BCG/p1680701364259049

**Suggestions on how to test this**: Visually inspect JSON metadata export and confirm files with no PID have "persistentId":"" in their JSON objects. Can also verify that v1.3 and older previewers work when opened in a separate page.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
