### PR TITLE
intermittent harvest tests failures #9240

### DIFF
--- a/src/test/java/edu/harvard/iq/dataverse/api/HarvestingClientsIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/HarvestingClientsIT.java
@@ -79,7 +79,7 @@ public class HarvestingClientsIT {
         // This method focuses on testing the native Dataverse harvesting client
         // API. 
         
-        String nickName = UtilIT.getRandomString(6);
+        String nickName = "h" + UtilIT.getRandomString(6);
         
 
         String clientApiPath = String.format(HARVEST_CLIENTS_API+"%s", nickName);
@@ -100,7 +100,6 @@ public class HarvestingClientsIT {
         assertEquals(UNAUTHORIZED.getStatusCode(), rCreate.getStatusCode());
 
         
-        Thread.sleep(1000L);
         // Try to create the same as admin user, should succeed:
         
         rCreate = given()
@@ -167,7 +166,7 @@ public class HarvestingClientsIT {
         // method, we don't need to pay too much attention to this method, aside 
         // from confirming the expected HTTP status code.
         
-        String nickName = UtilIT.getRandomString(6);
+        String nickName = "h" + UtilIT.getRandomString(6);
 
         String clientApiPath = String.format(HARVEST_CLIENTS_API+"%s", nickName);
         String clientJson = String.format("{\"dataverseAlias\":\"%s\","
@@ -178,7 +177,6 @@ public class HarvestingClientsIT {
                 + "\"metadataFormat\":\"%s\"}", 
                 harvestCollectionAlias, HARVEST_URL, ARCHIVE_URL, CONTROL_OAI_SET, HARVEST_METADATA_FORMAT);
         
-        Thread.sleep(1000L);
         Response createResponse = given()
                 .header(UtilIT.API_TOKEN_HTTP_HEADER, adminUserAPIKey)
                 .body(clientJson)


### PR DESCRIPTION
**What this PR does / why we need it**:

When the tests in HarvestingClientsIT were creating clients, they would use a random string 6 characters long for the identifier. Our "random strings" are random numbers in hex. But the identifier in this particular class has the constraint such that the string should not contain decimal digits only. So with the generation method above, the expected probability of a constraint violation should therefore be 0.625^6 = roughly 5.96% of the time. Which seems about right, as to the failure rate we've been seeing. 

I'm pretty sure we've run into this with dataverse aliases in the past. 


**Which issue(s) this PR closes**:

Closes #9240

**Special notes for your reviewer**:

I acknowledge that it's not awesome, the behavior of the api - the 500 it throws because of the constraint. I just wanted to keep this pr purely about fixing the test. The harvesting clients api in question is for admins only; and nobody will ever use it particularly frequently. So maybe we can fix this error handling one day... when everything else in the application is fixed. 

**Suggestions on how to test this**:

Seeing how the natural probability of failure was really low (i.e., it would keep passing most of the times if left as is), it would be difficult to confirm for sure that it's not going to happen again, ever. Just confirming that the test passes in the next jenkins run should be QA enough to merge it. If it starts failing again for whatever reason, we'll know soon enough. 

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
