### PR TITLE
#9498 - fixing issue while searching for TermUri field that is a compound field

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/search/IndexServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/search/IndexServiceBean.java
@@ -828,7 +828,7 @@ public class IndexServiceBean {
             }
 
             Set<String> langs = settingsService.getConfiguredLanguages();
-            Map<Long, JsonObject> cvocMap = datasetFieldService.getCVocConf(false);
+            Map<Long, JsonObject> cvocMap = datasetFieldService.getCVocConf(true);
             Set<String> metadataBlocksWithValue = new HashSet<>();
             for (DatasetField dsf : datasetVersion.getFlatDatasetFields()) {
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR will allow a compound field that is set as `"term-uri-field"` in `cvoc-conf.json` file to be indexed in SOLR with all values of `externalvocabularyvalue.value` table.
Without this PR, only when `"field-name"` equals `"term-uri-field"`,  values cached from a skosmos term will be indexed properly.

**Which issue(s) this PR closes**:

Closes #9498

**Suggestions on how to test this**:

Make sure that you can search Term in different languages using non compound or compound field with skosmos external vocab support (CVOC).
Example with non compound field :
```json
"field-name": "skosterm",
"term-uri-field": "skosterm",
```
Example with compound field :
```json
"field-name": "cvocDemo",
"term-uri-field": "cvocDemoTermURI",
```

**Is there a release notes update needed for this change?**:

Why not

**Additional documentation**:

related to commit 552a34a
Also, I have no idea if the change is needed is another function like json exporter.