### PR TITLE
TEST - 9575 - but from upstream branch

### DIFF
--- a/.github/workflows/container_app_push.yml
+++ b/.github/workflows/container_app_push.yml
@@ -18,10 +18,11 @@ env:
     BASE_IMAGE_TAG: unstable
     REGISTRY: "" # Empty means default to Docker Hub
     PLATFORMS: "linux/amd64,linux/arm64"
+    MASTER_BRANCH_TAG: alpha
 
 jobs:
     build:
-        name: Build & deploy
+        name: "Build & Test"
         runs-on: ubuntu-latest
         permissions:
             contents: read
@@ -49,12 +50,18 @@ jobs:
             - name: Build app container image with local architecture
               run: mvn -Pct package
 
-            # Note: Accessing, pushing tags etc. to DockerHub or GHCR will only succeed in upstream because secrets.
+            # TODO: add smoke / integration testing here
 
-            # Run this when triggered via push or schedule as reused workflow from base / maven unit tests
-            - if: ${{ github.event_name != 'pull_request' && github.ref_name == 'develop' }}
-              name: Push description to DockerHub
-              uses: peter-evans/dockerhub-description@v3
+    hub-description:
+        needs: build
+        name: Push image description to Docker Hub
+        # Run this when triggered via push or schedule as reused workflow from base / maven unit tests.
+        # Excluding PRs here means we will have no trouble with secrets access. Also avoid runs in forks.
+        if: ${{ github.event_name != 'pull_request' && github.ref_name == 'develop' && github.repository_owner == 'IQSS' }}
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v3
+            - uses: peter-evans/dockerhub-description@v3
               with:
                   username: ${{ secrets.DOCKERHUB_USERNAME }}
                   password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -62,6 +69,45 @@ jobs:
                   short-description: "Dataverse Application Container Image providing the executable"
                   readme-filepath: ./src/main/docker/README.md
 
+    # Note: Accessing, pushing tags etc. to DockerHub or GHCR will only succeed in upstream because secrets.
+    # We check for them here and subsequent jobs can rely on this to decide if they shall run.
+    check-secrets:
+        needs: build
+        name: Check for Secrets Availability
+        runs-on: ubuntu-latest
+        outputs:
+            available: ${{ steps.secret-check.outputs.available }}
+        steps:
+            - id: secret-check
+              # perform secret check & put boolean result as an output
+              shell: bash
+              run: |
+                  if [ "${{ secrets.DOCKERHUB_TOKEN }}" != '' ]; then
+                      echo "available=true" >> $GITHUB_OUTPUT;
+                  else
+                      echo "available=false" >> $GITHUB_OUTPUT;
+                  fi
+
+    deploy:
+        needs: check-secrets
+        name: "Package & Publish"
+        runs-on: ubuntu-latest
+        # Only run this job if we have access to secrets. This is true for events like push/schedule which run in
+        # context of main repo, but for PRs only true if coming from the main repo! Forks have no secret access.
+        if: needs.check-secrets.outputs.available == 'true'
+        steps:
+            - uses: actions/checkout@v3
+            - uses: actions/setup-java@v3
+              with:
+                  java-version: "11"
+                  distribution: 'adopt'
+            - uses: actions/cache@v3
+              with:
+                  path: ~/.m2
+                  key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+                  restore-keys: ${{ runner.os }}-m2
+
+            # Depending on context, we push to different targets. Login accordingly.
             - if: ${{ github.event_name != 'pull_request' }}
               name: Log in to Docker Hub registry
               uses: docker/login-action@v2
@@ -82,8 +128,8 @@ jobs:
             - name: Re-set image tag based on branch (if master)
               if: ${{ github.ref_name == 'master' }}
               run: |
-                  echo "IMAGE_TAG=alpha" >> $GITHUB_ENV
-                  echo "BASE_IMAGE_TAG=alpha" >> $GITHUB_ENV
+                  echo "IMAGE_TAG=${{ env.MASTER_BRANCH_TAG }}" >> $GITHUB_ENV
+                  echo "BASE_IMAGE_TAG=${{ env.MASTER_BRANCH_TAG }}" >> $GITHUB_ENV
             - name: Re-set image tag and container registry when on PR
               if: ${{ github.event_name == 'pull_request' }}
               run: |
@@ -97,6 +143,8 @@ jobs:
               if: ${{ github.event_name == 'pull_request' }}
               with:
                   header: app-registry-push
+                  hide_and_recreate: true
+                  hide_classify: "OUTDATED"
                   message: |
                       Pushed preview application image as [`ghcr.io/gdcc/dataverse:${{ env.IMAGE_TAG }}`](https://github.com/orgs/gdcc/packages/container/package/dataverse).
                       Use it by referencing it with its full name as printed above.

--- a/.github/workflows/container_app_push.yml
+++ b/.github/workflows/container_app_push.yml
@@ -146,5 +146,8 @@ jobs:
                   hide_and_recreate: true
                   hide_classify: "OUTDATED"
                   message: |
-                      Pushed preview application image as [`ghcr.io/gdcc/dataverse:${{ env.IMAGE_TAG }}`](https://github.com/orgs/gdcc/packages/container/package/dataverse).
-                      Use it by referencing it with its full name as printed above.
+                      :package: Pushed preview application image as
+                      ```
+                      ghcr.io/gdcc/dataverse:${{ env.IMAGE_TAG }}
+                      ```
+                      :ship: [See on GHCR](https://github.com/orgs/gdcc/packages/container/package/dataverse). Use by referencing with full name as printed above, mind the registry name.


### PR DESCRIPTION
This is a test PR to see if the logic implemented for #9575 / #9576 works.

As this is coming from the same upstream repo, secrets should be available and the preview image should be pushed to GHCR.