### PR TITLE
External Exporters bug fix

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
@@ -805,7 +805,7 @@ public class JsonPrinter {
                     .add("label", vm.getLabel())
                     .add("isWeightVar", vm.isIsweightvar())
                     .add("isWeighted",vm.isWeighted())
-                    .add("weightVariableId", vm.getWeightvariable().getId())
+                    .add("weightVariableId", (vm.getWeightvariable()==null) ? null : vm.getWeightvariable().getId())
                     .add("literalQuestion", vm.getLiteralquestion())
                     .add("interviewInstruction", vm.getInterviewinstruction())
                     .add("postQuestion", vm.getPostquestion())


### PR DESCRIPTION
**What this PR does / why we need it**: When there is no weight variable (which is tested in an IT test but not a unit test), the code give an NPE. This PR checks for a null response in getWeghtvariable() to avoid that.

This is a quick follow-up to #9175 which was merged before the IT test failure was noticed.

**Which issue(s) this PR closes**:

Closes #

**Special notes for your reviewer**:

**Suggestions on how to test this**: Let the IT tests run/succeed.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
