### PR TITLE
only run extractMetadataNcml on NetCDF or HDF5 files #9441

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/ingest/IngestServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/ingest/IngestServiceBean.java
@@ -1228,6 +1228,11 @@ public class IngestServiceBean {
      * NcML file already exists.
      */
     public boolean extractMetadataNcml(DataFile dataFile, Path tempLocationPath) {
+        String contentType = dataFile.getContentType();
+        if (!("application/netcdf".equals(contentType) || "application/x-hdf5".equals(contentType))) {
+            logger.fine("Returning early from extractMetadataNcml because content type is " + contentType + " rather than application/netcdf or application/x-hdf5");
+            return false;
+        }
         boolean ncmlFileCreated = false;
         logger.fine("extractMetadataNcml: dataFileIn: " + dataFile + ". tempLocationPath: " + tempLocationPath);
         InputStream inputStream = null;


### PR DESCRIPTION
**What this PR does / why we need it**:

We have extra, unwanted logging in server.log when non NetCDF/HDF5 files are uploaded:

For example, the Stata file at scripts/search/data/tabular/50by1000.dta yields this:

[#|2023-04-11T13:52:41.619+0000|INFO|Payara 5.2022.4|edu.harvard.iq.dataverse.ingest.IngestServiceBean|_ThreadID=97;_ThreadName=http-thread-pool::http-listener-1(2);_TimeMillis=1681221161619;_LevelValue=800;|
  NetcdfFiles.open() could not open file id null. Exception caught: java.io.IOException: java.io.IOException: Cant read /dv/temp/1877097125f-1cb93a7cb726: not a valid CDM file.|#]

[#|2023-04-11T13:52:41.619+0000|INFO|Payara 5.2022.4|edu.harvard.iq.dataverse.ingest.IngestServiceBean|_ThreadID=97;_ThreadName=http-thread-pool::http-listener-1(2);_TimeMillis=1681221161619;_LevelValue=800;|
  extractMetadataNcml: input stream is null! dataFileLocation was /dv/temp/1877097125f-1cb93a7cb726|#]

**Which issue(s) this PR closes**:

- Closes #9441

**Special notes for your reviewer**:

In Slack @landreev suggested wrapping `extractMetadataNcml` in a check for contentType. I did something similar (thanks for the suggestion!) but put the check inside the method itself because there are two calls to `extractMetadataNcml`. That is rather, than wrapping both calls, I'm adding a single check.

**Suggestions on how to test this**:

Logging should be reduced.

src/test/resources/hdf/hdf4/hdf4test will get a contentType of "application/octet-stream" because it's an old-style (pre 5) HDF file. It will be lumped in with Stata and any other non-NetCDF (application/netcdf) or non-HDF5 (application/x-hdf5) file.

Because we are now relying on the contentType to run the `extractMetadataNcml` method, files that were uploaded in the past and none identified as either NetCF5 or HDF5 will need to have their contentType detected (or redetected, I guess) before they will successfully produce an NcML aux file.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No.

**Is there a release notes update needed for this change?**:

No.

**Additional documentation**:

None.