### PR TITLE
allow war files to be deployed by the base image

### DIFF
--- a/modules/container-base/src/main/docker/scripts/init_1_generate_deploy_commands.sh
+++ b/modules/container-base/src/main/docker/scripts/init_1_generate_deploy_commands.sh
@@ -61,5 +61,6 @@ find "$DEPLOY_DIR" -mindepth 1 -maxdepth 1 -name "*.rar" -print0 \
   | while IFS= read -r -d '' file; do deploy "$file"; done
 
 # Then every other WAR, EAR, JAR or directory
-find "$DEPLOY_DIR" -mindepth 1 -maxdepth 1 ! -name "*.rar" -a -name "*.war" -o -name "*.ear" -o -name "*.jar" -o -type d -print0 \
-  | while IFS= read -r -d '' file; do deploy "$file"; done
+find "$DEPLOY_DIR" -mindepth 1 -maxdepth 1 \
+  \( ! -name "*.rar" -a -name "*.war" -o -name "*.ear" -o -name "*.jar" -o -type d \) \
+  -print0 | while IFS= read -r -d '' file; do deploy "$file"; done


### PR DESCRIPTION
**What this PR does / why we need it**:

https://guides.dataverse.org/en/5.13/container/base-image.html#locations says, "Any EAR or WAR file, exploded WAR directory etc are autodeployed on start" but only exploded WAR directories are currently supported. This PR allows WAR fles to be deployed.

<img width="1525" alt="Screenshot 2023-04-22 at 6 34 56 PM" src="https://user-images.githubusercontent.com/21006/233810514-105938d4-0be1-4f07-8122-8260cbe342d6.png">

**Which issue(s) this PR closes**:

Closes NONE

**Special notes for your reviewer**:

I tested this with a WAR file I built from https://github.com/IQSS/dataverse-people

**Suggestions on how to test this**:

I build the base image locally with a custom tag and used the following line in a Dockerfile to copy the war into place.

```
COPY ./target/dataverse-people.war ${DEPLOY_DIR}/
```

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No.

**Is there a release notes update needed for this change?**:

No.

**Additional documentation**:

None.