### PR TITLE
disable NetCDF/HDF5 metadata extraction for S3 direct upload

### DIFF
--- a/doc/sphinx-guides/source/developers/big-data-support.rst
+++ b/doc/sphinx-guides/source/developers/big-data-support.rst
@@ -36,6 +36,17 @@ At present, one potential drawback for direct-upload is that files are only part
 
 ``./asadmin create-jvm-options "-Ddataverse.files.<id>.ingestsizelimit=<size in bytes>"``
 
+.. _s3-direct-upload-features-disabled:
+
+Features that are Disabled if S3 Direct Upload is Enabled
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following features are disabled when S3 direct upload is enabled.
+
+- Unzipping of zip files. (See :ref:`compressed-files`.)
+- Extraction of metadata from FITS, NetCDF, and HDF5 files. (See :ref:`fits` and :ref:`netcdf-and-hdf5`.)
+- Creation of NcML auxiliary files (See :ref:`netcdf-and-hdf5`.)
+
 .. _cors-s3-bucket:
 
 Allow CORS for S3 Buckets

--- a/doc/sphinx-guides/source/user/dataset-management.rst
+++ b/doc/sphinx-guides/source/user/dataset-management.rst
@@ -329,6 +329,8 @@ You can also search for files within datasets that have been tagged as "Workflow
 
 |cw-image6|
 
+.. _fits:
+
 Astronomy (FITS)
 ----------------
 
@@ -373,6 +375,8 @@ Please note the following rules regarding these fields:
 - If the bounding box was successfully populated, the subsequent removal of the NetCDF or HDF5 file from the dataset does not automatically remove the bounding box from the dataset metadata. You must remove the bounding box manually, if desired.
 
 If the bounding box was successfully populated, :ref:`geospatial-search` should be able to find it.
+
+.. _compressed-files:
 
 Compressed Files
 ----------------

--- a/src/main/java/edu/harvard/iq/dataverse/dataaccess/S3AccessIO.java
+++ b/src/main/java/edu/harvard/iq/dataverse/dataaccess/S3AccessIO.java
@@ -815,6 +815,7 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
         if (key == null) {
             DataFile df = this.getDataFile();
             // TODO: (?) - should we worry here about the datafile having null for the owner here? 
+            // Yes, df.getOwner() can be null during S3 direct upload
             key = getMainFileKey(df.getOwner(), df.getStorageIdentifier(), driverId);
         }
         return key;

--- a/src/main/java/edu/harvard/iq/dataverse/ingest/IngestServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/ingest/IngestServiceBean.java
@@ -1197,7 +1197,12 @@ public class IngestServiceBean {
             StorageIO<DataFile> storageIO;
             try {
                 storageIO = dataFile.getStorageIO();
-                storageIO.open();
+                try {
+                    storageIO.open();
+                } catch (Exception ex) {
+                    logger.fine("fileMetadataExtractableFromNetcdf skipped because of exception calling dataFile.getStorageIO(): " + ex);
+                    return false;
+                }
                 if (storageIO.isLocalFile()) {
                     localFile = storageIO.getFileSystemPath().toFile();
                     dataFileLocation = localFile.getAbsolutePath();


### PR DESCRIPTION
**What this PR does / why we need it**:

The fileMetadataExtractableFromNetcdf method added in PR #9541 breaks S3 direct upload.

This pull requests catches the NullPointerException thrown by getMainFileKey in S3AccessIO.

**Which issue(s) this PR closes**:

- Closes #9601

**Special notes for your reviewer**:

Please note: before approving this, consider the larger (bigger diff) alternative at:

- #9611

As `if (driverType.equals("tmp"))` in IngestServiceBean.saveAndAddFilesToDataset() is executing, note that if S3 direct upload is enabled, driverType is "s3". However, if S3 direct upload is disabled (but S3 is still enabled), driverType is "tmp".

This means that methods like `extractMetadataNcml()` and code to generate thumbnails is not executed when S3 direct upload is enabled.

The behavior above is not changed by this pull request, but it did lead me to set expectations better in the guides.

**Suggestions on how to test this**:

Primary bug:

- enable S3 direct upload
- upload any file (should work) 
- upload a NetCDF or HDF5 file (expect no NcML file and no metadata extraction)

To test FITS extraction:

- enable S3 direct upload
- enable astro block
- upload a FITS file (expect no metadata extraction and the following error in the log: "fits is a filename/extension Dataverse doesn't know about. Consider adding it to the MimeTypeDetectionByFileExtension.properties file.")

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No.

**Is there a release notes update needed for this change?**:

No. I updated the guides instead.

**Additional documentation**:

I expanded our docs on what doesn't work during S3 direct upload, including NetCDF/HDF5 metadata extraction.