### PR TITLE
Payara downloads moved to Nexus

### DIFF
--- a/doc/sphinx-guides/source/installation/prerequisites.rst
+++ b/doc/sphinx-guides/source/installation/prerequisites.rst
@@ -55,7 +55,7 @@ Installing Payara
 
 - Download and install Payara (installed in ``/usr/local/payara5`` in the example commands below)::
 
-	# wget https://s3-eu-west-1.amazonaws.com/payara.fish/Payara+Downloads/5.2022.3/payara-5.2022.3.zip
+	# wget https://nexus.payara.fish/repository/payara-community/fish/payara/distributions/payara/5.2022.3/payara-5.2022.3.zip
 	# unzip payara-5.2022.3.zip
 	# mv payara5 /usr/local
 

--- a/doc/sphinx-guides/source/installation/prerequisites.rst
+++ b/doc/sphinx-guides/source/installation/prerequisites.rst
@@ -59,6 +59,8 @@ Installing Payara
 	# unzip payara-5.2022.3.zip
 	# mv payara5 /usr/local
 
+If nexus.payara.fish is ever down for maintenance, Payara distributions are also available from https://repo1.maven.org/maven2/fish/payara/distributions/payara/
+
 If you intend to install and run Payara under a service account (and we hope you do), chown -R the Payara hierarchy to root to protect it but give the service account access to the below directories:
 
 - Set service account permissions::


### PR DESCRIPTION
**What this PR does / why we need it**:

The Payara project moved their downloads from S3 to Nexus.

**Which issue(s) this PR closes**:

- Closes #9638

**Special notes for your reviewer**:

None

**Suggestions on how to test this**:

Test download link.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No

**Is there a release notes update needed for this change?**:

No

**Additional documentation**:

None