### PR TITLE
expand sslmode=require blurb to note required config change

### DIFF
--- a/doc/release-notes/5.13-release-notes.md
+++ b/doc/release-notes/5.13-release-notes.md
@@ -80,7 +80,7 @@ See [Metadata Blocks](https://guides.dataverse.org/en/5.13/api/native-api.html#m
 
 ### Advanced Database Settings
 
-You can now enable advanced database connection pool configurations useful for debugging and monitoring as well as other settings. Of particular interest may be `sslmode=require`. See the new [Database Persistence](https://guides.dataverse.org/en/5.13/installation/config.html#database-persistence) section of the Installation Guide for details. (PR #8915)
+You can now enable advanced database connection pool configurations useful for debugging and monitoring as well as other settings. Of particular interest may be `sslmode=require`, though installations already setting this parameter in the Postgres connection string will need to move it to `dataverse.db.parameters`. See the new [Database Persistence](https://guides.dataverse.org/en/5.13/installation/config.html#database-persistence) section of the Installation Guide for details. (PR #8915)
 
 ### Support for Cleaning up Leftover Files in Dataset Storage
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Expands the 5.13 `sslmode=require` release note blurb to note required config change.

**Which issue(s) this PR closes**:

Closes #9504

**Special notes for your reviewer**:

Just a doc change.

**Suggestions on how to test this**:

Add a `dataverse.db.parameters` setting if your test PG instance supports SSL.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No.

**Is there a release notes update needed for this change?**:

Yes.

**Additional documentation**:

None.