### PR TITLE
Make DDIExportTest XML validation non-flaky

### DIFF
--- a/src/test/java/edu/harvard/iq/dataverse/export/DDIExporterTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/export/DDIExporterTest.java
@@ -32,18 +32,25 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.logging.Logger;
 import javax.json.Json;
 import javax.json.JsonObject;
 import javax.json.JsonReader;
+import javax.xml.transform.Source;
+import javax.xml.validation.Schema;
+import javax.xml.validation.SchemaFactory;
+
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import org.xml.sax.SAXException;
 import org.xmlunit.assertj3.XmlAssert;
+import org.xmlunit.builder.Input;
 
 public class DDIExporterTest {
 
@@ -88,7 +95,7 @@ public class DDIExporterTest {
         // then
         String xml = XmlPrinter.prettyPrintXml(byteArrayOutputStream.toString(StandardCharsets.UTF_8));
         logger.fine(xml);
-        XmlAssert.assertThat(xml).isValid();
+        XmlAssert.assertThat(xml).isValidAgainst(Input.fromPath(Path.of("src/test/resources/xml/xsd/ddi-codebook-2.5/ddi_codebook_2_5.xsd")).build());
         logger.severe("DDIExporterTest.testExportDataset() creates XML that should now be valid, since DDIExportUtil has been fixed.");
     }
 

--- a/src/test/resources/xml/xsd/ddi-codebook-2.5/XHTML/xhtml-attribs-1.xsd
+++ b/src/test/resources/xml/xsd/ddi-codebook-2.5/XHTML/xhtml-attribs-1.xsd
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="http://www.w3.org/1999/xhtml"
+           xmlns="http://www.w3.org/1999/xhtml">
+
+  <xs:annotation>
+    <xs:documentation>
+      This is the XML Schema common attributes module for XHTML
+      $Id$
+    </xs:documentation>
+    <xs:documentation source="xhtml-copyright-1.xsd"/>
+    <xs:documentation
+         source="http://www.w3.org/TR/xhtml-modularization/abstract_modules.html#s_commonatts"/>
+  </xs:annotation>
+
+  <xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="../xml.xsd">
+    <xs:annotation>
+      <xs:documentation>
+        This import brings in the XML namespace attributes
+        The module itself does not provide the schemaLocation
+        and expects the driver schema to provide the
+        actual SchemaLocation.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:import>
+
+  <xs:attributeGroup name="id">
+    <xs:attribute name="id" type="xs:ID"/>
+  </xs:attributeGroup>
+
+  <xs:attributeGroup name="class">
+    <xs:attribute name="class" type="xs:NMTOKENS"/>
+  </xs:attributeGroup>
+
+  <xs:attributeGroup name="title">
+    <xs:attribute name="title" type="xs:string"/>
+  </xs:attributeGroup>
+
+  <xs:attributeGroup name="Core.attrib">
+    <xs:attributeGroup ref="id"/>
+    <xs:attributeGroup ref="class"/>
+    <xs:attributeGroup ref="title"/>
+    <xs:attributeGroup ref="Core.extra.attrib"/>
+  </xs:attributeGroup>
+
+  <xs:attributeGroup name="I18n.attrib">
+    <xs:attribute ref="xml:lang"/>
+    <xs:attributeGroup ref="I18n.extra.attrib"/>
+  </xs:attributeGroup>
+
+  <xs:attributeGroup name="Common.attrib">
+    <xs:attributeGroup ref="Core.attrib"/>
+    <xs:attributeGroup ref="I18n.attrib"/>
+    <xs:attributeGroup ref="Common.extra"/>
+  </xs:attributeGroup>
+
+
+  <!-- Global attributes -->
+  <xs:attribute name="id" type="xs:ID"/>
+  <xs:attribute name="class" type="xs:NMTOKENS"/>
+  <xs:attribute name="title" type="xs:string"/>
+
+  <xs:attributeGroup name="Global.core.attrib">
+    <xs:attribute ref="id"/>
+    <xs:attribute ref="class"/>
+    <xs:attribute ref="title"/>
+    <xs:attributeGroup ref="Global.core.extra.attrib"/>
+  </xs:attributeGroup>
+
+  <xs:attributeGroup name="Global.i18n.attrib">
+    <xs:attribute ref="xml:lang"/>
+    <xs:attributeGroup ref="Global.I18n.extra.attrib"/>
+  </xs:attributeGroup>
+
+  <xs:attributeGroup name="Global.common.attrib">
+    <xs:attributeGroup ref="Global.core.attrib"/>
+    <xs:attributeGroup ref="Global.i18n.attrib"/>
+    <xs:attributeGroup ref="Global.Common.extra"/>
+  </xs:attributeGroup>
+
+
+</xs:schema>

--- a/src/test/resources/xml/xsd/ddi-codebook-2.5/XHTML/xhtml-bdo-1.xsd
+++ b/src/test/resources/xml/xsd/ddi-codebook-2.5/XHTML/xhtml-bdo-1.xsd
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="http://www.w3.org/1999/xhtml"
+            xmlns="http://www.w3.org/1999/xhtml"
+            xmlns:xs="http://www.w3.org/2001/XMLSchema">
+    <xs:annotation>
+       <xs:documentation>
+          Bidirectional Override (bdo) Element
+          This is the XML Schema BDO Element module for XHTML
+
+          This modules declares the element 'bdo' and 'dir' attributes,
+          Used to override the  Unicode bidirectional algorithm for selected
+          fragments of text.
+          Bidirectional text support includes both the bdo element and
+          the 'dir' attribute.
+
+          $Id$
+      </xs:documentation>
+      <xs:documentation source="xhtml-copyright-1.xsd"/>
+      <xs:documentation
+         source="http://www.w3.org/TR/2001/REC-xhtml-modularization-20010410/abstract_modules.html#s_bdomodule"/>
+    </xs:annotation>
+
+    <xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="../xml.xsd">
+      <xs:annotation>
+         <xs:documentation>
+           This import brings in the XML namespace attributes
+           The module itself does not provide the schemaLocation
+           and expects the driver schema to provide the
+           actual SchemaLocation.
+         </xs:documentation>
+      </xs:annotation>
+    </xs:import>
+
+    <xs:attributeGroup name="bdo.attlist">
+      <xs:attribute ref="xml:lang"/>
+      <xs:attributeGroup ref="Core.attrib"/>
+      <xs:attribute name="dir" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:NMTOKEN">
+            <xs:enumeration value="ltr"/>
+            <xs:enumeration value="rtl"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:attributeGroup>
+
+    <xs:group name="bdo.content">
+       <xs:sequence>
+          <xs:group ref="Inline.mix" minOccurs="0" maxOccurs="unbounded"/>
+       </xs:sequence>
+    </xs:group>
+
+    <xs:complexType name="bdo.type" mixed="true">
+      <xs:group ref="bdo.content"/>
+      <xs:attributeGroup ref="bdo.attlist"/>
+    </xs:complexType>
+
+    <xs:element name="bdo" type="bdo.type"/>
+
+    <xs:attributeGroup name="dir.attrib">
+      <xs:attribute name="dir">
+        <xs:simpleType>
+          <xs:restriction base="xs:NMTOKEN">
+            <xs:enumeration value="ltr"/>
+            <xs:enumeration value="rtl"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:attributeGroup>
+
+    <!-- Global dir attribute -->
+    <xs:attribute name="dir">
+      <xs:simpleType>
+        <xs:restriction base="xs:NMTOKEN">
+          <xs:enumeration value="ltr"/>
+          <xs:enumeration value="rtl"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
+
+    <xs:attributeGroup name="Global.bdo.attrib">
+       <xs:attribute ref="dir"/>
+    </xs:attributeGroup>
+
+</xs:schema>

--- a/src/test/resources/xml/xsd/ddi-codebook-2.5/XHTML/xhtml-blkphras-1.xsd
+++ b/src/test/resources/xml/xsd/ddi-codebook-2.5/XHTML/xhtml-blkphras-1.xsd
@@ -1,0 +1,206 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="http://www.w3.org/1999/xhtml" 
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns="http://www.w3.org/1999/xhtml">
+      
+      
+    <xs:annotation>
+       <xs:documentation>
+          This is the XML Schema Block Phrasal support module for XHTML
+          $Id$
+       </xs:documentation>
+       <xs:documentation source="xhtml-copyright-1.xsd"/>
+    </xs:annotation>
+    
+    <xs:annotation>
+        <xs:documentation>
+           Block Phrasal
+           This module declares the elements and their attributes used to
+           support block-level phrasal markup.
+           This is the XML Schema block phrasal elements module for XHTML
+
+            * address, blockquote, pre, h1, h2, h3, h4, h5, h6
+      </xs:documentation>
+      <xs:documentation source="http://www.w3.org/TR/xhtml-modularization/abstract_modules.html#s_textmodule"/>
+    </xs:annotation>
+    
+    <xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="../xml.xsd"> 
+      <xs:annotation>
+        <xs:documentation>
+          This import brings in the XML namespace attributes 
+          The module itself does not provide the schemaLocation
+          and expects the driver schema to provide the 
+          actual SchemaLocation.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:import>    
+    
+    <!-- address -->
+    <xs:attributeGroup name="address.attlist">
+        <xs:attributeGroup ref="Common.attrib"/>
+    </xs:attributeGroup>
+   
+    <xs:group name="address.content">
+       <xs:sequence>
+          <xs:group ref="Inline.mix" minOccurs="0" maxOccurs="unbounded"/>       
+       </xs:sequence>
+    </xs:group>
+        
+    <xs:complexType name="address.type" mixed="true">
+        <xs:group ref="address.content"/>      
+        <xs:attributeGroup ref="address.attlist"/>
+    </xs:complexType>
+    
+    <xs:element name="address" type="address.type"/>
+    
+    <!-- blockquote -->
+    <xs:attributeGroup name="blockquote.attlist">
+        <xs:attributeGroup ref="Common.attrib"/>
+        <xs:attribute name="cite" type="URI"/>
+    </xs:attributeGroup>
+
+    <xs:group name="blockquote.content">
+       <xs:sequence>
+          <xs:group ref="Block.mix" maxOccurs="unbounded"/>       
+       </xs:sequence>
+    </xs:group>        
+    
+    <xs:complexType name="blockquote.type">
+        <xs:group ref="blockquote.content"/> 
+        <xs:attributeGroup ref="blockquote.attlist"/>
+    </xs:complexType>
+    
+    <xs:element name="blockquote" type="blockquote.type"/>
+    
+    <!-- pre -->
+    <xs:attributeGroup name="pre.attlist">
+        <xs:attribute ref="xml:space"/>
+        <xs:attributeGroup ref="Common.attrib"/>
+    </xs:attributeGroup>
+    
+    <xs:group name="pre.content">
+       <xs:sequence>    
+          <xs:group ref="InlinePre.mix" minOccurs="0" maxOccurs="unbounded"/>       
+       </xs:sequence>
+    </xs:group>        
+        
+    <xs:complexType name="pre.type" mixed="true">
+        <xs:group ref="pre.content"/>     
+        <xs:attributeGroup ref="pre.attlist"/>
+    </xs:complexType>
+    
+    <xs:element name="pre" type="pre.type"/>
+    
+    <!-- Heading Elements  -->
+    <xs:attributeGroup name="heading.attlist">
+        <xs:attributeGroup ref="Common.attrib"/>
+    </xs:attributeGroup>
+    
+    <xs:complexType name="heading.type" mixed="true">
+        <xs:group ref="Inline.mix" minOccurs="0" maxOccurs="unbounded"/>
+        <xs:attributeGroup ref="heading.attlist"/>
+    </xs:complexType>
+    
+    <xs:attributeGroup name="h1.attlist">
+        <xs:attributeGroup ref="Common.attrib"/>
+    </xs:attributeGroup>
+    
+    <xs:group name="h1.content">
+       <xs:sequence>    
+          <xs:group ref="Inline.mix" minOccurs="0" maxOccurs="unbounded"/>    
+       </xs:sequence>
+    </xs:group>
+    
+    <xs:complexType name="h1.type" mixed="true">
+        <xs:group ref="h1.content"/>
+        <xs:attributeGroup ref="h1.attlist"/>
+    </xs:complexType>
+       
+    <xs:element name="h1" type="h1.type"/>
+    
+    <xs:attributeGroup name="h2.attlist">
+        <xs:attributeGroup ref="Common.attrib"/>
+    </xs:attributeGroup>
+    
+    <xs:group name="h2.content">
+       <xs:sequence>    
+          <xs:group ref="Inline.mix" minOccurs="0" maxOccurs="unbounded"/>    
+       </xs:sequence>
+    </xs:group>
+    
+    <xs:complexType name="h2.type" mixed="true">
+        <xs:group ref="h2.content"/>
+        <xs:attributeGroup ref="h2.attlist"/>
+    </xs:complexType>
+    
+    <xs:element name="h2" type="h2.type"/>
+    
+    <xs:attributeGroup name="h3.attlist">
+        <xs:attributeGroup ref="Common.attrib"/>
+    </xs:attributeGroup>
+    
+    <xs:group name="h3.content">
+       <xs:sequence>    
+          <xs:group ref="Inline.mix" minOccurs="0" maxOccurs="unbounded"/>    
+       </xs:sequence>
+    </xs:group>
+    
+    <xs:complexType name="h3.type" mixed="true">
+        <xs:group ref="h3.content"/>
+        <xs:attributeGroup ref="h3.attlist"/>
+    </xs:complexType>
+    
+    <xs:element name="h3" type="h3.type"/>
+    
+    <xs:attributeGroup name="h4.attlist">
+        <xs:attributeGroup ref="Common.attrib"/>
+    </xs:attributeGroup>
+    
+    <xs:group name="h4.content">
+       <xs:sequence>    
+          <xs:group ref="Inline.mix" minOccurs="0" maxOccurs="unbounded"/>    
+       </xs:sequence>
+    </xs:group>
+    
+    <xs:complexType name="h4.type" mixed="true">
+        <xs:group ref="h4.content"/>
+        <xs:attributeGroup ref="h4.attlist"/>
+    </xs:complexType>
+    
+    <xs:element name="h4" type="h4.type"/>
+    
+    <xs:attributeGroup name="h5.attlist">
+        <xs:attributeGroup ref="Common.attrib"/>
+    </xs:attributeGroup>
+    
+    <xs:group name="h5.content">
+       <xs:sequence>    
+          <xs:group ref="Inline.mix" minOccurs="0" maxOccurs="unbounded"/>    
+       </xs:sequence>
+    </xs:group>
+    
+    <xs:complexType name="h5.type" mixed="true">
+        <xs:group ref="h5.content"/>
+        <xs:attributeGroup ref="h5.attlist"/>
+    </xs:complexType>
+    
+    <xs:element name="h5" type="h5.type"/>
+
+    <xs:attributeGroup name="h6.attlist">
+        <xs:attributeGroup ref="Common.attrib"/>
+    </xs:attributeGroup>
+    
+    <xs:group name="h6.content">
+       <xs:sequence>    
+          <xs:group ref="Inline.mix" minOccurs="0" maxOccurs="unbounded"/>    
+       </xs:sequence>
+    </xs:group>
+    
+    <xs:complexType name="h6.type" mixed="true">
+        <xs:group ref="h6.content"/>
+        <xs:attributeGroup ref="h6.attlist"/>
+    </xs:complexType>
+    
+    <xs:element name="h6" type="h6.type"/>
+    
+</xs:schema>

--- a/src/test/resources/xml/xsd/ddi-codebook-2.5/XHTML/xhtml-blkpres-1.xsd
+++ b/src/test/resources/xml/xsd/ddi-codebook-2.5/XHTML/xhtml-blkpres-1.xsd
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="http://www.w3.org/1999/xhtml"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns="http://www.w3.org/1999/xhtml">
+
+  <xs:annotation>
+    <xs:documentation>
+      This is the XML SchemaBlock presentation element module for XHTML
+      $Id$
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:annotation>
+    <xs:documentation>
+      Block Presentational Elements
+  
+        * hr
+  
+      This module declares the elements and their attributes used to
+      support block-level presentational markup.
+    </xs:documentation>
+    <xs:documentation source="xhtml-copyright-1.xsd"/>
+    <xs:documentation 
+         source="http://www.w3.org/TR/2001/REC-xhtml-modularization-20010410/abstract_modules.html#s_presentationmodule"/>    
+  </xs:annotation>
+
+  <xs:attributeGroup name="hr.attlist">
+    <xs:attributeGroup ref="Common.attrib"/>
+  </xs:attributeGroup>
+  
+  <xs:group name="hr.content">
+    <xs:sequence/>
+  </xs:group>  
+  
+  <xs:complexType name="hr.type">
+    <xs:group ref="hr.content"/>
+    <xs:attributeGroup ref="hr.attlist"/>
+  </xs:complexType>
+
+  <xs:element name="hr" type="hr.type"/>
+
+</xs:schema>

--- a/src/test/resources/xml/xsd/ddi-codebook-2.5/XHTML/xhtml-blkstruct-1.xsd
+++ b/src/test/resources/xml/xsd/ddi-codebook-2.5/XHTML/xhtml-blkstruct-1.xsd
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="http://www.w3.org/1999/xhtml"
+           xmlns="http://www.w3.org/1999/xhtml">
+
+  <xs:annotation>
+    <xs:documentation>
+      Block Structural
+
+        * div, p
+  
+      This module declares the elements and their attributes used to
+      support block-level structural markup.            
+          
+      This is the XML Schema Block Structural module for XHTML
+      $Id$
+    </xs:documentation>
+    <xs:documentation source="xhtml-copyright-1.xsd"/>
+  </xs:annotation>
+
+  <!-- div -->
+  <xs:attributeGroup name="div.attlist">
+    <xs:attributeGroup ref="Common.attrib"/>
+  </xs:attributeGroup>
+
+  <xs:group name="div.content">
+     <xs:sequence>
+        <xs:group ref="Flow.mix" minOccurs="0" maxOccurs="unbounded"/>     
+     </xs:sequence>
+  </xs:group>    
+
+  <xs:complexType name="div.type" mixed="true">
+    <xs:group ref="div.content"/>     
+    <xs:attributeGroup ref="div.attlist"/>
+  </xs:complexType>
+
+  <xs:element name="div" type="div.type"/>
+
+  <!-- p -->
+  <xs:attributeGroup name="p.attlist">
+    <xs:attributeGroup ref="Common.attrib"/>
+  </xs:attributeGroup>
+  
+  <xs:group name="p.content">
+     <xs:sequence>
+       <xs:group ref="Inline.mix" minOccurs="0" maxOccurs="unbounded"/>     
+     </xs:sequence>
+  </xs:group>      
+
+  <xs:complexType name="p.type" mixed="true">
+    <xs:group ref="p.content"/>       
+    <xs:attributeGroup ref="p.attlist"/>
+  </xs:complexType>
+
+  <xs:element name="p" type="p.type"/>
+
+</xs:schema>

--- a/src/test/resources/xml/xsd/ddi-codebook-2.5/XHTML/xhtml-charent-1.xsd
+++ b/src/test/resources/xml/xsd/ddi-codebook-2.5/XHTML/xhtml-charent-1.xsd
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  This schema module includes three named character entity files.
+-->
+<!DOCTYPE xs:schema [
+<!-- These are the entity sets for ISO Latin 1 characters for the XHTML -->
+<!ENTITY % HTMLlat1 PUBLIC
+   "-//W3C//ENTITIES Latin 1 for XHTML//EN"
+   "xhtml-lat1.ent">
+%HTMLlat1;
+<!-- These are the entity sets for special characters for the XHTML -->
+<!ENTITY % HTMLsymbol PUBLIC
+   "-//W3C//ENTITIES Symbols for XHTML//EN"
+   "xhtml-symbol.ent">
+%HTMLsymbol;
+<!-- These are the entity sets for symbol characters for the XHTML -->
+<!ENTITY % HTMLspecial PUBLIC
+   "-//W3C//ENTITIES Special for XHTML//EN"
+   "xhtml-special.ent">
+%HTMLspecial;
+]>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="http://www.w3.org/1999/xhtml"
+           xmlns="http://www.w3.org/1999/xhtml">
+
+  <xs:annotation>
+    <xs:documentation>
+      Character Entities for XHTML    
+      This is the XML Schema Character Entities module for XHTML
+
+      This module declares the set of character entities for XHTML,
+      including the Latin 1, Symbol and Special character collections.
+      XML Schema does not support Entities, hence Entities are enable
+      through an Internal DTD Subset.
+      
+      $Id$
+    </xs:documentation>
+    <xs:documentation source="xhtml-copyright-1.xsd"/>
+  </xs:annotation>
+
+</xs:schema>

--- a/src/test/resources/xml/xsd/ddi-codebook-2.5/XHTML/xhtml-datatypes-1.xsd
+++ b/src/test/resources/xml/xsd/ddi-codebook-2.5/XHTML/xhtml-datatypes-1.xsd
@@ -1,0 +1,147 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="http://www.w3.org/1999/xhtml"
+            xmlns="http://www.w3.org/1999/xhtml">
+
+    <xs:annotation>
+        <xs:documentation>
+          XHTML Datatypes
+          This is the XML Schema datatypes module for XHTML
+          
+          Defines containers for the XHTML datatypes, many of
+          these imported from other specifications and standards.
+          
+          $Id$
+        </xs:documentation>
+        <xs:documentation source="xhtml-copyright-1.xsd"/>
+        <xs:documentation 
+            source="http://www.w3.org/TR/2001/REC-xhtml-modularization-20010410/abstraction.html#s_common_attrtypes"/>        
+    </xs:annotation>
+    
+    <!-- nn for pixels or nn% for percentage length -->
+    <xs:simpleType name="Length">
+        <xs:union memberTypes="xs:nonNegativeInteger">
+           <xs:simpleType>
+             <xs:restriction base="xs:token">
+               <xs:pattern value="\d+[%]|\d*\.\d+[%]"/>
+              </xs:restriction>
+           </xs:simpleType>         
+        </xs:union>
+    </xs:simpleType>
+    
+    <!-- space-separated list of link types -->
+    <xs:simpleType name="LinkTypes">
+        <xs:list itemType="xs:NMTOKEN"/>
+    </xs:simpleType>
+    
+    <!-- single or comma-separated list of media descriptors -->
+    <xs:simpleType name="MediaDesc">
+        <xs:restriction base="xs:string"/>
+    </xs:simpleType>
+    
+    <!-- pixel, percentage, or relative -->
+    <xs:simpleType name="MultiLength">
+        <xs:union memberTypes="Length">
+           <xs:simpleType>
+             <xs:restriction base="xs:token">
+               <xs:pattern value="\d*\*"/>
+             </xs:restriction>
+           </xs:simpleType>         
+        </xs:union>
+    </xs:simpleType>
+    
+    <!-- one or more digits (NUMBER) -->
+    <xs:simpleType name="Number">
+        <xs:restriction base="xs:nonNegativeInteger"/>
+    </xs:simpleType>
+    
+    <!-- integer representing length in pixels -->
+    <xs:simpleType name="Pixels">
+        <xs:restriction base="xs:nonNegativeInteger"/>
+    </xs:simpleType>
+    
+    <!-- script expression -->
+    <xs:simpleType name="Script">
+        <xs:restriction base="xs:string"/>
+    </xs:simpleType>
+    
+    <!-- sixteen color names or RGB color expression-->
+    <xs:simpleType name="Color">
+        <xs:union memberTypes="xs:NMTOKEN">    
+           <xs:simpleType>                      
+              <xs:restriction base="xs:token">
+                 <xs:pattern value="#[0-9a-fA-F]{6}"/>
+              </xs:restriction>
+           </xs:simpleType>         
+        </xs:union>
+    </xs:simpleType>
+    
+    <!-- textual content -->
+    <xs:simpleType name="Text">
+        <xs:restriction base="xs:string"/>
+    </xs:simpleType>
+    
+    <!-- Imported Datatypes  -->
+    <!-- a single character, as per section 2.2 of [XML] -->
+    <xs:simpleType name="Character">
+        <xs:restriction base="xs:string">
+           <xs:length value="1" fixed="true"/>
+        </xs:restriction>
+    </xs:simpleType>
+    
+    <!-- a character encoding, as per [RFC2045] -->
+    <xs:simpleType name="Charset">
+        <xs:restriction base="xs:string"/>
+    </xs:simpleType>
+    
+    <!-- a space separated list of character encodings, as per [RFC2045] -->
+    <xs:simpleType name="Charsets">
+        <xs:list itemType="Charset"/>
+    </xs:simpleType>
+    
+    <!-- media type, as per [RFC2045] -->
+    <xs:simpleType name="ContentType">
+        <xs:list itemType="xs:string"/>
+    </xs:simpleType>
+    
+    <!-- comma-separated list of media types, as per [RFC2045] -->
+    <xs:simpleType name="ContentTypes">
+        <xs:list itemType="xs:string"/>
+    </xs:simpleType>
+    
+    <!-- date and time information. ISO date format -->
+    <xs:simpleType name="Datetime">
+        <xs:restriction base="xs:dateTime"/>
+    </xs:simpleType>
+    
+    <!-- formal public identifier, as per [ISO8879] -->
+    <xs:simpleType name="FPI">
+        <xs:restriction base="xs:normalizedString"/>
+    </xs:simpleType>
+    
+    <!-- a language code, as per [RFC3066] -->
+    <xs:simpleType name="LanguageCode">
+        <xs:restriction base="xs:language"/>
+    </xs:simpleType>
+    
+    <!-- a Uniform Resource Identifier, see [URI] -->
+    <xs:simpleType name="URI">
+        <xs:restriction base="xs:anyURI"/>
+    </xs:simpleType>
+    
+    <!-- a space-separated list of Uniform Resource Identifiers, see [URI] -->
+    <xs:simpleType name="URIs">
+        <xs:list itemType="xs:anyURI"/>
+    </xs:simpleType>
+    
+    <!-- comma-separated list of MultiLength -->
+    <xs:simpleType name="MultiLengths">
+        <xs:restriction base="xs:string"/>
+    </xs:simpleType>
+    
+    <!-- character Data -->
+    <xs:simpleType name="CDATA">
+        <xs:restriction base="xs:string"/>
+    </xs:simpleType>
+        
+</xs:schema>

--- a/src/test/resources/xml/xsd/ddi-codebook-2.5/XHTML/xhtml-framework-1.xsd
+++ b/src/test/resources/xml/xsd/ddi-codebook-2.5/XHTML/xhtml-framework-1.xsd
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="http://www.w3.org/1999/xhtml"
+           xmlns="http://www.w3.org/1999/xhtml">
+
+  <xs:annotation>
+    <xs:documentation>
+      This is the XML Schema Modular Framework support module for XHTML
+      $Id$
+    </xs:documentation>
+    <xs:documentation source="xhtml-copyright-1.xsd"/>
+  </xs:annotation>
+
+  <xs:annotation>
+    <xs:documentation>
+      XHTML Modular Framework
+      This required module instantiates the necessary modules
+      needed to support the XHTML modularization framework.
+
+      The Schema modules instantiated are:
+        +  notations
+        +  datatypes
+        +  common attributes
+        +  character entities
+    </xs:documentation>
+    <xs:documentation
+         source="http://www.w3.org/TR/xhtml-modularization/abstract_modules.html#s_commonatts"/>
+  </xs:annotation>
+
+  <xs:include schemaLocation="xhtml-notations-1.xsd">
+    <xs:annotation>
+      <xs:documentation>
+         Notations module
+         Declares XHTML notations for Attribute data types
+      </xs:documentation>
+    </xs:annotation>
+  </xs:include>
+
+  <xs:include schemaLocation="xhtml-datatypes-1.xsd">
+    <xs:annotation>
+      <xs:documentation>
+        This module defines XHTML Attribute DataTypes
+      </xs:documentation>
+      <xs:documentation
+          source="http://www.w3.org/TR/2001/REC-xhtml-modularization-20010410/abstraction.html#s_common_attrtypes"/>
+    </xs:annotation>
+  </xs:include>
+
+  <xs:include schemaLocation="xhtml-attribs-1.xsd">
+    <xs:annotation>
+      <xs:documentation>
+        This module defines Common attributes for XHTML
+      </xs:documentation>
+      <xs:documentation
+          source="http://www.w3.org/TR/2001/REC-xhtml-modularization-20010410/abstract_modules.html#s_commonatts"/>
+    </xs:annotation>
+  </xs:include>
+
+  <xs:include schemaLocation="xhtml-charent-1.xsd">
+    <xs:annotation>
+      <xs:documentation>
+        Character entities module
+        Note: Entities are not supported in XML Schema
+        The Schema Module uses DTDs to define Entities
+
+        This module defines
+          + XHTML Latin 1 Character Entities
+          + XHTML Special Characters
+          + XHTML Mathematical, Greek, and Symbolic Characters
+    </xs:documentation>
+    </xs:annotation>
+  </xs:include>
+
+</xs:schema>

--- a/src/test/resources/xml/xsd/ddi-codebook-2.5/XHTML/xhtml-hypertext-1.xsd
+++ b/src/test/resources/xml/xsd/ddi-codebook-2.5/XHTML/xhtml-hypertext-1.xsd
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="http://www.w3.org/1999/xhtml"
+           xmlns="http://www.w3.org/1999/xhtml">
+
+  <xs:annotation>
+    <xs:documentation>
+      Hypertext Module
+      This is the XML Schema Hypertext module for XHTML
+            
+        * a
+            
+      This module declares the anchor ('a') element type, which
+      defines the source of a hypertext link. The destination
+      (or link 'target') is identified via its 'id' attribute 
+      rather than the 'name' attribute as was used in HTML.
+
+      $Id$
+    </xs:documentation>
+    <xs:documentation source="xhtml-copyright-1.xsd"/>
+    <xs:documentation
+        source="http://www.w3.org/TR/2001/REC-xhtml-modularization-20010410/abstract_modules.html#s_hypertextmodule"/>    
+  </xs:annotation>
+
+
+  <xs:attributeGroup name="a.attlist">
+    <xs:attributeGroup ref="Common.attrib"/>
+    <xs:attribute name="href" type="URI"/>
+    <xs:attribute name="charset" type="Charset"/>
+    <xs:attribute name="type" type="ContentType"/>
+    <xs:attribute name="hreflang" type="LanguageCode"/>
+    <xs:attribute name="rel" type="LinkTypes"/>
+    <xs:attribute name="rev" type="LinkTypes"/>
+    <xs:attribute name="accesskey" type="Character"/>
+    <xs:attribute name="tabindex" type="Number"/>
+  </xs:attributeGroup>
+   
+  <xs:group name="a.content">
+     <xs:sequence>
+        <xs:group ref="InlNoAnchor.mix" minOccurs="0" maxOccurs="unbounded"/>     
+     </xs:sequence>
+  </xs:group>  
+
+  <xs:complexType name="a.type" mixed="true">
+     <xs:group ref="a.content"/>
+     <xs:attributeGroup ref="a.attlist"/>
+  </xs:complexType>
+ 
+  <xs:element name="a" type="a.type"/>
+
+</xs:schema>

--- a/src/test/resources/xml/xsd/ddi-codebook-2.5/XHTML/xhtml-inlphras-1.xsd
+++ b/src/test/resources/xml/xsd/ddi-codebook-2.5/XHTML/xhtml-inlphras-1.xsd
@@ -1,0 +1,220 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="http://www.w3.org/1999/xhtml"
+           xmlns="http://www.w3.org/1999/xhtml">
+
+  <xs:annotation>
+    <xs:documentation>
+         This is the XML Schema Inline Phrasal support module for XHTML
+         $Id$
+    </xs:documentation>
+    <xs:documentation source="xhtml-copyright-1.xsd"/>
+  </xs:annotation>
+
+  <xs:annotation>
+    <xs:documentation>
+      Inline Phrasal.
+      This module declares the elements and their attributes used to
+      support inline-level phrasal markup.
+      This is the XML Schema Inline Phrasal module for XHTML
+
+        * abbr, acronym, cite, code, dfn, em, kbd, q, samp, strong, var
+
+      $Id$
+    </xs:documentation>
+    <xs:documentation source="http://www.w3.org/TR/xhtml-modularization/abstract_modules.html#s_textmodule"/>
+  </xs:annotation>
+
+
+  <xs:attributeGroup name="abbr.attlist">
+    <xs:attributeGroup ref="Common.attrib"/>
+  </xs:attributeGroup>
+
+  <xs:group name="abbr.content">
+     <xs:sequence>
+       <xs:group ref="Inline.mix" minOccurs="0" maxOccurs="unbounded"/>
+     </xs:sequence>
+  </xs:group>
+
+  <xs:complexType name="abbr.type" mixed="true">
+    <xs:group ref="abbr.content"/>
+    <xs:attributeGroup ref="abbr.attlist"/>
+  </xs:complexType>
+
+  <xs:element name="abbr" type="abbr.type"/>
+
+  <xs:attributeGroup name="acronym.attlist">
+    <xs:attributeGroup ref="Common.attrib"/>
+  </xs:attributeGroup>
+
+  <xs:group name="acronym.content">
+     <xs:sequence>
+       <xs:group ref="Inline.mix" minOccurs="0" maxOccurs="unbounded"/>
+     </xs:sequence>
+  </xs:group>
+
+  <xs:complexType name="acronym.type" mixed="true">
+    <xs:group ref="acronym.content"/>
+    <xs:attributeGroup ref="acronym.attlist"/>
+  </xs:complexType>
+
+  <xs:element name="acronym" type="acronym.type"/>
+
+  <xs:attributeGroup name="cite.attlist">
+    <xs:attributeGroup ref="Common.attrib"/>
+  </xs:attributeGroup>
+
+  <xs:group name="cite.content">
+     <xs:sequence>
+       <xs:group ref="Inline.mix" minOccurs="0" maxOccurs="unbounded"/>
+     </xs:sequence>
+  </xs:group>
+
+  <xs:complexType name="cite.type" mixed="true">
+    <xs:group ref="cite.content"/>
+    <xs:attributeGroup ref="cite.attlist"/>
+  </xs:complexType>
+
+  <xs:element name="cite" type="cite.type"/>
+
+  <xs:attributeGroup name="code.attlist">
+    <xs:attributeGroup ref="Common.attrib"/>
+  </xs:attributeGroup>
+
+  <xs:group name="code.content">
+     <xs:sequence>
+       <xs:group ref="Inline.mix" minOccurs="0" maxOccurs="unbounded"/>
+     </xs:sequence>
+  </xs:group>
+
+  <xs:complexType name="code.type" mixed="true">
+    <xs:group ref="code.content"/>
+    <xs:attributeGroup ref="code.attlist"/>
+  </xs:complexType>
+
+  <xs:element name="code" type="code.type"/>
+
+  <xs:attributeGroup name="dfn.attlist">
+    <xs:attributeGroup ref="Common.attrib"/>
+  </xs:attributeGroup>
+
+  <xs:group name="dfn.content">
+     <xs:sequence>
+       <xs:group ref="Inline.mix" minOccurs="0" maxOccurs="unbounded"/>
+     </xs:sequence>
+  </xs:group>
+
+  <xs:complexType name="dfn.type" mixed="true">
+    <xs:group ref="dfn.content"/>
+    <xs:attributeGroup ref="dfn.attlist"/>
+  </xs:complexType>
+
+  <xs:element name="dfn" type="dfn.type"/>
+
+  <xs:attributeGroup name="em.attlist">
+    <xs:attributeGroup ref="Common.attrib"/>
+  </xs:attributeGroup>
+
+  <xs:group name="em.content">
+     <xs:sequence>
+       <xs:group ref="Inline.mix" minOccurs="0" maxOccurs="unbounded"/>
+     </xs:sequence>
+  </xs:group>
+
+  <xs:complexType name="em.type" mixed="true">
+    <xs:group ref="em.content"/>
+    <xs:attributeGroup ref="em.attlist"/>
+  </xs:complexType>
+
+  <xs:element name="em" type="em.type"/>
+
+
+  <xs:attributeGroup name="kbd.attlist">
+    <xs:attributeGroup ref="Common.attrib"/>
+  </xs:attributeGroup>
+
+  <xs:group name="kbd.content">
+     <xs:sequence>
+       <xs:group ref="Inline.mix" minOccurs="0" maxOccurs="unbounded"/>
+     </xs:sequence>
+  </xs:group>
+
+  <xs:complexType name="kbd.type" mixed="true">
+    <xs:group ref="kbd.content"/>
+    <xs:attributeGroup ref="kbd.attlist"/>
+  </xs:complexType>
+
+  <xs:element name="kbd" type="kbd.type"/>
+
+
+  <xs:attributeGroup name="samp.attlist">
+    <xs:attributeGroup ref="Common.attrib"/>
+  </xs:attributeGroup>
+
+  <xs:group name="samp.content">
+     <xs:sequence>
+       <xs:group ref="Inline.mix" minOccurs="0" maxOccurs="unbounded"/>
+     </xs:sequence>
+  </xs:group>
+
+  <xs:complexType name="samp.type" mixed="true">
+    <xs:group ref="samp.content"/>
+    <xs:attributeGroup ref="samp.attlist"/>
+  </xs:complexType>
+
+  <xs:element name="samp" type="samp.type"/>
+
+
+  <xs:attributeGroup name="strong.attlist">
+    <xs:attributeGroup ref="Common.attrib"/>
+  </xs:attributeGroup>
+
+  <xs:group name="strong.content">
+     <xs:sequence>
+       <xs:group ref="Inline.mix" minOccurs="0" maxOccurs="unbounded"/>
+     </xs:sequence>
+  </xs:group>
+
+  <xs:complexType name="strong.type" mixed="true">
+    <xs:group ref="strong.content"/>
+    <xs:attributeGroup ref="strong.attlist"/>
+  </xs:complexType>
+
+  <xs:element name="strong" type="strong.type"/>
+
+  <xs:attributeGroup name="var.attlist">
+    <xs:attributeGroup ref="Common.attrib"/>
+  </xs:attributeGroup>
+
+  <xs:group name="var.content">
+     <xs:sequence>
+       <xs:group ref="Inline.mix" minOccurs="0" maxOccurs="unbounded"/>
+     </xs:sequence>
+  </xs:group>
+
+  <xs:complexType name="var.type" mixed="true">
+    <xs:group ref="var.content"/>
+    <xs:attributeGroup ref="var.attlist"/>
+  </xs:complexType>
+
+  <xs:element name="var" type="var.type"/>
+
+  <xs:attributeGroup name="q.attlist">
+    <xs:attributeGroup ref="Common.attrib"/>
+    <xs:attribute name="cite" type="URI"/>
+  </xs:attributeGroup>
+
+  <xs:group name="q.content">
+     <xs:sequence>
+       <xs:group ref="Inline.mix" minOccurs="0" maxOccurs="unbounded"/>
+     </xs:sequence>
+  </xs:group>
+
+  <xs:complexType name="q.type" mixed="true">
+    <xs:group ref="q.content"/>
+    <xs:attributeGroup ref="q.attlist"/>
+  </xs:complexType>
+
+  <xs:element name="q" type="q.type"/>
+
+</xs:schema>

--- a/src/test/resources/xml/xsd/ddi-codebook-2.5/XHTML/xhtml-inlpres-1.xsd
+++ b/src/test/resources/xml/xsd/ddi-codebook-2.5/XHTML/xhtml-inlpres-1.xsd
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="http://www.w3.org/1999/xhtml"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns="http://www.w3.org/1999/xhtml">
+
+  <xs:annotation>
+    <xs:documentation>
+      This is the XML Schema Inline Presentation element module for XHTML
+      $Id$
+    </xs:documentation>
+    <xs:documentation source="xhtml-copyright-1.xsd"/>
+  </xs:annotation>
+
+  <xs:annotation>
+    <xs:documentation>
+      Inline Presentational Elements
+    
+        * b, big, i, small, sub, sup, tt
+    
+      This module declares the elements and their attributes used to
+      support inline-level presentational markup.
+    </xs:documentation>
+    <xs:documentation 
+         source="http://www.w3.org/TR/2001/REC-xhtml-modularization-20010410/abstract_modules.html#s_presentationmodule"/>
+  </xs:annotation>
+
+  <xs:attributeGroup name="InlPres.attlist">
+    <xs:attributeGroup ref="Common.attrib"/>
+  </xs:attributeGroup>
+
+  <xs:group name="InlPres.content">
+    <xs:sequence>
+       <xs:group ref="Inline.mix" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:group>  
+    
+  <xs:complexType name="InlPres.type" mixed="true">
+    <xs:group ref="InlPres.content"/>
+    <xs:attributeGroup ref="InlPres.attlist"/>
+  </xs:complexType>
+    
+  <xs:element name="b" type="InlPres.type"/>
+
+  <xs:element name="big" type="InlPres.type"/>
+
+  <xs:element name="i" type="InlPres.type"/>
+
+  <xs:element name="small" type="InlPres.type"/>
+
+  <xs:element name="sub" type="InlPres.type"/>
+
+  <xs:element name="sup" type="InlPres.type"/>
+
+  <xs:element name="tt" type="InlPres.type"/>
+
+</xs:schema>

--- a/src/test/resources/xml/xsd/ddi-codebook-2.5/XHTML/xhtml-inlstruct-1.xsd
+++ b/src/test/resources/xml/xsd/ddi-codebook-2.5/XHTML/xhtml-inlstruct-1.xsd
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="http://www.w3.org/1999/xhtml"
+           xmlns="http://www.w3.org/1999/xhtml">
+
+
+  <xs:annotation>
+    <xs:documentation>
+         This is the XML Schema Inline Structural support module for XHTML
+         $Id$
+    </xs:documentation>
+    <xs:documentation source="xhtml-copyright-1.xsd"/>
+  </xs:annotation>
+
+  <xs:annotation>
+    <xs:documentation>
+      Inline Structural.
+      This module declares the elements and their attributes 
+      used to support inline-level structural markup.      
+      This is the XML Schema Inline Structural element module for XHTML
+
+        * br, span
+      
+    </xs:documentation>
+    <xs:documentation source="http://www.w3.org/TR/xhtml-modularization/abstract_modules.html#s_textmodule"/>
+  </xs:annotation>
+
+  <xs:attributeGroup name="br.attlist">
+    <xs:attributeGroup ref="Core.attrib"/>
+  </xs:attributeGroup>
+  
+  <xs:group name="br.content">
+     <xs:sequence/>
+  </xs:group>  
+
+  <xs:complexType name="br.type">
+    <xs:group ref="br.content"/>    
+    <xs:attributeGroup ref="br.attlist"/>
+  </xs:complexType>
+
+  <xs:element name="br" type="br.type"/>
+
+  <xs:attributeGroup name="span.attlist">
+    <xs:attributeGroup ref="Common.attrib"/>
+  </xs:attributeGroup>
+  
+  <xs:group name="span.content">
+    <xs:sequence>
+       <xs:group ref="Inline.mix" minOccurs="0" maxOccurs="unbounded"/>     
+    </xs:sequence>
+  </xs:group>
+
+  <xs:complexType name="span.type" mixed="true">
+    <xs:group ref="span.content"/>   
+    <xs:attributeGroup ref="span.attlist"/>
+  </xs:complexType>
+
+  <xs:element name="span" type="span.type"/>
+
+</xs:schema>

--- a/src/test/resources/xml/xsd/ddi-codebook-2.5/XHTML/xhtml-inlstyle-1.xsd
+++ b/src/test/resources/xml/xsd/ddi-codebook-2.5/XHTML/xhtml-inlstyle-1.xsd
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="http://www.w3.org/1999/xhtml"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns="http://www.w3.org/1999/xhtml">
+
+  <xs:annotation>
+    <xs:documentation>
+      Inline Style module    
+      This is the XML Schema Inline Style module for XHTML
+      
+         * styloe attribute
+
+      This module declares the 'style' attribute, used to support inline 
+      style markup. 
+
+      $Id$
+    </xs:documentation>
+    <xs:documentation source="xhtml-copyright-1.xsd"/>
+    <xs:documentation 
+       source="http://www.w3.org/TR/2001/REC-xhtml-modularization-20010410/abstract_modules.html#s_styleattributemodule"/>    
+  </xs:annotation>
+
+  <xs:attributeGroup name="style.attrib">
+    <xs:attribute name="style" type="CDATA"/>
+  </xs:attributeGroup>
+
+</xs:schema>

--- a/src/test/resources/xml/xsd/ddi-codebook-2.5/XHTML/xhtml-list-1.xsd
+++ b/src/test/resources/xml/xsd/ddi-codebook-2.5/XHTML/xhtml-list-1.xsd
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="http://www.w3.org/1999/xhtml"
+           xmlns="http://www.w3.org/1999/xhtml">
+
+  <xs:annotation>
+    <xs:documentation>
+      List Module
+      This is the XML Schema Lists module for XHTML
+      List Module Elements
+    
+        * dl, dt, dd, ol, ul, li
+    
+      This module declares the list-oriented element types
+      and their attributes.
+      $Id$      
+    </xs:documentation>
+    <xs:documentation source="xhtml-copyright-1.xsd"/>
+    <xs:documentation
+      source="http://www.w3.org/TR/2001/REC-xhtml-modularization-20010410/abstract_modules.html#s_listmodule"/>      
+  </xs:annotation>
+
+  <xs:attributeGroup name="dt.attlist">
+    <xs:attributeGroup ref="Common.attrib"/>
+  </xs:attributeGroup>
+  
+  <xs:group name="dt.content">
+    <xs:sequence>
+      <xs:group ref="Inline.mix" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:group>
+
+  <xs:complexType name="dt.type" mixed="true">
+    <xs:group ref="dt.content"/>
+    <xs:attributeGroup ref="dt.attlist"/>
+  </xs:complexType>
+
+  <xs:element name="dt" type="dt.type"/>
+
+  <xs:attributeGroup name="dd.attlist">
+    <xs:attributeGroup ref="Common.attrib"/>
+  </xs:attributeGroup>
+  
+  <xs:group name="dd.content">
+    <xs:sequence>
+      <xs:group ref="Flow.mix" minOccurs="0" maxOccurs="unbounded"/>  
+    </xs:sequence>
+  </xs:group>
+
+  <xs:complexType name="dd.type" mixed="true">
+    <xs:group ref="dd.content"/>
+    <xs:attributeGroup ref="dd.attlist"/>
+  </xs:complexType>
+
+  <xs:element name="dd" type="dd.type"/>
+
+  <xs:attributeGroup name="dl.attlist">
+    <xs:attributeGroup ref="Common.attrib"/>
+  </xs:attributeGroup>
+
+  <xs:group name="dl.content">
+    <xs:sequence>
+      <xs:choice maxOccurs="unbounded">
+        <xs:element ref="dt"/>
+        <xs:element ref="dd"/>
+      </xs:choice>
+    </xs:sequence>
+  </xs:group>
+
+  <xs:complexType name="dl.type">
+    <xs:group ref="dl.content"/>
+    <xs:attributeGroup ref="dl.attlist"/>
+  </xs:complexType>
+
+  <xs:element name="dl" type="dl.type"/>
+
+  <xs:attributeGroup name="li.attlist">
+    <xs:attributeGroup ref="Common.attrib"/>
+  </xs:attributeGroup>
+  
+  <xs:group name="li.content">
+    <xs:sequence>
+      <xs:group ref="Flow.mix" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>      
+  </xs:group>
+
+  <xs:complexType name="li.type" mixed="true">
+    <xs:group ref="li.content"/>  
+    <xs:attributeGroup ref="li.attlist"/>
+  </xs:complexType>
+
+  <xs:element name="li" type="li.type"/>
+
+  <xs:attributeGroup name="ol.attlist">
+    <xs:attributeGroup ref="Common.attrib"/>
+  </xs:attributeGroup>
+
+  <xs:group name="ol.content">
+    <xs:sequence>
+      <xs:element ref="li" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:group>
+
+  <xs:complexType name="ol.type">
+    <xs:group ref="ol.content"/>  
+    <xs:attributeGroup ref="ol.attlist"/>
+  </xs:complexType>
+
+  <xs:element name="ol" type="ol.type"/>
+
+  <xs:attributeGroup name="ul.attlist">
+    <xs:attributeGroup ref="Common.attrib"/>
+  </xs:attributeGroup>
+  
+  <xs:group name="ul.content">
+    <xs:sequence>
+      <xs:element ref="li" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:group>
+
+  <xs:complexType name="ul.type">
+    <xs:group ref="ul.content"/>    
+    <xs:attributeGroup ref="ul.attlist"/>
+  </xs:complexType>
+
+  <xs:element name="ul" type="ul.type"/>
+
+</xs:schema>

--- a/src/test/resources/xml/xsd/ddi-codebook-2.5/XHTML/xhtml-notations-1.xsd
+++ b/src/test/resources/xml/xsd/ddi-codebook-2.5/XHTML/xhtml-notations-1.xsd
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="http://www.w3.org/1999/xhtml"
+           xmlns="http://www.w3.org/1999/xhtml">
+
+  <xs:annotation>
+    <xs:documentation>
+      Notations module
+      This is the XML Schema module for data type notations for XHTML
+      $Id$
+    </xs:documentation>
+    <xs:documentation source="xhtml-copyright-1.xsd"/>
+  </xs:annotation>
+  
+  <xs:annotation>
+    <xs:documentation>
+      Notations module
+      Defines the XHTML notations, many of these imported from 
+      other specifications and standards. When an existing FPI is
+      known, it is incorporated here.            
+    </xs:documentation>
+    <xs:documentation
+         source="http://www.w3.org/TR/2001/REC-xhtml-modularization-20010410/abstraction.html#s_common_attrtypes"/>        
+  </xs:annotation>
+
+  <!-- W3C XML 1.0 Recommendation -->
+  <xs:notation name="w3c-xml"
+    public="ISO 8879//NOTATION Extensible Markup Language (XML) 1.0//EN"/>
+
+  <!-- XML 1.0 CDATA -->
+  <xs:notation name="cdata" public="-//W3C//NOTATION XML 1.0: CDATA//EN"/>
+  
+  <!-- SGML Formal Public Identifiers -->
+  <xs:notation name="fpi"
+    public="ISO 8879:1986//NOTATION Formal Public Identifier//EN"/>
+
+  <!-- XHTML Notations ... -->
+  <!-- Length defined for cellpadding/cellspacing -->
+  <!-- nn for pixels or nn% for percentage length -->
+  <!-- a single character, as per section 2.2 of [XML] -->
+  <xs:notation name="character"
+    public="-//W3C//NOTATION XHTML Datatype: Character//EN"/>
+
+  <!-- a character encoding, as per [RFC2045] -->
+  <xs:notation name="charset"
+    public="-//W3C//NOTATION XHTML Datatype: Charset//EN"/>
+
+  <!-- a space separated list of character encodings, as per [RFC2045] -->
+  <xs:notation name="charsets"
+    public="-//W3C//NOTATION XHTML Datatype: Charsets//EN"/>
+
+  <!-- media type, as per [RFC2045] -->
+  <xs:notation name="contentType"
+    public="-//W3C//NOTATION XHTML Datatype: ContentType//EN"/>
+
+  <!-- comma-separated list of media types, as per [RFC2045] -->
+  <xs:notation name="contentTypes"
+    public="-//W3C//NOTATION XHTML Datatype: ContentTypes//EN"/>
+
+  <!-- date and time information. ISO date format -->
+  <xs:notation name="datetime"
+    public="-//W3C//NOTATION XHTML Datatype: Datetime//EN"/>
+
+  <!-- a language code, as per [RFC3066] -->
+  <xs:notation name="languageCode"
+    public="-//W3C//NOTATION XHTML Datatype: LanguageCode//EN"/>
+
+  <!-- nn for pixels or nn% for percentage length -->
+  <xs:notation name="length"
+    public="-//W3C//NOTATION XHTML Datatype: Length//EN"/>
+
+  <!-- space-separated list of link types -->
+  <xs:notation name="linkTypes"
+    public="-//W3C//NOTATION XHTML Datatype: LinkTypes//EN"/>
+
+  <!-- single or comma-separated list of media descriptors -->
+  <xs:notation name="mediaDesc"
+    public="-//W3C//NOTATION XHTML Datatype: MediaDesc//EN"/>
+
+  <!-- pixel, percentage, or relative -->
+  <xs:notation name="multiLength"
+    public="-//W3C//NOTATION XHTML Datatype: MultiLength//EN"/>
+
+  <!-- one or more digits (NUMBER) -->
+  <xs:notation name="number"
+    public="-//W3C//NOTATION XHTML Datatype: Number//EN"/>
+
+  <!-- one or more digits (NUMBER) -->
+  <xs:notation name="pixels"
+    public="-//W3C//NOTATION XHTML Datatype: Pixels//EN"/>
+
+  <!-- script expression -->
+  <xs:notation name="script"
+    public="-//W3C//NOTATION XHTML Datatype: Script//EN"/>
+
+  <!-- textual content -->
+  <xs:notation name="text" public="-//W3C//NOTATION XHTML Datatype: Text//EN"/>
+
+  <!-- a Uniform Resource Identifier, see [URI] -->
+  <xs:notation name="uri" public="-//W3C//NOTATION XHTML Datatype: URI//EN"/>
+
+  <!-- a space-separated list of Uniform Resource Identifiers, see [URI] -->
+  <xs:notation name="uris" public="-//W3C//NOTATION XHTML Datatype: URIs//EN"/>
+
+</xs:schema>

--- a/src/test/resources/xml/xsd/ddi-codebook-2.5/XHTML/xhtml-pres-1.xsd
+++ b/src/test/resources/xml/xsd/ddi-codebook-2.5/XHTML/xhtml-pres-1.xsd
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="http://www.w3.org/1999/xhtml"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns="http://www.w3.org/1999/xhtml">
+
+  <xs:annotation>
+    <xs:documentation>
+      This is the XML Schema Presentation module for XHTML
+      This is a REQUIRED module.
+      $Id$
+    </xs:documentation>
+    <xs:documentation source="xhtml-copyright-1.xsd"/>
+  </xs:annotation>
+
+  <xs:annotation>
+    <xs:documentation>
+      Presentational Elements
+
+      This module defines elements and their attributes for
+      simple presentation-related markup.
+ 
+      Elements defined here:
+
+        * hr
+        * b, big, i, small, sub, sup, tt
+    </xs:documentation>
+    <xs:documentation 
+        source="http://www.w3.org/TR/2001/REC-xhtml-modularization-20010410/abstract_modules.html#s_presentationmodule"/>
+  </xs:annotation>
+
+ <xs:include schemaLocation="xhtml-blkpres-1.xsd">
+    <xs:annotation>
+      <xs:documentation>
+        Block Presentational module
+        Elements defined here:
+ 
+         * hr
+      </xs:documentation>
+    </xs:annotation>
+  </xs:include>
+
+  <xs:include schemaLocation="xhtml-inlpres-1.xsd">
+    <xs:annotation>
+      <xs:documentation>
+        Inline Presentational module
+        Elements defined here:
+
+          * b, big, i, small, sub, sup, tt
+    </xs:documentation>
+    </xs:annotation>
+  </xs:include>
+
+</xs:schema>

--- a/src/test/resources/xml/xsd/ddi-codebook-2.5/XHTML/xhtml-table-1.xsd
+++ b/src/test/resources/xml/xsd/ddi-codebook-2.5/XHTML/xhtml-table-1.xsd
@@ -1,0 +1,323 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="http://www.w3.org/1999/xhtml" 
+           xmlns="http://www.w3.org/1999/xhtml" 
+           xmlns:xs="http://www.w3.org/2001/XMLSchema">
+    <xs:annotation>
+        <xs:documentation>
+          This is the XML Schema Tables module for XHTML
+          $Id$
+        </xs:documentation>
+        <xs:documentation source="xhtml-copyright-1.xsd"/>
+    </xs:annotation>
+    <xs:annotation>
+        <xs:documentation>
+          Tables
+      
+           * table, caption, thead, tfoot, tbody, colgroup, col, tr, th, td
+      
+          This module declares element types and attributes used to provide
+          table markup similar to HTML 4.0, including features that enable
+          better accessibility for non-visual user agents.
+        </xs:documentation>
+        <xs:documentation 
+           source="http://www.w3.org/TR/2001/REC-xhtml-modularization-20010410/abstract_modules.html#s_tablemodule"/>
+    </xs:annotation>
+
+    <xs:attributeGroup name="frame.attrib">
+        <xs:attribute name="frame">
+            <xs:simpleType>
+                <xs:restriction base="xs:NMTOKEN">
+                    <xs:enumeration value="void"/>
+                    <xs:enumeration value="above"/>
+                    <xs:enumeration value="below"/>
+                    <xs:enumeration value="hsides"/>
+                    <xs:enumeration value="lhs"/>
+                    <xs:enumeration value="rhs"/>
+                    <xs:enumeration value="vsides"/>
+                    <xs:enumeration value="box"/>
+                    <xs:enumeration value="border"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:attributeGroup>
+    
+    <xs:attributeGroup name="rules.attrib">
+        <xs:attribute name="rules">
+            <xs:simpleType>
+                <xs:restriction base="xs:NMTOKEN">
+                    <xs:enumeration value="none"/>
+                    <xs:enumeration value="groups"/>
+                    <xs:enumeration value="rows"/>
+                    <xs:enumeration value="cols"/>
+                    <xs:enumeration value="all"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:attributeGroup>
+    
+    <xs:attributeGroup name="CellVAlign.attrib">
+        <xs:attribute name="valign">
+            <xs:simpleType>
+                <xs:restriction base="xs:NMTOKEN">
+                    <xs:enumeration value="top"/>
+                    <xs:enumeration value="middle"/>
+                    <xs:enumeration value="bottom"/>
+                    <xs:enumeration value="baseline"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:attributeGroup>
+    
+    <xs:attributeGroup name="CellHAlign.attrib">
+        <xs:attribute name="align">
+            <xs:simpleType>
+                <xs:restriction base="xs:NMTOKEN">
+                    <xs:enumeration value="left"/>
+                    <xs:enumeration value="center"/>
+                    <xs:enumeration value="right"/>
+                    <xs:enumeration value="justify"/>
+                    <xs:enumeration value="char"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="char" type="Character"/>
+        <xs:attribute name="charoff" type="Length"/>
+    </xs:attributeGroup>
+    
+    <xs:attributeGroup name="scope.attrib">
+        <xs:attribute name="scope">
+            <xs:simpleType>
+                <xs:restriction base="xs:NMTOKEN">
+                    <xs:enumeration value="row"/>
+                    <xs:enumeration value="col"/>
+                    <xs:enumeration value="rowgroup"/>
+                    <xs:enumeration value="colgroup"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:attributeGroup>
+    
+    <xs:attributeGroup name="td.attlist">
+        <xs:attributeGroup ref="Common.attrib"/>
+        <xs:attribute name="abbr" type="Text"/>
+        <xs:attribute name="axis" type="CDATA"/>
+        <xs:attribute name="headers" type="xs:IDREFS"/>
+        <xs:attributeGroup ref="scope.attrib"/>
+        <xs:attribute name="rowspan" type="Number" default="1"/>
+        <xs:attribute name="colspan" type="Number" default="1"/>
+        <xs:attributeGroup ref="CellHAlign.attrib"/>
+        <xs:attributeGroup ref="CellVAlign.attrib"/>
+    </xs:attributeGroup>
+    
+    <xs:group name="td.content">
+       <xs:sequence>
+          <xs:group ref="Flow.mix" minOccurs="0" maxOccurs="unbounded"/>
+       </xs:sequence>
+    </xs:group>    
+    
+    <xs:complexType name="td.type" mixed="true">
+        <xs:group ref="td.content"/>
+        <xs:attributeGroup ref="td.attlist"/>
+    </xs:complexType>
+    
+    <xs:element name="td" type="td.type"/>
+    
+    <xs:attributeGroup name="th.attlist">
+        <xs:attributeGroup ref="Common.attrib"/>
+        <xs:attribute name="abbr" type="Text"/>
+        <xs:attribute name="axis" type="CDATA"/>
+        <xs:attribute name="headers" type="xs:IDREFS"/>
+        <xs:attributeGroup ref="scope.attrib"/>
+        <xs:attribute name="rowspan" type="Number" default="1"/>
+        <xs:attribute name="colspan" type="Number" default="1"/>
+        <xs:attributeGroup ref="CellHAlign.attrib"/>
+        <xs:attributeGroup ref="CellVAlign.attrib"/>
+    </xs:attributeGroup>
+    
+    <xs:group name="th.content">
+       <xs:sequence>
+          <xs:group ref="Flow.mix" minOccurs="0" maxOccurs="unbounded"/>
+       </xs:sequence>
+    </xs:group>     
+    
+    <xs:complexType name="th.type" mixed="true">
+        <xs:group ref="th.content"/>
+        <xs:attributeGroup ref="th.attlist"/>
+    </xs:complexType>
+    
+    <xs:element name="th" type="th.type"/>
+    
+    <xs:attributeGroup name="tr.attlist">
+        <xs:attributeGroup ref="Common.attrib"/>
+        <xs:attributeGroup ref="CellHAlign.attrib"/>
+        <xs:attributeGroup ref="CellVAlign.attrib"/>
+    </xs:attributeGroup>
+    
+    <xs:group name="tr.content">
+      <xs:sequence>
+        <xs:choice maxOccurs="unbounded">
+            <xs:element ref="th"/>
+            <xs:element ref="td"/>
+        </xs:choice>
+      </xs:sequence>
+    </xs:group>
+    
+    <xs:complexType name="tr.type">
+        <xs:group ref="tr.content"/>
+        <xs:attributeGroup ref="tr.attlist"/>
+    </xs:complexType>
+    
+    <xs:element name="tr" type="tr.type"/>
+    
+    <xs:attributeGroup name="col.attlist">
+        <xs:attributeGroup ref="Common.attrib"/>
+        <xs:attribute name="span" type="Number" default="1"/>
+        <xs:attribute name="width" type="MultiLength"/>
+        <xs:attributeGroup ref="CellHAlign.attrib"/>
+        <xs:attributeGroup ref="CellVAlign.attrib"/>
+    </xs:attributeGroup>
+
+    <xs:group name="col.content">
+       <xs:sequence/>
+    </xs:group>             
+    
+    <xs:complexType name="col.type">
+        <xs:group ref="col.content"/>    
+        <xs:attributeGroup ref="col.attlist"/>
+    </xs:complexType>
+    
+    <xs:element name="col" type="col.type"/>
+    
+    <xs:attributeGroup name="colgroup.attlist">
+        <xs:attributeGroup ref="Common.attrib"/>
+        <xs:attribute name="span" type="Number" default="1"/>
+        <xs:attribute name="width" type="MultiLength"/>
+        <xs:attributeGroup ref="CellHAlign.attrib"/>
+        <xs:attributeGroup ref="CellVAlign.attrib"/>
+    </xs:attributeGroup>
+    
+    <xs:group name="colgroup.content">
+        <xs:sequence>
+            <xs:element ref="col" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:group>
+    <xs:complexType name="colgroup.type">
+        <xs:group ref="colgroup.content"/>
+        <xs:attributeGroup ref="colgroup.attlist"/>
+    </xs:complexType>
+    
+    <xs:element name="colgroup" type="colgroup.type"/>
+    
+    <xs:attributeGroup name="tbody.attlist">
+        <xs:attributeGroup ref="Common.attrib"/>
+        <xs:attributeGroup ref="CellHAlign.attrib"/>
+        <xs:attributeGroup ref="CellVAlign.attrib"/>
+    </xs:attributeGroup>
+    
+    <xs:group name="tbody.content">
+        <xs:sequence>
+            <xs:element ref="tr" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:group>
+    
+    <xs:complexType name="tbody.type">
+        <xs:group ref="tbody.content"/>
+        <xs:attributeGroup ref="tbody.attlist"/>
+    </xs:complexType>
+    
+    <xs:element name="tbody" type="tbody.type"/>
+    
+    <xs:attributeGroup name="tfoot.attlist">
+        <xs:attributeGroup ref="Common.attrib"/>
+        <xs:attributeGroup ref="CellHAlign.attrib"/>
+        <xs:attributeGroup ref="CellVAlign.attrib"/>
+    </xs:attributeGroup>
+    
+    <xs:group name="tfoot.content">
+        <xs:sequence>
+            <xs:element ref="tr" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:group>
+    
+    <xs:complexType name="tfoot.type">
+        <xs:group ref="tfoot.content"/>
+        <xs:attributeGroup ref="tfoot.attlist"/>
+    </xs:complexType>
+    
+    <xs:element name="tfoot" type="tfoot.type"/>
+    
+    <xs:attributeGroup name="thead.attlist">
+        <xs:attributeGroup ref="Common.attrib"/>
+        <xs:attributeGroup ref="CellHAlign.attrib"/>
+        <xs:attributeGroup ref="CellVAlign.attrib"/>
+    </xs:attributeGroup>
+    
+    <xs:group name="thead.content">
+        <xs:sequence>
+            <xs:element ref="tr" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:group>
+    
+    <xs:complexType name="thead.type">
+        <xs:group ref="thead.content"/>
+        <xs:attributeGroup ref="thead.attlist"/>
+    </xs:complexType>
+    
+    <xs:element name="thead" type="thead.type"/>
+    
+    <xs:attributeGroup name="caption.attlist">
+        <xs:attributeGroup ref="Common.attrib"/>
+    </xs:attributeGroup>
+    
+    <xs:group name="caption.content">
+       <xs:sequence>
+         <xs:group ref="Inline.mix" minOccurs="0" maxOccurs="unbounded"/>
+       </xs:sequence>       
+    </xs:group>    
+
+    <xs:complexType name="caption.type" mixed="true">
+        <xs:group ref="caption.content"/>
+        <xs:attributeGroup ref="caption.attlist"/>
+    </xs:complexType>
+    
+    <xs:element name="caption" type="caption.type"/>
+    
+    <xs:attributeGroup name="table.attlist">
+        <xs:attributeGroup ref="Common.attrib"/>
+        <xs:attribute name="summary" type="Text"/>
+        <xs:attribute name="width" type="Length"/>
+        <xs:attribute name="border" type="Pixels"/>
+        <xs:attributeGroup ref="frame.attrib"/>
+        <xs:attributeGroup ref="rules.attrib"/>
+        <xs:attribute name="cellspacing" type="Length"/>
+        <xs:attribute name="cellpadding" type="Length"/>
+    </xs:attributeGroup>
+    
+    <xs:group name="table.content">
+        <xs:sequence>
+            <xs:element ref="caption" minOccurs="0"/>
+            <xs:choice>
+                <xs:element ref="col" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element ref="colgroup" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:choice>
+            <xs:choice>
+                <xs:sequence>
+                    <xs:element ref="thead" minOccurs="0"/>
+                    <xs:element ref="tfoot" minOccurs="0"/>
+                    <xs:element ref="tbody" maxOccurs="unbounded"/>
+                </xs:sequence>
+                <xs:choice>
+                    <xs:element ref="tr" maxOccurs="unbounded"/>
+                </xs:choice>
+            </xs:choice>
+        </xs:sequence>
+    </xs:group>
+    
+    <xs:complexType name="table.type">
+        <xs:group ref="table.content"/>
+        <xs:attributeGroup ref="table.attlist"/>
+    </xs:complexType>
+    
+    <xs:element name="table" type="table.type"/>
+
+</xs:schema>

--- a/src/test/resources/xml/xsd/ddi-codebook-2.5/XHTML/xhtml-text-1.xsd
+++ b/src/test/resources/xml/xsd/ddi-codebook-2.5/XHTML/xhtml-text-1.xsd
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="http://www.w3.org/1999/xhtml"
+           xmlns="http://www.w3.org/1999/xhtml">
+
+  <xs:annotation>
+    <xs:documentation>
+      Textual Content
+      This is the XML Schema Text module for XHTML
+
+      The Text module includes declarations for all core
+      text container elements and their attributes.
+    
+        +  block phrasal
+        +  block structural
+        +  inline phrasal
+        +  inline structural
+      
+      $Id$
+    </xs:documentation>
+    <xs:documentation source="xhtml-copyright-1.xsd"/>
+    <xs:documentation 
+        source="http://www.w3.org/TR/2001/REC-xhtml-modularization-20010410/abstract_modules.html#s_textmodule"/>          
+  </xs:annotation>
+
+  <xs:include schemaLocation="xhtml-blkphras-1.xsd">
+    <xs:annotation>
+      <xs:documentation>
+        Block Phrasal module
+        Elements defined here:
+
+          * address, blockquote, pre, h1, h2, h3, h4, h5, h6
+    </xs:documentation>
+    </xs:annotation>
+  </xs:include>
+
+  <xs:include schemaLocation="xhtml-blkstruct-1.xsd">
+    <xs:annotation>
+      <xs:documentation>
+        Block Structural module 
+        Elements defined here:
+
+          * div, p
+    </xs:documentation>
+    </xs:annotation>
+  </xs:include>
+
+  <xs:include schemaLocation="xhtml-inlphras-1.xsd">
+    <xs:annotation>
+      <xs:documentation>
+        Inline Phrasal module
+        Elements defined here:
+
+          * abbr, acronym, cite, code, dfn, em, kbd, q, samp, strong, var
+    </xs:documentation>
+    </xs:annotation>
+  </xs:include>
+
+  <xs:include schemaLocation="xhtml-inlstruct-1.xsd">
+    <xs:annotation>
+      <xs:documentation>
+        Inline Structural module 
+        Elements defined here:
+
+          * br,span
+    </xs:documentation>
+    </xs:annotation>
+  </xs:include>
+
+</xs:schema>

--- a/src/test/resources/xml/xsd/ddi-codebook-2.5/dc.xsd
+++ b/src/test/resources/xml/xsd/ddi-codebook-2.5/dc.xsd
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://purl.org/dc/elements/1.1/" targetNamespace="http://purl.org/dc/elements/1.1/" elementFormDefault="qualified" attributeFormDefault="unqualified">
+
+  <xs:annotation>
+    <xs:documentation xml:lang="en">
+      DCMES 1.1 XML Schema
+      XML Schema for http://purl.org/dc/elements/1.1/ namespace
+
+      Created 2003-04-02
+
+      Created by 
+
+      Tim Cole (t-cole3@uiuc.edu)
+      Tom Habing (thabing@uiuc.edu)
+      Jane Hunter (jane@dstc.edu.au)
+      Pete Johnston (p.johnston@ukoln.ac.uk),
+      Carl Lagoze (lagoze@cs.cornell.edu)
+
+      This schema declares XML elements for the 15 DC elements from the
+      http://purl.org/dc/elements/1.1/ namespace.
+
+      It defines a complexType SimpleLiteral which permits mixed content 
+      and makes the xml:lang attribute available. It disallows child elements by
+      use of minOcccurs/maxOccurs.
+
+      However, this complexType does permit the derivation of other complexTypes
+      which would permit child elements.
+
+      All elements are declared as substitutable for the abstract element any, 
+      which means that the default type for all elements is dc:SimpleLiteral.
+
+    </xs:documentation>
+
+  </xs:annotation>
+
+
+  <xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="xml.xsd">
+  </xs:import>
+
+  <xs:complexType name="SimpleLiteral" mixed="true">
+        <xs:annotation>
+        <xs:documentation xml:lang="en">
+            This is the default type for all of the DC elements.
+            It permits text content only with optional
+            xml:lang attribute.
+            Text is allowed because mixed="true", but sub-elements
+            are disallowed because minOccurs="0" and maxOccurs="0" 
+            are on the xs:any tag.
+
+    	    This complexType allows for restriction or extension permitting
+            child elements.
+    	</xs:documentation>
+		<xs:documentation xml:lang="en">This structure has been altered from 
+			its original declaration of:
+			<xs:complexType name="SimpleLiteral">
+				<xs:complexContent mixed="true">
+					<xs:restriction base="xs:anyType">
+						<xs:sequence>
+							<xs:any processContents="lax" minOccurs="0" maxOccurs="0"/>
+						</xs:sequence>
+						<xs:attribute ref="xml:lang" use="optional"/>
+					</xs:restriction>
+				</xs:complexContent>
+			</xs:complexType>		
+			Such a restriction from the xs:anyType is unnecessary, as this is 
+			implicit in all types. Further, the xs:any element with a minOccurs="0" 
+			causes issues with Apache Xml Beans. This declaration allows for an 
+			equivalent content model while still allowing extensions from this type
+			to declare elements to allow for true mixed content.
+		</xs:documentation>
+  	</xs:annotation>
+     <xs:attribute ref="xml:lang" use="optional"/>
+  </xs:complexType>
+
+  <xs:element name="any" type="SimpleLiteral" abstract="true"/>
+
+  <xs:element name="title" substitutionGroup="any"/>
+  <xs:element name="creator" substitutionGroup="any"/>
+  <xs:element name="subject" substitutionGroup="any"/>
+  <xs:element name="description" substitutionGroup="any"/>
+  <xs:element name="publisher" substitutionGroup="any"/>
+  <xs:element name="contributor" substitutionGroup="any"/>
+  <xs:element name="date" substitutionGroup="any"/>
+  <xs:element name="type" substitutionGroup="any"/>
+  <xs:element name="format" substitutionGroup="any"/>
+  <xs:element name="identifier" substitutionGroup="any"/>
+  <xs:element name="source" substitutionGroup="any"/>
+  <xs:element name="language" substitutionGroup="any"/>
+  <xs:element name="relation" substitutionGroup="any"/>
+  <xs:element name="coverage" substitutionGroup="any"/>
+  <xs:element name="rights" substitutionGroup="any"/>
+
+  <xs:group name="elementsGroup">
+  	<xs:annotation>
+    	<xs:documentation xml:lang="en">
+    	    This group is included as a convenience for schema authors
+            who need to refer to all the elements in the 
+            http://purl.org/dc/elements/1.1/ namespace.
+    	</xs:documentation>
+  	</xs:annotation>
+
+  <xs:sequence>
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
+      <xs:element ref="any"/>
+    </xs:choice>
+    </xs:sequence>
+  </xs:group>
+
+  <xs:complexType name="elementContainer">
+  	<xs:annotation>
+    	<xs:documentation xml:lang="en">
+    		This complexType is included as a convenience for schema authors who need to define a root
+    		or container element for all of the DC elements.
+    	</xs:documentation>
+  	</xs:annotation>
+
+    <xs:choice>
+      <xs:group ref="elementsGroup"/>
+    </xs:choice>
+  </xs:complexType>
+
+
+</xs:schema>

--- a/src/test/resources/xml/xsd/ddi-codebook-2.5/dcmitype.xsd
+++ b/src/test/resources/xml/xsd/ddi-codebook-2.5/dcmitype.xsd
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://purl.org/dc/dcmitype/" targetNamespace="http://purl.org/dc/dcmitype/" elementFormDefault="qualified" attributeFormDefault="unqualified">
+
+  <xs:annotation>
+    <xs:documentation xml:lang="en">
+      DCMI Type Vocabulary XML Schema
+      XML Schema for http://purl.org/dc/dcmitype/ namespace
+
+      Created 2003-04-02
+
+      Created by 
+
+      Tim Cole (t-cole3@uiuc.edu)
+      Tom Habing (thabing@uiuc.edu)
+      Jane Hunter (jane@dstc.edu.au)
+      Pete Johnston (p.johnston@ukoln.ac.uk),
+      Carl Lagoze (lagoze@cs.cornell.edu)
+
+      This schema defines a simpleType which enumerates
+      the allowable values for the DCMI Type Vocabulary.
+    </xs:documentation>
+
+ 
+  </xs:annotation>
+
+
+  <xs:simpleType name="DCMIType">
+     <xs:union>
+        <xs:simpleType>
+           <xs:restriction base="xs:Name">
+		<xs:enumeration value="Collection"/>
+		<xs:enumeration value="Dataset"/>
+		<xs:enumeration value="Event"/>
+		<xs:enumeration value="Image"/>
+		<xs:enumeration value="InteractiveResource"/>
+		<xs:enumeration value="Service"/>
+		<xs:enumeration value="Software"/>
+		<xs:enumeration value="Sound"/>
+		<xs:enumeration value="Text"/>
+		<xs:enumeration value="PhysicalObject"/>
+            </xs:restriction>
+        </xs:simpleType> 
+     </xs:union>
+  </xs:simpleType>
+
+</xs:schema>

--- a/src/test/resources/xml/xsd/ddi-codebook-2.5/dcterms.xsd
+++ b/src/test/resources/xml/xsd/ddi-codebook-2.5/dcterms.xsd
@@ -1,0 +1,322 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcmitype="http://purl.org/dc/dcmitype/" targetNamespace="http://purl.org/dc/terms/" xmlns="http://purl.org/dc/terms/" elementFormDefault="qualified" attributeFormDefault="unqualified">
+
+  <xs:annotation>
+    <xs:documentation xml:lang="en">
+      DCterms XML Schema
+      XML Schema for http://purl.org/dc/terms/ namespace
+
+      Created 2003-04-02
+
+      Created by 
+
+      Tim Cole (t-cole3@uiuc.edu)
+      Tom Habing (thabing@uiuc.edu)
+      Jane Hunter (jane@dstc.edu.au)
+      Pete Johnston (p.johnston@ukoln.ac.uk),
+      Carl Lagoze (lagoze@cs.cornell.edu)
+
+      This schema declares XML elements for the DC elements and
+      DC element refinements from the http://purl.org/dc/terms/ namespace.
+      
+      It reuses the complexType dc:SimpleLiteral, imported from the dc.xsd
+      schema, which permits simple element content, and makes the xml:lang
+      attribute available.
+
+      This complexType permits the derivation of other complexTypes
+      which would permit child elements.
+
+      DC elements are declared as substitutable for the abstract element dc:any, and 
+      DC element refinements are defined as substitutable for the base elements 
+      which they refine.
+
+      This means that the default type for all XML elements (i.e. all DC elements and 
+      element refinements) is dc:SimpleLiteral.
+
+      Encoding schemes are defined as complexTypes which are restrictions
+      of the dc:SimpleLiteral complexType. These complexTypes restrict 
+      values to an appropriates syntax or format using data typing,
+      regular expressions, or enumerated lists.
+  
+      In order to specify one of these encodings an xsi:type attribute must 
+      be used in the instance document.
+
+      Also, note that one shortcoming of this approach is that any type can be 
+      applied to any of the elements or refinements.  There is no convenient way
+      to restrict types to specific elements using this approach.
+
+    </xs:documentation>
+
+  </xs:annotation>
+
+
+  <xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="xml.xsd">
+  </xs:import>
+
+   <xs:import namespace="http://purl.org/dc/elements/1.1/" schemaLocation="dc.xsd"/>
+
+   <xs:import namespace="http://purl.org/dc/dcmitype/" schemaLocation="dcmitype.xsd"/>
+
+   <xs:element name="alternative" substitutionGroup="dc:title"/>
+
+   <xs:element name="tableOfContents" substitutionGroup="dc:description"/>
+   <xs:element name="abstract" substitutionGroup="dc:description"/>
+
+   <xs:element name="created" substitutionGroup="dc:date"/>
+   <xs:element name="valid" substitutionGroup="dc:date"/>
+   <xs:element name="available" substitutionGroup="dc:date"/>
+   <xs:element name="issued" substitutionGroup="dc:date"/>
+   <xs:element name="modified" substitutionGroup="dc:date"/>
+   <xs:element name="dateAccepted" substitutionGroup="dc:date"/>
+   <xs:element name="dateCopyrighted" substitutionGroup="dc:date"/>
+   <xs:element name="dateSubmitted" substitutionGroup="dc:date"/>
+
+   <xs:element name="extent" substitutionGroup="dc:format"/>
+   <xs:element name="medium" substitutionGroup="dc:format"/>
+
+   <xs:element name="isVersionOf" substitutionGroup="dc:relation"/>
+   <xs:element name="hasVersion" substitutionGroup="dc:relation"/>
+   <xs:element name="isReplacedBy" substitutionGroup="dc:relation"/>
+   <xs:element name="replaces" substitutionGroup="dc:relation"/>
+   <xs:element name="isRequiredBy" substitutionGroup="dc:relation"/>
+   <xs:element name="requires" substitutionGroup="dc:relation"/>
+   <xs:element name="isPartOf" substitutionGroup="dc:relation"/>
+   <xs:element name="hasPart" substitutionGroup="dc:relation"/>
+   <xs:element name="isReferencedBy" substitutionGroup="dc:relation"/>
+   <xs:element name="references" substitutionGroup="dc:relation"/>
+   <xs:element name="isFormatOf" substitutionGroup="dc:relation"/>
+   <xs:element name="hasFormat" substitutionGroup="dc:relation"/>
+   <xs:element name="conformsTo" substitutionGroup="dc:relation"/>
+
+   <xs:element name="spatial" substitutionGroup="dc:coverage"/>
+   <xs:element name="temporal" substitutionGroup="dc:coverage"/>
+
+   <xs:element name="audience" substitutionGroup="dc:any"/>
+
+   <xs:element name="mediator" substitutionGroup="audience"/>
+   <xs:element name="educationLevel" substitutionGroup="audience"/>
+
+   <xs:element name="accessRights" substitutionGroup="dc:rights"/>
+
+   <xs:element name="bibliographicCitation" substitutionGroup="dc:identifier"/>
+
+  <xs:complexType name="LCSH">
+   <xs:simpleContent>
+    <xs:restriction base="dc:SimpleLiteral">
+        <xs:simpleType>
+          <xs:restriction base="xs:string"/>
+        </xs:simpleType>
+        <xs:attribute ref="xml:lang" use="prohibited"/>
+    </xs:restriction>
+   </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:complexType name="MESH">
+   <xs:simpleContent>
+    <xs:restriction base="dc:SimpleLiteral">
+        <xs:simpleType>
+          <xs:restriction base="xs:string"/>
+        </xs:simpleType>
+        <xs:attribute ref="xml:lang" use="prohibited"/>
+    </xs:restriction>
+   </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:complexType name="DDC">
+   <xs:simpleContent>
+    <xs:restriction base="dc:SimpleLiteral">
+        <xs:simpleType>
+          <xs:restriction base="xs:string"/>
+        </xs:simpleType>
+        <xs:attribute ref="xml:lang" use="prohibited"/>
+    </xs:restriction>
+   </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:complexType name="LCC">
+   <xs:simpleContent>
+    <xs:restriction base="dc:SimpleLiteral">
+        <xs:simpleType>
+          <xs:restriction base="xs:string"/>
+        </xs:simpleType>
+        <xs:attribute ref="xml:lang" use="prohibited"/>
+    </xs:restriction>
+   </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:complexType name="UDC">
+   <xs:simpleContent>
+    <xs:restriction base="dc:SimpleLiteral">
+        <xs:simpleType>
+          <xs:restriction base="xs:string"/>
+        </xs:simpleType>
+        <xs:attribute ref="xml:lang" use="prohibited"/>
+    </xs:restriction>
+   </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:complexType name="Period">
+   <xs:simpleContent>
+    <xs:restriction base="dc:SimpleLiteral">
+        <xs:simpleType>
+          <xs:restriction base="xs:string"/>
+        </xs:simpleType>
+        <xs:attribute ref="xml:lang" use="prohibited"/>
+    </xs:restriction>
+   </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:complexType name="W3CDTF">
+   <xs:simpleContent>
+    <xs:restriction base="dc:SimpleLiteral">
+        <xs:simpleType>
+           <xs:union memberTypes="xs:gYear xs:gYearMonth xs:date xs:dateTime"/>
+        </xs:simpleType>
+        <xs:attribute ref="xml:lang" use="prohibited"/>
+    </xs:restriction>
+   </xs:simpleContent>
+  </xs:complexType> 
+
+  <xs:complexType name="DCMIType">
+   <xs:simpleContent>
+    <xs:restriction base="dc:SimpleLiteral">
+        <xs:simpleType>
+          <xs:restriction base="dcmitype:DCMIType"/>
+        </xs:simpleType>
+        <xs:attribute ref="xml:lang" use="prohibited"/>
+    </xs:restriction>
+   </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:complexType name="IMT">
+   <xs:simpleContent>
+    <xs:restriction base="dc:SimpleLiteral">
+        <xs:simpleType>
+          <xs:restriction base="xs:string"/>
+        </xs:simpleType>
+        <xs:attribute ref="xml:lang" use="prohibited"/>
+    </xs:restriction>
+   </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:complexType name="URI">
+   <xs:simpleContent>
+    <xs:restriction base="dc:SimpleLiteral">
+        <xs:simpleType>
+          <xs:restriction base="xs:anyURI"/>
+        </xs:simpleType>
+        <xs:attribute ref="xml:lang" use="prohibited"/>
+    </xs:restriction>
+   </xs:simpleContent>
+  </xs:complexType> 
+
+  <xs:complexType name="ISO639-2">
+   <xs:simpleContent>
+    <xs:restriction base="dc:SimpleLiteral">
+        <xs:simpleType>
+          <xs:restriction base="xs:string"/>
+        </xs:simpleType>
+        <xs:attribute ref="xml:lang" use="prohibited"/>
+    </xs:restriction>
+   </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:complexType name="RFC1766">
+   <xs:simpleContent>
+    <xs:restriction base="dc:SimpleLiteral">
+        <xs:simpleType>
+          <xs:restriction base="xs:language"/>
+        </xs:simpleType>
+        <xs:attribute ref="xml:lang" use="prohibited"/>
+    </xs:restriction>
+   </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:complexType name="RFC3066">
+   <xs:simpleContent>
+    <xs:restriction base="dc:SimpleLiteral">
+        <xs:simpleType>
+          <xs:restriction base="xs:language"/>
+        </xs:simpleType>
+        <xs:attribute ref="xml:lang" use="prohibited"/>
+    </xs:restriction>
+   </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:complexType name="Point">
+   <xs:simpleContent>
+    <xs:restriction base="dc:SimpleLiteral">
+        <xs:simpleType>
+          <xs:restriction base="xs:string"/>
+        </xs:simpleType>
+        <xs:attribute ref="xml:lang" use="prohibited"/>
+    </xs:restriction>
+   </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:complexType name="ISO3166">
+   <xs:simpleContent>
+    <xs:restriction base="dc:SimpleLiteral">
+        <xs:simpleType>
+          <xs:restriction base="xs:string"/>
+        </xs:simpleType>
+        <xs:attribute ref="xml:lang" use="prohibited"/>
+    </xs:restriction>
+   </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:complexType name="Box">
+   <xs:simpleContent>
+    <xs:restriction base="dc:SimpleLiteral">
+        <xs:simpleType>
+          <xs:restriction base="xs:string"/>
+        </xs:simpleType>
+        <xs:attribute ref="xml:lang" use="prohibited"/>
+    </xs:restriction>
+   </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:complexType name="TGN">
+   <xs:simpleContent>
+    <xs:restriction base="dc:SimpleLiteral">
+        <xs:simpleType>
+          <xs:restriction base="xs:string"/>
+        </xs:simpleType>
+        <xs:attribute ref="xml:lang" use="prohibited"/>
+    </xs:restriction>
+   </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:group name="elementsAndRefinementsGroup">
+  	<xs:annotation>
+    	<xs:documentation xml:lang="en">
+    		This group is included as a convenience for schema authors
+            who need to refer to all the DC elements and element refinements 
+            in the http://purl.org/dc/elements/1.1/ and 
+            http://purl.org/dc/terms namespaces. 
+            N.B. Refinements available via substitution groups.
+    	</xs:documentation>
+  	</xs:annotation>
+
+  <xs:sequence>
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
+	<xs:element ref="dc:any"/>
+    </xs:choice>
+  </xs:sequence>
+  </xs:group>	
+
+  <xs:complexType name="elementOrRefinementContainer">
+  	<xs:annotation>
+    	<xs:documentation xml:lang="en">
+    		This is included as a convenience for schema authors who need to define a root
+    		or container element for all of the DC elements and element refinements.
+    	</xs:documentation>
+  	</xs:annotation>
+
+    <xs:choice>
+      <xs:group ref="elementsAndRefinementsGroup"/>
+    </xs:choice>
+  </xs:complexType>
+
+
+</xs:schema>

--- a/src/test/resources/xml/xsd/ddi-codebook-2.5/ddi-xhtml11-model-1.xsd
+++ b/src/test/resources/xml/xsd/ddi-codebook-2.5/ddi-xhtml11-model-1.xsd
@@ -1,0 +1,490 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+Copyright (c) 2009 DDI Alliance, DDI 3.1, 2009-10-18
+
+This file is part of DDI 3.1 XML Schema.
+
+DDI 3.1 XML Schema is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by the
+Free Software Foundation, either version 3 of the License, or (at your
+option) any later version.
+
+DDI 3.1 XML Schema is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
+for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with DDI 3.1 XML Schema. If not, see <http://www.gnu.org/licenses/>.
+
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.w3.org/1999/xhtml" xmlns="http://www.w3.org/1999/xhtml">
+
+  <xs:annotation>
+    <xs:documentation>
+      This is the XML Schema module of common content models for XHTML11
+      $Id: ddi-xhtml11-model-1.xsd,v 1.1 2007/02/08 16:03:11 jgager Exp $
+    </xs:documentation>
+    <xs:documentation source="XHTML/xhtml-copyright-1.xsd"/>
+  </xs:annotation>
+
+  <xs:annotation>
+    <xs:documentation>
+      XHTML Document Model
+
+      This module describes the groupings of elements/attributes that make up
+      common content models for XHTML elements.
+
+      XHTML has following basic content models:
+
+          Inline.mix;          character-level elements
+          Block.mix;           block-like elements, eg., paragraphs and lists
+          Flow.mix;            any block or inline elements
+          HeadOpts.mix;        Head Elements
+          InlinePre.mix;     Special class for pre content model
+          InlineNoAnchor.mix;  Content model for Anchor
+
+      Any groups declared in this module may be used
+      to create element content models, but the above are
+      considered 'global' (insofar as that term applies here).
+
+      XHTML has the following Attribute Groups
+           Core.extra.attrib
+           I18n.extra.attrib
+           Common.extra
+
+      The above attribute Groups are considered Global
+
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:attributeGroup name="I18n.extra.attrib">
+    <xs:annotation>
+        <xs:documentation>
+           Extended I18n attribute
+        </xs:documentation>
+    </xs:annotation>
+    <xs:attributeGroup ref="dir.attrib">
+        <xs:annotation>
+          <xs:documentation>
+            "dir" Attribute from Bi Directional Text (bdo) Module
+          </xs:documentation>
+        </xs:annotation>
+    </xs:attributeGroup>
+  </xs:attributeGroup>
+
+  <xs:attributeGroup name="Common.extra">
+    <xs:annotation>
+       <xs:documentation>
+           Extended Common Attributes
+       </xs:documentation>
+    </xs:annotation>
+    <xs:attributeGroup ref="style.attrib">
+       <xs:annotation>
+         <xs:documentation>
+           "style" attribute from Inline Style Module
+         </xs:documentation>
+       </xs:annotation>
+     </xs:attributeGroup>
+  </xs:attributeGroup>
+
+  <xs:attributeGroup name="Core.extra.attrib">
+      <xs:annotation>
+        <xs:documentation>
+           Extend Core Attributes
+        </xs:documentation>
+      </xs:annotation>
+  </xs:attributeGroup>
+
+  <xs:attributeGroup name="Global.core.extra.attrib">
+      <xs:annotation>
+        <xs:documentation>
+           Extended Global Core Attributes
+        </xs:documentation>
+      </xs:annotation>
+  </xs:attributeGroup>
+
+  <xs:attributeGroup name="Global.I18n.extra.attrib">
+      <xs:annotation>
+        <xs:documentation>
+           Extended Global I18n attributes
+        </xs:documentation>
+      </xs:annotation>
+  </xs:attributeGroup>
+
+   <xs:attributeGroup name="Global.Common.extra">
+      <xs:annotation>
+        <xs:documentation>
+           Extended Global Common Attributes
+        </xs:documentation>
+      </xs:annotation>
+   </xs:attributeGroup>
+<!--
+  <xs:group name="HeadOpts.mix">
+    <xs:choice>
+      <xs:element ref="script"/>
+      <xs:element ref="style"/>
+      <xs:element ref="meta"/>
+      <xs:element ref="link"/>
+      <xs:element ref="object"/>
+    </xs:choice>
+  </xs:group>
+-->
+  <!--
+   ins and del are used to denote editing changes
+  -->
+<!--
+  <xs:group name="Edit.class">
+    <xs:choice>
+      <xs:element ref="ins"/>
+      <xs:element ref="del"/>
+    </xs:choice>
+  </xs:group>
+-->
+  <!--
+   script and noscript are used to contain scripts
+   and alternative content
+  -->
+<!--
+  <xs:group name="Script.class">
+    <xs:choice>
+      <xs:element ref="script"/>
+      <xs:element ref="noscript"/>
+    </xs:choice>
+  </xs:group>
+-->
+  <xs:group name="Misc.extra">
+    <xs:choice/>
+  </xs:group>
+
+  <!--
+   These elements are neither block nor inline, and can
+   essentially be used anywhere in the document body.
+  -->
+  <xs:group name="Misc.class">
+    <xs:choice/>
+<!--      <xs:group ref="Edit.class"/>
+      <xs:group ref="Script.class"/>
+      <xs:group ref="Misc.extra"/>
+    </xs:choice>
+ -->
+  </xs:group>
+
+  <!-- Inline Elements -->
+  <xs:group name="InlStruct.class">
+    <xs:choice>
+      <xs:element ref="br"/>
+      <xs:element ref="span"/>
+    </xs:choice>
+  </xs:group>
+
+  <xs:group name="InlPhras.class">
+    <xs:choice>
+      <xs:element ref="em"/>
+      <xs:element ref="strong"/>
+      <xs:element ref="dfn"/>
+      <xs:element ref="code"/>
+      <xs:element ref="samp"/>
+      <xs:element ref="kbd"/>
+      <xs:element ref="var"/>
+      <xs:element ref="cite"/>
+      <xs:element ref="abbr"/>
+      <xs:element ref="acronym"/>
+      <xs:element ref="q"/>
+    </xs:choice>
+  </xs:group>
+
+  <xs:group name="InlPres.class">
+    <xs:choice>
+      <xs:element ref="tt"/>
+      <xs:element ref="i"/>
+      <xs:element ref="b"/>
+      <xs:element ref="big"/>
+      <xs:element ref="small"/>
+      <xs:element ref="sub"/>
+      <xs:element ref="sup"/>
+    </xs:choice>
+  </xs:group>
+
+  <xs:group name="I18n.class">
+    <xs:sequence>
+      <xs:element ref="bdo"/>
+    </xs:sequence>
+  </xs:group>
+
+  <xs:group name="Anchor.class">
+    <xs:sequence>
+      <xs:element ref="a"/>
+    </xs:sequence>
+  </xs:group>
+<!--
+  <xs:group name="InlSpecial.class">
+    <xs:choice>
+      <xs:element ref="img"/>
+      <xs:element ref="map"/>
+      <xs:element ref="object"/>
+    </xs:choice>
+  </xs:group>
+
+  <xs:group name="InlForm.class">
+    <xs:choice>
+      <xs:element ref="input"/>
+      <xs:element ref="select"/>
+      <xs:element ref="textarea"/>
+      <xs:element ref="label"/>
+      <xs:element ref="button"/>
+    </xs:choice>
+  </xs:group>
+
+  <xs:group name="Inline.extra">
+    <xs:choice/>
+  </xs:group>
+
+  <xs:group name="Ruby.class">
+    <xs:sequence>
+      <xs:element ref="ruby"/>
+    </xs:sequence>
+  </xs:group>
+-->
+  <!--
+   Inline.class includes all inline elements,
+   used as a component in mixes
+  -->
+
+  <xs:group name="Inline.class">
+    <xs:choice>
+      <xs:group ref="InlStruct.class"/>
+      <xs:group ref="InlPhras.class"/>
+      <xs:group ref="InlPres.class"/>
+      <xs:group ref="I18n.class"/>
+      <xs:group ref="Anchor.class"/>
+<!--      <xs:group ref="InlSpecial.class"/>
+      <xs:group ref="InlForm.class"/>
+      <xs:group ref="Ruby.class"/>
+      <xs:group ref="Inline.extra"/> -->
+    </xs:choice>
+  </xs:group>
+
+  <!--
+     InlNoRuby.class includes all inline elements
+     except ruby
+  -->
+  <xs:group name="InlNoRuby.class">
+    <xs:choice>
+      <xs:group ref="InlStruct.class"/>
+      <xs:group ref="InlPhras.class"/>
+      <xs:group ref="InlPres.class"/>
+      <xs:group ref="I18n.class"/>
+      <xs:group ref="Anchor.class"/>
+<!--      <xs:group ref="InlSpecial.class"/> -->
+<!--      <xs:group ref="InlForm.class"/> -->
+<!--      <xs:group ref="Inline.extra"/> -->
+    </xs:choice>
+  </xs:group>
+
+
+  <!--
+    InlinePre.mix
+    Used as a component in pre model
+  -->
+  <xs:group name="InlinePre.mix">
+    <xs:choice>
+      <xs:group ref="InlStruct.class"/>
+      <xs:group ref="InlPhras.class"/>
+      <xs:element ref="tt"/>
+      <xs:element ref="i"/>
+      <xs:element ref="b"/>
+      <xs:group ref="I18n.class"/>
+      <xs:group ref="Anchor.class"/>
+<!--      <xs:element ref="script"/>
+      <xs:element ref="map"/>
+      <xs:group ref="Inline.extra"/> -->
+    </xs:choice>
+  </xs:group>
+
+  <!--
+    InlNoAnchor.class includes all non-anchor inlines,
+    used as a component in mixes
+  -->
+  <xs:group name="InlNoAnchor.class">
+    <xs:choice>
+      <xs:group ref="InlStruct.class"/>
+      <xs:group ref="InlPhras.class"/>
+      <xs:group ref="InlPres.class"/>
+      <xs:group ref="I18n.class"/>
+<!--      <xs:group ref="InlSpecial.class"/>
+      <xs:group ref="InlForm.class"/>
+      <xs:group ref="Ruby.class"/>
+      <xs:group ref="Inline.extra"/> -->
+    </xs:choice>
+  </xs:group>
+
+  <!--
+    InlNoAnchor.mix includes all non-anchor inlines
+  -->
+  <xs:group name="InlNoAnchor.mix">
+    <xs:choice>
+      <xs:group ref="InlNoAnchor.class"/>
+    </xs:choice>
+  </xs:group>
+
+  <!--
+    Inline.mix includes all inline elements, including Misc.class
+  -->
+  <xs:group name="Inline.mix">
+    <xs:choice>
+      <xs:group ref="Inline.class"/>
+    </xs:choice>
+  </xs:group>
+
+  <!--
+   InlNoRuby.mix includes all of inline.mix elements
+   except ruby
+  -->
+<!--
+  <xs:group name="InlNoRuby.mix">
+    <xs:choice>
+      <xs:group ref="InlNoRuby.class"/>
+      <xs:group ref="Misc.class"/>
+    </xs:choice>
+  </xs:group>
+-->
+
+  <!--
+    In the HTML 4 DTD, heading and list elements were included
+    in the block group. The Heading.class and
+    List.class groups must now be included explicitly
+    on element declarations where desired.
+  -->
+  <xs:group name="Heading.class">
+    <xs:choice>
+      <xs:element ref="h1"/>
+      <xs:element ref="h2"/>
+      <xs:element ref="h3"/>
+      <xs:element ref="h4"/>
+      <xs:element ref="h5"/>
+      <xs:element ref="h6"/>
+    </xs:choice>
+  </xs:group>
+
+  <xs:group name="List.class">
+    <xs:choice>
+      <xs:element ref="ul"/>
+      <xs:element ref="ol"/>
+      <xs:element ref="dl"/>
+    </xs:choice>
+  </xs:group>
+
+  <xs:group name="Table.class">
+    <xs:choice>
+      <xs:element ref="table"/>
+    </xs:choice>
+  </xs:group>
+<!--
+  <xs:group name="Form.class">
+    <xs:choice>
+      <xs:element ref="form"/>
+    </xs:choice>
+  </xs:group>
+
+  <xs:group name="Fieldset.class">
+    <xs:choice>
+      <xs:element ref="fieldset"/>
+    </xs:choice>
+  </xs:group>
+-->
+  <xs:group name="BlkStruct.class">
+    <xs:choice>
+      <xs:element ref="p"/>
+      <xs:element ref="div"/>
+    </xs:choice>
+  </xs:group>
+
+  <xs:group name="BlkPhras.class">
+    <xs:choice>
+      <xs:element ref="pre"/>
+      <xs:element ref="blockquote"/>
+      <xs:element ref="address"/>
+    </xs:choice>
+  </xs:group>
+
+  <xs:group name="BlkPres.class">
+    <xs:sequence>
+      <xs:element ref="hr"/>
+    </xs:sequence>
+  </xs:group>
+
+  <xs:group name="BlkSpecial.class">
+    <xs:choice>
+      <xs:group ref="Table.class"/>
+<!--      <xs:group ref="Form.class"/>
+      <xs:group ref="Fieldset.class"/> -->
+    </xs:choice>
+  </xs:group>
+
+  <xs:group name="Block.extra">
+    <xs:choice/>
+  </xs:group>
+
+  <!--
+    Block.class includes all block elements,
+    used as an component in mixes
+  -->
+  <xs:group name="Block.class">
+    <xs:choice>
+      <xs:group ref="BlkStruct.class"/>
+      <xs:group ref="BlkPhras.class"/>
+      <xs:group ref="BlkPres.class"/>
+      <xs:group ref="BlkSpecial.class"/>
+    </xs:choice>
+  </xs:group>
+
+  <!--
+   Block.mix includes all block elements plus %Misc.class;
+  -->
+  <xs:group name="Block.mix">
+    <xs:choice>
+      <xs:group ref="Heading.class"/>
+      <xs:group ref="List.class"/>
+      <xs:group ref="Block.class"/>
+    </xs:choice>
+  </xs:group>
+
+  <!--
+    All Content Elements
+    Flow.mix includes all text content, block and inline
+    Note that the "any" element included here allows us
+    to add data from any other namespace, a necessity
+    for compound document creation.
+    Note however that it is not possible to add
+    to any head level element without further
+    modification. To add RDF metadata to the head
+    of a document, modify the structure module.
+  -->
+  <xs:group name="Flow.mix">
+    <xs:choice>
+      <xs:group ref="Heading.class"/>
+      <xs:group ref="List.class"/>
+      <xs:group ref="Block.class"/>
+      <xs:group ref="Inline.class"/>
+    </xs:choice>
+  </xs:group>
+
+
+  <!--
+    BlkNoForm.mix includes all non-form block elements,
+       plus Misc.class
+  -->
+  <xs:group name="BlkNoForm.mix">
+    <xs:choice>
+      <xs:group ref="Heading.class"/>
+      <xs:group ref="List.class"/>
+      <xs:group ref="BlkStruct.class"/>
+      <xs:group ref="BlkPhras.class"/>
+      <xs:group ref="BlkPres.class"/>
+      <xs:group ref="Table.class"/>
+    </xs:choice>
+  </xs:group>
+
+</xs:schema>

--- a/src/test/resources/xml/xsd/ddi-codebook-2.5/ddi-xhtml11-modules-1.xsd
+++ b/src/test/resources/xml/xsd/ddi-codebook-2.5/ddi-xhtml11-modules-1.xsd
@@ -1,0 +1,569 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+Copyright (c) 2009 DDI Alliance, DDI 3.1, 2009-10-18
+
+This file is part of DDI 3.1 XML Schema.
+
+DDI 3.1 XML Schema is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by the
+Free Software Foundation, either version 3 of the License, or (at your
+option) any later version.
+
+DDI 3.1 XML Schema is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
+for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with DDI 3.1 XML Schema. If not, see <http://www.gnu.org/licenses/>.
+
+-->
+<xs:schema targetNamespace="http://www.w3.org/1999/xhtml" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.w3.org/1999/xhtml" blockDefault="#all">
+
+  <xs:annotation>
+    <xs:documentation>
+      This schema includes all modules for XHTML1.1 Document Type.
+      $Id: ddi-xhtml11-modules-1.xsd,v 1.1 2007/02/08 16:03:11 jgager Exp $
+    </xs:documentation>
+    <xs:documentation source="XHTML/xhtml-copyright-1.xsd"/>
+  </xs:annotation>
+
+  <xs:annotation>
+    <xs:documentation>
+     This schema includes all modules (and redefinitions)
+     for XHTML1.1 Document Type.
+     XHTML1.1 Document Type includes the following Modules
+
+       XHTML Core modules (Required for XHTML Family Conformance)
+            +  text
+            +  hypertext
+            +  lists
+            +  structure
+
+       Other XHTML modules
+            +  Edit
+            +  Bdo
+            +  Presentational
+            +  Link
+            +  Meta
+            +  Base
+            +  Scripting
+            +  Style
+            +  Image
+            +  Applet
+            +  Object
+            +  Param (Applet/Object modules require Param Module)
+            +  Tables
+            +  Forms
+            +  Client side image maps
+            +  Server side image maps
+
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:include schemaLocation="XHTML/xhtml-framework-1.xsd">
+    <xs:annotation>
+      <xs:documentation>
+        Schema Framework Component Modules:
+            +  notations
+            +  datatypes
+            +  common attributes
+            +  character entities
+      </xs:documentation>
+      <xs:documentation source="http://www.w3.org/TR/xhtml-modularization/abstract_modules.html#s_commonatts"/>
+    </xs:annotation>
+  </xs:include>
+
+  <xs:include schemaLocation="XHTML/xhtml-text-1.xsd">
+    <xs:annotation>
+      <xs:documentation>
+        Text module
+
+        The Text module includes declarations for all core
+        text container elements and their attributes.
+
+            +  block phrasal
+            +  block structural
+            +  inline phrasal
+            +  inline structural
+
+        Elements defined here:
+          * address, blockquote, pre, h1, h2, h3, h4, h5, h6
+          * div, p
+          * abbr, acronym, cite, code, dfn, em, kbd, q, samp, strong, var
+          * br, span
+      </xs:documentation>
+      <xs:documentation source="http://www.w3.org/TR/2001/REC-xhtml-modularization-20010410/abstract_modules.html#s_textmodule"/>
+    </xs:annotation>
+  </xs:include>
+
+  <xs:include schemaLocation="XHTML/xhtml-hypertext-1.xsd">
+    <xs:annotation>
+      <xs:documentation>
+         Hypertext module
+
+         Elements defined here:
+          * a
+      </xs:documentation>
+      <xs:documentation source="http://www.w3.org/TR/2001/REC-xhtml-modularization-20010410/abstract_modules.html#s_hypertextmodule"/>
+    </xs:annotation>
+  </xs:include>
+
+<!--
+  <xs:redefine schemaLocation="XHTML/xhtml-hypertext-1.xsd">
+    <xs:annotation>
+      <xs:documentation>
+         Hypertext module
+
+         Elements defined here:
+          * a
+      </xs:documentation>
+      <xs:documentation
+        source="http://www.w3.org/TR/2001/REC-xhtml-modularization-20010410/abstract_modules.html#s_hypertextmodule"/>
+    </xs:annotation>
+    <xs:attributeGroup name="a.attlist">
+       <xs:attributeGroup ref="a.attlist" />
+       <xs:attributeGroup ref="a.csim.attlist">
+          <xs:annotation>
+            <xs:documentation>
+              Redefinition by Client Side Image Map Module
+            </xs:documentation>
+          </xs:annotation>
+       </xs:attributeGroup>
+       <xs:attributeGroup ref="a.events.attlist">
+          <xs:annotation>
+            <xs:documentation>
+              Redefinition by XHTML Event Attribute Module
+            </xs:documentation>
+          </xs:annotation>
+       </xs:attributeGroup>
+    </xs:attributeGroup>
+  </xs:redefine>
+-->
+
+  <xs:include schemaLocation="XHTML/xhtml-list-1.xsd">
+    <xs:annotation>
+      <xs:documentation>
+        Lists module
+
+        Elements defined here:
+          * dt, dd, dl, ol, ul, li
+      </xs:documentation>
+      <xs:documentation source="http://www.w3.org/TR/2001/REC-xhtml-modularization-20010410/abstract_modules.html#s_listmodule"/>
+    </xs:annotation>
+  </xs:include>
+<!--
+ <xs:include schemaLocation="xhtml-edit-1.xsd">
+    <xs:annotation>
+      <xs:documentation>
+        Edit module
+
+        Elements defined here:
+          * ins, del
+      </xs:documentation>
+      <xs:documentation
+         source="http://www.w3.org/TR/xhtml-modularization/abstract_modules.html#s_editmodule"/>
+    </xs:annotation>
+  </xs:include>
+-->
+  <xs:include schemaLocation="XHTML/xhtml-bdo-1.xsd">
+    <xs:annotation>
+      <xs:documentation>
+        Bidirectional element module
+
+        Elements defined here:
+          * bdo
+      </xs:documentation>
+      <xs:documentation source="http://www.w3.org/TR/xhtml-modularization/abstract_modules.html#s_bdomodule"/>
+    </xs:annotation>
+  </xs:include>
+
+  <xs:include schemaLocation="XHTML/xhtml-pres-1.xsd">
+    <xs:annotation>
+      <xs:documentation>
+        Presentational module
+
+         Elements defined here:
+           * hr, b, big, i, small,sub, sup, tt
+      </xs:documentation>
+      <xs:documentation source="http://www.w3.org/TR/xhtml-modularization/abstract_modules.html#s_presentationmodule"/>
+    </xs:annotation>
+  </xs:include>
+<!--
+  <xs:include schemaLocation="XHTML/xhtml-link-1.xsd">
+    <xs:annotation>
+      <xs:documentation>
+        Link module
+
+        Elements defined here:
+          * link
+      </xs:documentation>
+      <xs:documentation
+         source="http://www.w3.org/TR/xhtml-modularization/abstract_modules.html#s_linkmodule"/>
+    </xs:annotation>
+  </xs:include>
+
+  <xs:include schemaLocation="xhtml-meta-1.xsd">
+    <xs:annotation>
+      <xs:documentation>
+        Meta module
+
+        Elements defined here:
+        * meta
+      </xs:documentation>
+      <xs:documentation
+         source="http://www.w3.org/TR/xhtml-modularization/abstract_modules.html#s_metamodule"/>
+    </xs:annotation>
+  </xs:include>
+
+  <xs:include schemaLocation="xhtml-base-1.xsd">
+    <xs:annotation>
+      <xs:documentation>
+        Base module
+
+        Elements defined here:
+          * base
+      </xs:documentation>
+      <xs:documentation
+         source="http://www.w3.org/TR/xhtml-modularization/abstract_modules.html#s_basemodule"/>
+    </xs:annotation>
+  </xs:include>
+
+  <xs:include schemaLocation="xhtml-script-1.xsd">
+    <xs:annotation>
+      <xs:documentation>
+        Scripting module
+
+        Elements defined here:
+          * script, noscript
+      </xs:documentation>
+      <xs:documentation
+         source="http://www.w3.org/TR/xhtml-modularization/abstract_modules.html#s_scriptmodule"/>
+    </xs:annotation>
+  </xs:include>
+
+  <xs:include schemaLocation="xhtml-style-1.xsd">
+    <xs:annotation>
+      <xs:documentation>
+        Style module
+
+        Elements defined here:
+          * style
+      </xs:documentation>
+      <xs:documentation
+         source="http://www.w3.org/TR/xhtml-modularization/abstract_modules.html#s_stylemodule"/>
+    </xs:annotation>
+  </xs:include>
+-->
+  <xs:include schemaLocation="XHTML/xhtml-inlstyle-1.xsd">
+    <xs:annotation>
+      <xs:documentation>
+        Style attribute module
+
+        Attribute defined here:
+          * style
+      </xs:documentation>
+      <xs:documentation source="http://www.w3.org/TR/xhtml-modularization/abstract_modules.html#s_styleattributemodule"/>
+    </xs:annotation>
+  </xs:include>
+<!--
+  <xs:redefine schemaLocation="xhtml-image-1.xsd">
+    <xs:annotation>
+      <xs:documentation>
+        Image module
+
+        Elements defined here:
+          * img
+      </xs:documentation>
+      <xs:documentation
+         source="http://www.w3.org/TR/xhtml-modularization/abstract_modules.html#s_imagemodule"/>
+    </xs:annotation>
+    <xs:attributeGroup name="img.attlist">
+       <xs:attributeGroup ref="img.attlist">
+           <xs:annotation>
+             <xs:documentation>
+                Original Image Attributes (in Image Module)
+             </xs:documentation>
+           </xs:annotation>
+       </xs:attributeGroup>
+       <xs:attributeGroup ref="img.csim.attlist">
+           <xs:annotation>
+             <xs:documentation>
+                Redefinition by Client Side Image Map Module
+             </xs:documentation>
+           </xs:annotation>
+       </xs:attributeGroup>
+       <xs:attributeGroup ref="img.ssimap.attlist">
+           <xs:annotation>
+             <xs:documentation>
+                Redefinition by Server Side Image Module
+             </xs:documentation>
+           </xs:annotation>
+       </xs:attributeGroup>
+    </xs:attributeGroup>
+  </xs:redefine>
+
+  <xs:redefine schemaLocation="XHTML/xhtml-csismap-1.xsd">
+    <xs:annotation>
+      <xs:documentation>
+        Client-side mage maps module
+
+        Elements defined here:
+          * area, map
+      </xs:documentation>
+      <xs:documentation
+         source="http://www.w3.org/TR/xhtml-modularization/abstract_modules.html#s_imapmodule"/>
+    </xs:annotation>
+    <xs:attributeGroup name="area.attlist">
+       <xs:attributeGroup ref="area.attlist">
+           <xs:annotation>
+             <xs:documentation>
+                Original Area Attributes (in CSI Module)
+             </xs:documentation>
+           </xs:annotation>
+       </xs:attributeGroup>
+       <xs:attributeGroup ref="area.events.attlist">
+           <xs:annotation>
+             <xs:documentation>
+                Redefinition by Events Attribute Module
+             </xs:documentation>
+           </xs:annotation>
+       </xs:attributeGroup>
+    </xs:attributeGroup>
+  </xs:redefine>
+
+  <xs:include schemaLocation="xhtml-ssismap-1.xsd">
+    <xs:annotation>
+      <xs:documentation>
+       Server-side image maps module
+
+        Attributes defined here:
+          * ismap on img
+      </xs:documentation>
+      <xs:documentation
+         source="http://www.w3.org/TR/xhtml-modularization/abstract_modules.html#s_servermapmodule"/>
+    </xs:annotation>
+ </xs:include>
+
+  <xs:redefine schemaLocation="xhtml-object-1.xsd">
+    <xs:annotation>
+      <xs:documentation>
+        Object module
+
+        Elements defined here:
+          * object
+      </xs:documentation>
+      <xs:documentation
+         source="http://www.w3.org/TR/xhtml-modularization/abstract_modules.html#s_objectmodule"/>
+    </xs:annotation>
+    <xs:attributeGroup name="object.attlist">
+       <xs:attributeGroup ref="object.attlist">
+           <xs:annotation>
+             <xs:documentation>
+                Original Object Attlist
+              </xs:documentation>
+           </xs:annotation>
+       </xs:attributeGroup>
+       <xs:attributeGroup ref="object.csim.attlist">
+           <xs:annotation>
+              <xs:documentation>
+                Redefinition by Client Image Map Module
+              </xs:documentation>
+           </xs:annotation>
+       </xs:attributeGroup>
+    </xs:attributeGroup>
+  </xs:redefine>
+
+  <xs:include schemaLocation="xhtml-param-1.xsd">
+    <xs:annotation>
+      <xs:documentation>
+        Param module
+
+        Elements defined here:
+          * param
+      </xs:documentation>
+    </xs:annotation>
+  </xs:include>
+-->
+  <xs:include schemaLocation="XHTML/xhtml-table-1.xsd">
+    <xs:annotation>
+      <xs:documentation>
+        Tables module
+
+        Elements defined here:
+          * table, caption, thead, tfoot, tbody, colgroup, col, tr, th, td
+      </xs:documentation>
+      <xs:documentation source="http://www.w3.org/TR/xhtml-modularization/abstract_modules.html#s_tablemodule"/>
+    </xs:annotation>
+  </xs:include>
+<!--
+  <xs:redefine schemaLocation="xhtml-form-1.xsd">
+    <xs:annotation>
+      <xs:documentation>
+        Forms module
+
+        Elements defined here:
+          * form, label, input, select, optgroup, option,
+          * textarea, fieldset, legend, button
+      </xs:documentation>
+      <xs:documentation
+         source="http://www.w3.org/TR/xhtml-modularization/abstract_modules.html#s_extformsmodule"/>
+    </xs:annotation>
+    <xs:attributeGroup name="form.attlist">
+       <xs:annotation>
+          <xs:documentation>
+            Changes to XHTML Form Attlist
+          </xs:documentation>
+       </xs:annotation>
+       <xs:attributeGroup ref="form.attlist">
+           <xs:annotation>
+             <xs:documentation>
+                Original Form Attributes (declared in Forms Module)
+             </xs:documentation>
+           </xs:annotation>
+       </xs:attributeGroup>
+       <xs:attributeGroup ref="form.events.attlist">
+           <xs:annotation>
+             <xs:documentation>
+                XHTML Events Module - Attribute additions
+             </xs:documentation>
+           </xs:annotation>
+       </xs:attributeGroup>
+    </xs:attributeGroup>
+
+    <xs:attributeGroup name="input.attlist">
+       <xs:annotation>
+          <xs:documentation>
+            Changes to XHTML Form Input Element
+          </xs:documentation>
+       </xs:annotation>
+       <xs:attributeGroup ref="input.attlist">
+           <xs:annotation>
+             <xs:documentation>
+                Original Input Attributes (in Forms Module)
+             </xs:documentation>
+           </xs:annotation>
+       </xs:attributeGroup>
+       <xs:attributeGroup ref="input.csim.attlist">
+           <xs:annotation>
+             <xs:documentation>
+                Redefinition by Client Side Image Map Module
+             </xs:documentation>
+           </xs:annotation>
+       </xs:attributeGroup>
+       <xs:attributeGroup ref="input.ssimap.attlist">
+           <xs:annotation>
+             <xs:documentation>
+                Redefinition by Server Side Image Map Module
+             </xs:documentation>
+           </xs:annotation>
+       </xs:attributeGroup>
+       <xs:attributeGroup ref="input.events.attlist">
+           <xs:annotation>
+             <xs:documentation>
+               Redefinition by Event Attribute Module
+             </xs:documentation>
+           </xs:annotation>
+       </xs:attributeGroup>
+    </xs:attributeGroup>
+
+
+    <xs:attributeGroup name="label.attlist">
+       <xs:attributeGroup ref="label.attlist">
+           <xs:annotation>
+             <xs:documentation>
+                Original Label Attributes (in Forms Module)
+             </xs:documentation>
+           </xs:annotation>
+       </xs:attributeGroup>
+       <xs:attributeGroup ref="label.events.attlist">
+           <xs:annotation>
+             <xs:documentation>
+               Redefinition by Event Attribute Module
+             </xs:documentation>
+           </xs:annotation>
+       </xs:attributeGroup>
+    </xs:attributeGroup>
+
+    <xs:attributeGroup name="select.attlist">
+       <xs:attributeGroup ref="select.attlist">
+           <xs:annotation>
+             <xs:documentation>
+                Original Select Attributes (in Forms Module)
+             </xs:documentation>
+           </xs:annotation>
+       </xs:attributeGroup>
+       <xs:attributeGroup ref="select.events.attlist">
+           <xs:annotation>
+             <xs:documentation>
+               Redefinition by Event Attribute Module
+             </xs:documentation>
+           </xs:annotation>
+       </xs:attributeGroup>
+    </xs:attributeGroup>
+
+    <xs:attributeGroup name="textarea.attlist">
+       <xs:attributeGroup ref="textarea.attlist">
+           <xs:annotation>
+             <xs:documentation>
+                Original TextArea Attributes (in Forms Module)
+             </xs:documentation>
+           </xs:annotation>
+       </xs:attributeGroup>
+       <xs:attributeGroup ref="textarea.events.attlist">
+           <xs:annotation>
+             <xs:documentation>
+               Redefinition by Event Attribute Module
+             </xs:documentation>
+           </xs:annotation>
+       </xs:attributeGroup>
+    </xs:attributeGroup>
+
+    <xs:attributeGroup name="button.attlist">
+       <xs:attributeGroup ref="button.attlist">
+           <xs:annotation>
+             <xs:documentation>
+                Original Button Attributes (in Forms Module)
+             </xs:documentation>
+           </xs:annotation>
+        </xs:attributeGroup>
+        <xs:attributeGroup ref="button.events.attlist">
+           <xs:annotation>
+             <xs:documentation>
+               Redefinition by Event Attribute Module
+             </xs:documentation>
+           </xs:annotation>
+       </xs:attributeGroup>
+    </xs:attributeGroup>
+  </xs:redefine>
+
+  <xs:include schemaLocation="xhtml-ruby-basic-1.xsd">
+    <xs:annotation>
+      <xs:documentation>
+        Ruby module
+
+        Elements defined here:
+          * ruby, rbc, rtc, rb, rt, rp
+
+        Note that either Ruby or Basic Ruby should be used but not both
+      </xs:documentation>
+      <xs:documentation
+         source="http://www.w3.org/TR/2001/REC-ruby-20010531/#simple-ruby1"/>
+    </xs:annotation>
+  </xs:include>
+
+  <xs:include schemaLocation="xhtml-events-1.xsd">
+    <xs:annotation>
+      <xs:documentation>
+        XHTML Events Modules
+
+        Attributes defined here:
+          XHTML Event Types
+      </xs:documentation>
+      <xs:documentation
+         source="http://www.w3.org/TR/xhtml-modularization/abstract_modules.html#s_intrinsiceventsmodule"/>
+    </xs:annotation>
+  </xs:include>
+-->
+</xs:schema>

--- a/src/test/resources/xml/xsd/ddi-codebook-2.5/ddi-xhtml11.xsd
+++ b/src/test/resources/xml/xsd/ddi-codebook-2.5/ddi-xhtml11.xsd
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+Copyright (c) 2009 DDI Alliance, DDI 3.1, 2009-10-18
+
+This file is part of DDI 3.1 XML Schema.
+
+DDI 3.1 XML Schema is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by the
+Free Software Foundation, either version 3 of the License, or (at your
+option) any later version.
+
+DDI 3.1 XML Schema is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
+for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with DDI 3.1 XML Schema. If not, see <http://www.gnu.org/licenses/>.
+
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.w3.org/1999/xhtml" targetNamespace="http://www.w3.org/1999/xhtml" blockDefault="#all">
+   <xs:annotation>
+      <xs:documentation>
+      This is the XML Schema driver for XHTML 1.1.
+      Please use this namespace for XHTML elements:
+
+         "http://www.w3.org/1999/xhtml"
+
+      $Id: ddi-xhtml11.xsd,v 1.1 2007/02/08 16:03:11 jgager Exp $
+    </xs:documentation>
+      <xs:documentation source="XHTML/xhtml-copyright-1.xsd"/>
+   </xs:annotation>
+   <xs:annotation>
+      <xs:documentation>
+      This is XHTML, a reformulation of HTML as a modular XML application
+      The Extensible HyperText Markup Language (XHTML)
+      Copyright ©1998-2003 World Wide Web Consortium
+      (Massachusetts Institute of Technology, Institut National de
+      Recherche en Informatique et en Automatique, Keio University).
+      All Rights Reserved.
+
+      Permission to use, copy, modify and distribute the XHTML Schema
+      modules and their accompanying xs:documentation for any purpose
+      and without fee is hereby granted in perpetuity, provided that the above
+      copyright notice and this paragraph appear in all copies.
+      The copyright holders make no representation about the suitability of
+      these XML Schema modules for any purpose.
+
+      They are provided "as is" without expressed or implied warranty.
+    </xs:documentation>
+   </xs:annotation>
+   <xs:annotation>
+      <xs:documentation>
+      This is the Schema Driver file for XHTML1.1
+      Document Type
+
+     This schema
+        + imports external schemas (xml.xsd)
+        + refedines (and include)s schema modules for XHTML1.1 Document Type.
+        + includes Schema for Named content model for the
+          XHTML1.1 Document Type
+
+        XHTML1.1 Document Type includes the following Modules
+           XHTML Core modules (Required for XHTML Family Conformance)
+            +  text
+            +  hypertext
+            +  lists
+            +  structure
+           Other XHTML modules
+            +  Edit
+            +  Bdo
+            +  Presentational
+            +  Link
+            +  Meta
+            +  Base
+            +  Scripting
+            +  Style
+            +  Image
+            +  Applet
+            +  Object
+            +  Param (Applet/Object modules require Param Module)
+            +  Tables
+            +  Forms
+            +  Client side image maps
+            +  Server side image maps
+            +  Ruby
+    </xs:documentation>
+   </xs:annotation>
+   <xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="xml.xsd">
+      <xs:annotation>
+         <xs:documentation>
+         This import brings in the XML namespace attributes
+         The XML attributes are used by various modules.
+       </xs:documentation>
+      </xs:annotation>
+   </xs:import>
+   <xs:include schemaLocation="ddi-xhtml11-model-1.xsd">
+      <xs:annotation>
+         <xs:documentation>
+        Document Model module for the XHTML1.1 Document Type.
+        This schema file defines all named models used by XHTML
+        Modularization Framework for XHTML1.1 Document Type
+      </xs:documentation>
+      </xs:annotation>
+   </xs:include>
+   <xs:include schemaLocation="ddi-xhtml11-modules-1.xsd">
+      <xs:annotation>
+         <xs:documentation>
+        Schema that includes all modules (and redefinitions)
+        for XHTML1.1 Document Type.
+      </xs:documentation>
+      </xs:annotation>
+   </xs:include>
+</xs:schema>

--- a/src/test/resources/xml/xsd/ddi-codebook-2.5/ddi_codebook_2_5.xsd
+++ b/src/test/resources/xml/xsd/ddi-codebook-2.5/ddi_codebook_2_5.xsd
@@ -1,0 +1,8482 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+Copyright (c) 2014 DDI Alliance, DDI 2.5, 2014-01-28
+
+This file is part of DDI 2.5 XML Schema.
+
+DDI 2.5 XML Schema is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by the
+Free Software Foundation, either version 3 of the License, or (at your
+option) any later version.
+
+DDI 2.5 XML Schema is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
+for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with DDI 2.5 XML Schema. If not, see <http://www.gnu.org/licenses/>.
+
+-->
+<!--
+DDI 2.5.1 XML Schema modifies DDI 2.5 by easing cardinality on many text 
+entries to better support multi-language content. It provides the element 
+dataFingerprint within fileTxt as a sub-minor, backward compatible bug correction. 
+This element was intended to be included in DDI 2.5. Documentation of new objects
+was expanded.
+
+These changes do not effect the namespace. 2013-11-14.
+
+-->
+<xs:schema xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:fn="http://www.w3.org/2005/xpath-functions" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:saxon="http://xml.apache.org/xslt" xmlns="ddi:codebook:2_5" xmlns:dc="http://purl.org/dc/terms/" targetNamespace="ddi:codebook:2_5" elementFormDefault="qualified" attributeFormDefault="unqualified">
+   <xs:annotation>
+      <xs:documentation>
+         This is a w3c Schema "Technical Implementation" of the DDI Conceptual Specification. 
+         This schema is intended for use in producing electronic versions of codebooks for quantitative social science data.
+         Please note that the attribute xml-lang in the a.globals group is an error that was persisted to retain backward compatibility. DO NOT USE THIS ATTRIBUTE. If this attribute has been used, transfer the content to xml:lang.
+   	  </xs:documentation>
+   </xs:annotation>
+
+   <xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="xml.xsd"/>
+   <xs:import namespace="http://www.w3.org/1999/xhtml" schemaLocation="ddi-xhtml11.xsd"/>
+   <xs:import namespace="http://purl.org/dc/terms/" schemaLocation="dcterms.xsd"/>
+   
+   <!-- Base Structures -->
+   
+   <xs:attributeGroup name="GLOBALS">
+      <xs:attribute name="ID" type="xs:ID" use="optional"/>
+      <xs:attribute name="xml-lang" type="xs:NMTOKEN" use="optional">
+         <xs:annotation>
+            <xs:documentation>DO NOT USE THIS ATTRIBUTE. Its inclusion is an error that was persisted to retain backward compatibility. If this attribute has been used, transfer the content to xml:lang.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute ref="xml:lang" use="optional"/>
+      <xs:attribute name="source" default="producer">
+         <xs:simpleType>
+            <xs:restriction base="xs:NMTOKEN">
+               <xs:enumeration value="archive"/>
+               <xs:enumeration value="producer"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="elementVersion" type="xs:string" use="optional">
+	  	<xs:annotation>
+			<xs:documentation>Captures version of the element</xs:documentation>
+		</xs:annotation>
+	  </xs:attribute>
+      <xs:attribute name="elementVersionDate" type="dateSimpleType" use="optional">
+	  	<xs:annotation>
+			<xs:documentation>Indicates version date for the element. Use YYYY-MM-DD, YYYY-MM, or YYYY formats.</xs:documentation>
+		</xs:annotation>
+	  </xs:attribute>
+      <xs:attribute name="ddiLifecycleUrn" type="xs:anyURI" use="optional">
+         <xs:annotation>
+            <xs:documentation>Used to capture the DDI-Lifecycle type URN for the element. This may be captured during translation from DDI-Lifecycle to DDI-Codebook structure or in preparation for transferring to a DDI-Lifecycle structure.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="ddiCodebookUrn" type="xs:anyURI" use="optional">
+         <xs:annotation>
+            <xs:documentation>Used to capture the DDI-Codebook type URN for the element. This is used to assign a DDI-Codebook specific URN to the element, according the format prescribed by the DDI-Codebook standard.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:attributeGroup>
+   
+   <xs:complexType name="baseElementType" abstract="true">
+      <xs:annotation>
+         <xs:documentation>
+				<xhtml:div>
+					<xhtml:h1 class="element_title">Base Element Type</xhtml:h1>
+					<xhtml:div>
+						<xhtml:h2 class="section_header">Description</xhtml:h2>
+						<xhtml:div class="description">This type forms the basis for all elements. Every element may contain the attributes defined the GLOBALS attribute group.</xhtml:div>
+					</xhtml:div>
+				</xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+      <xs:attributeGroup ref="GLOBALS"/>
+   </xs:complexType>
+   
+   <xs:complexType name="abstractTextType" mixed="true" abstract="true">
+      <xs:annotation>
+         <xs:documentation>
+				<xhtml:div>
+					<xhtml:h1 class="element_title">Abstract Text Type</xhtml:h1>
+					<xhtml:div>
+						<xhtml:h2 class="section_header">Description</xhtml:h2>
+						<xhtml:div class="description">This type forms the basis for all textual elements. Textual elements may contain text or a mix of select elements. This type is abstract and is refined by more specific types which will limit the allowable elements and attributes. Any textual element will be a subset of this type and can be processed as such.</xhtml:div>
+					</xhtml:div>
+				</xhtml:div>         
+         </xs:documentation>
+      </xs:annotation>
+      <xs:complexContent>
+         <xs:extension base="baseElementType">
+            <xs:sequence>
+               <xs:any namespace="##targetNamespace http://www.w3.org/1999/xhtml" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+            <xs:anyAttribute namespace="##local"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+   
+   <xs:complexType name="simpleTextType" mixed="true">
+         <xs:annotation>
+         <xs:documentation>
+				<xhtml:div>
+					<xhtml:h1 class="element_title">Simple Text Type</xhtml:h1>
+					<xhtml:div>
+						<xhtml:h2 class="section_header">Description</xhtml:h2>
+						<xhtml:div class="description">This type forms the basis of most textual elements. Elements using this type may have mixed content (text and child elements). The child elements are from the PHRASE, FORM, and xhtml:BlkNoForm.mix (a specific subset of XHTML) content groups. Note that if elements from the PHRASE and FORM groups must not be used with elements from the xhtml:BlkNoForm.mix group; one can use either elements from xhtml:BlkNoForm.mix or elements from the PHRASE and FORM groups. This type is extended in some cases to include additional attributes.</xhtml:div>
+					</xhtml:div>
+				</xhtml:div>  
+         </xs:documentation>
+      </xs:annotation>
+      <xs:complexContent>
+         <xs:restriction base="abstractTextType">
+            <xs:sequence>
+               <xs:choice minOccurs="0" maxOccurs="unbounded">
+                  <xs:group ref="PHRASE"/>
+                  <xs:group ref="FORM"/>         
+                  <xs:group ref="xhtml:BlkNoForm.mix"/>
+               </xs:choice>            
+            </xs:sequence>
+         </xs:restriction>
+      </xs:complexContent>
+   </xs:complexType>
+   
+   <xs:complexType name="conceptualTextType" mixed="true">
+      <xs:annotation>
+         <xs:documentation>
+				<xhtml:div>
+					<xhtml:h1 class="element_title">Conceptual Text Type</xhtml:h1>
+					<xhtml:div>
+						<xhtml:h2 class="section_header">Description</xhtml:h2>
+						<xhtml:div class="description">This type forms this basis for a textual element which may also provide for a conceptual (see concept) description of the element a longer description (see txt). If the concept and/or txt elements are used, then the element should contain no other child elements or text. Note that if elements from the PHRASE and FORM groups must not be used with elements from the xhtml:BlkNoForm.mix group; one can use either elements from xhtml:BlkNoForm.mix or elements from the PHRASE and FORM groups.</xhtml:div>
+					</xhtml:div>
+				</xhtml:div>          
+         </xs:documentation>
+      </xs:annotation>
+      <xs:complexContent>
+         <xs:restriction base="abstractTextType">
+            <xs:sequence>
+               <xs:choice minOccurs="0" maxOccurs="unbounded">
+                  <xs:group ref="PHRASE"/>
+                  <xs:group ref="FORM"/>         
+                  <xs:group ref="xhtml:BlkNoForm.mix"/>
+                  <xs:element ref="concept"/>
+                  <xs:element ref="txt"/>
+               </xs:choice>               
+            </xs:sequence>
+         </xs:restriction>
+      </xs:complexContent>
+   </xs:complexType>
+   
+   <xs:complexType name="tableAndTextType" mixed="true">
+      <xs:complexContent>
+         <xs:restriction base="abstractTextType">
+            <xs:sequence>
+               <xs:choice minOccurs="0" maxOccurs="unbounded">
+                  <xs:group ref="PHRASE"/>
+                  <xs:group ref="FORM"/>         
+                  <xs:group ref="xhtml:BlkNoForm.mix"/>
+                  <xs:element ref="table"/>               
+               </xs:choice>               
+            </xs:sequence>
+         </xs:restriction>
+      </xs:complexContent>
+   </xs:complexType>
+   
+   <xs:complexType name="materialReferenceType" mixed="true">
+      <xs:complexContent>
+         <xs:restriction base="abstractTextType">
+            <xs:sequence>
+               <xs:choice minOccurs="0" maxOccurs="unbounded">
+                  <xs:group ref="PHRASE"/>
+                  <xs:group ref="FORM"/>
+                  <xs:group ref="xhtml:BlkNoForm.mix"/>
+                  <xs:element ref="citation"/>               
+               </xs:choice>               
+            </xs:sequence>
+         </xs:restriction>
+      </xs:complexContent>
+   </xs:complexType>
+   
+   <xs:complexType name="simpleTextAndDateType" mixed="true">
+      <xs:complexContent>
+         <xs:extension base="simpleTextType">
+            <xs:attribute name="date" type="xs:string" use="optional"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+   
+   <xs:complexType name="phraseType" mixed="true">
+      <xs:annotation>
+         <xs:documentation>
+				<xhtml:div>
+					<xhtml:h1 class="element_title">Phrase Type</xhtml:h1>
+					<xhtml:div>
+						<xhtml:h2 class="section_header">Description</xhtml:h2>
+						<xhtml:div class="description">This type restricts the simpleTextType to allow for only child elements from the PHRASE content group. It still allows for mixed content (text and child elements).</xhtml:div>
+					</xhtml:div>
+				</xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+      <xs:complexContent>
+         <xs:restriction base="simpleTextType">
+            <xs:sequence>
+               <xs:choice minOccurs="0" maxOccurs="unbounded">
+                  <xs:group ref="PHRASE"/>
+               </xs:choice>               
+            </xs:sequence>
+         </xs:restriction>
+      </xs:complexContent>
+   </xs:complexType>
+   
+   <xs:complexType name="stringType">
+      <xs:annotation>
+         <xs:documentation>
+				<xhtml:div>
+					<xhtml:h1 class="element_title">String Type</xhtml:h1>
+					<xhtml:div>
+						<xhtml:h2 class="section_header">Description</xhtml:h2>
+						<xhtml:div class="description">This type restricts the base abstractTextType to only allow for text (i.e. no child elements).</xhtml:div>
+					</xhtml:div>
+				</xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:restriction base="abstractTextType">
+            <xs:simpleType>
+               <xs:restriction base="xs:string"/>
+            </xs:simpleType>
+         </xs:restriction>
+      </xs:simpleContent>
+   </xs:complexType>
+   
+   <xs:complexType name="integerType">
+      <xs:annotation>
+         <xs:documentation>
+				<xhtml:div>
+					<xhtml:h1 class="element_title">Integer Type</xhtml:h1>
+					<xhtml:div>
+						<xhtml:h2 class="section_header">Description</xhtml:h2>
+						<xhtml:div class="description">This type restricts the base abstractTextType to only allow for an integer as text content. No child elements are allowed.</xhtml:div>
+					</xhtml:div>
+				</xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:restriction base="abstractTextType">
+            <xs:simpleType>
+               <xs:restriction base="xs:integer"/>
+            </xs:simpleType>
+         </xs:restriction>
+      </xs:simpleContent>
+   </xs:complexType>
+   
+   <xs:simpleType name="dateSimpleType">
+      <xs:annotation>
+         <xs:documentation>
+				<xhtml:div>
+					<xhtml:h1 class="element_title">Date Simple Type</xhtml:h1>
+					<xhtml:div>
+						<xhtml:h2 class="section_header">Description</xhtml:h2>
+						<xhtml:div class="description">This simple type is a union of the various XML Schema date formats. Using this type, a date can be expressed as a year (YYYY), a year and month (YYYY-MM), a date (YYYY-MM-DD) or a complete date and time (YYYY-MM-DDThh:mm:ss). All of these formats allow for an optional timezone offset to be specified.</xhtml:div>
+					</xhtml:div>
+				</xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+      <xs:union memberTypes="xs:dateTime xs:date xs:gYearMonth xs:gYear"/>
+   </xs:simpleType>
+   
+   <xs:complexType name="dateType">
+      <xs:annotation>
+         <xs:documentation>
+				<xhtml:div>
+					<xhtml:h1 class="element_title">Date Type</xhtml:h1>
+					<xhtml:div>
+						<xhtml:h2 class="section_header">Description</xhtml:h2>
+						<xhtml:div class="description">This type restricts the base abstractTextType to allow for only the union of types defined in dateSimpleType as text content. No child elements are allowed.</xhtml:div>
+					</xhtml:div>
+				</xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:restriction base="abstractTextType">
+            <xs:simpleType>
+               <xs:restriction base="dateSimpleType"/>
+            </xs:simpleType>
+         </xs:restriction>
+      </xs:simpleContent>
+   </xs:complexType>
+   
+   <!-- PRHASE Elements -->
+   
+   <xs:group name="PHRASE">
+      <xs:choice>
+         <xs:element ref="ExtLink" minOccurs="0" maxOccurs="unbounded"/>
+         <xs:element ref="Link" minOccurs="0" maxOccurs="unbounded"/>
+      </xs:choice>
+   </xs:group>
+
+   <xs:complexType name="ExtLinkType" mixed="true">
+      <xs:complexContent>
+         <xs:extension base="baseElementType">
+            <xs:attribute name="URI" type="xs:string" use="required"/>
+            <xs:attribute name="role" type="xs:string"/>
+            <xs:attribute name="title" type="xs:string"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="ExtLink" type="ExtLinkType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">External Link</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">This element permits encoders to provide links from any arbitrary element containing ExtLink as a subelement to electronic resources outside the codebook.</xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:complexType name="LinkType" mixed="true">
+      <xs:complexContent>
+         <xs:extension base="baseElementType">
+            <xs:attribute name="refs" type="xs:IDREFS" use="required"/>
+            <xs:attribute name="role" type="xs:string"/>
+            <xs:attribute name="title" type="xs:string"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+   
+   <xs:element name="Link" type="LinkType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Link</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">This element permits encoders to provide links from any arbitrary element containing Link as a subelement to other elements in the codebook.</xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <!-- FORM Elements -->
+   
+   <xs:group name="FORM">
+      <xs:choice>
+         <xs:element ref="div"/>
+         <xs:element ref="emph"/>
+         <xs:element ref="head"/>
+         <xs:element ref="hi"/>
+         <xs:element ref="list"/>
+         <xs:element ref="p"/>
+      </xs:choice>
+   </xs:group>
+   
+   <xs:complexType name="formType" mixed="true" abstract="true">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Form Type</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">This type defines the basis for all elements in the FORM content group. This is derived from the abstractTextType. The content may still be mixed (text and child elements), but the child elements are restricted to be those from the PHRASE and FORM content groups, or the itm and label elements. Further, the possible attributes are restricted. This type is abstract, so specific form elements will further refine this type, but all elements in the FORM content group will conform to this structure and may be processed as such.</xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+      <xs:complexContent>
+         <xs:restriction base="abstractTextType">
+            <xs:sequence>
+               <xs:choice minOccurs="0" maxOccurs="unbounded">
+                  <xs:group ref="PHRASE"/>
+                  <xs:group ref="FORM"/>
+                  <xs:element ref="itm"/>
+                  <xs:element ref="label"/>
+               </xs:choice>               
+            </xs:sequence>
+            <xs:attribute name="n" type="xs:string"/>
+            <xs:attribute name="rend" type="xs:string"/>
+            <xs:attribute name="type" type="xs:string"/>
+         </xs:restriction>
+      </xs:complexContent>
+   </xs:complexType>
+   
+   <xs:complexType name="divType">
+      <xs:complexContent>
+         <xs:restriction base="formType">
+            <xs:sequence>
+               <xs:choice minOccurs="0" maxOccurs="unbounded">
+                  <xs:group ref="FORM"/>
+               </xs:choice>               
+            </xs:sequence>
+            <xs:attribute name="type" type="xs:string" use="prohibited"/>
+         </xs:restriction>
+      </xs:complexContent>
+   </xs:complexType>
+   
+   <xs:element name="div" type="divType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Division</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Formatting element: marks a subdivision in a text.</xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:complexType name="emphType" mixed="true">
+      <xs:complexContent>
+         <xs:restriction base="formType">
+            <xs:sequence>
+               <xs:choice minOccurs="0" maxOccurs="unbounded">
+                  <xs:element ref="hi"/>
+                  <xs:element ref="list"/>
+               </xs:choice>               
+            </xs:sequence>
+            <xs:attribute name="type" type="xs:string" use="prohibited"/>
+         </xs:restriction>
+      </xs:complexContent>
+   </xs:complexType>
+   
+   <xs:element name="emph" type="emphType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Emphasis</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Formatting element: marks words or phrases that are emphasized for rhetorical effect.</xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:complexType name="headType" mixed="true">
+      <xs:complexContent>
+         <xs:restriction base="formType">
+            <xs:sequence>
+               <xs:choice minOccurs="0" maxOccurs="unbounded">
+                  <xs:group ref="PHRASE"/>
+                  <xs:element ref="emph"/>
+                  <xs:element ref="hi"/>
+                  <xs:element ref="list"/>
+               </xs:choice>               
+            </xs:sequence>
+         </xs:restriction>
+      </xs:complexContent>
+   </xs:complexType>
+   
+   <xs:element name="head" type="headType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Head</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Formatting element: marks off a heading to a division, list, etc. </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:complexType name="hiType" mixed="true">
+      <xs:complexContent>
+         <xs:restriction base="formType">
+            <xs:sequence>
+               <xs:choice minOccurs="0" maxOccurs="unbounded">
+                  <xs:element ref="emph"/>
+                  <xs:element ref="list"/>
+               </xs:choice>               
+            </xs:sequence>
+            <xs:attribute name="type" type="xs:string" use="prohibited"/>
+         </xs:restriction>
+      </xs:complexContent>
+   </xs:complexType>
+   
+   <xs:element name="hi" type="hiType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Highlight</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Formatting element: marks a word or phrase as graphically distinct from the surrounding text, while making no claim for the reasons.</xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:complexType name="listType">
+      <xs:complexContent>
+         <xs:restriction base="formType">
+            <xs:sequence>
+               <xs:choice minOccurs="0" maxOccurs="unbounded">
+                  <xs:element ref="itm"/>
+                  <xs:element ref="label"/>
+               </xs:choice>               
+            </xs:sequence>
+            <xs:attribute name="type" default="simple">
+               <xs:simpleType>
+                  <xs:restriction base="xs:NMTOKEN">
+                     <xs:enumeration value="ordered"/>
+                     <xs:enumeration value="bulleted"/>
+                     <xs:enumeration value="simple"/>
+                     <xs:enumeration value="gloss"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:attribute>
+         </xs:restriction>
+      </xs:complexContent>
+   </xs:complexType>
+   
+   <xs:element name="list" type="listType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">List</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Formatting element: contains any sequence of items (entries) organized as a list.</xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:complexType name="itmType" mixed="true">
+      <xs:complexContent>
+         <xs:restriction base="formType">
+            <xs:sequence>
+               <xs:choice minOccurs="0" maxOccurs="unbounded">
+                  <xs:group ref="PHRASE"/>
+                  <xs:element ref="emph"/>
+                  <xs:element ref="hi"/>
+                  <xs:element ref="list"/>
+                  <xs:element ref="p"/>
+                  <xs:element ref="label"/>
+               </xs:choice>               
+            </xs:sequence>
+            <xs:attribute name="type" type="xs:string" use="prohibited"/>
+         </xs:restriction>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="itm" type="itmType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Item</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Formatting element: marks entries (items) in a list.</xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:complexType name="labelType" mixed="true">
+      <xs:complexContent>
+         <xs:restriction base="formType">
+            <xs:sequence>
+               <xs:choice minOccurs="0" maxOccurs="unbounded">
+                  <xs:group ref="PHRASE"/>
+                  <xs:element ref="emph"/>
+                  <xs:element ref="hi"/>               
+               </xs:choice>               
+            </xs:sequence>
+            <xs:attribute name="type" type="xs:string" use="prohibited"/>
+         </xs:restriction>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="label" type="labelType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Label</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Formatting element: contains the label associated with an item in a list; in glossaries, marks the term being defined. </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Label</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">A short description of the parent element. Attribute "level" indicates the level to which the element applies (variable group, nCube group, variable, etc.). The "vendor" attribute allows for specification of different labels for use with different vendors' software. Attribute "country" allows specification of a different label by country for the same element to which it applies. Attribute "sdatrefs" allows pointing to specific dates, universes, or other information encoded in the study description. The attributes "country" and "sdatrefs" are intended to cover instances of comparative data, by retaining consistency in some elements over time and geography, but altering, as appropriate, information pertaining to date, language, and/or location.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <recGrp rectype="A" keyvar="H-SEQ" recidvar="PRECORD"> 
+                           <labl>Person (A) Record</labl> 
+                        </recGrp>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <varGrp>
+                           <labl>Study Procedure Information</labl>
+                        </varGrp>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <varGrp>
+                           <labl>Political Involvement and National Goals</labl>
+                        </varGrp>
+                     ]]></xhtml:samp> 
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <varGrp>
+                           <labl>Household Variable Section</labl>
+                        </varGrp>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <nCubeGrp>
+                           <labl>Sex by Work Experience in 1999 by Income in 1999</labl>
+                        </nCubeGrp>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <nCubeGrp>
+                           <labl>Tenure by Age of Householder</labl>
+                        </nCubeGrp>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <var>
+                           <labl>Why No Holiday-No Money</labl>
+                        </var>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <catgryGrp>
+                           <labl>Other Agricultural and Related Occupations</labl>
+                        </catgryGrp>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <catgry>
+                           <labl>Better</labl>
+                        </catgry>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <catgry>
+                           <labl>About the same</labl> 
+                        </catgry>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <catgry>
+                           <labl>Inap.</labl> 
+                        </catgry>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <nCube>
+                           <labl>Age by Sex by Poverty Status</labl>
+                        </nCube>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <otherMat type="SAS data definition statements" level="study" URI="http:// www.icpsr.umich.edu">
+                           <labl>SAS Data Definition Statements for  ICPSR 6837</labl>
+                        </otherMat>
+                     ]]></xhtml:samp>
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:complexType name="pType" mixed="true">
+      <xs:complexContent>
+         <xs:restriction base="formType">
+            <xs:sequence>
+               <xs:choice minOccurs="0" maxOccurs="unbounded">
+                  <xs:group ref="PHRASE"/>
+                  <xs:element ref="emph"/>
+                  <xs:element ref="hi"/>
+                  <xs:element ref="list"/>
+               </xs:choice>               
+            </xs:sequence>
+               <xs:attribute name="type" type="xs:string" use="prohibited"/>
+         </xs:restriction>
+      </xs:complexContent>
+   </xs:complexType>
+   
+   <xs:element name="p" type="pType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Paragraph</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Marks a paragraph.</xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <!-- Codebook Elements -->
+   
+   <xs:complexType name="abstractType" mixed="true">
+      <xs:complexContent>
+         <xs:extension base="simpleTextAndDateType">
+            <xs:attribute name="contentType" use="optional">
+               <xs:simpleType>
+                  <xs:restriction base="xs:NMTOKEN">
+                     <xs:enumeration value="abstract"/>
+                     <xs:enumeration value="purpose"/>
+                     <xs:enumeration value="mixed"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:attribute>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+   
+   <xs:element name="abstract" type="abstractType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Abstract</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">An unformatted summary describing the purpose, nature, and scope of the data collection, special characteristics of its contents, major subject areas covered, and what questions the PIs attempted to answer when they conducted the study. A listing of major variables in the study is important here. In cases where a codebook contains more than one abstract (for example, one might be supplied by the data producer and another prepared by the data archive where the data are deposited), the "source" and "date" attributes may be used to distinguish the abstract versions. Maps to Dublin Core Description element. Inclusion of this element in the codebook is recommended. The "date" attribute should follow ISO convention of YYYY-MM-DD. The contentType attribute provides forward-compatibility with DDI 3 by describing where the content fits in that structure, or if is mixed in terms of what is contained.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <abstract date="1999-01-28" source="ICPSR"> Data on labor force activity for the week prior to the survey are supplied in this collection. Information is available on the employment status, occupation, and industry of persons 15 years old and over. Demographic variables such as age, sex, race, marital status, veteran status, household relationship, educational background, and Hispanic origin are included. In addition to providing these core data, the May survey also contains a supplement on work schedules for all applicable persons aged 15 years and older who were employed at the time of the survey. This supplement focuses on shift work, flexible hours, and work at home for both main and second jobs.</abstract>
+                     ]]></xhtml:samp>
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:complexType name="accsPlacType" mixed="true">
+      <xs:complexContent>
+         <xs:extension base="simpleTextType">
+            <xs:attribute name="URI" type="xs:string" use="optional"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="accsPlac" type="accsPlacType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Location of Data Collection</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Location where the data collection is currently stored. Use the URI attribute to provide a URN or URL for the storage site or the actual address from which the data may be downloaded.</xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:element name="actMin" type="simpleTextType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Actions to Minimize Losses</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Summary of actions taken to minimize data loss. Includes information on actions such as follow-up visits, supervisory checks, historical matching, estimation, etc.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <actMin>To minimize the number of unresolved cases and reduce the potential nonresponse bias, four follow-up contacts were made with agencies that had not responded by various stages of the data collection process.</actMin>
+                     ]]></xhtml:samp>
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:element name="altTitl" type="simpleTextType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Alternative Title</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">A title by which the work is commonly referred, or an abbreviation of the title.</xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:complexType name="anlyInfoType">
+      <xs:complexContent>
+         <xs:extension base="baseElementType">
+            <xs:sequence>
+               <xs:element ref="respRate" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="EstSmpErr" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="dataAppr" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+   
+   <xs:element name="anlyInfo" type="anlyInfoType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Data Appraisal</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Information on data appraisal.</xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:complexType name="anlyUnitType" mixed="true">
+      <xs:complexContent>
+         <xs:extension base="conceptualTextType">
+            <xs:attribute name="unit" type="xs:string" use="optional"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+   
+   <xs:element name="anlyUnit" type="anlyUnitType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Unit of Analysis</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Basic unit of analysis or observation that the file describes: individuals, families/households, groups, institutions/organizations, administrative units, etc. The "unit" attribute is included to permit the development of a controlled vocabulary for this element.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <anlyUnit>individuals</anlyUnit>
+                     ]]></xhtml:samp> 
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+     
+   <xs:element name="anlysUnit" type="conceptualTextType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Analysis Unit</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Provides information regarding whom or what the variable/nCube describes. The element may be repeated only to support multiple language expressions of the content.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <var>
+                           <anlysUnit>This variable reports election returns at the constituency level.</anlysUnit>
+                        </var>
+                     ]]></xhtml:samp> 
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <nCube>
+                           <anlysUnit>Household</anlysUnit>
+                        </nCube>
+                     ]]></xhtml:samp>
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:complexType name="AuthEntyType" mixed="true">
+      <xs:complexContent>
+         <xs:extension base="simpleTextType">
+            <xs:attribute name="affiliation" type="xs:string" use="optional"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="AuthEnty" type="AuthEntyType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Authoring Entity/Primary Investigator</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">
+                     <xhtml:p>The person, corporate body, or agency responsible for the work's substantive and intellectual content. Repeat the element for each author, and use "affiliation" attribute if available. Invert first and last name and use commas. Author of data collection (codeBook/stdyDscr/citation/rspStmt/AuthEnty) maps to Dublin Core Creator element. Inclusion of this element in codebook is recommended. </xhtml:p>
+                     <xhtml:p>The "author" in the Document Description should be the individual(s) or organization(s) directly responsible for the intellectual content of the DDI version, as distinct from the person(s) or organization(s) responsible for the intellectual content of the earlier paper or electronic edition from which the DDI edition may have been derived.</xhtml:p>
+                  </xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <AuthEnty>United States Department of Commerce. Bureau of the Census</AuthEnty>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <AuthEnty affiliation="European Commission">Rabier, Jacques-Rene</AuthEnty>
+                     ]]></xhtml:samp> 
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+ 
+   <xs:element name="avlStatus" type="simpleTextType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Availability Status</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Statement of collection availability. An archive may need to indicate that a collection is unavailable because it is embargoed for a period of time, because it has been superseded, because a new edition is imminent, etc. It is anticipated that a controlled vocabulary will be developed for this element.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <avlStatus>This collection is superseded by CENSUS OF POPULATION, 1880 [UNITED STATES]: PUBLIC USE SAMPLE (ICPSR 6460).</avlStatus>
+                     ]]></xhtml:samp>
+                 </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:complexType name="backwardType" mixed="true">
+      <xs:complexContent>
+         <xs:extension base="simpleTextType">
+            <xs:attribute name="qstn" type="xs:IDREFS" use="optional"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="backward" type="backwardType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Backflow</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Contains a reference to IDs of possible preceding questions. The "qstn" IDREFS may be used to specify the question IDs.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <var>
+                           <qstn>
+                              <backward qstn="Q12 Q13 Q14 Q15">For responses on a similar topic, see questions 12-15.</backward>
+                           </qstn> 
+                        </var>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <var>
+                           <qstn>
+                              <backward qstn="Q143"/>
+                           </qstn> 
+                        </var>
+                     ]]></xhtml:samp> 
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:complexType name="biblCitType" mixed="true">
+      <xs:complexContent>
+         <xs:extension base="simpleTextType">
+            <xs:attribute name="format" type="xs:string" use="optional"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="biblCit" type="biblCitType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Bibliographic Citation</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Complete bibliographic reference containing all of the standard elements of a citation that can be used to cite the work. The "format" attribute is provided to enable specification of the particular citation style used, e.g., APA, MLA, Chicago, etc.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <biblCit format="MRDF">Rabier, Jacques-Rene, and Ronald Inglehart. EURO-BAROMETER 11: YEAR OF  THE CHILD IN EUROPE, APRIL 1979 [Codebook file]. Conducted by Institut Francais D'Opinion Publique (IFOP), Paris, et al. ICPSR ed. Ann Arbor, MI: Inter-university Consortium for Political and Social Resarch [producer and distributor], 1981.</biblCit>
+                     ]]></xhtml:samp>
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:complexType name="boundPolyType">
+      <xs:complexContent>
+         <xs:extension base="baseElementType">
+            <xs:sequence>
+               <xs:element ref="polygon" maxOccurs="unbounded"/>
+            </xs:sequence>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="boundPoly" type="boundPolyType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Geographic Bounding Polygon</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">
+                     <xhtml:p>This field allows the creation of multiple polygons to describe in a more detailed manner the geographic area covered by the dataset. It should only be used to define the outer boundaries of a covered area. For example, in the United States, such polygons can be created to define boundaries for Hawaii, Alaska, and the continental United States, but not interior boundaries for the contiguous states. This field is used to refine a coordinate-based search, not to actually map an area. </xhtml:p>
+                     <xhtml:p>If the boundPoly element is used, then geoBndBox MUST be present, and all points enclosed by the boundPoly MUST be contained within the geoBndBox. Elements westBL, eastBL, southBL, and northBL of the geoBndBox should each be represented in at least one point of the boundPoly description. </xhtml:p>
+                  </xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <geogCover>Nevada State</geogCover>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <boundPoly>
+                           <polygon>
+                              <point>
+                                 <gringLat>42.002207</gringLat>
+                                 <gringLon>-120.005729004</gringLon>
+                              </point>
+                              <point>
+                                 <gringLat>42.002207</gringLat>
+                                 <gringLon>-114.039663</gringLon>
+                              </point>
+                              <point>
+                                 <gringLat>35.9</gringLat>
+                                 <gringLon>-114.039663</gringLon>
+                              </point>
+                              <point>
+                                 <gringLat>36.080</gringLat>
+                                 <gringLon>-114.544</gringLon>
+                              </point>
+                              <point>
+                                 <gringLat>35.133</gringLat>
+                                 <gringLon>-114.542</gringLon>
+                              </point>
+                              <point>
+                                 <gringLat>35.00208499998</gringLat>
+                                 <gringLon>-114.63288</gringLon>
+                              </point>
+                              <point>
+                                 <gringLat>35.00208499998</gringLat>
+                                 <gringLon>-114.63323</gringLon>
+                              </point>
+                              <point>
+                                 <gringLat>38.999</gringLat>
+                                 <gringLon>-120.005729004</gringLon>
+                              </point>
+                              <point>
+                                 <gringLat>42.002207</gringLat>
+                                 <gringLon>-120.005729004</gringLon>
+                              </point>
+                           </polygon>
+                        </boundPoly>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <geogCover>Norway</geogCover>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <boundPoly>
+                           <polygon>
+                              <point>
+                                 <gringLat>80.76416</gringLat>
+                                 <gringLon>33.637497</gringLon>
+                              </point>
+                              <point>
+                                 <gringLat>80.76416</gringLat>
+                                 <gringLon>10.2</gringLon>
+                              </point>
+                              <point>
+                                 <gringLat>62.48395</gringLat>
+                                 <gringLon>4.789583</gringLon>
+                              </point>
+                              <point>
+                                 <gringLat>57.987915</gringLat>
+                                 <gringLon>4.789583</gringLon>
+                              </point>
+                              <point>
+                                 <gringLat>57.987915</gringLat>
+                                 <gringLon>11.8</gringLon>
+                              </point>
+                              <point>
+                                 <gringLat>61.27794</gringLat>
+                                 <gringLon>13.2336</gringLon>
+                              </point>
+                              <point>
+                                 <gringLat>63.19012</gringLat>
+                                 <gringLon>13.2336</gringLon>
+                              </point>
+                              <point>
+                                 <gringLat>67.28615</gringLat>
+                                 <gringLon>17.24580</gringLon>
+                              </point>
+                              <point>
+                                 <gringLat>68.14297</gringLat>
+                                 <gringLon>21.38362</gringLon>
+                              </point>
+                              <point>
+                                 <gringLat>68.14297</gringLat>
+                                 <gringLon>25.50054</gringLon>
+                              </point>
+                              <point>
+                                 <gringLat>69.39685</gringLat>
+                                 <gringLon>27.38137</gringLon>
+                              </point>
+                              <point>
+                                 <gringLat>68.76991</gringLat>
+                                 <gringLon>28.84424</gringLon>
+                              </point>
+                              <point>
+                                 <gringLat>68.76991</gringLat>
+                                 <gringLon>31.31021</gringLon>
+                              </point>
+                              <point>
+                                 <gringLat>71.42</gringLat>
+                                 <gringLon>31.31021</gringLon>
+                              </point>
+                              <point>
+                                 <gringLat>71.42</gringLat>
+                                 <gringLon>33.637497</gringLon>
+                              </point>
+                              <point>
+                                 <gringLat>80.76416</gringLat>
+                                 <gringLon>33.637497</gringLon>
+                              </point>
+                           </polygon>
+                        </boundPoly>
+                     ]]></xhtml:samp>
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:element name="caseQnty" type="simpleTextType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Number of cases / Record Quantity</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Number of cases or observations.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <caseQnty>1011</caseQnty>
+                     ]]></xhtml:samp>
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:complexType name="catStatType" mixed="true">
+      <xs:complexContent>
+         <xs:extension base="simpleTextType">
+            <xs:attribute name="type" default="freq">
+               <xs:simpleType>
+                  <xs:restriction base="xs:NMTOKEN">
+                     <xs:enumeration value="freq"/>
+                     <xs:enumeration value="percent"/>
+                     <xs:enumeration value="crosstab"/>
+                     <xs:enumeration value="other"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:attribute>
+            <xs:attribute name="otherType" type="xs:NMTOKEN" use="optional"/>
+            <xs:attribute name="URI" type="xs:string" use="optional"/>
+            <xs:attribute name="methrefs" type="xs:IDREFS" use="optional"/>
+            <xs:attribute name="wgtd" default="not-wgtd">
+               <xs:simpleType>
+                  <xs:restriction base="xs:NMTOKEN">
+                     <xs:enumeration value="wgtd"/>
+                     <xs:enumeration value="not-wgtd"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:attribute>
+            <xs:attribute name="wgt-var" type="xs:IDREFS" use="optional"/>
+            <xs:attribute name="weight" type="xs:IDREFS" use="optional"/>
+            <xs:attribute name="sdatrefs" type="xs:IDREFS" use="optional"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="catStat" type="catStatType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Category Level Statistic</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">May include frequencies, percentages, or crosstabulation results. This field can contain one of the following: 1. textual information (e.g., PCDATA), or 2. non-parseable character data (e.g., the statistics), or 3. some other form of external information (table, image, etc.) In case 1, the tag can be used to mark up character data; tables can also be included in the actual markup. In cases 2 or 3, the element can be left empty and the "URI" attribute used to refer to the external object containing the information. The attribute "type" indicates the type of statistics presented - frequency, percent, or crosstabulation. If a value of "other" is used for this attribute, the "otherType" attribute should take a value from a controlled vocabulary. This option should only be used when applying a controlled vocabulary to this attribute. Use the complex element controlledVocabUsed to identify the controlled vocabulary to which the selected term belongs.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <var>
+                           <catgryGrp>
+                              <catStat type="freq">256</catStat>
+                           </catgryGrp>
+                        </var>
+                     ]]></xhtml:samp> 
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:element name="catValu" type="simpleTextType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Category Value</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">The explicit response.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <var>
+                           <catgry missing="Y" missType="inap">
+                              <catValu>9</catValu> 
+                           </catgry>
+                        </var>
+                     ]]></xhtml:samp> 
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:complexType name="catLevelType">
+      <xs:complexContent>
+         <xs:extension base="baseElementType">
+            <xs:attribute name="levelnm" type="xs:string"/>
+            <xs:attribute name="geoMap" type="xs:IDREFS"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="catLevel" type="catLevelType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Category Level</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Used to describe the levels of the category hierarchy. Note that we do not indicate nesting levels or roll-up structures here. This is done to be able to support ragged hierarchies. A category level may be linked to one or more maps of the variable content. This id done by referencing the IDs of the appropriate geoMap elements in the attribute <xhtml:code>geoMap</xhtml:code>.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <catlevel ID="Level1" levelnm="Broader sectors"/>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <catlevel ID="Level2" levelnm="Narrower sectors"/>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <catlevel ID="Level3" levelnm="Occupations" geoMap="GEO_1 GEO_2"/>
+                     ]]></xhtml:samp>                  
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:complexType name="catgryType">
+      <xs:complexContent>
+         <xs:extension base="baseElementType">
+            <xs:sequence>
+               <xs:element ref="catValu" minOccurs="0"/>
+               <xs:element ref="labl" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="txt" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="catStat" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="mrow" minOccurs="0"/>
+            </xs:sequence>
+            <xs:attribute name="missing" default="N">
+               <xs:simpleType>
+                  <xs:restriction base="xs:NMTOKEN">
+                     <xs:enumeration value="Y"/>
+                     <xs:enumeration value="N"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:attribute>
+            <xs:attribute name="missType" type="xs:string" use="optional"/>
+            <xs:attribute name="country" type="xs:string" use="optional"/>
+            <xs:attribute name="sdatrefs" type="xs:IDREFS" use="optional"/>
+            <xs:attribute name="excls" default="true">
+               <xs:simpleType>
+                  <xs:restriction base="xs:NMTOKEN">
+                     <xs:enumeration value="true"/>
+                     <xs:enumeration value="false"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:attribute>
+            <xs:attribute name="catgry" type="xs:IDREFS" use="optional"/>
+            <xs:attribute name="level" type="xs:IDREF" use="optional"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="catgry" type="catgryType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Category</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">
+                     <xhtml:p>A description of a particular response.</xhtml:p>
+                     <xhtml:p>The attribute "missing" indicates whether this category group contains missing data or not. </xhtml:p>
+                     <xhtml:p>The attribute "missType" is used to specify the type of missing data, e.g., inap., don't know, no answer, etc. </xhtml:p>
+                     <xhtml:p>The attribute "country" allows for the denotation of country-specific category values.</xhtml:p>
+                     <xhtml:p>The "sdatrefs" attribute records the ID values of all elements within the  summary data description that apply to this category. </xhtml:p>
+                     <xhtml:p>The exclusiveness attribute ("excls") should be set to "false" if the category can appear in more than one place in the classification hierarchy.</xhtml:p>
+                     <xhtml:p>The attribute "catgry" is an IDREF referencing any child categories of this category element. Used to capture nested hierarchies of categories.</xhtml:p>
+                     <xhtml:p>The attribute "level" is an IDREF referencing the catLevel ID in which this category exists.</xhtml:p>
+                  </xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <catlevel ID="Level1" levelnm="Broader sectors"/>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <catlevel ID="Level2" levelnm="Narrower sectors"/>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <catlevel ID="Level3" levelnm="Occupations"/>
+                     ]]></xhtml:samp>
+                     <!-- ... -->
+                  <xhtml:samp class="xml_sample"><![CDATA[
+                        <catgry ID="C1" catgry="C2" Level="Level1">
+                           <catValu>0</catValu>
+                           <labl>Management, professional and related occupations</labl>
+                        </catgry>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <catgry ID="C2" catgry="C3, C4" Level="Level2">
+                           <catValu>01</catValu>
+                           <labl>Management occupations</labl>
+                        </catgry>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <catgry ID="C3" Level="Level3">
+                           <catValu>011</catValu>
+                           <labl>Top executives</labl>
+                        </catgry>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <catgry ID="C4" Level="Level3">
+                           <catValu>012</catValu>
+                           <labl>Financial managers</labl>
+                        </catgry>
+                     ]]></xhtml:samp>
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:complexType name="catgryGrpType">
+      <xs:complexContent>
+         <xs:extension base="baseElementType">
+            <xs:sequence>
+               <xs:element ref="labl" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="catStat" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="txt" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+            <xs:attribute name="missing" default="N">
+               <xs:simpleType>
+                  <xs:restriction base="xs:NMTOKEN">
+                     <xs:enumeration value="Y"/>
+                     <xs:enumeration value="N"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:attribute>
+            <xs:attribute name="missType" type="xs:string" use="optional"/>
+            <xs:attribute name="catgry" type="xs:IDREFS" use="optional"/>
+            <xs:attribute name="catGrp" type="xs:IDREFS" use="optional"/>
+            <xs:attribute name="levelno" type="xs:string" use="optional"/>
+            <xs:attribute name="levelnm" type="xs:string" use="optional"/>
+            <xs:attribute name="compl" default="true">
+               <xs:simpleType>
+                  <xs:restriction base="xs:NMTOKEN">
+                     <xs:enumeration value="true"/>
+                     <xs:enumeration value="false"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:attribute>
+            <xs:attribute name="excls" default="true">
+               <xs:simpleType>
+                  <xs:restriction base="xs:NMTOKEN">
+                     <xs:enumeration value="true"/>
+                     <xs:enumeration value="false"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:attribute>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="catgryGrp" type="catgryGrpType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Category Group</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">A description of response categories that might be grouped together. The attribute "missing" indicates whether this category group contains missing data or not. The attribute "missType" is used to specify the type of missing data, e.g., inap., don't know, no answer, etc. The attribute catGrp is used to indicate all the subsidiary category groups which nest underneath the current category group. This allows for the encoding of a hierarchical structure of category groups. The "levelno" attribute allows the addition of a level number, and "levelnm" allows the addition of a level name to the category group. The completeness attribute ("compl") should be set to "false" if the category group is incomplete (not a complete aggregate of all sub-nodes or children). The exclusiveness attribute ("excls") should be set to "false" if the category group can appear in more than one place in the classification hierarchy.</xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:element name="citReq" type="simpleTextType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Citation Requirement</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Text of requirement that a data collection should be cited properly in articles or other publications that are based on analysis of the data.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <citReq>Publications based on ICPSR data collections should acknowledge those sources by  means of bibliographic citations. To ensure that such source attributions are captured for social science bibliographic utilities, citations must appear in footnotes or in the reference section of publications.</citReq>
+                     ]]></xhtml:samp>
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:complexType name="citationType">
+      <xs:complexContent>
+         <xs:extension base="baseElementType">
+            <xs:sequence>
+               <xs:element ref="titlStmt"/>
+               <xs:element ref="rspStmt" minOccurs="0"/>
+               <xs:element ref="prodStmt" minOccurs="0"/>
+               <xs:element ref="distStmt" minOccurs="0"/>
+               <xs:element ref="serStmt" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="verStmt" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="biblCit" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="holdings" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="notes" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:group ref="dc:elementsAndRefinementsGroup"/>
+            </xs:sequence>
+            <xs:attribute name="MARCURI" type="xs:string" use="optional"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="citation" type="citationType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Bibliographic Citation</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">
+                     <xhtml:p>This element encodes the bibliographic information for the work at the level specified: (1) Document Description, Citation (of Marked-up Document), (2) Document Description, Citation (of Marked-up Document Source), (3) Study Description, Citation (of Study), (4) Study Description, Other Material, and (5) Other Material for the study itself. Bibliographic information includes title information, statement of responsibility, production and distribution information, series and version information, text of a preferred bibliographic citation, and notes (if any). </xhtml:p>
+                     <xhtml:p>A MARCURI attribute is provided to link to the MARC record for the citation.</xhtml:p>
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:complexType name="cleanOpsType" mixed="true">
+      <xs:complexContent>
+         <xs:extension base="simpleTextType">
+            <xs:attribute name="agency" type="xs:string" use="optional"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="cleanOps" type="cleanOpsType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Cleaning Operations</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Methods used to "clean" the data collection, e.g., consistency checking, wild code checking, etc. The "agency" attribute permits specification of the agency doing the data cleaning.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <cleanOps>Checks for undocumented codes were performed, and data were subsequently revised in consultation with the principal investigator.</cleanOps>
+                     ]]></xhtml:samp>
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:element name="codInstr" type="simpleTextType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Coder Instructions</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Any special instructions to those who converted information from one form to another for a particular variable. This might include the reordering of numeric information into another form or the conversion of textual information into numeric information.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <var>
+                           <codInstr>Use the standard classification tables to present responses to the question: What is your occupation? into numeric codes.</codInstr>
+                        </var>
+                     ]]></xhtml:samp> 
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:complexType name="codeBookType">
+      <xs:complexContent>
+         <xs:extension base="baseElementType">
+            <xs:sequence>
+               <xs:element ref="docDscr" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="stdyDscr" maxOccurs="unbounded"/>
+               <xs:element ref="fileDscr" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="dataDscr" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="otherMat" minOccurs="0" maxOccurs="unbounded">
+               	<xs:annotation>
+               		<xs:documentation>This should be used for materials that are primarily descriptions of the content and use of the study, such as appendices, sampling information, weighting details, methodological and technical details, publications based upon the study content, related studies or collection of studies, etc. This section is intended to include or to link to materials used in the production of the study or useful in the analysis of the study.</xs:documentation>
+               	</xs:annotation>
+               </xs:element>
+            </xs:sequence>
+            <xs:attribute name="version" type="xs:string" fixed="2.5"/>
+            <xs:attribute name="codeBookAgency" type="xs:NCName" use="optional"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+   
+   <xs:element name="codeBook" type="codeBookType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Codebook</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">
+                     <xhtml:p>Every element in the DDI DTD/Schema has the following attributes:</xhtml:p>
+                     <xhtml:p>ID - This uniquely identifies each element.</xhtml:p>
+                     <xhtml:p>xml-lang - Use of this attribute is deprecated, and it will no longer be supported in the next major version of the DDI specification. For newly created XML documents, please use xml:lang.</xhtml:p>
+                     <xhtml:p>xml:lang - This attribute specifies the language used in the contents and attribute values of any element in the XML document. Use of ISO (<xhtml:a href="http://www.iso.org/">www.iso.org</xhtml:a>) language codes is recommended.</xhtml:p>
+                     <xhtml:p>source - This attribute identifies the source that provided information in the element. If the documentation contains two differing sets of information on Sampling Procedure -- one provided by the data producer and one by the archive where the data is deposited -- this information can be distinguished through the use of the source attribute.</xhtml:p>
+                     <xhtml:p>Note also that the DDI contains a linking mechanism permitting arbitrary links between internal elements (See Link) and from internal elements to external sources (See ExtLink).</xhtml:p>
+                     <xhtml:p>The top-level element, codeBook, also includes a version attribute to specify the version number of the DDI specification.</xhtml:p>
+                     <xhtml:p>codeBookAgency - This attribute holds the agency name of the creator or maintainer of the codeBook instance as a whole, and is designed to support forward compatibility with DDI-Lifecycle. Recommend the agency name as filed with the DDI Agency ID Registry with optional additional sub-agency extensions.</xhtml:p>
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:complexType name="cohortType">
+      <xs:complexContent>
+         <xs:extension base="baseElementType">
+            <xs:sequence>
+               <xs:element ref="range" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+            <xs:attribute name="catRef" type="xs:IDREF" use="optional"/>
+            <xs:attribute name="value" type="xs:string" use="optional"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="cohort" type="cohortType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Cohort</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">The element cohort is used when the nCube contains a limited number of categories from a particular variable, as opposed to the full range of categories. The attribute "catRef" is an IDREF to the actual category being used. The attribute "value" indicates the actual value attached to the category that is being used.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <dmns>
+                           <cohort catRef="CV24_1" value="1"/>
+                        </dmns>
+                     ]]></xhtml:samp> 
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:complexType name="collDateType" mixed="true">
+      <xs:complexContent>
+         <xs:extension base="simpleTextAndDateType">
+            <xs:attribute name="event" default="single">
+               <xs:simpleType>
+                  <xs:restriction base="xs:NMTOKEN">
+                     <xs:enumeration value="start"/>
+                     <xs:enumeration value="end"/>
+                     <xs:enumeration value="single"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:attribute>
+            <xs:attribute name="cycle" type="xs:string" use="optional"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="collDate" type="collDateType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Date of Collection</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Contains the date(s) when the data were collected. Use the event attribute to specify "start", "end", or "single" for each date entered. The ISO standard for dates (YYYY-MM-DD) is recommended for use with the "date" attribute. The "cycle" attribute permits specification of the relevant cycle, wave, or round of data. Maps to Dublin Core Coverage element. Inclusion of this element in the codebook is recommended.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <collDate event="single" date="1998-11-10">10 November 1998</collDate>
+                     ]]></xhtml:samp> 
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:element name="collMode" type="conceptualTextType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Mode of Data Collection</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">The method used to collect the data; instrumentation characteristics. XHTML formatting may be used in the txt element for forward-compatibility with DDI 3.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <collMode>telephone interviews</collMode>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <collMode>face-to-face interviews</collMode>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <collMode>mail questionnaires</collMode>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <collMode>computer-aided telephone interviews (CATI)</collMode>
+                     ]]></xhtml:samp>
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:element name="collSitu" type="simpleTextType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Characteristics of Data Collection Situation</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Description of noteworthy aspects of the data collection situation. Includes information on factors such as cooperativeness of respondents, duration of interviews, number of call-backs, etc.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <collSitu>There were 1,194 respondents who answered questions in face-to-face interviews lasting approximately 75 minutes each.</collSitu>
+                     ]]></xhtml:samp> 
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:element name="collSize" type="simpleTextType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Extent of Collection</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Summarizes the number of physical files that exist in a collection, recording the number of files that contain data and noting whether the collection contains machine-readable documentation and/or other supplementary files and information such as data dictionaries, data definition statements, or data collection instruments. </xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <collSize>1 data file + machine-readable documentation (PDF) + SAS data definition statements</collSize>
+                     ]]></xhtml:samp>
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:complexType name="colspecType">
+      <xs:complexContent>
+         <xs:extension base="baseElementType">
+            <xs:attribute name="colnum" type="xs:string" use="optional"/>
+            <xs:attribute name="colname" type="xs:NMTOKEN"/>
+            <xs:attribute name="colwidth" type="xs:string"/>
+            <xs:attribute name="colsep" type="xs:string"/>
+            <xs:attribute name="rowsep" type="xs:string"/>
+            <xs:attribute name="align">
+               <xs:simpleType>
+                  <xs:restriction base="xs:NMTOKEN">
+                     <xs:enumeration value="left"/>
+                     <xs:enumeration value="right"/>
+                     <xs:enumeration value="center"/>
+                     <xs:enumeration value="justify"/>
+                     <xs:enumeration value="char"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:attribute>
+            <xs:attribute name="char" type="xs:string"/>
+            <xs:attribute name="charoff" type="xs:NMTOKEN"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+   
+   <xs:element name="colspec" type="colspecType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Column Specification</xhtml:h1>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:element name="complete" type="simpleTextType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Completeness of Study Stored</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">This item indicates the relationship of the data collected to the amount of data coded and stored in the data collection. Information as to why certain items of collected information were not included in the data file stored by the archive should be provided. </xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <complete>Because of embargo provisions, data values for some variables have been masked. Users should consult the data definition statements to see which variables are under embargo. A new version of the collection will be released by ICPSR after embargoes are lifted.</complete>
+                     ]]></xhtml:samp>
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:complexType name="conceptType" mixed="true">
+      <xs:complexContent>
+         <xs:extension base="simpleTextType">
+            <xs:attribute name="vocab" type="xs:string"/>
+            <xs:attribute name="vocabURI" type="xs:string"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="concept" type="conceptType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Concept</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">The general subject to which the parent element may be seen as pertaining. This element serves the same purpose as the keywords and topic classification elements, but at the data description level. The "vocab" attribute is provided to indicate the controlled vocabulary, if any, used in the element, e.g., LCSH (Library of Congress Subject Headings), MeSH (Medical Subject Headings), etc. The "vocabURI" attribute specifies the location for the full controlled vocabulary.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <nCubeGrp>
+                           <concept>Income</concept>
+                        </nCubeGrp>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <nCubeGrp>
+                           <concept vocab="LCSH" vocabURI="http://lcweb.loc.gov/catdir/cpso/lcco/lcco.html" source="archive">more experience</concept>
+                        </nCubeGrp>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <var>
+                           <concept>Income</concept>
+                        </var>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <var>
+                           <concept vocab="LCSH" vocabURI="http://lcweb.loc.gov/catdir/cpso/lcco/lcco.html" source="archive">SF: 311-312 draft horses</concept>
+                        </var>
+                     ]]></xhtml:samp> 
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:element name="conditions" type="simpleTextType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Conditions</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Indicates any additional information that will assist the user in understanding the access and use conditions of the data collection.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <conditions>The data are available without restriction. Potential users of these datasets are advised, however, to contact the original principal investigator Dr. J. Smith (Institute for Social Research, The University of Michigan, Box 1248, Ann Arbor, MI 48106), about their intended uses of the data. Dr. Smith would also appreciate receiving copies of reports based on the datasets.</conditions>
+                     ]]></xhtml:samp>
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:complexType name="confDecType" mixed="true">
+      <xs:complexContent>
+         <xs:extension base="simpleTextType">
+            <xs:attribute name="required" default="yes">
+               <xs:simpleType>
+                  <xs:restriction base="xs:NMTOKEN">
+                     <xs:enumeration value="yes"/>
+                     <xs:enumeration value="no"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:attribute>
+            <xs:attribute name="formNo" type="xs:string"/>
+            <xs:attribute name="URI" type="xs:string"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="confDec" type="confDecType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Confidentiality Declaration</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">This element is used to determine if signing of a confidentiality declaration is needed to access a resource. The "required" attribute is used to aid machine processing of this element, and the default specification is "yes". The "formNo" attribute indicates the number or ID of the form that the user must fill out. The "URI" attribute may be used to provide a URN or URL for online access to a confidentiality declaration form.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <confDec formNo="1">To download this dataset, the user must sign a declaration of confidentiality.</confDec>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <confDec URI="http://www.icpsr.umich.edu/HMCA/CTSform/contents.html"> To obtain this dataset, the user must complete a Restricted Data Use Agreement.</confDec>
+                     ]]></xhtml:samp>
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:complexType name="contactType" mixed="true">
+      <xs:complexContent>
+         <xs:extension base="simpleTextType">
+            <xs:attribute name="affiliation" type="xs:string"/>
+            <xs:attribute name="URI" type="xs:string"/>
+            <xs:attribute name="email" type="xs:string"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="contact" type="contactType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Contact Persons</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Names and addresses of individuals responsible for the work. Individuals listed as contact persons will be used as resource persons regarding problems or questions raised by the user community. The URI attribute should be used to indicate a URN or URL for the homepage of  the contact individual. The email attribute is used to indicate an email address for the contact individual. </xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <contact affiliation="University of Wisconsin" email="jsmith@...">Jane Smith</contact>
+                     ]]></xhtml:samp>
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:complexType name="ConOpsType" mixed="true">
+      <xs:complexContent>
+         <xs:extension base="simpleTextType">
+            <xs:attribute name="agency" type="xs:string"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="ConOps" type="ConOpsType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Control Operations</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Methods to facilitate data control performed by the primary investigator or by the data archive. Specify any special programs used for such operations. The "agency" attribute maybe used to refer to the agency that performed the control operation.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <ConOps source="ICPSR">Ten percent of data entry forms were reentered to check for accuracy.</ConOps>
+                     ]]></xhtml:samp>
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:complexType name="controlledVocabUsedType">
+      <xs:complexContent>
+         <xs:extension base="baseElementType">
+            <xs:sequence>
+               <xs:element ref="codeListID" minOccurs="0"/>
+               <xs:element ref="codeListName" minOccurs="0"/>
+               <xs:element ref="codeListAgencyName" minOccurs="0"/>
+               <xs:element ref="codeListVersionID" minOccurs="0"/>
+               <xs:element ref="codeListURN" minOccurs="0"/>
+               <xs:element name="codeListSchemeURN" minOccurs="0"/>
+               <xs:element ref="usage" minOccurs="1" maxOccurs="unbounded"/>
+            </xs:sequence>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+   
+   <xs:element name="controlledVocabUsed" type="controlledVocabUsedType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Controlled Vocabulary Used</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Provides a code value, as well as a reference to the code list from which the value is taken. Note that the CodeValue can be restricted to reference an enumeration.</xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:element name="codeListID" type="stringType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Code List ID</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Identifies the code list that the value is taken from.</xhtml:div>
+               </xhtml:div>
+					<xhtml:div>
+						<xhtml:h2 class="section_header">Example</xhtml:h2>
+						<xhtml:div class="example">
+							<xhtml:samp class="xml_sample"><![CDATA[
+<codeListID>TimeMethod</codeListID>
+]]>
+							</xhtml:samp>
+						</xhtml:div>
+					</xhtml:div>            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:element name="codeListName" type="stringType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Code List Name</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Identifies the code list that the value is taken from with a human-readable name.</xhtml:div>
+               </xhtml:div>
+			   <xhtml:div>
+						<xhtml:h2 class="section_header">Example</xhtml:h2>
+						<xhtml:div class="example">
+							<xhtml:samp class="xml_sample"><![CDATA[
+<codeListName>Time Method</codeListName>]]>
+							</xhtml:samp>
+						</xhtml:div>
+					</xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:element name="codeListAgencyName" type="stringType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Code List Agency Name</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Agency maintaining the code list.</xhtml:div>
+               </xhtml:div>
+					<xhtml:div>
+						<xhtml:h2 class="section_header">Example</xhtml:h2>
+						<xhtml:div class="example">
+							<xhtml:samp class="xml_sample"><![CDATA[
+<codeListAgencyName>DDI Alliance</codeListAgencyName>]]>
+							</xhtml:samp>
+						</xhtml:div>
+					</xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:element name="codeListVersionID" type="stringType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Code List Version ID</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Version of the code list. (Default value is 1.0)</xhtml:div>
+               </xhtml:div>
+					<xhtml:div>
+						<xhtml:h2 class="section_header">Example</xhtml:h2>
+						<xhtml:div class="example">
+							<xhtml:samp class="xml_sample"><![CDATA[
+<codeListVersionID>1.1</codeListVersionID>]]>
+							</xhtml:samp>
+						</xhtml:div>
+					</xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:element name="codeListURN" type="stringType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Code List URN</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Identifies the code list that the value is taken from with a URN.</xhtml:div>
+               </xhtml:div>
+					<xhtml:div>
+						<xhtml:h2 class="section_header">Example</xhtml:h2>
+						<xhtml:div class="example">
+							<xhtml:samp class="xml_sample"><![CDATA[
+<codeListURN>urn:ddi-cv:TimeMethod:1.1</codeListURN>]]>
+							</xhtml:samp>
+						</xhtml:div>
+					</xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:element name="codeListSchemeURN" type="stringType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Code List Scheme URN</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Identifies the code list scheme using a URN.</xhtml:div>
+               </xhtml:div>
+					<xhtml:div>
+						<xhtml:h2 class="section_header">Example</xhtml:h2>
+						<xhtml:div class="example">
+							<xhtml:samp class="xml_sample"><![CDATA[<codeListSchemeURN>http://www.ddialliance.org/Specification/DDI-CV/TimeMethod_1.1_Genericode1.0_DDI-CVProfile1.0.xml</codeListSchemeURN>]]></xhtml:samp>
+						</xhtml:div>
+					</xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:element name="usage" type="usageType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Usage</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Defines where in the instance the controlled vocabulary which is identified is utilized. A controlled vocabulary may occur either in the content of an element or in an attribute on an element. The usage can either point to a collection of elements using an XPath via the selector element or point to a more specific collection of elements via their identifier using the specificElements element. If the controlled vocabulary occurs in an attribute within the element, the attribute element identifies the specific attribute. When specific elements are specified, an authorized code value may also be provided. If the current value of the element or attribute identified is not in the controlled vocabulary or is not identical to a code value, the authorized code value identifies a valid code value corresponding to the meaning of the content in the element or attribute.</xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:complexType name="usageType">
+      <xs:sequence>
+         <xs:choice>
+            <xs:element ref="selector"/>
+            <xs:element ref="specificElements"/>
+         </xs:choice>
+         <xs:element ref="attribute" minOccurs="0"/>
+      </xs:sequence>
+   </xs:complexType>
+   
+   <xs:simpleType name="selectorType">
+      <xs:restriction base="xs:string">
+         <xs:pattern value="((//|/)(([\i-[:]][\c-[:]]*:)?[\i-[:]][\c-[:]]*|\*|[\i-[:]][\c-[:]]*:\*))+"/>
+      </xs:restriction>
+   </xs:simpleType>
+   
+   <xs:element name="selector" type="selectorType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Selector</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Identifies a collection of elements in which a controlled vocabulary is used. This is a simplified XPath which must correspond to the actual instance in which it occurs, which is to say that the fully qualified element names here must correspond to those in the instance. This XPath can only identify elements and does not allow for any predicates. The XPath must either be rooted or deep.</xhtml:div>
+						<xhtml:div>
+							<xhtml:h2 class="section_header">Example</xhtml:h2>
+							<xhtml:div class="example">
+								<xhtml:samp class="xml_sample"><![CDATA[<selector>/codeBook/stdyDscr/method/dataColl/timeMeth</selector>]]></xhtml:samp>
+							</xhtml:div>
+						</xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:complexType name="specificElementsType">
+      <xs:attribute name="refs" type="xs:IDREFS" use="required"/>
+      <xs:attribute name="authorizedCodeValue" type="xs:NMTOKEN" use="optional"/>
+   </xs:complexType>
+   
+   <xs:element name="specificElements" type="specificElementsType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Specific Elements</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Identifies a collection of specific elements via their identifiers in the refs attribute, which allows for a tokenized list of identifier values which must correspond to identifiers which exist in the instance. The authorizedCodeValue attribute can be used to provide a valid code value corresponding to the meaning of the content in the element or attribute when the identified element or attribute does not use an actual valid value from the controlled vocabulary.</xhtml:div>
+				  </xhtml:div>
+					<xhtml:div>
+						<xhtml:h2 class="section_header">Example</xhtml:h2>
+						<xhtml:div class="example">
+							<xhtml:samp class="xml_sample"><![CDATA[<specificElements refs="ICPSR4328timeMeth" authorizedCodeValue="CrossSection"/>]]></xhtml:samp>
+</xhtml:div>
+</xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:simpleType name="attributeType">
+      <xs:restriction base="xs:string">
+         <xs:pattern value="@(([\i-[:]][\c-[:]]*:)?[\i-[:]][\c-[:]]*|\*|[\i-[:]][\c-[:]]*:\*)"/>
+      </xs:restriction>
+   </xs:simpleType>
+   
+   <xs:element name="attribute" type="attributeType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Attribute</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Identifies an attribute within the element(s) identified by the selector or specificElements in which the controlled vocabulary is used. The fully qualified name used here must correspond to that in the instance, which is to say that if the attribute is namespace qualified, the prefix used here must match that which is defined in the instance.</xhtml:div>
+               </xhtml:div>
+<xhtml:div>
+<xhtml:h2 class="section_header">Example</xhtml:h2>
+<xhtml:div class="example">
+<xhtml:samp class="xml_sample">
+<![CDATA[<attribute>type</attribute>]]>
+							</xhtml:samp>
+						</xhtml:div>
+					</xhtml:div>
+	            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:element name="copyright" type="simpleTextType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Copyright</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Copyright statement for the work at the appropriate level. Copyright for data collection (codeBook/stdyDscr/citation/prodStmt/copyright) maps to Dublin Core Rights. Inclusion of this element is recommended.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <copyright>Copyright(c) ICPSR, 2000</copyright>
+                     ]]></xhtml:samp>
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:complexType name="CubeCoordType">
+      <xs:complexContent>
+         <xs:extension base="baseElementType">
+            <xs:attribute name="coordNo" type="xs:string"/>
+            <xs:attribute name="coordVal" type="xs:string"/>
+            <xs:attribute name="coordValRef" type="xs:IDREF"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+   
+   <xs:element name="CubeCoord" type="CubeCoordType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1></xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">This is an empty element containing only the attributes listed below. It is used to identify the coordinates of the data item within a logical nCube describing aggregate data. CubeCoord is repeated for each dimension of the nCube giving the coordinate number ("coordNo") and coordinate value ("coordVal"). Coordinate value reference ("cordValRef") is an ID reference to the variable that carries the coordinate value. The attributes provide a complete coordinate location of a cell within the nCube.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <CubeCoord coordNo="1" coordVal="3"/>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <CubeCoord coordNo="2" coordVal="7"/>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <CubeCoord coordNo="3" coordVal="2"/>
+                     ]]></xhtml:samp> 
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:complexType name="dataAccsType">
+      <xs:complexContent>
+         <xs:extension base="baseElementType">
+            <xs:sequence>
+               <xs:element ref="setAvail" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="useStmt" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="notes" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+   
+   <xs:element name="dataAccs" type="dataAccsType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Data Access</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">This section describes access conditions and terms of use for the data collection. In cases where access conditions differ across individual files or variables, multiple access conditions can be specified. The access conditions applying to a study, file, variable group, or variable can be indicated by an IDREF attribute on the study, file, variable group, or variable elements called "access".</xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:complexType name="dataApprType" mixed="true">
+      <xs:complexContent>
+         <xs:extension base="simpleTextType">
+            <xs:attribute name="type" type="xs:string" use="optional"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+   
+   <xs:element name="dataAppr" type="dataApprType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Other Forms of Data Appraisal</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Other issues pertaining to data appraisal. Describe here issues such as response variance, nonresponse rate and testing for bias, interviewer and response bias, confidence levels, question bias, etc. Attribute type allows for optional typing of data appraisal processes and option for controlled vocabulary.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <dataAppr>These data files were obtained from the United States House of Representatives, who received them from the Census Bureau accompanied by the following caveats: "The numbers contained herein are not official 1990 decennial Census counts. The numbers represent estimates of the population based on a statistical adjustment method applied to the official 1990 Census figures using a sample survey intended to measure overcount or undercount in the Census results. On July 15, 1991, the Secretary of Commerce decided not to adjust the official 1990 decennial Census counts (see 56 Fed. Reg. 33582, July 22, 1991). In reaching his decision, the Secretary determined that there was not sufficient evidence that the adjustment method accurately distributed the population across and within states. The numbers contained in these tapes, which had to be produced prior to the Secretary's decision, are now known to be biased. Moreover, the tapes do not satisfy standards for the publication of Federal statistics, as established in Statistical Policy Directive No. 2, 1978, Office of Federal Statistical Policy and Standards. Accordingly, the Department of Commerce deems that these numbers cannot be used for any purpose that legally requires use of data from the decennial Census and assumes no responsibility for the accuracy of the data for any purpose whatsoever. The Department will provide no assistance in interpretation or use of these numbers."</dataAppr>
+                     ]]></xhtml:samp>
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:element name="dataChck" type="simpleTextType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Extent of Processing Checks</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Indicate here, at the file level, the types of checks and operations performed on the data file. A controlled vocabulary may be developed for this element in the future. The following examples are based on ICPSR's Extent of Processing scheme:</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <dataChck>The archive produced a codebook for this collection.</dataChck>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <dataChck>Consistency checks were performed by Data Producer/ Principal  Investigator.</dataChck>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <dataChck>Consistency checks performed by the archive.</dataChck>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <dataChck>The archive generated SAS and/or SPSS data definition  statements for this collection.</dataChck>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <dataChck>Frequencies were provided by Data Producer/Principal Investigator.</dataChck>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <dataChck>Frequencies provided by the archive.</dataChck>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <dataChck>Missing data codes were standardized by Data  Producer/ Principal Investigator.</dataChck>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <dataChck>Missing data codes were standardized by the archive.</dataChck>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <dataChck>The archive performed recodes and/or calculated derived variables. </dataChck>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <dataChck>Data were reformatted by the archive.</dataChck>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <dataChck>Checks for undocumented codes were performed by  Data Producer/Principal Investigator.</dataChck>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <dataChck>Checks for undocumented codes were performed by the archive.</dataChck>
+                     ]]></xhtml:samp>
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:complexType name="dataCollType">
+      <xs:complexContent>
+         <xs:extension base="baseElementType">
+            <xs:sequence>
+               <xs:element ref="timeMeth" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="dataCollector" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="collectorTraining" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="frequenc" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="sampProc" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="sampleFrame" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="targetSampleSize" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="deviat" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="collMode" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="resInstru" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="instrumentDevelopment" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="sources" minOccurs="0"/>
+               <xs:element ref="collSitu" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="actMin" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="ConOps" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="weight" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="cleanOps" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="dataColl" type="dataCollType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Data Collection Methdology</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Information about the methodology employed in a data collection.</xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:complexType name="sampleFrameType">
+      <xs:complexContent>
+         <xs:extension base="baseElementType">
+            <xs:sequence>
+               <xs:element ref="sampleFrameName" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="labl" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="txt" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="validPeriod" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="custodian" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="useStmt" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="universe" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="frameUnit" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="referencePeriod" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="updateProcedure" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="sampleFrame" type="sampleFrameType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Sample Frame</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Sample frame describes the sampling frame used for identifying the population from which the sample was taken. For example, a telephone book may be a sample frame for a phone survey. In addition to the name, label and text describing the sample frame, this structure lists who maintains the sample frame, the period for which it is valid, a use statement, the universe covered, the type of unit contained in the frame as well as the number of units available, the reference period of the frame and procedures used to update the frame. Use multiple use statements to provide different uses under different conditions. Repeat elements within the use statement to support multiple languages.</xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:element name="sampleFrameName" type="stringType">
+		<xs:annotation>
+			<xs:documentation>
+				<xhtml:div>
+
+					<xhtml:h1 class="element_title">Sample Frame Name</xhtml:h1>
+
+					<xhtml:div>
+						<xhtml:h2 class="section_header">Description</xhtml:h2>
+						<xhtml:div class="description">Name of the sample frame.</xhtml:div>
+					</xhtml:div>
+
+					<xhtml:div>
+						<xhtml:h2 class="section_header">Example</xhtml:h2>
+						<xhtml:div class="example">
+							<xhtml:samp class="xml_sample"><![CDATA[
+<sampleFrameName>City of St. Paul Directory</sampleFrameName>]]></xhtml:samp>
+</xhtml:div>
+</xhtml:div>
+
+</xhtml:div>
+</xs:documentation>
+</xs:annotation>
+</xs:element>
+   
+   <xs:complexType name="eventDateType">
+      <xs:simpleContent>
+         <xs:extension base="dateType">
+            <xs:attribute name="event">
+               <xs:simpleType>
+                  <xs:restriction base="xs:NMTOKEN">
+                     <xs:enumeration value="start"/>
+                     <xs:enumeration value="end"/>
+                     <xs:enumeration value="single"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   
+   <xs:element name="validPeriod" type="eventDateType">
+<xs:annotation>
+<xs:documentation>
+<xhtml:div>
+
+<xhtml:h1 class="element_title">Valid Period</xhtml:h1>
+
+<xhtml:div>
+<xhtml:h2 class="section_header">Description</xhtml:h2>
+<xhtml:div class="description">Defines a time period for the validity of the sampling frame. Enter dates in YYYY-MM-DD format.</xhtml:div>
+</xhtml:div>
+
+<xhtml:div>
+<xhtml:h2 class="section_header">Example</xhtml:h2>
+<xhtml:div class="example">
+<xhtml:samp class="xml_sample"><![CDATA[
+<validPeriod event=start">2009-07-01</validPeriod>
+<validPeriod event="end">2011-06-30</validPeriod>
+]]>
+							</xhtml:samp>
+						</xhtml:div>
+					</xhtml:div>
+				</xhtml:div>
+			</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+
+   <xs:element name="referencePeriod" type="eventDateType">
+		<xs:annotation>
+			<xs:documentation>
+				<xhtml:div>
+
+					<xhtml:h1 class="element_title">Reference Period</xhtml:h1>
+
+					<xhtml:div>
+						<xhtml:h2 class="section_header">Description</xhtml:h2>
+						<xhtml:div class="description">Indicates the period of time in which the sampling frame was actually used for the study in question. Use ISO 8601 date/time formats to enter the relevant date(s).</xhtml:div>
+					</xhtml:div>
+
+					<xhtml:div>
+						<xhtml:h2 class="section_header">Example</xhtml:h2>
+						<xhtml:div class="example">
+							<xhtml:samp class="xml_sample"><![CDATA[
+<referencePeriod event="single">2009-06-01</referencePeriod>
+]]>
+							</xhtml:samp>
+						</xhtml:div>
+					</xhtml:div>
+				</xhtml:div>
+			</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+   
+   <xs:complexType name="frameUnitType">
+      <xs:complexContent>
+         <xs:extension base="baseElementType">
+            <xs:sequence>
+               <xs:element ref="unitType"/>
+               <xs:element ref="txt" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+            <xs:attribute name="isPrimary" type="xs:boolean" default="true"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="frameUnit" type="frameUnitType">
+		<xs:annotation>
+			<xs:documentation>
+				<xhtml:div>
+
+					<xhtml:h1 class="element_title">Frame Unit</xhtml:h1>
+
+					<xhtml:div>
+						<xhtml:h2 class="section_header">Description</xhtml:h2>
+						<xhtml:div class="description">Provides information about the sampling frame unit. The attribute "isPrimary" is boolean, indicating whether the unit is primary or not.</xhtml:div>
+					</xhtml:div>
+
+					<xhtml:div>
+						<xhtml:h2 class="section_header">Example</xhtml:h2>
+						<xhtml:div class="example">
+							<xhtml:samp class="xml_sample"><![CDATA[
+<frameUnit isPrimary="true"><unitType numberOfUnits="150000">Primary listed owners of published phone numbers in the City of St. Paul</unitType></frameUnit>
+]]>
+							</xhtml:samp>
+						</xhtml:div>
+					</xhtml:div>
+				</xhtml:div>
+			</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+
+   <xs:complexType name="unitTypeType">
+      <xs:simpleContent>
+         <xs:extension base="stringType">
+            <xs:attribute name="numberOfUnits" type="xs:integer" use="optional"/>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+
+   <xs:element name="unitType" type="unitTypeType">
+		<xs:annotation>
+			<xs:documentation>
+				<xhtml:div>
+
+					<xhtml:h1 class="element_title">Unit Type</xhtml:h1>
+
+					<xhtml:div>
+						<xhtml:h2 class="section_header">Description</xhtml:h2>
+						<xhtml:div class="description">Describes the type of sampling frame unit. The attribute "numberOfUnits" provides the number of units in the sampling frame.</xhtml:div>
+					</xhtml:div>
+
+					<xhtml:div>
+						<xhtml:h2 class="section_header">Example</xhtml:h2>
+						<xhtml:div class="example">
+							<xhtml:samp class="xml_sample"><![CDATA[
+<unitType numberOfUnits=150000">Primary listed owners of published phone numbers in the City of St. Paul</unitType>
+]]>
+							</xhtml:samp>
+						</xhtml:div>
+					</xhtml:div>
+				</xhtml:div>
+			</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+
+   <xs:complexType name="targetSampleSizeType">
+      <xs:complexContent>
+         <xs:extension base="baseElementType">
+            <xs:sequence>
+               <xs:element ref="sampleSize" minOccurs="0"/>
+               <xs:element ref="sampleSizeFormula" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="targetSampleSize" type="targetSampleSizeType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Target Sample Size</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Provides both the target size of the sample (this is the number in the original sample, not the number of respondents) as well as the formula used for determining the sample size.</xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:element name="sampleSize" type="integerType">
+		<xs:annotation>
+			<xs:documentation>
+				<xhtml:div>
+
+					<xhtml:h1 class="element_title">Sample Size</xhtml:h1>
+
+					<xhtml:div>
+						<xhtml:h2 class="section_header">Description</xhtml:h2>
+						<xhtml:div class="description">This element provides the targeted sample size in integer format.</xhtml:div>
+					</xhtml:div>
+
+					<xhtml:div>
+						<xhtml:h2 class="section_header">Example</xhtml:h2>
+						<xhtml:div class="example">
+							<xhtml:samp class="xml_sample"><![CDATA[
+<sampleSize>385</sampleSize>
+]]>
+							</xhtml:samp>
+						</xhtml:div>
+					</xhtml:div>
+				</xhtml:div>
+			</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+   
+   <xs:element name="sampleSizeFormula" type="stringType">
+		<xs:annotation>
+			<xs:documentation>
+				<xhtml:div>
+
+					<xhtml:h1 class="element_title">Sample Size Formula</xhtml:h1>
+
+					<xhtml:div>
+						<xhtml:h2 class="section_header">Description</xhtml:h2>
+						<xhtml:div class="description">This element includes the formula that was used to determine the sample size.</xhtml:div>
+					</xhtml:div>
+
+					<xhtml:div>
+						<xhtml:h2 class="section_header">Example</xhtml:h2>
+						<xhtml:div class="example">
+							<xhtml:samp class="xml_sample"><![CDATA[
+<sampleSizeFormula>n0=Z2pq/e2=(1.96)2(.5)(.5)/(.05)2=385 individuals</sampleSizeFormula>
+]]>
+							</xhtml:samp>
+						</xhtml:div>
+					</xhtml:div>
+				</xhtml:div>
+			</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+   <xs:complexType name="instrumentDevelopmentType" mixed="true">
+      <xs:complexContent>
+         <xs:extension base="simpleTextType">
+            <xs:attribute name="type" type="xs:string" use="optional"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+   
+   <xs:element name="instrumentDevelopment" type="instrumentDevelopmentType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Instrument Development</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Describe any development work on the data collection instrument. Type attribute allows for the optional use of a defined development type with or without use of a controlled vocabulary.</xhtml:div>
+               </xhtml:div>
+					<xhtml:div>
+						<xhtml:h2 class="section_header">Example</xhtml:h2>
+						<xhtml:div class="example">
+							<xhtml:samp class="xml_sample"><![CDATA[
+<instrumentDevelopment type="pretesting">The questionnaire was pre-tested with split-panel tests, as well as an analysis of non-response rates for individual items, and response distributions.</instrumentDevelopment>
+]]>
+							</xhtml:samp>
+						</xhtml:div>
+					</xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:element name="updateProcedure" type="simpleTextType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Instrument Development</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Description of how and with what frequency the sample frame is updated.</xhtml:div>
+               </xhtml:div>
+					<xhtml:div>
+						<xhtml:h2 class="section_header">Example</xhtml:h2>
+						<xhtml:div class="example">
+							<xhtml:samp class="xml_sample"><![CDATA[
+<updateProcedure>Changes are collected as they occur through registration and loss of phone number from the specified geographic area. Data are compiled for the date June 1st of odd numbered years, and published on July 1st for the following two-year period.</updateProcedure>
+]]>
+							</xhtml:samp>
+						</xhtml:div>
+					</xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:complexType name="custodianType">
+      <xs:simpleContent>
+         <xs:extension base="stringType">
+            <xs:attribute name="affiliation" type="xs:string" use="optional"/>
+            <xs:attribute name="abbr" type="xs:string" use="optional"/>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+
+   <xs:element name="custodian" type="custodianType">
+      <xs:annotation>
+         <xs:documentation>
+				<xhtml:div>
+					<xhtml:h1 class="element_title">Custodian</xhtml:h1>
+					<xhtml:div>
+						<xhtml:h2 class="section_header">Description</xhtml:h2>
+						<xhtml:div class="description">Custodian identifies the agency or individual who is responsible for creating or maintaining the sample frame. Attribute affiliation provides the affiliation of the custodian with an agency or organization. Attribute abbr provides an abbreviation for the custodian.</xhtml:div>
+					</xhtml:div>
+					<xhtml:div>
+						<xhtml:h2 class="section_header">Example</xhtml:h2>
+						<xhtml:div class="example">
+							<xhtml:samp class="xml_sample"><![CDATA[
+<custodian>DEX Publications</custodian>
+]]>
+							</xhtml:samp>
+						</xhtml:div>
+					</xhtml:div>
+				</xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:complexType name="collectorTrainingType" mixed="true">
+      <xs:complexContent>
+         <xs:extension base="simpleTextType">
+            <xs:attribute name="type" type="xs:string" use="optional"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="collectorTraining" type="collectorTrainingType">
+      <xs:annotation>
+         <xs:documentation>
+				<xhtml:div>
+					<xhtml:h1 class="element_title">Collector Training</xhtml:h1>
+					<xhtml:div>
+						<xhtml:h2 class="section_header">Description</xhtml:h2>
+						<xhtml:div class="description">Describes the training provided to data collectors including internviewer training, process testing, compliance with standards etc. This is repeatable for language and to capture different aspects of the training process. The type attribute allows specification of the type of training being described.</xhtml:div>
+					</xhtml:div>
+					<xhtml:div>
+						<xhtml:h2 class="section_header">Example</xhtml:h2>
+						<xhtml:div class="example">
+							<xhtml:samp class="xml_sample"><![CDATA[
+<collectorTraining type="interviewer training">Describe research project, describe population and sample, suggest methods and language for approaching subjects, explain questions and key terms of survey instrument.</collectorTraining>
+]]>
+							</xhtml:samp>
+						</xhtml:div>
+					</xhtml:div>
+				</xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:complexType name="dataCollectorType" mixed="true">
+      <xs:complexContent>
+         <xs:extension base="simpleTextType">
+            <xs:attribute name="abbr" type="xs:string"/>
+            <xs:attribute name="affiliation" type="xs:string"/>
+            <xs:attribute name="role" type="xs:string" use="optional"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="dataCollector" type="dataCollectorType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Data Collector</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">The entity (individual, agency, or institution) responsible for administering the questionnaire or interview or compiling the data. This refers to the entity collecting the data, not to the entity producing the documentation. Attribute "abbr" may be used to list common abbreviations given to agencies, etc. Attribute "affiliation" may be used to record affiliation of the data collector. The role attribute specifies the role of person in the data collection process.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <dataCollector abbr="SRC" affiliation="University of Michigan" role="questionnaire administration">Survey Research Center</dataCollector>
+                     ]]></xhtml:samp>
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:complexType name="dataDscrType">
+      <xs:complexContent>
+         <xs:extension base="baseElementType">
+            <xs:sequence>
+               <xs:element ref="varGrp" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="nCubeGrp" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="var" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="nCube" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="notes" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="dataDscr" type="dataDscrType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Variable Description</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Description of variables.</xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:complexType name="dataItemType">
+      <xs:complexContent>
+         <xs:extension base="baseElementType">
+            <xs:sequence>
+               <xs:element ref="CubeCoord" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="physLoc" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+            <xs:attribute name="varRef" type="xs:IDREF"/>
+            <xs:attribute name="nCubeRef" type="xs:IDREF"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="dataItem" type="dataItemType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1></xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Identifies a physical storage location for an individual data entry, serving as a link between the physical location and the logical content description of each data item. The attribute "varRef" is an IDREF that points to a discrete variable description. If the data item is located within an nCube (aggregate data), use the attribute "nCubeRef" (IDREF) to point to the appropriate nCube and the element CubeCoord to identify the coordinates of the data item within the nCube.</xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:complexType name="dataKindType" mixed="true">
+      <xs:complexContent>
+         <xs:extension base="conceptualTextType">
+            <xs:attribute name="type" type="xs:string" use="optional"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="dataKind" type="dataKindType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Kind of Data</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">The type of data included in the file: survey data, census/enumeration data, aggregate data, clinical data, event/transaction data, program source code, machine-readable text, administrative records data, experimental data, psychological test, textual data, coded textual, coded documents, time budget diaries, observation data/ratings, process-produced data, etc. This element maps to Dublin Core Type element. The type attribute can be used for forward-compatibility with DDI 3, by providing a type for use of controlled vocabulary, as this is descriptive in DDI 2 and CodeValue in DDI 3.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <dataKind type="numeric">survey data</dataKind>
+                     ]]></xhtml:samp>
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:element name="dataMsng" type="simpleTextType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Missing Data</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">This element can be used to give general information about missing data, e.g., that missing data have been standardized across the collection, missing data are present because of merging, etc.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <dataMsng>Missing data are represented by blanks.</dataMsng>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <dataMsng>The codes "-1" and "-2" are used to represent missing data.</dataMsng>
+                     ]]></xhtml:samp> 
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:element name="dataSrc" type="simpleTextType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Data Sources</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Used to list the book(s), article(s), serial(s), and/or machine-readable data file(s)--if any--that served as the source(s) of the data collection. </xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <dataSrc> "Voting Scores." CONGRESSIONAL QUARTERLY ALMANAC 33 (1977), 487-498.</dataSrc>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <dataSrc>United States Internal Revenue Service Quarterly Payroll File</dataSrc>
+                     ]]></xhtml:samp> 
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:element name="defntn" type="simpleTextType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Definition</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Rationale for why the group was constituted in this way.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <varGrp>
+                           <defntn>The following eight variables were only asked in Ghana.</defntn>
+                        </varGrp>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <nCubeGrp>
+                           <defntn>The following four nCubes form a single presentation table.</defntn>
+                        </nCubeGrp>
+                     ]]></xhtml:samp>
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:element name="depDate" type="simpleTextAndDateType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Date of Deposit</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">The date that the work was deposited with the archive that originally received it. The ISO standard for dates (YYYY-MM-DD) is recommended for use with the "date" attribute.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <depDate date="1999-01-25">January 25, 1999</depDate>
+                     ]]></xhtml:samp>
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:element name="deposReq" type="simpleTextType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Deposit Requirement</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Information regarding user responsibility for informing archives of their use of data through providing citations to the published work or providing copies of the manuscripts. </xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <deposReq> To provide funding agencies with essential information about use of archival resources and to facilitate the exchange of information about ICPSR participants' research activities, users of ICPSR data are requested to send to ICPSR bibliographic citations for, or copies of, each completed manuscript or thesis abstract. Please indicate in a cover letter which data were used.</deposReq>
+                     ]]></xhtml:samp>
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:complexType name="depositrType" mixed="true">
+      <xs:complexContent>
+         <xs:extension base="simpleTextType">
+            <xs:attribute name="abbr" type="xs:string"/>
+            <xs:attribute name="affiliation" type="xs:string"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="depositr" type="depositrType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Depositor</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">The name of the person (or institution) who provided this work to the archive storing it. </xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <depositr abbr="BJS" affiliation="U.S. Department of Justice">Bureau of Justice Statistics</depositr>
+                     ]]></xhtml:samp>
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:complexType name="derivationType">
+      <xs:complexContent>
+         <xs:extension base="baseElementType">
+            <xs:sequence>
+               <xs:element ref="drvdesc" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="drvcmd" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+            <xs:attribute name="var" type="xs:IDREFS"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="derivation" type="derivationType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Derivation</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Used only in the case of a derived variable, this element provides both a description of how the derivation was performed and the command used to generate the derived variable, as well as a specification of the other variables in the study used to generate the derivation. The "var" attribute provides the ID values of the other variables in the study used to generate this derived variable.</xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:element name="deviat" type="simpleTextType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Major Deviations from the Sample Design</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Information indicating correspondence as well as discrepancies between the sampled units (obtained) and available statistics for the population (age, sex-ratio, marital status, etc.) as a whole. XHTML formatting may be used in this element for forward-compatibility with DDI 3. </xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <deviat>The suitability of Ohio as a research site reflected its similarity to the United States as a whole. The evidence extended by Tuchfarber (1988) shows that Ohio is representative of the United States in several ways: percent urban and rural, percent of the population that is African American, median age, per capita income, percent living below the poverty level, and unemployment rate. Although results generated from an Ohio sample are not empirically generalizable to the United States, they may be suggestive of what might be expected nationally.</deviat>
+                     ]]></xhtml:samp>
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:complexType name="dataFingerprintType">
+      <xs:sequence>
+	     <xs:element name="digitalFingerprintValue" type="xs:string"/>
+		 <xs:element name="algorithmSpecification" type="xs:string" minOccurs="0"/>
+		 <xs:element name="algorithmVersion" type="xs:string" minOccurs="0"/>
+	  </xs:sequence>
+	  <xs:attribute name="type" use="required">
+         <xs:simpleType>
+            <xs:restriction base="xs:NMTOKEN">
+               <xs:enumeration value="data"/>
+               <xs:enumeration value="dataFile"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:complexType>
+
+   <xs:element name="dataFingerprint" type="dataFingerprintType">
+      <xs:annotation>
+	     <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Data Fingerprint</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Allows for assigning a hash value (digital fingerprint) to the data or data file. Set the attribute flag to "data" when the hash value provides a digital fingerprint to the data contained in the file regardless of the storage format (ASCII, SAS, binary, etc.). One approach to compute a data fingerprint is the Universal Numerical Fingerprint (UNF). Set the attribute flag to "dataFile" if the digital fingerprint is only for the data file in its current storage format. Provide the digital fingerprint in digitalFingerprintValue and identify the algorithm specification used (add version as a separate entry if it is not part of the specification entry).</xhtml:div>
+               </xhtml:div>
+					<xhtml:div>
+						<xhtml:h2 class="section_header">Example</xhtml:h2>
+						<xhtml:div class="example">
+							<xhtml:samp class="xml_sample"><![CDATA[
+<dataFingerprint type="data"><digitalFingerprintValue>UNF:3:DaYlT6QSX9r0D50ye+tXpA== </digitalFingerprintValue>
+<algorithmSpecification>UNF v5.0 Calculation Producture [http://thedata.org/book/unf-version-5-0]</algorithmSpecification><algorithmVersion>UNF V5</algorithmVersion></dataFingerprint>
+
+]]>
+							</xhtml:samp>
+						</xhtml:div>
+					</xhtml:div>
+            </xhtml:div>
+		 </xs:documentation>
+	  </xs:annotation>
+   </xs:element>
+
+   <xs:complexType name="dimensnsType">
+      <xs:complexContent>
+         <xs:extension base="baseElementType">
+            <xs:sequence>
+               <xs:element ref="caseQnty" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="varQnty" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="logRecL" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="recPrCas" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="recNumTot" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="dimensns" type="dimensnsType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">File Dimensions</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Dimensions of the overall file.</xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:element name="disclaimer" type="simpleTextType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Disclaimer</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Information regarding responsibility for uses of the data collection. This element may be repeated to support multiple language expressions of the content.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <disclaimer>The original collector of the data, ICPSR, and the relevant funding agency bear no responsibility for uses of this collection or for interpretations or inferences based upon such uses.</disclaimer>
+                     ]]></xhtml:samp>
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:element name="distDate" type="simpleTextAndDateType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Date of Distribution</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Date that the work was made available for distribution/presentation. The ISO standard for dates (YYYY-MM-DD) is recommended for use with the "date" attribute.  If using a text entry in the element content, the element may be repeated to support multiple language expressions.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <distDate date="1999-01-25">January 25, 1999</distDate>
+                     ]]></xhtml:samp>
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:complexType name="distStmtType">
+      <xs:complexContent>
+         <xs:extension base="baseElementType">
+            <xs:sequence>
+               <xs:element ref="distrbtr" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="contact" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="depositr" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="depDate" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="distDate" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="distStmt" type="distStmtType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Distributor Statement</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Distribution statement for the work at the appropriate level: marked-up document; marked-up document source; study; study description, other material; other material for study.</xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:complexType name="distrbtrType" mixed="true">
+      <xs:complexContent>
+         <xs:extension base="simpleTextType">
+            <xs:attribute name="abbr" type="xs:string"/>
+            <xs:attribute name="affiliation" type="xs:string"/>
+            <xs:attribute name="URI" type="xs:string"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+   
+   <xs:element name="distrbtr" type="distrbtrType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Distributor</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">The organization designated by the author or producer to generate copies of the particular work including any necessary editions or revisions. Names and addresses may be specified and other archives may be co-distributors. A URI attribute is included to provide an URN or URL to the ordering service or download facility on a Web site. </xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <distrbtr abbr="ICPSR" affiliation="Institute for Social Research" URI="http://www.icpsr.umich.edu">Ann Arbor, MI: Inter-university Consortium for Political and Social Research</distrbtr>
+                     ]]></xhtml:samp>
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:complexType name="dmnsType">
+      <xs:complexContent>
+         <xs:extension base="baseElementType">
+            <xs:sequence>
+               <xs:element ref="cohort" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+            <xs:attribute name="rank" type="xs:string"/>
+            <xs:attribute name="varRef" type="xs:IDREF"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+   
+   <xs:element name="dmns" type="dmnsType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Dimension</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">This element defines a variable as a dimension of the nCube, and should be repeated to describe each of the cube's dimensions. The attribute "rank" is used to define the coordinate order (rank="1", rank="2", etc.) The attribute "varRef" is an IDREF that points to the variable that makes up this dimension of the nCube.</xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:complexType name="docDscrType">
+      <xs:complexContent>
+         <xs:extension base="baseElementType">
+            <xs:sequence>
+               <xs:element ref="citation" minOccurs="0"/>
+               <xs:element ref="guide" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="docStatus" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="docSrc" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="controlledVocabUsed" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="notes" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+   
+   <xs:element name="docDscr" type="docDscrType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Document Description</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">The Document Description consists of bibliographic information describing the DDI-compliant document itself as a whole. This Document Description can be considered the wrapper or header whose elements uniquely describe the full contents of the compliant DDI file. Since the Document Description section is used to identify the DDI-compliant file within an electronic resource discovery environment, this section should be as complete as possible. The author in the Document Description should be the individual(s) or organization(s) directly responsible for the intellectual content of the DDI version, as distinct from the person(s) or organization(s) responsible for the intellectual content of the earlier paper or electronic edition from which the DDI edition may have been derived. The producer in the Document Description should be the agency or person that prepared the marked-up document. Note that the Document Description section contains a Documentation Source subsection consisting of information about the source of the DDI-compliant file-- that is, the hardcopy or electronic codebook that served as the source for the marked-up codebook. These sections allow the creator of the DDI file to produce version, responsibility, and other descriptions relating to both the creation of that DDI file as a separate and reformatted version of source materials (either print or electronic) and the original source materials themselves. </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:complexType name="docSrcType">
+      <xs:complexContent>
+         <xs:extension base="baseElementType">
+            <xs:sequence>
+               <xs:element ref="titlStmt"/>
+               <xs:element ref="rspStmt" minOccurs="0"/>
+               <xs:element ref="prodStmt" minOccurs="0"/>
+               <xs:element ref="distStmt" minOccurs="0"/>
+               <xs:element ref="serStmt" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="verStmt" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="biblCit" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="holdings" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="notes" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+            <xs:attribute name="MARCURI" type="xs:string"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+   
+   <xs:element name="docSrc" type="docSrcType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Documentation Source</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Citation for the source document. This element encodes the bibliographic information describing the source codebook, including title information, statement of responsibility, production and distribution information, series and version information, text of a preferred bibliographic citation, and notes (if any). Information for this section should be taken directly from the source document whenever possible. If additional information is obtained and entered in the elements within this section, the source of this information should be noted in the source attribute of the particular element tag. A MARCURI attribute is provided to link to the MARC record for this citation.</xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:element name="docStatus" type="simpleTextType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Documentation Status</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Use this field to indicate if the documentation is being presented/distributed before it has been finalized. Some data producers and social science data archives employ data processing strategies that provide for release of data and documentation at various stages of processing. The element may be repeated to support multiple language expressions of the content.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <docStatus>This marked-up document includes a provisional data dictionary and brief citation only for the purpose of providing basic access to the data file. A complete codebook will be published at a later date.</docStatus>
+                     ]]></xhtml:samp>
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:complexType name="drvcmdType" mixed="true">
+      <xs:complexContent>
+         <xs:extension base="simpleTextType">
+            <xs:attribute name="syntax" type="xs:string"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+   
+   <xs:element name="drvcmd" type="drvcmdType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Derivation Command</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">The actual command used to generate the derived variable. The "syntax" attribute is used to indicate the command language employed (e.g., SPSS, SAS, Fortran, etc.). The element may be repeated to support multiple language expressions of the content.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <var>
+                           <derivation>
+                              <drvcmd syntax="SPSS">RECODE V1 TO V3 (0=1) (1=0) (2=-1) INTO DEFENSE WELFAREHEALTH. </drvcmd>
+                           </derivation>
+                        </var>
+                     ]]></xhtml:samp> 
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:element name="drvdesc" type="simpleTextType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Derivation Description</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">A textual description of the way in which this variable was derived. The element may be repeated to support multiple language expressions of the content.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <var>
+                           <derivation>
+                              <drvdesc> VAR215.01 "Outcome of first pregnancy" (1988 NSFG=VAR611 PREGOUT1) If R has never been pregnant (VAR203 PREGNUM EQ 0) then OUTCOM01 is blank/inapplicable. Else, OUTCOM01 is transferred from VAR225 OUTCOME for R's 1st pregnancy. </drvdesc>
+                           </derivation>
+                        </var>
+                     ]]></xhtml:samp> 
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:element name="eastBL" type="phraseType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">East Bounding Longitude</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">The easternmost coordinate delimiting the geographic extent of the dataset. A valid range of values, expressed in decimal degrees (positive east and positive north), is: -180,0 &lt;= East Bounding Longitude Value &lt;= 180,0</xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:complexType name="embargoType" mixed="true">
+      <xs:complexContent>
+         <xs:extension base="simpleTextAndDateType">
+            <xs:attribute name="event" default="notBefore">
+               <xs:simpleType>
+                  <xs:restriction base="xs:NMTOKEN">
+                     <xs:enumeration value="notBefore"/>
+                     <xs:enumeration value="notAfter"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:attribute>
+            <xs:attribute name="format" type="xs:string"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="embargo" type="embargoType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Embargo</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">
+                     <xhtml:p>Provides information on variables/nCubes which are not currently available because of policies established by the principal investigators and/or data producers. The ISO standard for dates (YYYY-MM-DD) is recommended for use with the "date" attribute. An "event" attribute is provided to specify "notBefore" or "notAfter" ("notBefore" is the default). A "format" attribute is provided to ensure that this information will be machine-processable, and specifies a format for the embargo element.</xhtml:p>
+                     <xhtml:p>The "format" attribute could be used to specify other conventions for the way that information within the embargo element is set out, if conventions for encoding embargo information were established in the future.</xhtml:p>
+							<xhtml:p>This element may be repeated to support multiple language expressions of the content.</xhtml:p>
+                  </xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <var>
+                           <embargo event="notBefore" date="2001-09-30"> The data associated with this variable/nCube will not become available until September 30, 2001, because of embargo provisions established by the data producers.</embargo>
+                        </var>
+                     ]]></xhtml:samp> 
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:complexType name="entryType">
+      <xs:simpleContent>
+         <xs:extension base="stringType">
+            <xs:attribute name="colname" type="xs:NMTOKEN" use="optional"/>
+            <xs:attribute name="namest" type="xs:NMTOKEN"/>
+            <xs:attribute name="nameend" type="xs:NMTOKEN"/>
+            <xs:attribute name="morerows" type="xs:string"/>
+            <xs:attribute name="colsep" type="xs:string"/>
+            <xs:attribute name="rowsep" type="xs:string"/>
+            <xs:attribute name="align">
+               <xs:simpleType>
+                  <xs:restriction base="xs:NMTOKEN">
+                     <xs:enumeration value="left"/>
+                     <xs:enumeration value="right"/>
+                     <xs:enumeration value="center"/>
+                     <xs:enumeration value="justify"/>
+                     <xs:enumeration value="char"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:attribute>
+            <xs:attribute name="char" type="xs:string"/>
+            <xs:attribute name="charoff" type="xs:NMTOKEN"/>
+            <xs:attribute name="valign">
+               <xs:simpleType>
+                  <xs:restriction base="xs:NMTOKEN">
+                     <xs:enumeration value="top"/>
+                     <xs:enumeration value="middle"/>
+                     <xs:enumeration value="bottom"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   
+   <xs:element name="entry" type="entryType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Table Entry</xhtml:h1>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:element name="EstSmpErr" type="simpleTextType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Estimates of Sampling Error</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Measure of how precisely one can estimate a population value from a given sample.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <EstSmpErr> To assist NES analysts, the PC SUDAAN program was used to compute sampling errors for a wide-ranging example set of proportions estimated from the 1996 NES Pre-election Survey dataset. For each estimate, sampling errors were computed for the total sample and for twenty demographic and political affiliation subclasses of the 1996 NES Pre-election Survey sample. The results of these sampling error computations were then summarized and translated into the general usage sampling error table provided in Table 11. The mean value of deft, the square root of the design effect, was found to be 1.346. The design effect was primarily due to weighting effects (Kish, 1965) and did not vary significantly by subclass size. Therefore the generalized variance table is produced by multiplying the simple random sampling standard error for each proportion and sample size by the average deft for the set of sampling error computations.</EstSmpErr>
+                     ]]></xhtml:samp>
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:element name="fileCont" type="simpleTextType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Contents of Files</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Abstract or description of the file. A summary describing the purpose, nature, and scope of the data file, special characteristics of its contents, major subject areas covered, and what questions the PIs attempted to answer when they created the file. A listing of major variables in the file is important here. In the case of multi-file collections, this uniquely describes the contents of each file.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <fileCont>Part 1 contains both edited and constructed variables describing demographic and family relationships, income, disability, employment, health insurance status, and utilization data for all of 1987.</fileCont>
+                     ]]></xhtml:samp> 
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:complexType name="fileDscrType">
+      <xs:complexContent>
+         <xs:extension base="baseElementType">
+            <xs:sequence>
+               <xs:element ref="fileTxt" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="locMap" minOccurs="0"/>
+               <xs:element ref="notes" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+            <xs:attribute name="URI" type="xs:string"/>
+            <xs:attribute name="sdatrefs" type="xs:IDREFS"/>
+            <xs:attribute name="methrefs" type="xs:IDREFS"/>
+            <xs:attribute name="pubrefs" type="xs:IDREFS"/>
+            <xs:attribute name="access" type="xs:IDREFS"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="fileDscr" type="fileDscrType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Data Files Description</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">
+                     <xhtml:p>Information about the data file(s) that comprises a collection. This section can be repeated for collections with multiple files. </xhtml:p>
+                     <xhtml:p>The "URI" attribute may be a URN or a URL that can be used to retrieve the file. The "sdatrefs" are summary data description references that record the ID values of all elements within the summary data description section of the Study Description that might apply to the file. These elements include: time period covered, date of collection, nation or country, geographic coverage, geographic unit, unit of analysis, universe, and kind of data. The "methrefs" are methodology and processing references that record the ID values of all elements within the study methodology and processing section of the Study Description that might apply to the file. These elements include information on data collection and data appraisal (e.g., sampling, sources, weighting, data cleaning, response rates, and sampling error estimates). The "pubrefs" attribute provides a link to publication/citation references and records the ID values of all citations elements within Other Study Description Materials or Other Study-Related Materials that pertain to this file. "Access" records the ID values of all elements in the Data Access section that describe access conditions for this file.</xhtml:p>
+                     <xhtml:p>Remarks: When a codebook documents two different physical instantiations of a data file, e.g., logical record length (or OSIRIS) and card-image version, the Data File Description should be repeated to describe the two separate files. An ID should be assigned to each file so that in the Variable section the location of each variable on the two files can be distinguished using the unique file IDs.</xhtml:p>
+                  </xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <fileDscr ID="CARD-IMAGE" URI="www.icpsr.umich.edu/cgi-bin/archive.prl?path=ICPSR&amp;num=7728"/>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <fileDscr ID="LRECL" URI="www.icpsr.umich.edu/cgi-bin/archive.prl?path=ICPSR&amp;num=7728"/>
+                     ]]></xhtml:samp> 
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:element name="fileName" type="simpleTextType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">File Name</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Contains a short title that will be used to distinguish a particular file/part from other files/parts in the data collection. The element may be repeated to support multiple language expressions of the content.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <fileName ID="File1">Second-Generation Children Data</fileName>
+                     ]]></xhtml:samp> 
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:element name="filePlac" type="simpleTextType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Place of File Production</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Indicates whether the file was produced at an archive or produced elsewhere.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <filePlac>Washington, DC: United States Department of Commerce, Bureau of the Census</filePlac>
+                     ]]></xhtml:samp> 
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:element name="fileQnty" type="simpleTextType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Number of Files</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Total number of physical files associated with a collection.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <fileQnty>5 files</fileQnty>
+                     ]]></xhtml:samp> 
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:complexType name="fileStrcType">
+      <xs:complexContent>
+         <xs:extension base="baseElementType">
+            <xs:sequence>
+               <xs:element ref="recGrp" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="notes" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+            <xs:attribute name="type" default="rectangular">
+               <xs:simpleType>
+                  <xs:restriction base="xs:NMTOKEN">
+                     <xs:enumeration value="rectangular"/>
+                     <xs:enumeration value="hierarchical"/>
+                     <xs:enumeration value="relational"/>
+                     <xs:enumeration value="nested"/>
+                     <xs:enumeration value="other"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:attribute>
+            <xs:attribute name="otherType" type="xs:NMTOKEN" use="optional"/>
+            <xs:attribute name="fileStrcRef" type="xs:IDREF" use="optional"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="fileStrc" type="fileStrcType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">File Structure</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Type of file structure. The attribute "type" is used to indicate hierarchical, rectangular, relational, or nested (the default is rectangular). If the file is rectangular, the next relevant element is File Dimensions. If the "other" value is used for the type attribute, then the otherType attribute should have a value specifying the other type.The otherType attribute should only be used when applying a controlled vocabulary to this attribute. Use the complex element controlledVocabUsed to identify the controlled vocabulary to which the selected term belongs. The fileStrcRef attribute allows for multiple data files with different coverage but the same file structure to share a single fileStrc. The file structure is fully described in the first fileTxt within the fileDscr and then the fileStrc in subsequent fileTxt descriptions would reference the first fileStrcRef rather than repeat the details.</xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:complexType name="fileTxtType">
+      <xs:complexContent>
+         <xs:extension base="baseElementType">
+            <xs:sequence>
+               <xs:element ref="fileName" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="fileCitation" minOccurs="0"/>
+               <xs:element ref="dataFingerprint" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="fileCont" minOccurs="0"/>
+               <xs:element ref="fileStrc" minOccurs="0"/>
+               <xs:element ref="dimensns" minOccurs="0"/>
+               <xs:element ref="fileType" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="format" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="filePlac" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="dataChck" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="ProcStat" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="dataMsng" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="software" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="verStmt" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+   
+   <xs:element name="fileTxt" type="fileTxtType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">File-by-File Description</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Provides descriptive information about the data file. A file name and a full bibliographic citation for the file may be entered, as well as a data fingerprint, if available. Information about the physical properties of the data file is also supported. Make sure to fill out topcClass for the study as these can be used by the data file. Note coverage constraints in fileCont.</xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:element name="fileCitation" type="citationType">
+		<xs:annotation>
+			<xs:documentation>
+				<xhtml:div>
+
+					<xhtml:h1 class="element_title">File Citation</xhtml:h1>
+
+					<xhtml:div>
+						<xhtml:h2 class="section_header">Description</xhtml:h2>
+						<xhtml:div class="description">The complex element fileCitation provides for a full bibliographic citation option for each data file described in fileDscr. To support accurate citation of a data file the minimum element set includes: titl, IDNo, authEnty, producer, and prodDate. If a DOI is available for the data file enter this in the IDNo (this element is repeatable). If a hash value (digital fingerprint) has been created for the data file enter the information regarding its value and algorithm specification in digitalFingerprint.</xhtml:div>
+					</xhtml:div>
+
+					<xhtml:div>
+						<xhtml:h2 class="section_header">Example</xhtml:h2>
+						<xhtml:div class="example">
+							<xhtml:samp class="xml_sample"><![CDATA[
+<fileCitation>
+<titlStmt>
+<titl>ABC News/Washington Post Monthly Poll, December 2010</titl>
+<IDNo>http://dx.doi.org/10.3886/ICPSR32547.v1</IDNo>
+</titlStmt>
+<rspStmt>
+<AuthEnty>ABC News</AuthEnty>
+<AuthEnty>The Washington Post</AuthEnty>
+</rspStmt>
+<prodStmt>
+<producer>ABC News</producer>
+<prodDate>2011</prodDate>
+</prodStmt>
+</fileCitation>
+]]>
+							</xhtml:samp>
+						</xhtml:div>
+					</xhtml:div>
+				</xhtml:div>
+			</xs:documentation>
+		</xs:annotation>
+</xs:element>
+   
+   <xs:complexType name="fileTypeType" mixed="true">
+      <xs:complexContent>
+         <xs:extension base="simpleTextType">
+            <xs:attribute name="charset" type="xs:string"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+   
+   <xs:element name="fileType" type="fileTypeType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Type of File</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Types of data files include raw data (ASCII, EBCDIC, etc.) and software-dependent files such as SAS datasets, SPSS export files, etc. If the data are of mixed types (e.g., ASCII and packed decimal), state that here. Note that the element varFormat permits specification of the data format at the variable level. The "charset" attribute allows one to specify the character set used in the file, e.g., US-ASCII, EBCDIC, UNICODE UTF-8, etc. The element may be repeated to support multiple language expressions of the content.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <fileType charset="US-ASCII">ASCII data file</fileType>
+                     ]]></xhtml:samp> 
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:element name="format" type="simpleTextType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Data Format</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Physical format of the data file: Logical record length format, card-image format (i.e., data with multiple records per case), delimited format, free format, etc. The element may be repeated to support multiple language expressions of the content.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <format>comma-delimited</format>
+                     ]]></xhtml:samp> 
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:complexType name="forwardType" mixed="true">
+      <xs:complexContent>
+         <xs:extension base="simpleTextType">
+            <xs:attribute name="qstn" type="xs:IDREFS"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="forward" type="forwardType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Forward Progression</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Contains a reference to IDs of possible following questions. The "qstn" IDREFS may be used to specify the question IDs.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <var>
+                           <qstn>
+                              <forward qstn="Q120 Q121 Q122 Q123 Q124">If yes, please ask questions 120-124.</forward>
+                           </qstn>
+                        </var>
+                     ]]></xhtml:samp> 
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:complexType name="frequencType" mixed="true">
+      <xs:complexContent>
+         <xs:extension base="simpleTextType">
+            <xs:attribute name="freq" type="xs:string"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+   
+   <xs:element name="frequenc" type="frequencType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Frequency of Data Collection</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">For data collected at more than one point in time, the frequency with which the data were collected. The "freq" attribute is included to permit the development of a controlled vocabulary for this element.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <freq>monthly</freq>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <freq>quarterly</freq>
+                     ]]></xhtml:samp>
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:complexType name="fundAgType" mixed="true">
+      <xs:complexContent>
+         <xs:extension base="simpleTextType">
+            <xs:attribute name="abbr" type="xs:string"/>
+            <xs:attribute name="role" type="xs:string"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="fundAg" type="fundAgType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Funding Agency/Sponsor</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">The source(s) of funds for production of the work. If different funding agencies sponsored different stages of the production process, use the "role" attribute to distinguish them.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <fundAg abbr="NSF" role="infrastructure">National Science Foundation</fundAg>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <fundAg abbr="SUN" role="equipment">Sun Microsystems</fundAg>
+                     ]]></xhtml:samp>
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:complexType name="geoBndBoxType">
+      <xs:complexContent>
+         <xs:extension base="baseElementType">
+            <xs:sequence>
+               <xs:element ref="westBL"/>
+               <xs:element ref="eastBL"/>
+               <xs:element ref="southBL"/>
+               <xs:element ref="northBL"/>
+            </xs:sequence>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="geoBndBox" type="geoBndBoxType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Geographic Bounding Box</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">The fundamental geometric description for any dataset that models geography. GeoBndBox is the minimum box, defined by west and east longitudes and north and south latitudes, that includes the largest geographic extent of the dataset's geographic coverage. This element is used in the first pass of a coordinate-based search. If the boundPoly element is included, then the geoBndBox element MUST be included.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <geogCover>Nevada State</geogCover>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <geoBndBox>
+                           <westBL>-120.005729004</westBL>
+                           <eastBL>-114.039663</eastBL>
+                           <southBL>35.00208499998</southBL>
+                           <northBL>42.002207</northBL>
+                        </geoBndBox>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <geogCover>Norway</geogCover>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <geoBndBox>
+                           <westBL>4.789583</westBL>
+                           <eastBL>33.637497</eastBL>
+                           <southBL>57.987915</southBL>
+                           <northBL>80.76416</northBL>
+                        </geoBndBox>
+                     ]]></xhtml:samp>
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:complexType name="geoMapType">
+      <xs:complexContent>
+         <xs:extension base="baseElementType">
+            <xs:attribute name="URI" type="xs:string"/>
+            <xs:attribute name="mapformat" type="xs:string"/>
+            <xs:attribute name="levelno" type="xs:string"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="geoMap" type="geoMapType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Geographic Map</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">This element is used to point, using a "URI" attribute, to an external map that displays the geography in question. The "levelno" attribute indicates the level of the geographic hierarchy relayed in the map. The "mapformat" attribute indicates the format of the map.</xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:element name="geogCover" type="conceptualTextType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Geographic Coverage</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Information on the geographic coverage of the data. Includes the total geographic scope of the data, and any additional levels of geographic coding provided in the variables. Maps to Dublin Core Coverage element. Inclusion of this element in the codebook is recommended. Fpor forward-compatibility, DDI 3 XHTML tags may be used in this element.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <geogCover>State of California</geogCover>
+                     ]]></xhtml:samp>
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:element name="geogUnit" type="conceptualTextType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Geographic Unit</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Lowest level of geographic aggregation covered by the data.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <geogUnit>state</geogUnit>
+                     ]]></xhtml:samp> 
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:complexType name="grantNoType" mixed="true">
+      <xs:complexContent>
+         <xs:extension base="simpleTextType">
+            <xs:attribute name="agency" type="xs:string"/>
+            <xs:attribute name="role" type="xs:string"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="grantNo" type="grantNoType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Grant Number</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">The grant/contract number of the project that sponsored the effort. If more than one, indicate the appropriate agency using the "agency" attribute. If different funding agencies sponsored different stages of the production process, use the "role" attribute to distinguish the grant numbers. </xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <grantNo agency="Bureau of Justice Statistics">J-LEAA-018-77</grantNo>
+                     ]]></xhtml:samp>
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:element name="gringLat" type="phraseType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">G-Ring Latitude</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Latitude (y coordinate) of a point. Valid range   expressed in decimal degrees is as follows: -90,0 to 90,0 degrees (latitude)</xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:element name="gringLon" type="phraseType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">G-Ring Longitude</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Longitude (x coordinate) of a point. Valid range expressed in decimal degrees is as follows: -180,0 to 180,0 degrees (longitude)</xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:element name="guide" type="simpleTextType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Guide to Codebook</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">List of terms and definitions used in the documentation. Provided to assist users in using the document correctly. This element was intended to reflect the section in OSIRIS codebooks that assisted users in reading and interpreting a codebook. Each OSIRIS codebook contained a sample codebook page that defined the codebook conventions.  The element may be repeated to support multiple language expressions of the content.</xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:complexType name="holdingsType" mixed="true">
+      <xs:complexContent>
+         <xs:extension base="simpleTextType">
+            <xs:attribute name="location" type="xs:string"/>
+            <xs:attribute name="callno" type="xs:string"/>
+            <xs:attribute name="URI" type="xs:string"/>
+            <xs:attribute name="media" type="xs:string"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+   
+   <xs:element name="holdings" type="holdingsType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Holdings Information</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Information concerning either the physical or electronic holdings of the cited work. Attributes include: location--The physical location where a copy is held; callno--The call number for a work at the location specified; and URI--A URN or URL for accessing the electronic copy of the cited work. </xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <holdings location="ICPSR DDI Repository" callno="inap." URI="http://www.icpsr.umich.edu/DDIrepository/">Marked-up Codebook for Current Population Survey, 1999: Annual Demographic File</holdings>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <holdings location="University of Michigan Graduate Library" callno="inap." URI="http://www.umich.edu/library/">Codebook for Current Population Survey, 1999: Annual Demographic File </holdings>
+                     ]]></xhtml:samp>
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:complexType name="IDNoType" mixed="true">
+      <xs:complexContent>
+         <xs:extension base="simpleTextType">
+            <xs:attribute name="agency" type="xs:string"/>
+            <xs:attribute name="level">
+               <xs:simpleType>
+                  <xs:restriction base="xs:NMTOKEN">
+                     <xs:enumeration value="study"/>
+                     <xs:enumeration value="file"/>
+                     <xs:enumeration value="project"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:attribute>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="IDNo" type="IDNoType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Identification Number</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Unique string or number (producer's or archive's number). An "agency" attribute is supplied. Identification Number of data collection maps to Dublin Core Identifier element. </xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <IDNo agency="ICPSR">6678</IDNo>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <IDNo agency="ZA">2010</IDNo>
+                     ]]></xhtml:samp>
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:element name="imputation" type="simpleTextType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Imputation</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">According to the Statistical Terminology glossary maintained by the National Science Foundation, this is "the process by which one estimates missing values for items that a survey respondent failed to provide," and if applicable in this context, it refers to the type of procedure used. When applied to an nCube, imputation takes into consideration all of the dimensions that are part of that nCube. This element may be repeated to support multiple language expressions of the content.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <var>
+                           <imputation>This variable contains values that were derived by substitution.</imputation>
+                        </var>
+                     ]]></xhtml:samp> 
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:complexType name="invalrngType">
+      <xs:complexContent>
+         <xs:extension base="baseElementType">
+            <xs:sequence>
+               <xs:choice minOccurs="1" maxOccurs="unbounded">
+                  <xs:element ref="item"/>
+                  <xs:element ref="range"/>
+               </xs:choice>
+               <xs:element ref="key" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="notes" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="invalrng" type="invalrngType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Range of Invalid Data Values</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Values for a particular variable that represent   missing data, not applicable responses, etc.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <invalrng>
+                           <range UNITS="INT" min="98" max="99"/> 
+                           <key> 
+                     			98 DK 
+                     			99 Inappropriate
+                     		</key> 
+                        </invalrng>
+                     ]]></xhtml:samp> 
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:complexType name="itemType">
+      <xs:complexContent>
+         <xs:extension base="baseElementType">
+            <xs:attribute name="UNITS" default="INT">
+               <xs:simpleType>
+                  <xs:restriction base="xs:NMTOKEN">
+                     <xs:enumeration value="INT"/>
+                     <xs:enumeration value="REAL"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:attribute>
+            <xs:attribute name="VALUE" type="xs:string" use="required"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="item" type="itemType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Value Item</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">The counterpart to Range; used to encode individual values. This is an empty element consisting only of its attributes. The "UNITS" attribute permits the specification of integer/real numbers. The "VALUE" attribute specifies the actual value.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <valrng>
+                           <item VALUE="1"/>
+                           <item VALUE="2"/>
+                           <item VALUE="3"/> 
+                        </valrng>
+                     ]]></xhtml:samp>
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:element name="ivuInstr" type="simpleTextType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Interviewer Instructions</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Specific instructions to the individual conducting an interview.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <var>
+                           <qstn>
+                              <ivuInstr>Please prompt the respondent if they are reticent to answer this question.</ivuInstr>
+                           </qstn>
+                        </var>
+                     ]]></xhtml:samp> 
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:element name="key" type="tableAndTextType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Range Key</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">This element permits a listing of the category values and labels. While this information is coded separately in the Category element, there may be some value in having this information in proximity to the range of valid and invalid values. A table is permissible in this element.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <valrng>
+                           <range UNITS="INT" maxExclusive="95" min="05" max="80"> </range> 
+                           <key>
+                        		05 (PSU) Parti Socialiste Unifie et extreme gauche (Lutte Ouvriere) [United Socialists and extreme left (Workers Struggle)] 
+                        		50 Les Verts [Green Party] 
+                        		80 (FN) Front National et extreme droite [National Front and extreme right] 
+                     		</key>
+                        </valrng>
+                     ]]></xhtml:samp>
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:complexType name="keywordType" mixed="true">
+      <xs:complexContent>
+         <xs:extension base="simpleTextType">
+            <xs:attribute name="vocab" type="xs:string"/>
+            <xs:attribute name="vocabURI" type="xs:string"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="keyword" type="keywordType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Keywords</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Words or phrases that describe salient aspects of a data collection's content. Can be used for building keyword indexes and for classification and retrieval purposes. A controlled vocabulary can be employed. Maps to Dublin Core Subject element. The "vocab" attribute is provided for specification of the controlled vocabulary in use, e.g., LCSH, MeSH, etc. The "vocabURI" attribute specifies the location for the full controlled vocabulary. </xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <keyword vocab="ICPSR Subject Thesaurus" vocabURI="http://www.icpsr.umich.edu/thesaurus/subject.html">quality of life</keyword>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <keyword vocab="ICPSR Subject Thesaurus" vocabURI="http://www.icpsr.umich.edu/thesaurus/subject.html">family</keyword>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <keyword vocab="ICPSR Subject Thesaurus" vocabURI="http://www.icpsr.umich.edu/thesaurus/subject.html">career goals</keyword>
+                     ]]></xhtml:samp>
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:complexType name="lablType" mixed="true">
+      <xs:complexContent>
+         <xs:extension base="simpleTextType">
+            <xs:attribute name="level" type="xs:string"/>
+            <xs:attribute name="vendor" type="xs:string"/>
+            <xs:attribute name="country" type="xs:string"/>
+            <xs:attribute name="sdatrefs" type="xs:IDREFS"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+   
+   <xs:element name="labl" type="lablType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Label</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">A short description of the parent element. In the variable label, the length of this phrase may depend on the statistical analysis system used (e.g., some versions of SAS permit 40-character labels, while some versions of SPSS permit 120 characters), although the DDI itself imposes no restrictions on the number of characters allowed. A "level" attribute is included to permit coding of the level to which the label applies, i.e. record group, variable group, variable, category group, category, nCube group, nCube, or other study-related materials. The "vendor" attribute was provided to allow for specification of different labels for use with different vendors' software. The attribute "country" allows for the denotation of country-specific labels. The "sdatrefs" attribute records the ID values of all elements within the Summary Data Description section of the Study Description that might apply to the label. These elements include: time period covered, date of collection, nation or country, geographic coverage, geographic unit, unit of analysis, universe, and kind of data.</xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:complexType name="locMapType">
+      <xs:complexContent>
+         <xs:extension base="baseElementType">
+            <xs:sequence>
+               <xs:element ref="dataItem" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+   
+   <xs:element name="locMap" type="locMapType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Location Map</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">This element maps individual data entries to one or more physical storage locations. It is used to describe the physical location of aggregate/tabular data in cases where the nCube model is employed.</xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:complexType name="locationType">
+      <xs:complexContent>
+         <xs:extension base="baseElementType">
+            <xs:attribute name="StartPos" type="xs:string"/>
+            <xs:attribute name="EndPos" type="xs:string"/>
+            <xs:attribute name="width" type="xs:string"/>
+            <xs:attribute name="RecSegNo" type="xs:string"/>
+            <xs:attribute name="fileid" type="xs:IDREF"/>
+            <xs:attribute name="locMap" type="xs:IDREF"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+   
+   <xs:element name="location" type="locationType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Location</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">This is an empty element containing only the attributes listed below. Attributes include "StartPos" (starting position of variable), "EndPos" (ending position of variable), "width" (number of columns the variable occupies), "RecSegNo" (the record segment number, deck or card number the variable is located on), and "fileid", an IDREF link to the fileDscr element for the file that this location is within (this is necessary in cases where the same variable may be coded in two different files, e.g., a logical record length type file and a card image type file). Note that if there is no width or ending position, then the starting position should be the ordinal position in the file, and the file would be described as free-format. The attribute "locMap" is an IDREF to the element locMap and serves as a pointer to indicate that the location information for the nCube's cells (aggregate data) is located in that section.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <var>
+                           <location StartPos="55" EndPos="57" width="3" RecSegNo="2" fileid="CARD-IMAGE"/>
+                           <location StartPos="167" EndPos="169" fileid="LRECL"/>
+                        </var>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <nCube>
+                           <location locMap="LM"/>
+                        </nCube>
+                     ]]></xhtml:samp>
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:element name="logRecL" type="simpleTextType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Logical Record Length</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Logical record length, i.e., number of characters of data in the record.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example"> 
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <logRecL>27</logRecL>
+                     ]]></xhtml:samp> 
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:complexType name="measureType">
+      <xs:complexContent>
+         <xs:extension base="baseElementType">
+            <xs:attribute name="varRef" type="xs:IDREF"/>
+            <xs:attribute name="aggrMeth">
+               <xs:simpleType>
+                  <xs:restriction base="xs:NMTOKEN">
+                     <xs:enumeration value="sum"/>
+                     <xs:enumeration value="average"/>
+                     <xs:enumeration value="count"/>
+                     <xs:enumeration value="mode"/>
+                     <xs:enumeration value="median"/>
+                     <xs:enumeration value="maximum"/>
+                     <xs:enumeration value="minimum"/>
+                     <xs:enumeration value="percent"/>
+                     <xs:enumeration value="other"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:attribute>
+            <xs:attribute name="otherAggrMeth" type="xs:NMTOKEN" use="optional"/>
+            <xs:attribute name="measUnit" type="xs:string"/>
+            <xs:attribute name="scale" type="xs:string"/>
+            <xs:attribute name="origin" type="xs:string"/>
+            <xs:attribute name="additivity">
+               <xs:simpleType>
+                  <xs:restriction base="xs:NMTOKEN">
+                     <xs:enumeration value="stock"/>
+                     <xs:enumeration value="flow"/>
+                     <xs:enumeration value="non-additive"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:attribute>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="measure" type="measureType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Measure</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">The element measure indicates the measurement features of the cell content: type of aggregation used, measurement unit, and measurement scale. An origin point is recorded for anchored scales, to be used in determining relative movement along the scale. Additivity indicates whether an aggregate is a stock (like the population at a given point in time) or a flow (like the number of births or deaths over a certain period of time). The non-additive flag is to be used for measures that for logical reasons cannot be aggregated to a higher level - for instance, data that only make sense at a certain level of aggregation, like a classification. Two nCubes may be identical except for their measure - for example, a count of persons by age and percent of persons by age. Measure is an empty element that includes the following attributes: "varRef" is an IDREF; "aggrMeth" indicates the type of aggregation method used, for example 'sum', 'average', 'count'; "measUnit" records the measurement unit, for example 'km', 'miles', etc.; "scale" records unit of scale, for example 'x1', 'x1000'; "origin" records the point of origin for anchored scales;"additivity" records type of additivity such as 'stock', 'flow', 'non-additive'. If a value of "other" is used for the aggrMeth attribute, a term from a controlled vocabulary should be placed in the "otherAggrMeth" attribute, and a the complex element controlledVocabUsed should be used to specify the controlled vocabulary.</xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:complexType name="methodType">
+      <xs:complexContent>
+         <xs:extension base="baseElementType">
+            <xs:sequence>
+               <xs:element ref="dataColl" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="notes" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="anlyInfo" minOccurs="0"/>
+               <xs:element ref="stdyClas" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="dataProcessing" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="codingInstructions" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="method" type="methodType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Methodology and Processing</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">This section describes the methodology and processing involved in a data collection.</xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:complexType name="codingInstructionsType">
+      <xs:complexContent>
+         <xs:extension base="baseElementType">
+            <xs:sequence>
+               <xs:element ref="txt" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="command" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+            <xs:attribute name="type" type="xs:string" use="optional"/>
+            <xs:attribute name="relatedProcesses" type="xs:IDREFS" use="optional"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+   
+   <xs:element name="codingInstructions" type="codingInstructionsType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Coding Instructions</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Describe specific coding instructions used in data processing, cleaning, assession, or tabulation. Element relatedProcesses allows linking a coding instruction to one or more processes such as dataProcessing, dataAppr, cleanOps, etc. Use the txt element to describe instructions in a human readable form.</xhtml:div>
+               </xhtml:div>
+						<xhtml:div>
+							<xhtml:h2 class="section_header">Example</xhtml:h2>
+							<xhtml:div class="example">
+								<xhtml:samp class="xml_sample"><![CDATA[
+<codingInstructions relatedProcesses="cleanOps_7334" type="recode">
+<txt>recode undocumented/wild codes to missing, i.e., 0.</txt>
+<command formalLanguage="SPSS">RECODE V1 TO V100 (10 THROUGH HIGH = 0)</command>
+</codingInstructions>
+]]>
+								</xhtml:samp>
+							</xhtml:div>
+						</xhtml:div>
+            </xhtml:div>
+         .</xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:complexType name="commandType">
+      <xs:simpleContent>
+         <xs:extension base="stringType">
+            <xs:attribute name="formalLanguage" type="xs:string"/>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+
+   <xs:element name="command" type="commandType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Command</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Provide command code for the coding instruction. The formalLanguage attribute identifies the language of the command code.</xhtml:div>
+               </xhtml:div>
+						<xhtml:div>
+							<xhtml:h2 class="section_header">Example</xhtml:h2>
+							<xhtml:div class="example">
+								<xhtml:samp class="xml_sample"><![CDATA[
+<command formalLanguage="SPSS">RECODE V1 TO V100 (10 THROUGH HIGH = 0)</command>
+]]>
+								</xhtml:samp>
+							</xhtml:div>
+						</xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:complexType name="dataProcessingType" mixed="true">
+      <xs:complexContent>
+         <xs:extension base="simpleTextType">
+            <xs:attribute name="type" type="xs:string" use="optional"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="dataProcessing" type="dataProcessingType">
+      <xs:annotation>
+				<xs:documentation>
+					<xhtml:div>
+						<xhtml:h1 class="element_title">Data Processing</xhtml:h1>
+						<xhtml:div>
+							<xhtml:h2 class="section_header">Description</xhtml:h2>
+							<xhtml:div class="description">Describes various data processing procedures not captured elsewhere in the documentation, such as topcoding, recoding, suppression, tabulation, etc. The "type" attribute supports better classification of this activity, including the optional use of a controlled vocabulary.</xhtml:div>
+						</xhtml:div>
+						<xhtml:div>
+							<xhtml:h2 class="section_header">Example</xhtml:h2>
+							<xhtml:div class="example">
+								<xhtml:samp class="xml_sample"><![CDATA[
+<dataProcessing type="topcoding">The income variables in this study (RESP_INC, HHD_INC, and SS_INC) were topcoded to protect confidentiality.</dataProcessing>
+]]>
+								</xhtml:samp>
+							</xhtml:div>
+						</xhtml:div>
+					</xhtml:div>
+				</xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:complexType name="miType" mixed="true">
+      <xs:complexContent>
+         <xs:extension base="phraseType">
+            <xs:attribute name="varRef" type="xs:IDREF" use="required"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="mi" type="miType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Mathematical Identifier</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Token element containing the smallest unit in the mrow that carries meaning.</xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:complexType name="mrowType">
+      <xs:complexContent>
+         <xs:extension base="baseElementType">
+            <xs:sequence>
+               <xs:element ref="mi" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="mrow" type="mrowType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Mathematical Row</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">This element is a wrapper containing the presentation expression mi. It creates a single string without spaces consisting of the individual elements described within it. It can be used to create a single variable by concatenating other variables into a single string. It is used to create linking variables composed of multiple non-contiguous parts, or to define unique strings for various category values of a single variable.</xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:complexType name="nCubeType">
+      <xs:complexContent>
+         <xs:extension base="baseElementType">
+            <xs:sequence>
+               <xs:element ref="location" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="labl" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="txt" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="universe" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="imputation" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="security" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="embargo" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="respUnit" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="anlysUnit" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="verStmt" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="purpose" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="dmns" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="measure" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="notes" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+            <xs:attribute name="name" type="xs:string"/>
+            <xs:attribute name="sdatrefs" type="xs:IDREFS"/>
+            <xs:attribute name="methrefs" type="xs:IDREFS"/>
+            <xs:attribute name="pubrefs" type="xs:IDREFS"/>
+            <xs:attribute name="access" type="xs:IDREFS"/>
+            <xs:attribute name="dmnsQnty" type="xs:string"/>
+            <xs:attribute name="cellQnty" type="xs:string"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="nCube" type="nCubeType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">nCube</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">
+                     <xhtml:p>Describes the logical structure of an n-dimensional array, in which each coordinate intersects with every other dimension at a single point. The nCube has been designed for use in the markup of aggregate data. Repetition of the following elements is provided to support multi-language content: anlysUnit, embargo, imputation, purpose, respUnit, and security. This element includes the following attributes:</xhtml:p>
+                     <xhtml:p>The attribute "name" includes a short label for the nCube. Following the rules of many statistical analysis systems such as SAS and SPSS, names are usually up to eight characters long.</xhtml:p>
+                     <xhtml:p>The "sdatrefs" are summary data description references which record the ID values of all elements within the summary data description section of the Study Description which might apply to the nCube. These elements include: time period covered, date of collection, nation or country, geographic coverage, geographic unit, unit of analysis, universe, and kind of data.</xhtml:p>
+                     <xhtml:p>The "methrefs" are methodology and processing references which record the ID values of all elements within the study methodology and processing section of the Study Description which might apply to the nCube. These elements include information on data collection and data appraisal (e.g., sampling, sources, weighting, data cleaning, response rates, and sampling error estimates).</xhtml:p>
+                     <xhtml:p>The "pubrefs" attribute provides a link to publication/citation references and records the ID values of all citations elements in Other Study Description Materials or Other Study-Related Materials that pertain to this nCube.</xhtml:p>
+                     <xhtml:p>The "access" attribute records the ID values of all elements in the Data Access section that describe access conditions for this nCube. The "dmnsQnty" attribute notes the number of dimensions in the nCube. The "cellQnty" attribute indicates the total number of cells in the nCube.</xhtml:p>
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:complexType name="nCubeGrpType">
+      <xs:complexContent>
+         <xs:extension base="baseElementType">
+            <xs:sequence>
+               <xs:element ref="labl" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="txt" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="concept" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="defntn" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="universe" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="notes" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+            <xs:attribute name="type" default="other">
+               <xs:simpleType>
+                  <xs:restriction base="xs:NMTOKEN">
+                     <xs:enumeration value="section"/>
+                     <xs:enumeration value="multipleResp"/>
+                     <xs:enumeration value="grid"/>
+                     <xs:enumeration value="display"/>
+                     <xs:enumeration value="repetition"/>
+                     <xs:enumeration value="subject"/>
+                     <xs:enumeration value="version"/>
+                     <xs:enumeration value="iteration"/>
+                     <xs:enumeration value="analysis"/>
+                     <xs:enumeration value="pragmatic"/>
+                     <xs:enumeration value="record"/>
+                     <xs:enumeration value="file"/>
+                     <xs:enumeration value="randomized"/>
+                     <xs:enumeration value="other"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:attribute>
+            <xs:attribute name="otherType" type="xs:NMTOKEN" use="optional"/>
+            <xs:attribute name="nCube" type="xs:IDREFS"/>
+            <xs:attribute name="nCubeGrp" type="xs:IDREFS"/>
+            <xs:attribute name="name" type="xs:string"/>
+            <xs:attribute name="sdatrefs" type="xs:IDREFS"/>
+            <xs:attribute name="methrefs" type="xs:IDREFS"/>
+            <xs:attribute name="pubrefs" type="xs:IDREFS"/>
+            <xs:attribute name="access" type="xs:IDREFS"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="nCubeGrp" type="nCubeGrpType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">nCube Group</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">
+                     <xhtml:p>A group of nCubes that may share a common subject, arise from the interpretation of a single question, or are linked by some other factor. This element makes it possible to identify all nCubes derived from a simple presentation table, and to provide the original table title and universe, as well as reference the source. Specific nesting patterns can be described using the attribute nCubeGrp.</xhtml:p>
+                     <xhtml:p>nCube groups are also created this way in order to permit nCubes to belong to multiple groups, including multiple subject groups, without causing overlapping groups. nCubes that are linked by the same use of the same variable need not be identified by an nCubeGrp element because they are already linked by a common variable element. Note that as a result of the strict sequencing required by XML, all nCube Groups must be marked up before the Variable element is opened. That is, the mark-up author cannot mark up a nCube Group, then mark up its constituent nCubes, then mark up another nCube Group.</xhtml:p>
+                     <xhtml:p>The "type" attribute refers to the general type of grouping of the nCubes. Specific nCube Groups, included within the 'type' attribute, are: </xhtml:p>
+                     <xhtml:p>Display: nCubes that are part of the same presentation table.</xhtml:p>
+                     <xhtml:p>Subject: nCubes that address a common topic or subject, e.g., income, poverty, children. </xhtml:p>
+                     <xhtml:p>Iteration: nCubes that appear in different sections of the data file measuring a common subject in different ways, e.g., using different universes, units of measurement, etc. </xhtml:p>
+                     <xhtml:p>Pragmatic: An nCube group without shared properties.</xhtml:p>
+                     <xhtml:p>Record: nCubes from a single record in a hierarchical file.</xhtml:p>
+                     <xhtml:p>File: nCube from a single file in a multifile study.</xhtml:p>
+                     <xhtml:p>Other: nCubes that do not fit easily into any of the categories listed above, e.g., a group of nCubes whose documentation is in another language. A term from a controlled vocabulary may be placed into the otherType attribute if this value is used.</xhtml:p>
+                     <xhtml:p>The otherType attribute should only be used when applying a controlled vocabulary, and when the type attribute has been given a value of "other". Use the complex element controlledVocabUsed to identify the controlled vocabulary to which the selected term belongs.</xhtml:p>
+                     <xhtml:p>The "nCube" attribute is used to reference all the IDs of the nCubes belonging to the group.</xhtml:p>
+                     <xhtml:p>The "nCubeGrp" attribute is used to reference all the subsidiary nCube groups which nest underneath the current nCubeGrp. This allows for encoding of a hierarchical structure of nCube groups.</xhtml:p>
+                     <xhtml:p>The attribute "name" provides a name, or short label, for the group.</xhtml:p>
+                     <xhtml:p>The "sdatrefs" are summary data description references that record the ID values of all elements within the summary data description section of the Study Description that might apply to the group. These elements include: time period covered, date of collection, nation or country, geographic coverage, geographic unit, unit of analysis, universe, and kind of data.</xhtml:p>
+                     <xhtml:p>The "methrefs" are methodology and processing references which record the ID values of all elements within the study methodology and processing section of the Study Description which might apply to the group. These elements include information on data collection and data appraisal (e.g., sampling, sources, weighting, data cleaning, response rates, and sampling error estimates).</xhtml:p>
+                     <xhtml:p>The "pubrefs" attribute provides a link to publication/citation references and records the ID values of all citations elements within Section codeBook/stdyDscr/othrStdyMat or codeBook/otherMat that pertain to this nCube group.</xhtml:p>
+                     <xhtml:p>The "access" attribute records the ID values of all elements in codeBook/stdyDscr/dataAccs of the document that describe access conditions for this nCube group.</xhtml:p>
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:complexType name="nationType" mixed="true">
+      <xs:complexContent>
+         <xs:extension base="conceptualTextType">
+            <xs:attribute name="abbr" type="xs:string"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="nation" type="nationType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Country</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Indicates the country or countries covered in the file. Attribute "abbr" may be used to list common abbreviations; use of ISO country codes is recommended. Maps to Dublin Core Coverage element. Inclusion of this element is recommended. For forward-compatibility, DDI 3 XHTML tags may be used in this element.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <nation abbr="GB">United Kingdom</nation>
+                     ]]></xhtml:samp> 
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:element name="northBL" type="phraseType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">North Bounding Latitude</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">The northernmost coordinate delimiting the geographic extent of the dataset. A valid range of values, expressed in decimal degrees (positive east and positive north), is: -90,0 &lt;= North Bounding Latitude Value &lt;= 90,0 ; North Bounding Latitude Value = South Bounding Latitude Value</xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:complexType name="notesType" mixed="true">
+      <xs:complexContent>
+         <xs:extension base="tableAndTextType">
+            <xs:attribute name="type" type="xs:string"/>
+            <xs:attribute name="subject" type="xs:string"/>
+            <xs:attribute name="level" type="xs:string"/>
+            <xs:attribute name="resp" type="xs:string"/>
+            <xs:attribute name="sdatrefs" type="xs:IDREFS"/>
+            <xs:attribute name="parent" type="xs:IDREFS" use="optional"/>
+            <xs:attribute name="sameNote" type="xs:IDREF" use="optional"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="notes" type="notesType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Notes and comments</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">
+                     <xhtml:p>For clarifying information/annotation regarding the parent element.</xhtml:p>
+                     <xhtml:p>The attributes for notes permit a controlled vocabulary to be developed ("type" and "subject"), indicate the "level" of the DDI to which the note applies (study, file, variable, etc.), and identify the author of the note ("resp").</xhtml:p>
+                     <xhtml:p>The parent attribute is used to support capturing information obtained while preparing files for translation to DDI 3. It provides the ID(s) of the element this note is related to.</xhtml:p>
+                     <xhtml:p>The sameNote attribute is used to support capturing information obtained while preparing files for translation to DDI 3. If the same note is used multiple times all the parent IDs can be captured in a single note and all duplicate notes can reference the note containing the related to references in the attribute sameNote.</xhtml:p>
+                  </xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <docDscr>
+                           <verStmt>
+                              <notes resp="Jane Smith">Additional information on derived variables  has been added to this marked-up version of the documentation.</notes>
+                           </verStmt>
+                        </docDscr>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <docDscr>
+                           <citation>
+                              <notes resp="Jane Smith">This citation was prepared by the archive based on information received from the markup authors.</notes>
+                           </citation>
+                        </docDscr>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <docSrc>
+                           <verStmt>
+                              <notes resp="Jane Smith">The source codebook was produced from original hardcopy materials using  Optical Character Recognition (OCR).</notes>
+                           </verStmt>
+                        </docSrc>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <docSrc>
+                           <notes>A machine-readable version of the source codebook was supplied by the Zentralarchiv</notes>
+                        </docSrc>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <docDscr>
+                           <notes>This Document Description, or header information, can be used  within an electronic resource discovery environment.</notes>
+                        </docDscr>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <stdyDscr>
+                           <verStmt>
+                              <notes resp="Jane Smith">Data for 1998 have been added to this version of the data collection.</notes>
+                           </verStmt>
+                        </stdyDscr>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <stdyDscr>
+                           <citation>
+                              <notes resp="Jane Smith">This citation was sent to ICPSR by the  agency depositing the data.</notes>
+                           </citation>
+                        </stdyDscr>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <stdyInfo>
+                           <notes>Data on employment and income refer to the preceding year, although demographic data refer to the time of the survey.</notes>
+                        </stdyInfo>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <method>
+                           <notes>Undocumented codes were found in this data collection. Missing data are represented by blanks.</notes>
+                        </method>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <method>
+                           <notes>For this collection, which focuses on employment, unemployment, and gender equality, data from EUROBAROMETER 44.3: HEALTH CARE ISSUES AND PUBLIC SECURITY, FEBRUARY-APRIL 1996 (ICPSR 6752) were merged with an oversample.</notes>
+                        </method>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <setAvail>
+                           <notes> Data from the Bureau of Labor Statistics used in the analyses for the final report are not provided as part of this collection.</notes>
+                        </setAvail>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <dataAccs>
+                           <notes>Users should note that this is a beta version of the data. The investigators therefore request that users who encounter any problems with the dataset contact them at the above address.</notes>
+                        </dataAccs>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <fileStrc>
+                           <notes>The number of arrest records for an individual is dependent on the number of arrests an offender had.</notes>
+                        </fileStrc>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <fileTxt>
+                           <verStmt>
+                              <notes>Data for all previously-embargoed variables are now available in  this version of the file.</notes>
+                           </verStmt>
+                        </fileTxt>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <fileDscr>
+                           <notes>There is a restricted version of this file containing confidential information,  access to which is controlled by the principal investigator.</notes>
+                        </fileDscr>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <varGrp>
+                           <notes>This variable group was created for the purpose of combining all derived variables.</notes>
+                        </varGrp>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <varGrp>
+                           <notes source="archive" resp="John Data">This variable group and all other variable groups in this data file were organized according to a schema developed by the adhoc advisory committee. </notes>
+                        </varGrp>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <nCubeGrp>
+                           <notes>This nCube Group was created for the purpose of presenting a cross-tabulation between variables "Tenure" and "Age of householder."</notes>
+                        </nCubeGrp>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <valrng>
+                           <notes subject="political party">Starting with Euro-Barometer 2 the coding of this variable has been standardized following an approximate ordering of each country's political parties along a "left" to "right" continuum in the first digit of the codes. Parties coded 01-39 are generally considered on the "left", those coded 40-49 in the "center", and those coded 60-89 on the "right" of the political spectrum. Parties coded 50-59 cannot be readily located in the traditional meaning of "left" and "right". The second digit of the codes is not significant to the "left-right" ordering. Codes 90-99 contain the response "other party" and various missing data responses. Users may modify these codings or part of these codings in order to suit their specific needs. </notes>
+                        </valrng>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <invalrng>
+                           <notes>Codes 90-99 contain the response "other party" and various missing data responses. </notes>
+                        </invalrng>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <var>
+                           <verStmt>
+                              <notes>The labels for categories 01 and 02 for this variable, were inadvertently switched in the first version of this variable and have now been corrected.</notes>
+                           </verStmt>
+                        </var>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <var>
+                           <notes>This variable was created by recoding location of residence to Census regions.</notes>
+                        </var>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <nCube>
+                           <verStmt>
+                              <notes>The labels for categories 01 and 02 in dimension 1 were inadvertently switched in the first version of the cube, and have now been corrected.</notes>
+                           </verStmt>
+                        </nCube>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <nCube>
+                           <notes>This nCube was created to meet the needs of local low income programs in determining eligibility for federal funds.</notes>
+                        </nCube>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <dataDscr>
+                           <notes>The variables in this study are identical to earlier waves. </notes>
+                        </dataDscr>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <otherMat>
+                           <notes>Users should be aware that this questionnaire was modified  during the CAI process.</notes>
+                        </otherMat>
+                     ]]></xhtml:samp>
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:element name="origArch" type="simpleTextType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Archive Where Study Originally Stored</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Archive from which the data collection was obtained; the originating archive. </xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <origArch>Zentralarchiv fuer empirische Sozialforschung</origArch>
+                     ]]></xhtml:samp>
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:complexType name="othIdType" mixed="true">
+      <xs:complexContent>
+         <xs:extension base="simpleTextType">
+            <xs:attribute name="type" type="xs:string"/>
+            <xs:attribute name="role" type="xs:string"/>
+            <xs:attribute name="affiliation" type="xs:string"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="othId" type="othIdType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Other Identifications /Acknowledgments</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Statements of responsibility not recorded in the title and statement of responsibility areas. Indicate here the persons or bodies connected with the work, or significant persons or bodies connected with previous editions and not already named in the description. For example, the name of the person who edited the marked-up documentation might be cited in codeBook/docDscr/rspStmt/othId, using the "role" and "affiliation" attributes. Other identifications/acknowledgments for data collection (codeBook/stdyDscr/citation/rspStmt/othId) maps to Dublin Core Contributor element.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <othId role="editor" affiliation="INRA">Jane Smith</othId>
+                     ]]></xhtml:samp> 
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:complexType name="othRefsType" mixed="true">
+      <xs:complexContent>
+         <xs:restriction base="abstractTextType">
+            <xs:sequence>
+               <xs:choice minOccurs="0" maxOccurs="unbounded">
+                  <xs:group ref="PHRASE"/>
+                  <xs:group ref="FORM"/>
+                  <xs:group ref="xhtml:BlkNoForm.mix"/>
+                  <xs:element ref="citation"/>
+               </xs:choice>
+            </xs:sequence>
+         </xs:restriction>
+      </xs:complexContent>
+   </xs:complexType>
+   
+   <xs:element name="othRefs" type="othRefsType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Other References Notes</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Indicates other pertinent references. Can take the form of bibliographic citations. </xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <othRefs>Part II of the documentation, the Field Representative's Manual, is provided in hardcopy form only.</othRefs>
+                     ]]></xhtml:samp> 
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:complexType name="otherMatType">
+      <xs:complexContent>
+         <xs:extension base="baseElementType">
+            <xs:choice>
+               <xs:sequence>
+                  <xs:element ref="labl" minOccurs="0" maxOccurs="unbounded"/>
+                  <xs:element ref="txt" minOccurs="0" maxOccurs="unbounded"/>
+                  <xs:element ref="notes" minOccurs="0" maxOccurs="unbounded"/>
+                  <xs:element ref="table" minOccurs="0" maxOccurs="unbounded"/>
+                  <xs:element ref="citation" minOccurs="0"/>
+                  <xs:element ref="otherMat" minOccurs="0" maxOccurs="unbounded"/>
+               </xs:sequence>
+            </xs:choice>
+            <xs:attribute name="type" type="xs:string"/>
+            <xs:attribute name="level" type="xs:NMTOKEN" use="required"/>
+            <xs:attribute name="URI" type="xs:string"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+   
+   <xs:element name="otherMat" type="otherMatType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Other Study-Related Materials</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">
+                     <xhtml:p>This section allows for the inclusion of other materials that are related to the study as identified and labeled by the DTD/Schema users (encoders). The' materials may be entered as PCDATA (ASCII text) directly into the document (through use of the "txt" element). This ection may also serve as a "container" for other electronic materials such as setup files by providing a brief description of the study-related materials accompanied by the attributes "type" and "level" defining the material further. The "URI" attribute may be used to indicate the location of the other study-related materials.</xhtml:p>
+                     <xhtml:p>Other Study-Related Materials may include: questionnaires, coding notes, SPSS/SAS/Stata setup files (and others), user manuals, continuity guides, sample computer software programs, glossaries of terms, interviewer/project instructions, maps, database schema, data dictionaries, show cards, coding information, interview schedules, missing values information, frequency files, variable maps, etc.</xhtml:p>
+                     <xhtml:p>The "level" attribute is used to clarify the relationship of the other materials to components of the study. Suggested values for level include specifications of the item level to which the element applies: e.g., level= data; level=datafile; level=studydsc; level=study. The URI attribute need not be used in every case; it is intended for capturing references to other materials separate from the codebook itself. In Section 5, Other Material is recursively defined.</xhtml:p>
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:complexType name="othrStdyMatType">
+      <xs:complexContent>
+         <xs:extension base="baseElementType">
+            <xs:sequence>
+               <xs:element ref="relMat" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="relStdy" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="relPubl" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="othRefs" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+   
+   <xs:element name="othrStdyMat" type="othrStdyMatType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Other Study Description Materials</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Other materials relating to the study description. This section describes other materials that are related to the study description that are primarily descriptions of the content and use of the study, such as appendices, sampling information, weighting details, methodological and technical details, publications based upon the study content, related studies or collections of studies, etc. This section may point to other materials related to the description of the study through use of the generic citation element, which is available for each element in this section. This maps to Dublin Core Relation element. Note that codeBook/otherMat (Other Study-Related Materials), should be used for materials used in the production of the study or useful in the analysis of the study. The materials in codeBook/otherMat may be entered as PCDATA (ASCII text) directly into the document (through use of the txt element). That section may also serve as a "container" for other electronic materials by providing a brief description of the study-related materials accompanied by the "type" and "level" attributes further defining the materials. Other Study-Related Materials in codeBook/otherMat may include: questionnaires, coding notes, SPSS/SAS/Stata setup files (and others), user manuals, continuity guides, sample computer software programs, glossaries of terms, interviewer/project instructions, maps, database schema, data dictionaries, show cards, coding information, interview schedules, missing values information, frequency files, variable maps, etc.</xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:element name="parTitl" type="simpleTextType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Parallel Title</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Title translated into another language.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <titl>Politbarometer West [Germany], Partial Accumulation, 1977-1995</titl>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <parTitl>Politbarometer, 1977-1995: Partielle Kumulation</parTitl>
+                     ]]></xhtml:samp>
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:complexType name="physLocType">
+      <xs:complexContent>
+         <xs:extension base="baseElementType">
+            <xs:attribute name="type" type="xs:string"/>
+            <xs:attribute name="recRef" type="xs:IDREF"/>
+            <xs:attribute name="startPos" type="xs:string"/>
+            <xs:attribute name="width" type="xs:string"/>
+            <xs:attribute name="endPos" type="xs:string"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="physLoc" type="physLocType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1></xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">
+                     <xhtml:p>This is an empty element containing only the attributes listed below. Attributes include "type" (type of file structure: rectangular, hierarchical, two-dimensional, relational), "recRef" (IDREF link to the appropriate file or recGrp element within a file), "startPos" (starting position of variable or data item), "endPos" (ending position of variable or data item), "width" (number of columns the variable/data item occupies), "RecSegNo" (the record segment number, deck or card number the variable or data item is located on), and "fileid" (an IDREF link to the fileDscr element for the file that includes this physical location).</xhtml:p>
+                     <xhtml:p>Remarks: Where the same variable is coded in two different files, e.g., a fixed format file and a relational database file, simply repeat the physLoc element with the alternative location information. Note that if there is no width or ending position, then the starting position should be the ordinal position in the file, and the file would be described as free-format. New attributes will be added as other storage formats are described within the DDI.</xhtml:p>
+                  </xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <physLoc type="rectangular" recRef="R1" startPos="55" endPos="57" width="3"/>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <physLoc type="hierarchical" recRef="R6" startPos="25" endPos="25" width="1"/>
+                     ]]></xhtml:samp> 
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:complexType name="pointType">
+      <xs:complexContent>
+         <xs:extension base="baseElementType">
+            <xs:sequence>
+               <xs:element ref="gringLat"/>
+               <xs:element ref="gringLon"/>
+            </xs:sequence>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="point" type="pointType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Point</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">0-dimensional geometric primitive, representing a position, but not having extent. In this declaration, point is limited to a longitude/latitude coordinate system.</xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:complexType name="polygonType">
+      <xs:complexContent>
+         <xs:extension base="baseElementType">
+            <xs:sequence>
+               <xs:element ref="point" maxOccurs="unbounded"/>
+            </xs:sequence>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="polygon" type="polygonType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Polygon</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">The minimum polygon that covers a geographical area, and is delimited by at least 4 points (3 sides), in which the last point coincides with the first point.</xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:element name="postQTxt" type="simpleTextType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">PostQuestion Text</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Text describing what occurs after the literal question has been asked.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <var>
+                           <qstn>
+                              <postQTxt>The next set of questions will ask about your financial situation.</postQTxt> 
+                           </qstn>
+                        </var>
+                     ]]></xhtml:samp> 
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:element name="preQTxt" type="simpleTextType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">PreQuestion Text</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Text describing a set of conditions under which a question might be asked.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <var>
+                           <qstn>
+                              <preQTxt>For those who did not go away on a holiday of four days or more in 1985...</preQTxt>
+                           </qstn>
+                        </var>
+                     ]]></xhtml:samp> 
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:element name="ProcStat" type="simpleTextType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Processing Status</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Processing status of the file. Some data producers and social science data archives employ data processing strategies that provide for release of data and documentation at various stages of processing.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <ProcStat>Available from the DDA. Being processed.</ProcStat>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <ProcStat>The principal investigator notes that the data in Public Use Tape 5 are released prior to final cleaning and editing, in order to provide prompt access to the NMES data by the research and policy community.</ProcStat>
+                     ]]></xhtml:samp> 
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:element name="prodDate" type="simpleTextAndDateType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Date of Production</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Date when the marked-up document/marked-up document source/data collection/other material(s) were produced (not distributed or archived). The ISO standard for dates (YYYY-MM-DD) is recommended for use with the date attribute. Production date for data collection (codeBook/stdyDscr/citation/prodStmt/prodDate) maps to Dublin Core Date element.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <prodDate date="1999-01-25">January 25, 1999</prodDate>
+                     ]]></xhtml:samp>
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:element name="prodPlac" type="simpleTextType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Place of Production</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Address of the archive or organization that produced the work.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <prodPlac>Ann Arbor, MI: Inter-university Consortium for Political and Social Research</prodPlac>
+                     ]]></xhtml:samp>
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:complexType name="prodStmtType">
+      <xs:complexContent>
+         <xs:extension base="baseElementType">
+            <xs:sequence>
+               <xs:element ref="producer" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="copyright" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="prodDate" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="prodPlac" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="software" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="fundAg" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="grantNo" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="prodStmt" type="prodStmtType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Production Statement</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Production statement for the work at the appropriate level: marked-up document; marked-up document source; study; study description, other material; other material for study.</xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:complexType name="producerType" mixed="true">
+      <xs:complexContent>
+         <xs:extension base="simpleTextType">
+            <xs:attribute name="abbr" type="xs:string"/>
+            <xs:attribute name="affiliation" type="xs:string"/>
+            <xs:attribute name="role" type="xs:string"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+   
+   <xs:element name="producer" type="producerType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Producer</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">The producer is the person or organization with the financial or administrative responsibility for the physical processes whereby the document was brought into existence. Use the "role" attribute to distinguish different stages of involvement in the production process, such as original producer. Producer of data collection (codeBook/stdyDscr/citation/prodStmt/producer) maps to Dublin Core Publisher element. The "producer" in the Document Description should be the agency or person that prepared the marked-up document.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <producer abbr="ICPSR" affiliation="Institute for Social Research">Inter-university Consortium for Political and Social Research</producer>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <producer abbr="MNPoll" affiliation="Minneapolis Star Tibune Newspaper"
+                                  role="original producer">Star Tribune Minnesota Poll</producer>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <producer abbr="MRDC" affiliation="University of Minnesota" role="final production">Machine Readable Data Center</producer>
+                     ]]></xhtml:samp>
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:complexType name="purposeType" mixed="true">
+      <xs:complexContent>
+         <xs:extension base="simpleTextType">
+            <xs:attribute name="sdatrefs" type="xs:IDREFS"/>
+            <xs:attribute name="methrefs" type="xs:IDREFS"/>
+            <xs:attribute name="pubrefs" type="xs:IDREFS"/>
+            <xs:attribute name="URI" type="xs:string"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="purpose" type="purposeType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1></xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Explains the purpose for which a particular nCube was created.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <nCube>
+                           <purpose>Meets reporting requirements for the Federal Reserve Board</purpose>
+                        </nCube>
+                     ]]></xhtml:samp> 
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:complexType name="qstnType" mixed="true">
+      <xs:complexContent>
+         <xs:restriction base="abstractTextType">
+            <xs:sequence>
+               <xs:choice minOccurs="0" maxOccurs="unbounded">
+                  <xs:group ref="PHRASE"/>
+                  <xs:group ref="FORM"/>
+                  <xs:group ref="xhtml:BlkNoForm.mix"/>
+                  <xs:element ref="preQTxt"/>
+                  <xs:element ref="qstnLit"/>
+                  <xs:element ref="postQTxt"/>
+                  <xs:element ref="forward"/>
+                  <xs:element ref="backward"/>
+                  <xs:element ref="ivuInstr"/>
+               </xs:choice>               
+            </xs:sequence>
+            <xs:attribute name="qstn" type="xs:IDREF"/>
+            <xs:attribute name="var" type="xs:IDREFS"/>
+            <xs:attribute name="seqNo" type="xs:string"/>
+            <xs:attribute name="sdatrefs" type="xs:IDREFS"/>
+            <xs:attribute name="responseDomainType" use="optional">
+               <xs:simpleType>
+                  <xs:restriction base="xs:NMTOKEN">
+                     <xs:enumeration value="text"/>
+                     <xs:enumeration value="numeric"/>
+                     <xs:enumeration value="code"/>
+                     <xs:enumeration value="category"/>
+                     <xs:enumeration value="datetime"/>
+                     <xs:enumeration value="geographic"/>
+                     <xs:enumeration value="multiple"/>
+                     <xs:enumeration value="other"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:attribute>
+            <xs:attribute name="otherResponseDomainType" type="xs:NMTOKEN" use="optional"/>
+         </xs:restriction>
+      </xs:complexContent>
+   </xs:complexType>
+   
+   <xs:element name="qstn" type="qstnType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Question</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">The question element may have mixed content. The element itself may contain text for the question, with the subelements being used to provide further information about the question. Alternatively, the question element may be empty and only the subelements used. The element has a unique question ID attribute which can be used to link a variable with other variables where the same question has been asked. This would allow searching for all variables that share the same question ID, perhaps because the questions was asked several times in a panel design. The "ID" attribute contains a unique identifier for the question. "Var" references the ID(s) of the variable(s) relating to the question. The attribute "seqNo" refers to the sequence number of the question. The attribute "sdatrefs" may be used to reference elements in the summary data description section of the Study Description which might apply to this question. These elements include: time period covered, date of collection, nation or country, geographic coverage, geographic unit, unit of analysis, universe, and kind of data. The responseDomainType attribute was added to capture the specific DDI 3 response domain type to facilitate translation between DDI 2 and DDI 3. If this is given a value of "other" then a term from a controlled vocabulary should be put into the "otherResponseDomainType" attribute.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <var>
+                           <qstn ID="Q125">When you get together with your friends, would you say you discuss political matters frequently, occasionally, or never?</qstn>
+                        </var>
+                     ]]></xhtml:samp> 
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:complexType name="qstnLitType" mixed="true">
+      <xs:complexContent>
+         <xs:extension base="simpleTextType">
+            <xs:attribute name="sdatrefs" type="xs:IDREFS"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="qstnLit" type="qstnLitType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Literal Question</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Text of the actual, literal question asked.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <var>
+                           <qstn>
+                              <qstnLit>Why didn't you go away in 1985?</qstnLit>
+                           </qstn>
+                        </var>
+                     ]]></xhtml:samp>
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:complexType name="rangeType">
+      <xs:complexContent>
+         <xs:extension base="baseElementType">
+            <xs:attribute name="UNITS" default="INT">
+               <xs:simpleType>
+                  <xs:restriction base="xs:NMTOKEN">
+                     <xs:enumeration value="INT"/>
+                     <xs:enumeration value="REAL"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:attribute>
+            <xs:attribute name="min" type="xs:string"/>
+            <xs:attribute name="minExclusive" type="xs:string"/>
+            <xs:attribute name="max" type="xs:string"/>
+            <xs:attribute name="maxExclusive" type="xs:string"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="range" type="rangeType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Value Range</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">This is the actual range of values. The "UNITS" attribute permits the specification of integer/real numbers. The "min" and "max" attributes specify the lowest and highest values that are part of the range. The "minExclusive" and "maxExclusive" attributes specify values that are immediately outside the range. This is an empty element consisting only of its attributes.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">For example, x &lt; 1 or 10 &lt;= x &lt; 20 would be expressed as:
+               	<xhtml:samp class="xml_sample"><![CDATA[
+                        <range maxExclusive="1"/>
+                     ]]></xhtml:samp>
+               	     <xhtml:samp class="xml_sample"><![CDATA[
+                        <range min="10" maxExclusive="20"/>
+                     ]]></xhtml:samp>
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:complexType name="recDimnsnType">
+      <xs:complexContent>
+         <xs:extension base="baseElementType">
+            <xs:sequence>
+               <xs:element ref="varQnty" minOccurs="0"/>
+               <xs:element ref="caseQnty" minOccurs="0"/>
+               <xs:element ref="logRecL" minOccurs="0"/>
+            </xs:sequence>
+            <xs:attribute name="level" type="xs:string"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="recDimnsn" type="recDimnsnType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Dimensions (of record)</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Information about the physical characteristics of the record. The "level" attribute on this element should be set to "record".</xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:complexType name="recGrpType">
+      <xs:complexContent>
+         <xs:extension base="baseElementType">
+            <xs:sequence>
+               <xs:element ref="labl" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="recDimnsn" minOccurs="0"/>
+            </xs:sequence>
+            <xs:attribute name="recGrp" type="xs:IDREFS"/>
+            <xs:attribute name="rectype" type="xs:string"/>
+            <xs:attribute name="keyvar" type="xs:IDREFS"/>
+            <xs:attribute name="rtypeloc" type="xs:string"/>
+            <xs:attribute name="rtypewidth" type="xs:string" default="1"/>
+            <xs:attribute name="rtypevtype" default="numeric">
+               <xs:simpleType>
+                  <xs:restriction base="xs:NMTOKEN">
+                     <xs:enumeration value="numeric"/>
+                     <xs:enumeration value="character"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:attribute>
+            <xs:attribute name="recidvar" type="xs:string"/>
+
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="recGrp" type="recGrpType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Record or Record Group</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Used to describe record groupings if the file is hierarchical or relational. The attribute "recGrp" allows a record group to indicate subsidiary record groups which nest underneath; this allows for the encoding of a hierarchical structure of record groups. The attribute "rectype" indicates the type of record, e.g., "A records" or "Household records." The attribute "keyvar" is an IDREF that provides the link to other record types. In a hierarchical study consisting of individual and household records, the "keyvar" on the person record will indicate the household to which it belongs. The attribute "rtypeloc" indicates the starting column location of the record type indicator variable on each record of the data file. The attribute "rtypewidth" specifies the width, for files with many different record types. The attribute "rtypevtype" specifies the type of the indicator variable. The "recidvar" indicates the variable that identifies the record group.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <fileStrc type="hierarchical"> 
+                           <recGrp rectype="Person" keyvar="HHDID">
+                              <labl>CPS 1999 Person-Level Record</labl>
+                              <recDimnsn>
+                                 <varQnty>133</varQnty>
+                                 <caseQnty>1500</caseQnty>
+                                 <logRecL>852</logRecL>
+                              </recDimnsn>
+                           </recGrp> 
+                        </fileStrc>
+                     ]]></xhtml:samp>
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:element name="recNumTot" type="simpleTextType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Overall Number of Records</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Overall record count in file. Particularly helpful in instances such as files with multiple cards/decks or records per case.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <dimensns>
+                           <recNumTot>2400</recNumTot>
+                        </dimensns>
+                     ]]></xhtml:samp>
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:element name="recPrCas" type="simpleTextType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Records per Case</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Records per case in the file. This element should be used for card-image data or other files in which there are multiple records per case.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <dimensns>
+                           <recPrCas>5</recPrCas>
+                        </dimensns>
+                     ]]></xhtml:samp> 
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Records per Case</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Records per case in the file. This element   should be used for card-image data or other files in which there are multiple records per case.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <dimensns>
+                           <recPrCas>5</recPrCas>
+                        </dimensns>
+                     ]]></xhtml:samp> 
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:complexType name="relMatType" mixed="true">
+      <xs:complexContent>
+         <xs:extension base="materialReferenceType">
+            <xs:attribute name="callno" type="xs:string"/>
+            <xs:attribute name="label" type="xs:string"/>
+            <xs:attribute name="media" type="xs:string"/>
+            <xs:attribute name="type" type="xs:string"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="relMat" type="relMatType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Related Materials</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Describes materials related to the study description, such as appendices, additional information on sampling found in other documents, etc. Can take the form of bibliographic citations. This element can contain either PCDATA or a citation or both, and there can be multiple occurrences of both the citation and PCDATA within a single element. May consist of a single URI or a series of URIs comprising a series of citations/references to external materials which can be objects as a whole (journal articles) or parts of objects (chapters or appendices in articles or documents).</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <relMat> Full details on the research design and procedures, sampling methodology, content areas, and questionnaire design, as well as percentage distributions by respondent's sex, race, region, college plans, and drug use, appear in the annual ISR volumes MONITORING THE FUTURE: QUESTIONNAIRE RESPONSES FROM THE NATION'S HIGH SCHOOL SENIORS.</relMat>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <relMat>Current Population Survey, March 1999: Technical Documentation  includes an abstract, pertinent information about the file, a glossary, code lists, and a data dictionary. One copy accompanies each file order. When ordered separately, it is available from Marketing Services Office, Customer Service Center, Bureau of the Census, Washington, D.C. 20233. </relMat>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <relMat>A more precise explanation regarding the CPS sample design is provided in Technical Paper 40, The Current Population Survey: Design and Methodology. Chapter 5 of this paper provides documentation on the weighting procedures for the CPS both with and without supplement questions.</relMat>
+                     ]]></xhtml:samp>
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:element name="relPubl" type="materialReferenceType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Related Publications</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Bibliographic and access information aboutvarticles and reports based on the data in this collection. Can take the formbof bibliographic citations. </xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <relPubl>Economic Behavior Program Staff. SURVEYS OF CONSUMER FINANCES. Annual volumes 1960 through 1970. Ann Arbor, MI: Institute for Social Research.</relPubl>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <relPubl>Data from the March Current Population Survey are published most  frequently in the Current Population Reports P- 20 and P- 60 series. These  reports are available from the Superintendent of Documents, U. S. Government  Printing Office, Washington, DC 20402. They also are available on the INTERNET  at http://www. census. gov. Forthcoming reports will be cited in Census and  You, the Monthly Product Announcement (MPA), and the Bureau of the Census  Catalog and Guide. </relPubl>
+                     ]]></xhtml:samp>
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+      
+   <xs:element name="relStdy" type="materialReferenceType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Related Studies</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Information on the relationship of the current data collection to others (e.g., predecessors, successors, other waves or rounds) or to other editions of the same file. This would include the names of additional data collections generated from the same data collection vehicle plus other collections directed at the same general topic. Can take the form of bibliographic citations. </xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <relStdy>ICPSR distributes a companion study to this collection titled FEMALE LABOR FORCE PARTICIPATION AND MARITAL INSTABILITY, 1980: [UNITED STATES] (ICPSR 9199).</relStdy>
+                     ]]></xhtml:samp>
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:complexType name="resInstruType" mixed="true">
+      <xs:complexContent>
+         <xs:extension base="conceptualTextType">
+            <xs:attribute name="type" type="xs:string"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="resInstru" type="resInstruType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Type of Research Instrument</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">The type of data collection instrument used. "Structured" indicates an instrument in which all respondents are asked the same questions/tests, possibly with precoded answers. If a small portion of such a questionnaire includes open-ended questions, provide appropriate comments. "Semi-structured" indicates that the research instrument contains mainly open-ended questions. "Unstructured" indicates that in-depth interviews were conducted. The "type" attribute is included to permit the development of a controlled vocabulary for this element.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <resInstru>structured</resInstru>
+                     ]]></xhtml:samp>
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:element name="respRate" type="simpleTextType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Response Rate</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">The percentage of sample members who provided information. This may include a broader description of stratified response rates, information affecting resonse rates etc.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <respRate>For 1993, the estimated inclusion rate for TEDS-eligible providers was 91 percent, with the inclusion rate for all treatment providers estimated at 76 percent (including privately and publicly funded providers).</respRate>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <respRate>The overall response rate was 82%, although retail firms with an annual sales volume of more than $5,000,000 were somewhat less likely to respond.</respRate>
+                     ]]></xhtml:samp> 
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:element name="respUnit" type="simpleTextType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Response Unit</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Provides information regarding who provided the information contained within the variable/nCube, e.g., respondent, proxy, interviewer. This element may be repeated only to support multiple language expressions of the content.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <var>
+                           <respUnit>Head of household</respUnit>
+                        </var>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <nCube>
+                           <respUnit>Head of household</respUnit>
+                        </nCube>
+                     ]]></xhtml:samp>
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:element name="restrctn" type="simpleTextType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Restrictions</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Any restrictions on access to or use of the collection such as privacy certification or distribution restrictions should be indicated here. These can be restrictions applied by the author, producer, or disseminator of the data collection. If the data are restricted to only a certain class of user, specify which type. </xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <restrctn> In preparing the data file(s) for this collection, the National Center for Health Statistics (NCHS) has removed direct identifiers and characteristics that might lead to identification of data subjects. As an additional precaution NCHS requires, under Section 308(d) of the Public Health Service Act (42 U.S.C. 242m), that data collected by NCHS not be used for any purpose other than statistical analysis and reporting. NCHS further requires that analysts not use the data to learn the identity of any persons or establishments and that the director of NCHS be notified if any identities are inadvertently discovered. ICPSR member institutions and other users ordering data from ICPSR are expected to adhere to these restrictions.</restrctn>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <restrctn> ICPSR obtained these data from the World Bank under the terms of a contract which states that the data are for the sole use of ICPSR and may not be sold or provided to third parties outside of ICPSR membership. Individuals at institutions that are not members of the ICPSR may obtain these data directly from the World Bank.</restrctn>
+                     ]]></xhtml:samp>
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:complexType name="rowType">
+      <xs:complexContent>
+         <xs:extension base="baseElementType">
+            <xs:sequence>
+               <xs:element ref="entry" maxOccurs="unbounded"/>
+            </xs:sequence>
+            <xs:attribute name="rowsep" type="xs:string"/>
+            <xs:attribute name="valign">
+               <xs:simpleType>
+                  <xs:restriction base="xs:NMTOKEN">
+                     <xs:enumeration value="top"/>
+                     <xs:enumeration value="middle"/>
+                     <xs:enumeration value="bottom"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:attribute>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="row" type="rowType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Table Row</xhtml:h1>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:complexType name="rspStmtType">
+      <xs:complexContent>
+         <xs:extension base="baseElementType">
+            <xs:sequence>
+               <xs:element ref="AuthEnty" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="othId" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="rspStmt" type="rspStmtType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Responsibility Statement</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Responsibility for the creation of the work at the appropriate level: marked-up document; marked-up document source; study; study description, other material; other material for study.</xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:element name="sampProc" type="conceptualTextType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Sampling Procedure</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">The type of sample and sample design used to select the survey respondents to represent the population. May include reference to the target sample size and the sampling fraction.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <sampProc>National multistage area probability sample</sampProc>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <sampProc>Simple random sample</sampProc>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <sampProc>Stratified random sample</sampProc>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <sampProc>Quota sample</sampProc>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <sampProc>The 8,450 women interviewed for the NSFG, Cycle IV, were drawn from households in which  someone had been interviewed for the National Health Interview Survey (NHIS), between October 1985 and March 1987.</sampProc>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <sampProc>Samples sufficient to produce approximately 2,000 families with completed interviews were drawn in each state. Families containing one or more Medicaid or uninsured persons were oversampled. XHTML content may be used for formatting.</sampProc>
+                     ]]></xhtml:samp>
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:element name="security" type="simpleTextAndDateType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Security</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Provides information regarding levels of access, e.g., public, subscriber, need to know. The ISO standard for dates (YYYY-MM-DD) is recommended for use with the date attribute.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <var>
+                           <security date="1998-05-10"> This variable has been recoded for reasons of confidentiality. Users should contact the archive for information on obtaining access.</security>
+                        </var>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <var>
+                           <security date="1998-05-10">Variable(s) within this nCube have been recoded for reasons of confidentiality.  Users should contact the archive for information on obtaining access.</security>
+                        </var>
+                     ]]></xhtml:samp> 
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:element name="serInfo" type="simpleTextType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Series Information</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Contains a history of the series and a summary of those features that apply to the series as a whole.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <serInfo>The Current Population Survey (CPS) is a household sample survey conducted monthly by the Census Bureau to provide estimates of employment, unemployment, and other characteristics of the general labor force, estimates of the population as a whole, and estimates of various subgroups in the population. The entire non-institutionalized population of the United States is sampled to obtain the respondents for this survey series.</serInfo>
+                     ]]></xhtml:samp>
+                 </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:complexType name="serNameType" mixed="true">
+      <xs:complexContent>
+         <xs:extension base="simpleTextType">
+            <xs:attribute name="abbr" type="xs:string"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="serName" type="serNameType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Series Name</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">The name of the series to which the work belongs.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <serName abbr="CPS">Current Population Survey Series</serName>
+                     ]]></xhtml:samp>
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:complexType name="serStmtType">
+      <xs:complexContent>
+         <xs:extension base="baseElementType">
+            <xs:sequence>
+               <xs:element ref="serName" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="serInfo" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+            <xs:attribute name="URI" type="xs:string"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="serStmt" type="serStmtType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Series Statement</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Series statement for the work at the appropriate level: marked-up document; marked-up document source; study; study description, other material; other material for study. The URI attribute is provided to point to a central Internet repository of series information. Repeat this field if the study is part of more than one series. Repetition of the internal content should be used to support multiple languages only.</xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:complexType name="setAvailType">
+      <xs:complexContent>
+         <xs:extension base="baseElementType">
+            <xs:sequence>
+               <xs:element ref="accsPlac" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="origArch" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="avlStatus" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="collSize" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="complete" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="fileQnty" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="notes" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+            <xs:attribute name="media" type="xs:string"/>
+            <xs:attribute name="callno" type="xs:string"/>
+            <xs:attribute name="label" type="xs:string"/>
+            <xs:attribute name="type" type="xs:string"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="setAvail" type="setAvailType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Data Set Availability</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Information on availability and storage of the collection. The "media" attribute may be used in combination with any of the subelements. See Location of Data Collection.</xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:complexType name="softwareType" mixed="true">
+      <xs:complexContent>
+         <xs:extension base="simpleTextAndDateType">
+            <xs:attribute name="version" type="xs:string"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="software" type="softwareType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Software used in Production</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Software used to produce the work. A "version" attribute permits specification of the software version number. The "date" attribute is provided to enable specification of the date (if any) for the software release. The ISO standard for dates (YYYY-MM-DD) is recommended for use with the date attribute.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <docDscr>
+                           <citation>
+                              <prodStmt>
+                                 <software version="1.0">MRDC Codebook Authoring Tool</software>
+                              </prodStmt>
+                           </citation>
+                        </docDscr>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <docDscr>
+                           <citation>
+                              <prodStmt>
+                                 <software version="8.0">Arbortext Adept Editor</software>
+                              </prodStmt>
+                           </citation>
+                        </docDscr>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <docDscr>
+                           <docSrc>
+                              <prodStmt>
+                                 <software version="4.0">PageMaker</software>
+                              </prodStmt>
+                           </docSrc>
+                        </docDscr>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <stdyDscr>
+                           <citation>
+                              <prodStmt>
+                                 <software version="6.12">SAS</software>
+                              </prodStmt>
+                           </citation>
+                        </stdyDscr>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <fileTxt>
+                           <software version="6.12">The SAS transport file was generated by the SAS CPORT procedure.</software>
+                        </fileTxt>
+                     ]]></xhtml:samp>
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:complexType name="sourcesType">
+      <xs:complexContent>
+         <xs:extension base="baseElementType">
+            <xs:choice>
+               <xs:sequence>
+                  <xs:element ref="dataSrc" minOccurs="0" maxOccurs="unbounded"/>
+                  <xs:element ref="sourceCitation" minOccurs="0" maxOccurs="unbounded"/>
+                  <xs:element ref="srcOrig" minOccurs="0" maxOccurs="unbounded"/>
+                  <xs:element ref="srcChar" minOccurs="0" maxOccurs="unbounded"/>
+                  <xs:element ref="srcDocu" minOccurs="0" maxOccurs="unbounded"/>
+                  <xs:element ref="sources" minOccurs="0" maxOccurs="unbounded"/>
+               </xs:sequence>
+            </xs:choice>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="sources" type="sourcesType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Sources Statement</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Description of sources used for the data collection. The element is nestable so that the sources statement might encompass a series of discrete source statements, each of which could contain the facts about an individual source. This element maps to Dublin Core Source element.</xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:element name="sourceCitation" type="citationType">
+			<xs:annotation>
+				<xs:documentation>
+					<xhtml:div>
+
+						<xhtml:h1 class="element_title">Source Citation</xhtml:h1>
+
+						<xhtml:div>
+							<xhtml:h2 class="section_header">Description</xhtml:h2>
+							<xhtml:div class="description">This complex element allows the inclusion of a standard citation for the sources used in collecting and creating the dataset.</xhtml:div>
+						</xhtml:div>
+
+						<xhtml:div>
+							<xhtml:h2 class="section_header">Example</xhtml:h2>
+							<xhtml:div class="example">
+								<xhtml:samp class="xml_sample"><![CDATA[
+<sourceCitation>
+<titlStmt>
+<titl>Tenth Decennial Census of the United States, 1880. Volume I. Statistics of the Population of the United States at the Tenth Census.</titl>
+</titlStmt>
+<rspStmt>
+<AuthEnty affiliation="U.S. Department of Commerce">United States Census Bureau</AuthEnty>
+</rspStmt>
+<prodStmt>
+<producer>Government Printing Office</producer>
+<prodDate>1883</prodDate>
+</prodStmt>
+</sourceCitation>
+]]>
+								</xhtml:samp>
+							</xhtml:div>
+						</xhtml:div>
+					</xhtml:div>
+				</xs:documentation>
+			</xs:annotation>
+		</xs:element>
+   
+   <xs:element name="southBL" type="phraseType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">South Bounding Latitude</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">The southernmost coordinate delimiting the geographic extent of the dataset. A valid range of values, expressed in decimal degrees (positive east and positive north), is: -90,0 &lt;=South Bounding Latitude Value &lt;= 90,0 ; South Bounding Latitude Value &lt;= North Bounding Latitude Value</xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:complexType name="specPermType" mixed="true">
+      <xs:complexContent>
+         <xs:extension base="simpleTextType">
+            <xs:attribute name="required" default="yes">
+               <xs:simpleType>
+                  <xs:restriction base="xs:NMTOKEN">
+                     <xs:enumeration value="yes"/>
+                     <xs:enumeration value="no"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:attribute>
+            <xs:attribute name="formNo" type="xs:string"/>
+            <xs:attribute name="URI" type="xs:string"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="specPerm" type="specPermType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Special Permissions</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">This element is used to determine if any special permissions are required to access a resource. The "required" attribute is used to aid machine processing of this element, and the default specification is "yes". The "formNo" attribute indicates the number or ID of the form that the user must fill out. The "URI" attribute may be used to provide a URN or URL for online access to a special permissions form.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <specPerm formNo="4">The user must apply for special permission to use this dataset locally and must complete a confidentiality form.</specPerm>
+                     ]]></xhtml:samp> 
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:element name="srcChar" type="simpleTextType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Characteristics of Source Noted</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Assessment of characteristics and quality of source material. May not be relevant to survey data. This element may be repeated to support multiple language expressions of the content.</xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:element name="srcDocu" type="simpleTextType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Documentation and Access to Sources</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Level of documentation of the original sources. May not be relevant to survey data. This element may be repeated to support multiple language expressions of the content.</xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:element name="srcOrig" type="conceptualTextType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Origins of Sources</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">For historical materials, information about the origin(s) of the sources and the rules followed in establishing the sources should be specified. May not be relevant to survey data. This element may be repeated to support multiple language expressions of the content.</xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:complexType name="stdCatgryType" mixed="true">
+      <xs:complexContent>
+         <xs:extension base="simpleTextAndDateType">
+            <xs:attribute name="URI" type="xs:string"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+   
+   <xs:element name="stdCatgry" type="stdCatgryType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Standard Categories</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Standard category codes used in the variable, like industry codes, employment codes, or social class codes. The attribute "date" is provided to indicate the version of the code in place at the time of the study. The attribute "URI" is provided to indicate a URN or URL that can be used to obtain an electronic list of the category codes.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <var>
+                           <stdCatgry date="1981" source="producer">U. S. Census of Population and Housing, Classified Index of Industries and Occupations </stdCatgry>
+                        </var>
+                     ]]></xhtml:samp> 
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:complexType name="stdyClasType" mixed="true">
+      <xs:complexContent>
+         <xs:extension base="simpleTextType">
+            <xs:attribute name="type" type="xs:string" use="optional"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+   
+   <xs:element name="stdyClas" type="stdyClasType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Class of the Study</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Generally used to give the data archive's class or study status number, which indicates the processing status of the study. May also be used as a text field to describe processing status. This element may be repeated to support multiple language expressions of the content.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <stdyClas>ICPSR Class II</stdyClas>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <stdyClas>DDA Class C</stdyClas>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <stdyClas>Available from the DDA. Being processed. </stdyClas>
+                     ]]></xhtml:samp> 
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:complexType name="stdyDscrType">
+      <xs:complexContent>
+         <xs:extension base="baseElementType">
+            <xs:sequence>
+               <xs:element ref="citation" maxOccurs="unbounded"/>
+               <xs:element ref="studyAuthorization" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="stdyInfo" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="studyDevelopment" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="method" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="dataAccs" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="othrStdyMat" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="notes" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+            <xs:attribute name="access" type="xs:IDREFS"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="stdyDscr" type="stdyDscrType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Study Description</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">The Study Description consists of information about the data collection, study, or compilation that the DDI-compliant documentation file describes. This section includes information about how the study should be cited, who collected or compiled the data, who distributes the data, keywords about the content of the data, summary (abstract) of the content of the data, data collection methods and processing, etc. Note that some content of the Study Description's Citation -- e.g., Responsibility Statement -- may be identical to that of the Documentation Citation. This is usually the case when the producer of a data collection also produced the print or electronic codebook for that data collection.</xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:complexType name="studyDevelopmentType">
+      <xs:complexContent>
+         <xs:extension base="baseElementType">
+            <xs:sequence>
+               <xs:element ref="developmentActivity" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="studyDevelopment" type="studyDevelopmentType">
+      <xs:annotation>
+         <xs:documentation>
+				<xhtml:div>
+					<xhtml:h1 class="element_title">Study Development</xhtml:h1>
+					<xhtml:div>
+						<xhtml:h2 class="section_header">Description</xhtml:h2>
+						<xhtml:div class="description">Describe the process of study development as a series of development activities. These activities can be typed using a controlled vocabulary. Describe the activity, listing participants with their role and affiliation, resources used (sources of information), and the outcome of the development activity.</xhtml:div>
+					</xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:p>This would allow you to provide inputs for a number of development activities you wanted to capture using separate entry screens and tagged storage of developmentActivity using the type attribute. For example if there was an activity related to data availability the developmentActivity might be as follows:</xhtml:p>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+								<developmentActivity type="checkDataAvailability">
+									<description>A number of potential sources were evaluated for content, consistency and quality</description>
+									<participant affiliation="NSO" role="statistician">John Doe</participant>
+									</resource>
+										<dataSrc>Study S</dataSrc>
+										<srcOrig>Collected in 1970 using unknown sampling method</srcOrig>
+										<srcChar>Information incomplete missing X province</srcChar>
+									</resource>
+									<outcome>Due to quality issues this was determined not to be a viable source of data for the study</outcome>
+								</developmentActivity>
+                     ]]></xhtml:samp>
+                     <xhtml:p>This generic structure would allow you to designate additional design activities etc.</xhtml:p>
+                  </xhtml:div>
+               </xhtml:div>
+				</xhtml:div>
+			</xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:complexType name="developmentActivityType">
+      <xs:complexContent>
+         <xs:extension base="baseElementType">
+            <xs:sequence>
+               <xs:element name="description" type="simpleTextType" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="participant" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="resource" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element name="outcome" type="simpleTextType" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+            <xs:attribute name="type" type="xs:string" use="optional"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="developmentActivity" type="developmentActivityType"/>
+
+   <xs:complexType name="participantType">
+      <xs:simpleContent>
+         <xs:extension base="stringType">
+            <xs:attribute name="affiliation" type="xs:string" use="optional"/>
+            <xs:attribute name="abbr" type="xs:string" use="optional"/>
+            <xs:attribute name="role" type="xs:string" use="optional"/>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+
+   <xs:element name="participant" type="participantType"/>
+
+   <xs:complexType name="resourceType">
+      <xs:complexContent>
+         <xs:extension base="baseElementType">
+            <xs:sequence>
+               <xs:element name="dataSrc" type="simpleTextType" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="srcOrig" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="srcChar" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="srcDocu" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="resource" type="resourceType"/>
+
+   <xs:complexType name="studyAuthorizationType">
+      <xs:complexContent>
+         <xs:extension base="baseElementType">
+            <xs:sequence>
+               <xs:element ref="authorizingAgency" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="authorizationStatement" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+            <xs:attribute name="date" type="dateSimpleType" use="optional"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="studyAuthorization" type="studyAuthorizationType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Study Authorization</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Provides structured information on the agency that authorized the study, the date of authorization, and an authorization statement.</xhtml:div>
+               </xhtml:div>
+						<xhtml:div>
+							<xhtml:h2 class="section_header">Example</xhtml:h2>
+							<xhtml:div class="example">
+								<xhtml:samp class="xml_sample"><![CDATA[
+<studyAuthorization date="2010-11-04">
+<authorizingAgency affiliation="University of Georgia" abbr="HSO">Human Subjects Office</authorizingAgency>
+<authorizationStatement>Statement of authorization issued bu OUHS on 2010-11-04</authorizationStatement></studyAuthorization>
+]]>
+								</xhtml:samp>
+							</xhtml:div>
+						</xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:complexType name="authorizingAgencyType">
+      <xs:simpleContent>
+         <xs:extension base="stringType">
+            <xs:attribute name="affiliation" type="xs:string" use="optional"/>
+            <xs:attribute name="abbr" type="xs:string" use="optional"/>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   
+   <xs:element name="authorizingAgency" type="authorizingAgencyType">
+      <xs:annotation>
+				<xs:documentation>
+					<xhtml:div>
+						<xhtml:h1 class="element_title">Authorizing Agency</xhtml:h1>
+						<xhtml:div>
+							<xhtml:h2 class="section_header">Description</xhtml:h2>
+							<xhtml:div class="description">Name of the agent or agency that authorized the study. The "affiliation" attribute indicates the institutional affiliation of the authorizing agent or agency. The "abbr" attribute holds the abbreviation of the authorizing agent's or agency's name.</xhtml:div>
+						</xhtml:div>
+						<xhtml:div>
+							<xhtml:h2 class="section_header">Example</xhtml:h2>
+							<xhtml:div class="example">
+								<xhtml:samp class="xml_sample"><![CDATA[
+<authorizingAgency affiliation="Purdue University" abbr="OUHS">Office for Use of Human Subjects</authorizingAgency>
+]]>
+								</xhtml:samp>
+							</xhtml:div>
+						</xhtml:div>
+					</xhtml:div>
+				</xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:element name="authorizationStatement" type="simpleTextType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Authorization Statement</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">The text of the authorization. Use XHTML to capture significant structure in the document.</xhtml:div>
+               </xhtml:div>
+						<xhtml:div>
+							<xhtml:h2 class="section_header">Example</xhtml:h2>
+							<xhtml:div class="example">
+								<xhtml:samp class="xml_sample"><![CDATA[
+<authorizationStatement>Required documentation covering the study purpose, disclosure information, questionnaire content, and consent statements was delivered to the OUHS on 2010-10-01 and was reviewed by the compliance officer. Statement of authorization for the described study was issued on 2010-11-04</authorizationStatement>
+]]>
+								</xhtml:samp>
+							</xhtml:div>
+						</xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:complexType name="stdyInfoType">
+      <xs:complexContent>
+         <xs:extension base="baseElementType">
+            <xs:sequence>
+               <xs:element ref="studyBudget" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="subject" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="abstract" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="sumDscr" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="qualityStatement" minOccurs="0"/>
+               <xs:element ref="notes" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="exPostEvaluation" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="stdyInfo" type="stdyInfoType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Study Scope</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">This section contains information about the data collection's scope across several dimensions, including substantive content, geography, and time.</xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:complexType name="qualityStatementType">
+      <xs:complexContent>
+         <xs:extension base="baseElementType">
+            <xs:sequence>
+               <xs:element ref="standardsCompliance" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element name="otherQualityStatement" type="simpleTextType" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="qualityStatement" type="qualityStatementType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Quality Statement</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">This structure consists of two parts, standardsCompliance and otherQualityStatements. In standardsCompliance list all specific standards complied with during the execution of this study. Note the standard name and producer and how the study complied with the standard. Enter any additional quality statements in otherQualityStatements.</xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:complexType name="standardsComplianceType">
+      <xs:complexContent>
+         <xs:extension base="baseElementType">
+            <xs:sequence>
+               <xs:element ref="standard"/>
+               <xs:element name="complianceDescription" type="simpleTextType" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="standardsCompliance" type="standardsComplianceType">
+			<xs:annotation>
+				<xs:documentation>
+					<xhtml:div>
+						<xhtml:h1 class="element_title">Standards Compliance</xhtml:h1>
+						<xhtml:div>
+							<xhtml:h2 class="section_header">Description</xhtml:h2>
+							<xhtml:div class="description">This section lists all specific standards complied with during the execution of this study. Specify the standard(s)' name(s) and producer(s) and describe how the study complied with each standard in complianceDescription. Enter any additional quality statements in otherQualityStatement.</xhtml:div>
+						</xhtml:div>
+						<xhtml:div>
+							<xhtml:h2 class="section_header">Example</xhtml:h2>
+							<xhtml:div class="example">
+								<xhtml:samp class="xml_sample"><![CDATA[
+<standardsCompliance><standard>
+<standardName>Data Documentation Initiative</standardName>
+<producer>DDI Alliance</producer></standard>
+<complianceDescription>Study metadata was created in compliance with the Data Documentation Initiative (DDI) standard</complianceDescription>
+</standardsCompliance>
+]]>
+								</xhtml:samp>
+							</xhtml:div>
+						</xhtml:div>
+					</xhtml:div>
+				</xs:documentation>
+			</xs:annotation>
+		</xs:element>
+
+
+   <xs:complexType name="standardType">
+      <xs:complexContent>
+         <xs:extension base="baseElementType">
+            <xs:sequence>
+               <xs:element ref="standardName" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="producer" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="standard" type="standardType">
+		<xs:annotation>
+			<xs:documentation>
+				<xhtml:div>
+					<xhtml:h1 class="element_title">Standard</xhtml:h1>
+					<xhtml:div>
+						<xhtml:h2 class="section_header">Description</xhtml:h2>
+						<xhtml:div class="description">Describes a standard with which the study complies.</xhtml:div>
+					</xhtml:div>
+				</xhtml:div>
+			</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+
+   <xs:complexType name="standardNameType">
+      <xs:simpleContent>
+         <xs:extension base="stringType">
+            <xs:attribute name="date" type="dateSimpleType" use="optional"/>
+            <xs:attribute name="version" type="xs:string" use="optional"/>
+            <xs:attribute name="URI" type="xs:anyURI" use="optional"/>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+
+   <xs:element name="standardName" type="standardNameType">
+		<xs:annotation>
+			<xs:documentation>
+				<xhtml:div>
+					<xhtml:h1 class="element_title">Standard Name</xhtml:h1>
+					<xhtml:div>
+						<xhtml:h2 class="section_header">Description</xhtml:h2>
+						<xhtml:div class="description">Contains the name of the standard with which the study complies. The "date" attribute specifies the date when the standard was published, the "version" attribute includes the specific version of the standard with which the study is compliant, and the "URI" attribute includes the URI for the actual standard.</xhtml:div>
+					</xhtml:div>
+					<xhtml:div>
+						<xhtml:h2 class="section_header">Example</xhtml:h2>
+						<xhtml:div class="example">
+							<xhtml:samp class="xml_sample"><![CDATA[
+<standardName date="2009-10-18" version="3.1" URI="http://www.ddialliance.org/Specification/DDI-Lifecycle/3.1/">Data Documentation Initiative</standardName>
+]]>
+							</xhtml:samp>
+						</xhtml:div>
+					</xhtml:div>
+				</xhtml:div>
+			</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+
+   <xs:complexType name="exPostEvaluationType">
+      <xs:complexContent>
+         <xs:extension base="baseElementType">
+            <xs:sequence>
+               <xs:element ref="evaluator" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="evaluationProcess" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="outcomes" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+            <xs:attribute name="completionDate" type="dateSimpleType" use="optional"/>
+            <xs:attribute name="type" type="xs:string" use="optional"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="exPostEvaluation" type="exPostEvaluationType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Post Evaluation Procedures</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Use this section to describe evaluation procedures not address in data evaluation processes. These may include issues such as timing of the study, sequencing issues, cost/budget issues, relevance, instituional or legal arrangments etc. of the study. The completionDate attribute holds the date the evaluation was completed. The type attribute is an optional type to identify the type of evaluation with or without the use of a controlled vocabulary.</xhtml:div>
+               </xhtml:div>
+					<xhtml:div>
+						<xhtml:h2 class="section_header">Example</xhtml:h2>
+						<xhtml:div class="example">
+							<xhtml:samp class="xml_sample"><![CDATA[
+<exPostEvaluation date="2003" type="comprehensive">
+<evaluator affiliation="United Nations" abbr="UNSD" role="consultant">United Nations Statistical Division</evaluator>
+<evaluationProcess>In-depth review of pre-collection and collection procedures</evaluationProcess>
+<outcomes>The following steps were highly effective in increasing response rates, and should be repeated in the next collection cycle...</outcomes>
+</exPostEvaluation>
+]]>
+							</xhtml:samp>
+						</xhtml:div>
+					</xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:complexType name="evaluatorType">
+      <xs:simpleContent>
+         <xs:extension base="stringType">
+            <xs:attribute name="affiliation" type="xs:string" use="optional"/>
+            <xs:attribute name="abbr" type="xs:string" use="optional"/>
+            <xs:attribute name="role" type="xs:string" use="optional"/>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   
+   <xs:element name="evaluator" type="evaluatorType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Evaluator Type</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">The evaluator element identifies persons or organizations involved in the evaluation. The affiliation attribute contains the affiliation of the individual or organization. The abbr attribute holds an abbreviation for the individual or organization. The role attribute indicates the role played by the individual or organization in the evaluation process.</xhtml:div>
+               </xhtml:div>
+					<xhtml:div>
+						<xhtml:h2 class="section_header">Example</xhtml:h2>
+						<xhtml:div class="example">
+							<xhtml:samp class="xml_sample"><![CDATA[
+<evaluator affiliation="United Nations" abbr="UNSD" role="consultant">United Nations Statistical Division</evaluator>
+]]>
+							</xhtml:samp>
+						</xhtml:div>
+					</xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:element name="evaluationProcess" type="simpleTextType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Evaluation Process</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Describes the evaluation process followed.</xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:element name="outcomes" type="simpleTextType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Evaluation Outcomes</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Describe the outcomes of the evaluation.</xhtml:div>
+               </xhtml:div>
+					<xhtml:div>
+						<xhtml:h2 class="section_header">Example</xhtml:h2>
+						<xhtml:div class="example">
+							<xhtml:samp class="xml_sample"><![CDATA[
+<outcomes>The following steps were highly effective in increasing response rates, and should be repeated in the next collection cycle...</outcomes>
+]]>
+							</xhtml:samp>
+						</xhtml:div>
+					</xhtml:div>
+             </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:element name="studyBudget" type="simpleTextType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Study Budget</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Describe the budget of the project in as much detail as needed. Use XHTML structure elements to identify discrete pieces of information in a way that facilitates direct transfer of information on the study budget between DDI 2 and DDI 3 structures.</xhtml:div>
+               </xhtml:div>
+					<xhtml:div>
+						<xhtml:h2 class="section_header">Example</xhtml:h2>
+						<xhtml:div class="example">
+							<xhtml:samp class="xml_sample"><![CDATA[
+<studyBudget>The budget for the study covers a 5 year award period distributed between direct and indirect costs including: Staff, ...</studyBudget>
+]]>
+							</xhtml:samp>
+						</xhtml:div>
+					</xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:element name="subTitl" type="simpleTextType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Subtitle</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">A secondary title used to amplify or state certain limitations on the main title. It may repeat information already in the main title. </xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <titl>Monitoring the Future: A Continuing Study of American Youth, 1995</titl>
+                     ]]></xhtml:samp> 
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <subTitl>A Continuing Study of American Youth, 1995</subTitl>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <titl>Census of Population, 1950 [United States]: Public Use Microdata Sample</titl>
+                     ]]></xhtml:samp> 
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <subTitl>Public Use Microdata Sample</subTitl>
+                     ]]></xhtml:samp> 
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:complexType name="subjectType">
+      <xs:complexContent>
+         <xs:extension base="baseElementType">
+            <xs:sequence>
+               <xs:element ref="keyword" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="topcClas" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+   
+   <xs:element name="subject" type="subjectType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Subject Information</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Subject information describing the data collection's intellectual content.</xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:complexType name="sumDscrType">
+      <xs:complexContent>
+         <xs:extension base="baseElementType">
+            <xs:sequence>
+               <xs:element ref="timePrd" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="collDate" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="nation" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="geogCover" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="geogUnit" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="geoBndBox" minOccurs="0"/>
+               <xs:element ref="boundPoly" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="anlyUnit" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="universe" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="dataKind" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+   
+   <xs:element name="sumDscr" type="sumDscrType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Summary Data Description</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Information about the and geographic coverage of the study and unit of analysis.</xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:complexType name="sumStatType" mixed="true">
+      <xs:complexContent>
+         <xs:extension base="simpleTextType">
+            <xs:attribute name="wgtd" default="not-wgtd">
+               <xs:simpleType>
+                  <xs:restriction base="xs:NMTOKEN">
+                     <xs:enumeration value="wgtd"/>
+                     <xs:enumeration value="not-wgtd"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:attribute>
+            <xs:attribute name="wgt-var" type="xs:IDREFS"/>
+            <xs:attribute name="weight" type="xs:IDREFS"/>
+            <xs:attribute name="type" use="required">
+               <xs:simpleType>
+                  <xs:restriction base="xs:NMTOKEN">
+                     <xs:enumeration value="mean"/>
+                     <xs:enumeration value="medn"/>
+                     <xs:enumeration value="mode"/>
+                     <xs:enumeration value="vald"/>
+                     <xs:enumeration value="invd"/>
+                     <xs:enumeration value="min"/>
+                     <xs:enumeration value="max"/>
+                     <xs:enumeration value="stdev"/>
+                     <xs:enumeration value="other"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:attribute>
+            <xs:attribute name="otherType" type="xs:NMTOKEN" use="optional"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+   
+   <xs:element name="sumStat" type="sumStatType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Summary Statistics</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">
+                     <xhtml:p>One or more statistical measures that describe the responses to a particular variable and may include one or more standard summaries, e.g., minimum and maximum values, median, mode, etc. The attribute "wgtd" indicates whether the statistics are weighted or not. The "weight" attribute is an IDREF(S) to the weight element(s) in the study description.</xhtml:p>
+                     <xhtml:p>The attribute "type" denotes the type of statistics being shown: mean, median, mode, valid cases, invalid cases, minimum, maximum, or standard deviation. If a value of "other" is used here, a value taken from a controlled vocabulary should be put in the "otherType" attribute. This option should only be used when applying a controlled vocabulary to this attribute. Use the complex element controlledVocabUsed to identify the controlled vocabulary to which the selected term belongs.</xhtml:p>
+                  </xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <var>
+                           <sumStat type="min">0</sumStat>
+                        </var>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <var>
+                           <sumStat type="max">9</sumStat>
+                        </var>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <var>
+                           <sumStat type="median">4</sumStat>
+                        </var>
+                     ]]></xhtml:samp> 
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:complexType name="tableType">
+      <xs:complexContent>
+         <xs:extension base="baseElementType">
+            <xs:sequence>
+               <xs:element ref="titl" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="tgroup" maxOccurs="unbounded"/>
+            </xs:sequence>
+            <xs:attribute name="frame">
+               <xs:simpleType>
+                  <xs:restriction base="xs:NMTOKEN">
+                     <xs:enumeration value="top"/>
+                     <xs:enumeration value="bottom"/>
+                     <xs:enumeration value="topbot"/>
+                     <xs:enumeration value="all"/>
+                     <xs:enumeration value="sides"/>
+                     <xs:enumeration value="none"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:attribute>
+            <xs:attribute name="colsep" type="xs:string"/>
+            <xs:attribute name="rowsep" type="xs:string"/>
+            <xs:attribute name="pgwide" type="xs:string"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+   
+   <xs:element name="table" type="tableType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Table</xhtml:h1>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:complexType name="tbodyType">
+      <xs:complexContent>
+         <xs:extension base="baseElementType">
+            <xs:sequence>
+               <xs:element ref="row" maxOccurs="unbounded"/>
+            </xs:sequence>
+            <xs:attribute name="valign">
+               <xs:simpleType>
+                  <xs:restriction base="xs:NMTOKEN">
+                     <xs:enumeration value="top"/>
+                     <xs:enumeration value="middle"/>
+                     <xs:enumeration value="bottom"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:attribute>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+   
+   <xs:element name="tbody" type="tbodyType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Table Body</xhtml:h1>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:complexType name="tgroupType">
+      <xs:complexContent>
+         <xs:extension base="baseElementType">
+            <xs:sequence>
+               <xs:element ref="colspec" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="thead" minOccurs="0"/>
+               <xs:element ref="tbody"/>
+            </xs:sequence>
+            <xs:attribute name="cols" type="xs:string" use="required"/>
+            <xs:attribute name="colsep" type="xs:string"/>
+            <xs:attribute name="rowsep" type="xs:string"/>
+            <xs:attribute name="align">
+               <xs:simpleType>
+                  <xs:restriction base="xs:NMTOKEN">
+                     <xs:enumeration value="left"/>
+                     <xs:enumeration value="right"/>
+                     <xs:enumeration value="center"/>
+                     <xs:enumeration value="justify"/>
+                     <xs:enumeration value="char"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:attribute>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+   
+   <xs:element name="tgroup" type="tgroupType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Table Group</xhtml:h1>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:complexType name="theadType">
+      <xs:complexContent>
+         <xs:extension base="baseElementType">
+            <xs:sequence>
+               <xs:element ref="row" maxOccurs="unbounded"/>
+            </xs:sequence>
+            <xs:attribute name="valign">
+               <xs:simpleType>
+                  <xs:restriction base="xs:NMTOKEN">
+                     <xs:enumeration value="top"/>
+                     <xs:enumeration value="middle"/>
+                     <xs:enumeration value="bottom"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:attribute>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+   
+   <xs:element name="thead" type="theadType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Table Head</xhtml:h1>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:complexType name="timeMethType" mixed="true">
+      <xs:complexContent>
+         <xs:extension base="conceptualTextType">
+            <xs:attribute name="method" type="xs:string"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+   
+   <xs:element name="timeMeth" type="timeMethType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Time Method</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">The time method or time dimension of the data collection. The "method" attribute is included to permit the development of a controlled vocabulary for this element. For forward-compatibility, DDI 3 XHTML tags may be used in this element.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <timeMeth>panel survey</timeMeth>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <timeMeth>cross-section</timeMeth>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <timeMeth>trend study</timeMeth>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <timeMeth>time-series</timeMeth>
+                     ]]></xhtml:samp>
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:complexType name="timePrdType" mixed="true">
+      <xs:complexContent>
+         <xs:extension base="simpleTextAndDateType">
+            <xs:attribute name="event" default="single">
+               <xs:simpleType>
+                  <xs:restriction base="xs:NMTOKEN">
+                     <xs:enumeration value="start"/>
+                     <xs:enumeration value="end"/>
+                     <xs:enumeration value="single"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:attribute>
+            <xs:attribute name="cycle" type="xs:string"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="timePrd" type="timePrdType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Time Period Covered</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">The time period to which the data refer. This item reflects the time period covered by the data, not the dates of coding or making documents machine-readable or the dates the data were collected. Also known as span. Use the event attribute to specify "start", "end", or "single" for each date entered. The ISO standard for dates (YYYY-MM-DD) is recommended for use with the "date" attribute. The "cycle" attribute permits specification of the relevant cycle, wave, or round of data. Maps to Dublin Core Coverage element. Inclusion of this element is recommended. </xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <timePrd event="start" date="1998-05-01">May 1, 1998</timePrd>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <timePrd event="end" date="1998-05-31">May 31, 1998</timePrd>
+                     ]]></xhtml:samp> 
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:element name="titl" type="simpleTextType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Title</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Full authoritative title for the work at the appropriate level: marked-up document; marked-up document source; study; other material(s) related to study description; other material(s) related to study. The study title will in most cases be identical to the title for the marked-up document. A full title should indicate the geographic scope of the data collection as well as the time period covered. Title of data collection (codeBook/stdyDscr/citation/titlStmt/titl) maps to Dublin Core Title element. This element is required in the Study Description citation. </xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <titl>Domestic Violence Experience in Omaha, Nebraska, 1986-1987</titl>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <titl>Census of Population, 1950 [United States]: Public Use Microdata Sample</titl>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <titl>Monitoring the Future: A Continuing Study of American Youth, 1995</titl>
+                     ]]></xhtml:samp>
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:complexType name="titlStmtType">
+      <xs:complexContent>
+         <xs:extension base="baseElementType">
+            <xs:sequence>
+               <xs:element ref="titl"/>
+               <xs:element ref="subTitl" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="altTitl" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="parTitl" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="IDNo" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="titlStmt" type="titlStmtType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Title Statement</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Title statement for the work at the appropriate level: marked-up document; marked-up document source; study; study description, other materials; other materials for study.</xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:complexType name="topcClasType" mixed="true">
+      <xs:complexContent>
+         <xs:extension base="simpleTextType">
+            <xs:attribute name="vocab" type="xs:string"/>
+            <xs:attribute name="vocabURI" type="xs:string"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="topcClas" type="topcClasType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Topic Classification</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">The classification field indicates the broad substantive topic(s) that the data cover. Library of Congress subject terms may be used here. The "vocab" attribute is provided for specification of the controlled vocabulary in use, e.g., LCSH, MeSH, etc. The "vocabURI" attribute specifies the location for the full controlled vocabulary. Maps to Dublin Core Subject element. Inclusion of this element in the codebook is recommended.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <topcClas vocab="LOC Subject Headings" vocabURI="http://www.loc.gov/catdir/cpso/lcco/lcco.html">Public opinion -- California -- Statistics</topcClas>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <topcClas vocab="LOC Subject Headings" vocabURI="http://www.loc.gov/catdir/cpso/lcco/lcco.html">Elections -- California</topcClas>
+                     ]]></xhtml:samp>
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:element name="TotlResp" type="simpleTextType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Total Responses</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">The number of responses to this variable. This element might be used if the number of responses does not match added case counts. It may also be used to sum the frequencies for variable categories.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <var>
+                           <TotlResp>1,056</TotlResp>
+                        </var>
+                     ]]></xhtml:samp>
+                  <xhtml:samp class="xml_sample"><![CDATA[
+                        <var>
+                           <TotlResp>There are only 725 responses to this question since it was not asked in Tanzania.</TotlResp>
+                        </var>
+                     ]]></xhtml:samp> 
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:complexType name="txtType" mixed="true">
+      <xs:complexContent>
+         <xs:extension base="tableAndTextType">
+            <xs:attribute name="level" type="xs:string"/>
+            <xs:attribute name="sdatrefs" type="xs:IDREFS"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="txt" type="txtType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Descriptive Text</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Lengthier description of the parent element. The attribute "level" indicates the level to which the element applies. The attribute "sdatrefs" allows pointing to specific dates, universes, or other information encoded in the study description.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <varGrp type="subject">
+                           <txt>The following five variables refer to respondent attitudes toward national environmental policies: air pollution, urban sprawl, noise abatement, carbon dioxide emissions, and nuclear waste.</txt>
+                        </varGrp>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <nCubeGrp type="subject">
+                           <txt>The following four nCubes are grouped to present a cross tabulation of the variables Sex, Work experience in 1999, and Income in 1999.</txt>
+                        </nCubeGrp>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <var>
+                           <txt>Total population for the agency for the year reported.</txt>
+                        </var>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <catgryGrp>
+                           <txt>When the respondent indicated his political party reference, his response was coded on a scale of 1-99 with parties with a left-wing orientation coded on the low end of the scale and parties with a right-wing orientation coded on the high end of the scale.  Categories 90-99 were reserved miscellaneous responses.</txt>
+                        </catgryGrp>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <catgry>
+                           <txt>Inap., question not asked in Ireland, Northern Ireland, and Luxembourg.</txt>
+                        </catgry>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <nCube>
+                           <txt>Detailed poverty status for age cohorts over a period of five years, to be used in determining program eligibility</txt>
+                        </nCube>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <otherMat URI="http://www.icpsr.umich.edu/..">
+                           <txt>This is a PDF version of the original questionnaire provided by the principal investigator.</txt>
+                        </otherMat>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <otherMat>
+                           <txt>Glossary of Terms. Below are terms that may  prove useful in working with the technical documentation for this study.. </txt>
+                        </otherMat>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <otherMat>
+                           <txt>This is a PDF version of the original questionnaire provided by the principal investigator.</txt>
+                        </otherMat>
+                     ]]></xhtml:samp>
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:element name="undocCod" type="simpleTextType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">List of Undocumented Codes</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Values whose meaning is unknown.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <var>
+                           <undocCod>Responses for categories 9 and 10 are unavailable.</undocCod>
+                        </var>
+                     ]]></xhtml:samp> 
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:complexType name="universeType" mixed="true">
+      <xs:complexContent>
+         <xs:extension base="conceptualTextType">
+            <xs:attribute name="level" type="xs:string"/>
+            <xs:attribute name="clusion" default="I">
+               <xs:simpleType>
+                  <xs:restriction base="xs:NMTOKEN">
+                     <xs:enumeration value="I"/>
+                     <xs:enumeration value="E"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:attribute>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+   
+   <xs:element name="universe" type="universeType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Universe</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">The group of persons or other elements that are the object of research and to which any analytic results refer. Age,nationality, and residence commonly help to delineate a given universe, but any of a number of factors may be involved, such as sex, race, income, veteran status, criminal convictions, etc. The universe may consist of elements other than persons, such as housing units, court cases, deaths, countries, etc. In general, it should be possible to tell from the description of the universe whether a given individual or element (hypothetical or real) is a member of the population under study. A "level" attribute is included to permit coding of the level to which universe applies, i.e., the study level, the file level (if different from study), the record group, the variable group, the nCube group, the variable, or the nCube level. The "clusion" attribute provides for specification of groups included (I) in or excluded (E) from the universe. If all the variables/nCubes described in the data documentation relate to the same population, e.g., the same set of survey respondents, this element would be unnecessary at data description level. In this case, universe can be fully described at the study level. For forward-compatibility, DDI 3 XHTML tags may be used in this element. This element may be repeated only to support multiple language expressions of the content.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <universe clusion="I">Individuals 15-19 years of age. </universe>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <universe clusion="E">Individuals younger than 15 and older than 19 years of age.</universe>
+                     ]]></xhtml:samp>
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:complexType name="useStmtType">
+      <xs:complexContent>
+         <xs:extension base="baseElementType">
+            <xs:sequence>
+               <xs:element ref="confDec" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="specPerm" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="restrctn" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="contact" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="citReq" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="deposReq" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="conditions" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="disclaimer" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+   
+   <xs:element name="useStmt" type="useStmtType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Use Statement</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Information on terms of use for the data collection. This element may be repeated only to support multiple language expressions of the content.</xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:complexType name="valrngType">
+      <xs:complexContent>
+         <xs:extension base="baseElementType">
+            <xs:sequence>
+               <xs:choice minOccurs="1" maxOccurs="unbounded">
+                  <xs:element ref="item"/>
+                  <xs:element ref="range"/>
+               </xs:choice>
+               <xs:element ref="key" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="notes" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+   
+   <xs:element name="valrng" type="valrngType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Range of Valid Data Values</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Values for a particular variable that represent legitimate responses.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <valrng>
+                           <range min="1" max="3"/>
+                        </valrng>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <valrng>
+                           <item VALUE="1"/>
+                           <item VALUE="2"/>
+                           <item VALUE="3"/>
+                        </valrng>
+                     ]]></xhtml:samp>
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:complexType name="varType">
+      <xs:complexContent>
+         <xs:extension base="baseElementType">
+            <xs:sequence>
+               <xs:element ref="location" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="labl" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="imputation" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="security" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="embargo" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="respUnit" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="anlysUnit" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="qstn" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="valrng" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="invalrng" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="undocCod" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="universe" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="TotlResp" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="sumStat" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="txt" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="stdCatgry" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="catgryGrp" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="catgry" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="codInstr" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="verStmt" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="concept" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="derivation" minOccurs="0"/>
+               <xs:element ref="varFormat" minOccurs="0"/>
+               <xs:element ref="geoMap" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="catLevel" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="notes" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+            <xs:attribute name="name" type="xs:string" use="required"/>
+            <xs:attribute name="wgt" default="not-wgt">
+               <xs:simpleType>
+                  <xs:restriction base="xs:NMTOKEN">
+                     <xs:enumeration value="wgt"/>
+                     <xs:enumeration value="not-wgt"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:attribute>
+            <xs:attribute name="wgt-var" type="xs:IDREFS"/>
+            <xs:attribute name="weight" type="xs:IDREFS"/>
+            <xs:attribute name="qstn" type="xs:IDREFS"/>
+            <xs:attribute name="files" type="xs:IDREFS"/>
+            <xs:attribute name="vendor" type="xs:string"/>
+            <xs:attribute name="dcml" type="xs:string"/>
+            <xs:attribute name="intrvl" default="discrete">
+               <xs:simpleType>
+                  <xs:restriction base="xs:NMTOKEN">
+                     <xs:enumeration value="contin"/>
+                     <xs:enumeration value="discrete"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:attribute>
+            <xs:attribute name="rectype" type="xs:string"/>
+            <xs:attribute name="sdatrefs" type="xs:IDREFS"/>
+            <xs:attribute name="methrefs" type="xs:IDREFS"/>
+            <xs:attribute name="pubrefs" type="xs:IDREFS"/>
+            <xs:attribute name="access" type="xs:IDREFS"/>
+            <xs:attribute name="aggrMeth">
+               <xs:simpleType>
+                  <xs:restriction base="xs:NMTOKEN">
+                     <xs:enumeration value="sum"/>
+                     <xs:enumeration value="average"/>
+                     <xs:enumeration value="count"/>
+                     <xs:enumeration value="mode"/>
+                     <xs:enumeration value="median"/>
+                     <xs:enumeration value="maximum"/>
+                     <xs:enumeration value="minimum"/>
+                     <xs:enumeration value="percent"/>
+                     <xs:enumeration value="other"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:attribute>
+            <xs:attribute name="otherAggrMeth" type="xs:NMTOKEN" use="optional"/>
+            <xs:attribute name="measUnit" type="xs:string"/>
+            <xs:attribute name="scale" type="xs:string"/>
+            <xs:attribute name="origin" type="xs:string"/>
+            <xs:attribute name="nature">
+               <xs:simpleType>
+                  <xs:restriction base="xs:NMTOKEN">
+                     <xs:enumeration value="nominal"/>
+                     <xs:enumeration value="ordinal"/>
+                     <xs:enumeration value="interval"/>
+                     <xs:enumeration value="ratio"/>
+                     <xs:enumeration value="percent"/>
+                     <xs:enumeration value="other"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:attribute>
+            <xs:attribute name="additivity">
+               <xs:simpleType>
+                  <xs:restriction base="xs:NMTOKEN">
+                     <xs:enumeration value="stock"/>
+                     <xs:enumeration value="flow"/>
+                     <xs:enumeration value="non-additive"/>
+                     <xs:enumeration value="other"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:attribute>
+            <xs:attribute name="otherAdditivity" type="xs:NMTOKEN" use="optional"/>
+            <xs:attribute name="temporal" default="N">
+               <xs:simpleType>
+                  <xs:restriction base="xs:NMTOKEN">
+                     <xs:enumeration value="Y"/>
+                     <xs:enumeration value="N"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:attribute>
+            <xs:attribute name="geog" default="N">
+               <xs:simpleType>
+                  <xs:restriction base="xs:NMTOKEN">
+                     <xs:enumeration value="Y"/>
+                     <xs:enumeration value="N"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:attribute>
+            <xs:attribute name="geoVocab" type="xs:string"/>
+            <xs:attribute name="catQnty" type="xs:string"/>
+            <xs:attribute name="representationType">
+               <xs:simpleType>
+                  <xs:restriction base="xs:NMTOKEN">
+                     <xs:enumeration value="text"/>
+                     <xs:enumeration value="numeric"/>
+                     <xs:enumeration value="code"/>
+                     <xs:enumeration value="datetime"/>
+                     <xs:enumeration value="other"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:attribute>
+            <xs:attribute name="otherRepresentationType" type="xs:NMTOKEN" use="optional"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+   
+   <xs:element name="var" type="varType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Variable</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">
+                     <xhtml:p>This element describes all of the features of a single variable in a social science data file. The following elements are repeatable to support multi-language content: anlysUnit, embargo, imputation, respUnit, security, TotlResp. It includes the following attributes: </xhtml:p>
+                     <xhtml:p>The attribute "name" usually contains the so-called "short label" for the variable, limited to eight characters in many statistical analysis systems such as SAS or SPSS. </xhtml:p>
+                     <xhtml:p>The attribute "wgt" indicates whether the variable is a weight. </xhtml:p>
+                     <xhtml:p>The attribute "wgt-var" references the weight variable(s) for this variable. </xhtml:p>
+                     <xhtml:p>The attribute "qstn" is a reference to the question ID for the variable. </xhtml:p>
+                     <xhtml:p>The attribute "files" is the IDREF identifying the file(s) to which the variable belongs. </xhtml:p>
+                     <xhtml:p>The attribute "vendor" is the origin of the proprietary format and includes SAS, SPSS, ANSI, and ISO. </xhtml:p>
+                     <xhtml:p>The attribute "dcml" refers to the number of decimal points in the variable. </xhtml:p>
+                     <xhtml:p>The attribute "intrvl" indicates the interval type; options are discrete or continuous.</xhtml:p>
+                     <xhtml:p>The "rectype" attribute refers to the record type to which the variable belongs. </xhtml:p>
+                     <xhtml:p>The "sdatrefs" are summary data description references which record the ID values of all elements within the summary data description section of the Study Description which might apply to the variable. These elements include: time period covered, date of collection, nation or country, geographic coverage, geographic unit, unit of analysis, universe, and kind of data. </xhtml:p>
+                     <xhtml:p>The "methrefs" are methodology and processing references which record the ID values of all elements within the study methodology and processing section of the Study Description which might apply to the variable. These elements include information on data collection and data appraisal (e.g., sampling, sources, weighting, data cleaning, response rates, and sampling error estimates). </xhtml:p>
+                     <xhtml:p>The "pubrefs" attribute provides a link to publication/citation references and records the ID values of all citations elements within Other Study Description Materials or Other Study-Related Materials that pertain to this variable. </xhtml:p>
+                     <xhtml:p>The attribute "access" records the ID values of all elements in the Data Access section that describe access conditions for this variable. </xhtml:p>
+                     <xhtml:p>The "aggrMeth" attribute indicates the type of aggregation method used, for example 'sum', 'average', 'count'. If a value of "other" is given a term from a controlled vocabulary should be used in the "otherAggrMeth" attribute.</xhtml:p>
+                     <xhtml:p>The "otherAggrMeth" attribute holds a value from a controlled vocabulary when the aggrMeth attribute has a value of "other".This option should only be used when applying a controlled vocabulary to this attribute. Use the complex element controlledVocabUsed to identify the controlled vocabulary to which the selected term belongs.</xhtml:p>
+                     <xhtml:p>The attribute "measUnit" records the measurement unit, for example 'km', 'miles', etc. </xhtml:p>
+                     <xhtml:p>The "scale" attribute records unit of scale, for example 'x1', 'x1000', etc.</xhtml:p>
+                     <xhtml:p>The attribute "origin" records the point of origin for anchored scales.</xhtml:p>
+                     <xhtml:p>The "nature" attribute records the nature of the variable, whether it is 'nominal', 'ordinal', 'interval', 'ratio', or 'percent'. If the 'other' value is used, a value from a controlled vocabulary should be put into the otherNature attribute.</xhtml:p>
+                     <xhtml:p>The "otherNature" attribute should be used when the nature attribute has a value of "other". This option should only be used when applying a controlled vocabulary to this attribute. Use the complex element controlledVocabUsed to identify the controlled vocabulary to which the selected term belongs.</xhtml:p>
+                     <xhtml:p>The attribute "additivity" records type of additivity, such as 'stock', 'flow', 'non-additive'. When the "other" value is used, a value from a controlled vocabulary should be put into the "otherAdditivity" attribute.</xhtml:p>
+                     <xhtml:p>The "otherAdditivity" attribute is used only when the "additivity" attribute has a value of "other". This option should only be used when applying a controlled vocabulary to this attribute. Use the complex element controlledVocabUsed to identify the controlled vocabulary to which the selected term belongs.</xhtml:p>
+                     <xhtml:p>The attribute "temporal" indicates whether the variable relays time-related information. </xhtml:p>
+                     <xhtml:p>The "geog" attribute indicates whether the variable relays geographic information.</xhtml:p>
+                     <xhtml:p>The attribute "geoVocab" records the coding scheme used in the variable.</xhtml:p>
+                     <xhtml:p>The attribute "catQnty" records the number of categories found in the variable, and is used primarily for aggregate data files for verifying cell counts in nCubes.</xhtml:p>
+                     <xhtml:p>The "representationType" attribute was added to capture the specific DDI 3 representation type to facilitate translation between DDI 2 and DDI 3. If the "other" value is used, a term from a controlled vocabulary may be supplied in the otherRepresentationType attribute.</xhtml:p>
+                     <xhtml:p>The "otherRepresentationType" attribute should be used when the representationType attribute has a value of "other". This option should only be used when applying a controlled vocabulary to this attribute. Use the complex element controlledVocabUsed to identify the controlled vocabulary to which the selected term belongs.</xhtml:p>
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   
+   <xs:complexType name="varFormatType" mixed="true">
+      <xs:complexContent>
+         <xs:extension base="simpleTextType">
+            <xs:attribute name="type" default="numeric">
+               <xs:simpleType>
+                  <xs:restriction base="xs:NMTOKEN">
+                     <xs:enumeration value="character"/>
+                     <xs:enumeration value="numeric"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:attribute>
+            <xs:attribute name="formatname" type="xs:string"/>
+            <xs:attribute name="schema" default="ISO">
+               <xs:simpleType>
+                  <xs:restriction base="xs:NMTOKEN">
+                     <xs:enumeration value="SAS"/>
+                     <xs:enumeration value="SPSS"/>
+                     <xs:enumeration value="IBM"/>
+                     <xs:enumeration value="ANSI"/>
+                     <xs:enumeration value="ISO"/>
+                     <xs:enumeration value="XML-Data"/>
+                     <xs:enumeration value="other"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:attribute>
+            <xs:attribute name="otherSchema" type="xs:NMTOKEN" use="optional"/>
+            <xs:attribute name="category" default="other">
+               <xs:simpleType>
+                  <xs:restriction base="xs:NMTOKEN">
+                     <xs:enumeration value="date"/>
+                     <xs:enumeration value="time"/>
+                     <xs:enumeration value="currency"/>
+                     <xs:enumeration value="other"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:attribute>
+            <xs:attribute name="otherCategory" type="xs:NMTOKEN" use="optional"/>
+            <xs:attribute name="URI" type="xs:string"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+   
+   <xs:element name="varFormat" type="varFormatType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Variable Format</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">The technical format of the variable in question. Attributes for this element include: "type," which indicates if the variable is character or numeric; "formatname," which in some cases may provide the name of the particular, proprietary format actually used; "schema," which identifies the vendor or standards body that defined the format (acceptable choices are SAS, SPSS, IBM, ANSI, ISO, XML-data or other); "category," which describes what kind of data the format represents, and includes date, time, currency, or "other" conceptual possibilities; and "URI," which supplies a network identifier for the format definition. If the "other" value is used for the schema attribute, a value from a controlled vocabulary must be used with the "otherSchema" attribute, and the complex element controlledVocabUsed should be used to identify the controlled vocabulary to which the selected term belongs. For the category attribute, a value from a controlled vocabulary may be provided if the "other" value is chosen. In this case, the term from the controlled vocabulary should be placed in the "othercategory" attribute, and the controlledVocabUsed element should also be filled in.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <var>
+                           <varFormat type="numeric" schema="SAS" formatname="DATE" category="date">The number in this  variable is stored in the form 'ddmmmyy' in SAS format.</varFormat>
+                        </var>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <var>
+                           <varFormat type="numeric" formatname="date.iso8601" schema="XML-Data" category="date" URI="http://www.w3.org/TR/1998/NOTE-XML-data/">19541022</varFormat>
+                        </var>
+                     ]]></xhtml:samp> 
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:complexType name="varGrpType">
+      <xs:complexContent>
+         <xs:extension base="baseElementType">
+            <xs:sequence>
+               <xs:element ref="labl" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="txt" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="concept" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="defntn" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="universe" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="notes" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+            <xs:attribute name="type" default="other">
+               <xs:simpleType>
+                  <xs:restriction base="xs:NMTOKEN">
+                     <xs:enumeration value="section"/>
+                     <xs:enumeration value="multipleResp"/>
+                     <xs:enumeration value="grid"/>
+                     <xs:enumeration value="display"/>
+                     <xs:enumeration value="repetition"/>
+                     <xs:enumeration value="subject"/>
+                     <xs:enumeration value="version"/>
+                     <xs:enumeration value="iteration"/>
+                     <xs:enumeration value="analysis"/>
+                     <xs:enumeration value="pragmatic"/>
+                     <xs:enumeration value="record"/>
+                     <xs:enumeration value="file"/>
+                     <xs:enumeration value="randomized"/>
+                     <xs:enumeration value="other"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:attribute>
+            <xs:attribute name="otherType" type="xs:NMTOKEN" use="optional"/>
+            <xs:attribute name="var" type="xs:IDREFS"/>
+            <xs:attribute name="varGrp" type="xs:IDREFS"/>
+            <xs:attribute name="name" type="xs:string"/>
+            <xs:attribute name="sdatrefs" type="xs:IDREFS"/>
+            <xs:attribute name="methrefs" type="xs:IDREFS"/>
+            <xs:attribute name="pubrefs" type="xs:IDREFS"/>
+            <xs:attribute name="access" type="xs:IDREFS"/>
+            <xs:attribute name="nCube" type="xs:string"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+   
+   <xs:element name="varGrp" type="varGrpType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Variable Group</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">
+                     <xhtml:p>A group of variables that may share a common subject, arise from the interpretation of a single question, or are linked by some other factor.</xhtml:p>
+                     <xhtml:p>Variable groups are created this way in order to permit variables to belong to multiple groups, including multiple subject groups such as a group of variables on sex and income, or to a subject and a multiple response group, without causing overlapping groups. Variables that are linked by use of the same question need not be identified by a Variable Group element because they are linked by a common unique question identifier in the Variable element. Note that as a result of the strict sequencing required by XML, all Variable Groups must be marked up before the Variable element is opened. That is, the mark-up author cannot mark up a Variable Group, then mark up its constituent variables, then mark up another Variable Group.</xhtml:p>
+                     <xhtml:p>The "type" attribute refers to the general type of grouping of the variables, e.g., subject, multiple response. Use the value of "other" if the value is to come from an external controlled vocabulary, and place the term into the otherType attribute.</xhtml:p>
+                     <xhtml:p>The "otherType" attribute is used when the "type" attribute has a value of "other". This option should only be used when applying a controlled vocabulary to this attribute. Use the complex element controlledVocabUsed to identify the controlled vocabulary to which the selected term belongs.</xhtml:p>
+                     <xhtml:p>Specific variable groups, included within the "type" attribute, are:</xhtml:p>
+                     <xhtml:p>Section: Questions which derive from the same section of the questionnaire, e.g., all variables located in Section C.</xhtml:p>
+                     <xhtml:p>Multiple response: Questions where the respondent has the opportunity to select more than one answer from a variety of choices, e.g., what newspapers have you read in the past month (with the respondent able to select up to five choices).</xhtml:p>
+                     <xhtml:p>Grid: Sub-questions of an introductory or main question but which do not constitute a multiple response group, e.g., I am going to read you some events in the news lately and you tell me for each one whether you are very interested in the event, fairly interested in the fact, or not interested in the event.</xhtml:p>
+                     <xhtml:p>Display: Questions which appear on the same interview screen (CAI) together or are presented to the interviewer or respondent as a group.</xhtml:p>
+                     <xhtml:p>Repetition: The same variable (or group of variables) which are repeated for different groups of respondents or for the same respondent at a different time.</xhtml:p>
+                     <xhtml:p>Subject: Questions which address a common topic or subject, e.g., income, poverty, children.</xhtml:p>
+                     <xhtml:p>Version: Variables, often appearing in pairs, which represent different aspects of the same question, e.g., pairs of variables (or groups) which are adjusted/unadjusted for inflation or season or whatever, pairs of variables with/without missing data imputed, and versions of the same basic question.</xhtml:p>
+                     <xhtml:p>Iteration: Questions that appear in different sections of the data file measuring a common subject in different ways, e.g., a set of variables which report the progression of respondent income over the life course.</xhtml:p>
+                     <xhtml:p>Analysis: Variables combined into the same index, e.g., the components of a calculation, such as the numerator and the denominator of an economic statistic.</xhtml:p>
+                     <xhtml:p>Pragmatic: A variable group without shared properties.</xhtml:p>
+                     <xhtml:p>Record: Variable from a single record in a hierarchical file.</xhtml:p>
+                     <xhtml:p>File: Variable from a single file in a multifile study.</xhtml:p>
+                     <xhtml:p>Randomized: Variables generated by CAI surveys produced by one or more random number variables together with a response variable, e.g, random variable X which could equal 1 or 2 (at random) which in turn would control whether Q.23 is worded "men" or "women", e.g., would you favor helping [men/women] laid off from a factory obtain training for a new job?</xhtml:p>
+                     <xhtml:p>Other: Variables which do not fit easily into any of the categories listed above, e.g., a group of variables whose documentation is in another language.</xhtml:p>
+                     <xhtml:p>The "var" attribute is used to reference all the constituent variable IDs in the group.</xhtml:p>
+                     <xhtml:p>The "varGrp" attribute is used to reference all the subsidiary variable groups which nest underneath the current varGrp. This allows for encoding of a hierarchical structure of variable groups. </xhtml:p>
+                     <xhtml:p>The attribute "name" provides a name, or short label, for the group.</xhtml:p>
+                     <xhtml:p>The "sdatrefs" are summary data description references that record the ID values of all elements within the summary data description section of the Study Description that might apply to the group. These elements include: time period covered, date of collection, nation or country, geographic coverage, geographic unit, unit of analysis, universe, and kind of data.</xhtml:p>
+                     <xhtml:p>The "methrefs" are methodology and processing references which record the ID values of all elements within the study methodology and processing section of the Study Description which might apply to the group. These elements include information on data collection and data appraisal (e.g., sampling, sources, weighting, data cleaning, response rates, and sampling error estimates).</xhtml:p>
+                     <xhtml:p>The "pubrefs" attribute provides a link to publication/citation references and records the ID values of all citations elements within codeBook/stdyDscr/othrStdyMat or codeBook/otherMat that pertain to this variable group. </xhtml:p>
+                     <xhtml:p>The "access" attribute records the ID values of all elements in codeBook/stdyDscr/dataAccs of the document that describe access conditions for this variable group.</xhtml:p>
+                     <xhtml:p>The attribute "nCube" was included in 2.0 and subsequent versions in ERROR. DO NOT USE THIS ATTRIBUTE. It is retained only for purposes of backward-compatibility.</xhtml:p>
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:element name="varQnty" type="simpleTextType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Overall Variable Count</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Number of variables.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <varQnty>27</varQnty>
+                     ]]></xhtml:samp> 
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:complexType name="verRespType" mixed="true">
+      <xs:complexContent>
+         <xs:extension base="simpleTextType">
+            <xs:attribute name="affiliation" type="xs:string"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="verResp" type="verRespType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Version Responsibility Statement</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">The organization or person responsible for the version of the work.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <verResp>Zentralarchiv fuer Empirische Sozialforschung</verResp>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <verResp>Inter-university Consortium for Political and Social  Research</verResp>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <var>
+                           <verStmt>
+                              <verResp>Zentralarchiv fuer Empirische Sozialforschung</verResp>
+                           </verStmt>
+                        </var>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <nCube>
+                           <verStmt>
+                              <verResp>Zentralarchiv fuer Empirische Sozialforschung</verResp>
+                           </verStmt>
+                        </nCube>
+                     ]]></xhtml:samp>
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:complexType name="verStmtType">
+      <xs:complexContent>
+         <xs:extension base="baseElementType">
+            <xs:sequence>
+               <xs:element ref="version" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="verResp" minOccurs="0" maxOccurs="unbounded"/>
+               <xs:element ref="notes" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="verStmt" type="verStmtType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Version Statement</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Version statement for the work at the appropriate level: marked-up document; marked-up document source; study; study description, other material; other material for study. A version statement may also be included for a data file, a variable, or an nCube.</xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <verStmt>
+                           <version type="version" date="1999-01-25">Second version</version>
+                        </verStmt>
+                     ]]></xhtml:samp>
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:complexType name="versionType" mixed="true">
+      <xs:complexContent>
+         <xs:extension base="simpleTextAndDateType">
+            <xs:attribute name="type" type="xs:string"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:element name="version" type="versionType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Version</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">Also known as release or edition. If there have been substantive changes in the data/documentation since their creation, this statement should be used at the appropriate level. The ISO standard for dates (YYYY-MM-DD) is recommended for use with the "date" attribute. </xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <version type="edition" date="1999-01-25">Second ICPSR Edition</version>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <var>
+                           <verStmt>
+                              <version type="version" date="1999-01-25">Second version of V25</version>
+                           </verStmt>
+                        </var>
+                     ]]></xhtml:samp>
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <nCube>
+                           <verStmt>
+                              <version type="version" date="1999-01-25">Second version of N25</version>
+                           </verStmt>
+                        </nCube>
+                     ]]></xhtml:samp>
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:element name="weight" type="simpleTextType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">Weighting</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">The use of sampling procedures may make it necessary to apply weights to produce accurate statistical results. Describe here the criteria for using weights in analysis of a collection. If a weighting formula or coefficient was developed, provide this formula, define its elements, and indicate how the formula is applied to data. </xhtml:div>
+               </xhtml:div>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Example</xhtml:h2>
+                  <xhtml:div class="example">
+                     <xhtml:samp class="xml_sample"><![CDATA[
+                        <weight>The 1996 NES dataset includes two final person-level analysis weights which incorporate sampling, nonresponse, and post-stratification factors. One weight (variable #4) is for longitudinal micro-level analysis using the 1996 NES Panel. The other weight (variable #3) is for analysis of the 1996 NES combined sample (Panel component cases plus Cross-section supplement cases). In addition, a Time Series Weight (variable #5) which corrects for Panel attrition was constructed. This weight should be used in analyses which compare the 1996 NES to earlier unweighted National Election Study data collections.</weight>
+                     ]]></xhtml:samp>
+                  </xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+   <xs:element name="westBL" type="phraseType">
+      <xs:annotation>
+         <xs:documentation>
+            <xhtml:div>
+               <xhtml:h1 class="element_title">West Bounding Longitude</xhtml:h1>
+               <xhtml:div>
+                  <xhtml:h2 class="section_header">Description</xhtml:h2>
+                  <xhtml:div class="description">The westernmost coordinate delimiting the geographic extent of the dataset. A valid range of values, expressed in decimal degrees (positive east and positive north), is: -180,0 &lt;=West Bounding Longitude Value &lt;= 180,0</xhtml:div>
+               </xhtml:div>
+            </xhtml:div>
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
+
+</xs:schema>

--- a/src/test/resources/xml/xsd/ddi-codebook-2.5/xml.xsd
+++ b/src/test/resources/xml/xsd/ddi-codebook-2.5/xml.xsd
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="http://www.w3.org/XML/1998/namespace" xmlns:xs="http://www.w3.org/2001/XMLSchema" xml:lang="en">
+
+ <xs:annotation>
+  <xs:documentation>
+   See http://www.w3.org/XML/1998/namespace.html and
+   http://www.w3.org/TR/REC-xml for information about this namespace.
+  </xs:documentation>
+ </xs:annotation>
+
+ <xs:annotation>
+  <xs:documentation>This schema defines attributes and an attribute group
+	suitable for use by
+	schemas wishing to allow xml:base, xml:lang or xml:space attributes
+	on elements they define.
+
+	To enable this, such a schema must import this schema
+	for the XML namespace, e.g. as follows:
+	&lt;schema . . .&gt;
+	 . . .
+	 &lt;import namespace="http://www.w3.org/XML/1998/namespace"
+		    schemaLocation="http://www.w3.org/2001/03/xml.xsd"/&gt;
+
+	Subsequently, qualified reference to any of the attributes
+	or the group defined below will have the desired effect, e.g.
+
+	&lt;type . . .&gt;
+	 . . .
+	 &lt;attributeGroup ref="xml:specialAttrs"/&gt;
+
+	 will define a type which will schema-validate an instance
+	 element with any of those attributes</xs:documentation>
+ </xs:annotation>
+
+ <xs:annotation>
+  <xs:documentation>In keeping with the XML Schema WG's standard versioning
+   policy, this schema document will persist at
+   http://www.w3.org/2001/03/xml.xsd.
+   At the date of issue it can also be found at
+   http://www.w3.org/2001/xml.xsd.
+   The schema document at that URI may however change in the future,
+   in order to remain compatible with the latest version of XML Schema
+   itself.  In other words, if the XML Schema namespace changes, the version
+   of this document at
+   http://www.w3.org/2001/xml.xsd will change
+   accordingly; the version at
+   http://www.w3.org/2001/03/xml.xsd will not change.
+  </xs:documentation>
+ </xs:annotation>
+
+ <xs:attribute name="lang" type="xs:language">
+  <xs:annotation>
+   <xs:documentation>In due course, we should install the relevant ISO 2- and 3-letter
+	 codes as the enumerated possible values . . .</xs:documentation>
+  </xs:annotation>
+ </xs:attribute>
+
+ <xs:attribute name="space" default="preserve">
+  <xs:simpleType>
+   <xs:restriction base="xs:NCName">
+    <xs:enumeration value="default"/>
+    <xs:enumeration value="preserve"/>
+   </xs:restriction>
+  </xs:simpleType>
+ </xs:attribute>
+
+ <xs:attribute name="base" type="xs:anyURI">
+  <xs:annotation>
+   <xs:documentation>See http://www.w3.org/TR/xmlbase/ for
+		     information about this attribute.</xs:documentation>
+  </xs:annotation>
+ </xs:attribute>
+
+ <xs:attributeGroup name="specialAttrs">
+  <xs:attribute ref="xml:base"/>
+  <xs:attribute ref="xml:lang"/>
+  <xs:attribute ref="xml:space"/>
+ </xs:attributeGroup>
+
+</xs:schema>


### PR DESCRIPTION
**What this PR does / why we need it**:

A lot of unit testing in Github Actions failed because the DDI XML schemas could not be downloaded and validation failed.

This PR adds the necessary files as test resources to the tree, so we don't need to download them. By loading them in the test we avoid the failures.

**Which issue(s) this PR closes**:

- Closes #9617 

**Special notes for your reviewer**:
@landreev I assigned you and requested your review as you flipped the switch to test for valid XML...

Here are some failed actions, where you can see the error: 
- https://github.com/IQSS/dataverse/actions/runs/5073375089/jobs/9112324489
- https://github.com/IQSS/dataverse/actions/runs/5070201120/jobs/9104893386
- https://github.com/IQSS/dataverse/actions/runs/5072343226/jobs/9109918346

 There are plenty more at https://github.com/IQSS/dataverse/actions/workflows/maven_unit_test.yml

**Suggestions on how to test this**:
Uhm yeah well... The tests should not fail anymore now. Just let 'em run. This fixes a test that failed for the wrong reasons...

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
No

**Is there a release notes update needed for this change?**:
No

**Additional documentation**:
None
