### PR TITLE
#9565 Fix metrics API "file/byType/monthly" by using specific key cache

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/api/Metrics.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Metrics.java
@@ -412,7 +412,7 @@ public class Metrics extends AbstractApiBean {
         } catch (IllegalArgumentException ia) {
             return error(BAD_REQUEST, ia.getLocalizedMessage());
         }
-        String metricName = "filesByType";
+        String metricName = "filesByTypeMonthly";
 
         JsonArray jsonArray = MetricsUtil.stringToJsonArray(metricsSvc.returnUnexpiredCacheAllTime(metricName, null, d));
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix metrics API "file/byType/monthly" by using specific key cache

**Which issue(s) this PR closes**:

Closes #9565 

**Suggestions on how to test this**:

Call first `metrics/files/byType` :

```
curl https://$SERVER_URL/api/info/metrics/files/byType?parentAlias=$ALIAS
```

And after call `metrics/files/byType/monthly` :

```
curl https://$SERVER_URL/api/info/metrics/files/byType/monthly?parentAlias=$ALIAS
```