### PR TITLE
9338 Fixes Roles behavior in the UI and API

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DataverseRoleServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DataverseRoleServiceBean.java
@@ -303,7 +303,6 @@ public class DataverseRoleServiceBean implements java.io.Serializable {
         Set<DataverseRole> roles = dv.getRoles();
         roles.addAll(findBuiltinRoles());
 
-        //while (!dv.isEffectivelyPermissionRoot()) {
         while (dv.getOwner() != null) {
             dv = dv.getOwner();
             roles.addAll(dv.getRoles());

--- a/src/main/java/edu/harvard/iq/dataverse/DataverseRoleServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DataverseRoleServiceBean.java
@@ -303,7 +303,8 @@ public class DataverseRoleServiceBean implements java.io.Serializable {
         Set<DataverseRole> roles = dv.getRoles();
         roles.addAll(findBuiltinRoles());
 
-        while (!dv.isEffectivelyPermissionRoot()) {
+        //while (!dv.isEffectivelyPermissionRoot()) {
+        while (dv.getOwner() != null) {
             dv = dv.getOwner();
             roles.addAll(dv.getRoles());
         }

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/ListRolesCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/ListRolesCommand.java
@@ -28,7 +28,6 @@ public class ListRolesCommand extends AbstractCommand<Set<DataverseRole>> {
     @Override
     public Set<DataverseRole> execute(CommandContext ctxt) throws CommandException {
         return ctxt.roles().availableRoles(definitionPoint.getId());
-        //return definitionPoint.getRoles();
     }
 
     

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/ListRolesCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/ListRolesCommand.java
@@ -27,7 +27,8 @@ public class ListRolesCommand extends AbstractCommand<Set<DataverseRole>> {
 
     @Override
     public Set<DataverseRole> execute(CommandContext ctxt) throws CommandException {
-        return definitionPoint.getRoles();
+        return ctxt.roles().availableRoles(definitionPoint.getId());
+        //return definitionPoint.getRoles();
     }
 
     


### PR DESCRIPTION
**What this PR does / why we need it**:

See the opening comment in the linked issue, it has a detailed description of the 3 major issues: Inherited roles (roles defined in the ancestral collections) not listed by either the API or UI; and then 2 inconsistencies between the API (`/api/dataverses/*/roles` and `/api/dataverses/*/assignments`) and the permissions page in the UI. 

**Which issue(s) this PR closes**:

Closes #9338

**Special notes for your reviewer**:

It really looks like it took very minimal changes after all, 2 lines basically: 
- Changed the `availableRoles()` method in `DataverseRoleServiceBean` to ignore the "permissionroot" boolean when looking for the extra Roles defined on the ancestral collections. 
- Changed the `/api/dataverses/*/roles` to use the service method above, instead of simply listing `definitionPoint.getRoles()`, for consistency between the two. 

(Did I miss anything?)

Please note the PR addresses one more UI/API inconsistency. Copy-and-pasting my comment from the issue below: (please let me know if there's any reason we don't want this!)

> One other difference in how the roles are listed in the UI vs the API: the page show all the available roles, the builtin + the defined ones. The `/api/dataverses/*/roles` api only shows the defined kind. There's probably no reason for it not to show all the *available* roles, just like the page, is there? 
> As of now, we have separate apis for the builtin and defined roles. But the former is under `/api/admin`, so it's not available to regular curator users. 

I.e., as implemented in this PR, the `/api/dataverses/*/roles` API will list ALL the roles available for the collection, just like the UI page. 

**Suggestions on how to test this**:

(will add)

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
