### PR TITLE
9647 bugfix facets on files page

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
@@ -684,12 +684,14 @@ public class DatasetPage implements java.io.Serializable {
 
     private List<FileMetadata> selectFileMetadatasForDisplay() {
         final Set<Long> searchResultsIdSet;
-        if (StringUtil.isEmpty(fileLabelSearchTerm) && StringUtil.isEmpty(fileTypeFacet) && StringUtil.isEmpty(fileAccessFacet) && StringUtil.isEmpty(fileTagsFacet)) {
-            // But, if no search terms were specified, we return the full
-            // list of the files in the version:
+        if (isIndexedVersion() && StringUtil.isEmpty(fileLabelSearchTerm) && StringUtil.isEmpty(fileTypeFacet) && StringUtil.isEmpty(fileAccessFacet) && StringUtil.isEmpty(fileTagsFacet)) {
+            // Indexed version: we need facets, they are set as a side effect of getFileIdsInVersionFromSolr method.
+            // But, no search terms were specified, we will return the full
+            // list of the files in the version: we discard the getFileIdsInVersionFromSolr.
+            getFileIdsInVersionFromSolr(workingVersion.getId(), this.fileLabelSearchTerm);
             // Since the search results should include the full set of fmds if all the
             // terms/facets are empty, setting them to null should just be
-            // an optimization for the loop below
+            // an optimization to skip the loop below
             searchResultsIdSet = null;
         } else if (isIndexedVersion()) {
             // We run the search even if no search term and/or facets are

--- a/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
@@ -687,7 +687,7 @@ public class DatasetPage implements java.io.Serializable {
         if (isIndexedVersion() && StringUtil.isEmpty(fileLabelSearchTerm) && StringUtil.isEmpty(fileTypeFacet) && StringUtil.isEmpty(fileAccessFacet) && StringUtil.isEmpty(fileTagsFacet)) {
             // Indexed version: we need facets, they are set as a side effect of getFileIdsInVersionFromSolr method.
             // But, no search terms were specified, we will return the full
-            // list of the files in the version: we discard the getFileIdsInVersionFromSolr.
+            // list of the files in the version: we discard the result from getFileIdsInVersionFromSolr.
             getFileIdsInVersionFromSolr(workingVersion.getId(), this.fileLabelSearchTerm);
             // Since the search results should include the full set of fmds if all the
             // terms/facets are empty, setting them to null should just be

--- a/src/main/webapp/filesFragment.xhtml
+++ b/src/main/webapp/filesFragment.xhtml
@@ -144,7 +144,7 @@
                         </button>
                         <ul class="dropdown-menu">
                             <!-- link for "All" - all file types: -->
-                            <li><h:outputLink value="/dataset.xhtml">
+                            <li><h:outputLink rel="nofollow" value="/dataset.xhtml">
                                     <h:outputText styleClass="#{empty DatasetPage.fileTypeFacet ? 'highlightBold' : ''}" value="#{bundle['file.results.filter.all']}"/>
                                     <f:param name="persistentId" value="#{DatasetPage.persistentId}"/>
                                     <f:param name="version" value="#{DatasetPage.version}"/>
@@ -158,7 +158,7 @@
                                 </h:outputLink></li>
                             <li role="separator" class="divider"></li>
                             <ui:repeat value="#{DatasetPage.fileTypeFacetLabels}" var="facetLabel">
-                                <li><h:outputLink value="/dataset.xhtml">
+                                <li><h:outputLink rel="nofollow" value="/dataset.xhtml">
                                         <h:outputFormat styleClass="#{facetLabel.name == DatasetPage.fileTypeFacet ? 'highlightBold' : ''}" value="#{facetLabel.name} &#40;{0}&#41;">
                                             <f:param value="#{facetLabel.count}"/>
                                         </h:outputFormat>
@@ -185,7 +185,7 @@
                         </button>
                         <ul class="dropdown-menu">
                             <!-- link for "All" - i.e., all (both) types of access: -->
-                            <li><h:outputLink value="/dataset.xhtml">
+                            <li><h:outputLink rel="nofollow" value="/dataset.xhtml">
                                     <h:outputText styleClass="#{empty DatasetPage.fileAccessFacet ? 'highlightBold' : ''}" value="#{bundle['file.results.filter.all']}"/>
                                     <f:param name="persistentId" value="#{DatasetPage.persistentId}"/>
                                     <f:param name="version" value="#{DatasetPage.version}"/>
@@ -199,7 +199,7 @@
                                 </h:outputLink></li>
                             <li role="separator" class="divider"></li>
                             <ui:repeat value="#{DatasetPage.fileAccessFacetLabels}" var="facetLabel">
-                                <li><h:outputLink value="/dataset.xhtml">
+                                <li><h:outputLink rel="nofollow" value="/dataset.xhtml">
                                         <h:outputFormat styleClass="#{facetLabel.name == DatasetPage.fileAccessFacet ? 'highlightBold' : ''}" value="#{facetLabel.name} &#40;{0}&#41;">
                                             <f:param value="#{facetLabel.count}"/>
                                         </h:outputFormat>
@@ -226,7 +226,7 @@
                         </button>
                         <ul class="dropdown-menu">
                             <!-- link for "All" - i.e., all file tags: -->
-                            <li><h:outputLink value="/dataset.xhtml">
+                            <li><h:outputLink rel="nofollow" value="/dataset.xhtml">
                                     <h:outputText styleClass="#{empty DatasetPage.fileTagsFacet ? 'highlightBold' : ''}" value="#{bundle['file.results.filter.all']}"/>
                                     <f:param name="persistentId" value="#{DatasetPage.persistentId}"/>
                                     <f:param name="version" value="#{DatasetPage.version}"/>
@@ -240,7 +240,7 @@
                                 </h:outputLink></li>
                             <li role="separator" class="divider"></li>
                             <ui:repeat value="#{DatasetPage.fileTagsFacetLabels}" var="facetLabel">
-                                <li><h:outputLink value="/dataset.xhtml">
+                                <li><h:outputLink rel="nofollow" value="/dataset.xhtml">
                                         <h:outputFormat styleClass="#{facetLabel.name == DatasetPage.fileTagsFacet ? 'highlightBold' : ''}" value="#{facetLabel.name} &#40;{0}&#41;">
                                             <f:param value="#{facetLabel.count}"/>
                                         </h:outputFormat>
@@ -278,7 +278,7 @@
                             <span class="glyphicon glyphicon-sort"></span> #{bundle['file.results.btn.sort']} <span class="caret"></span>
                         </button>
                         <ul class="dropdown-menu pull-right text-left">
-                            <li><h:outputLink value="/dataset.xhtml">
+                            <li><h:outputLink rel="nofollow" value="/dataset.xhtml">
                                     <h:outputText styleClass="#{((empty DatasetPage.fileSortField) or DatasetPage.fileSortField == 'name') and (empty DatasetPage.fileSortOrder) ? 'highlightBold' : ''}" value="#{bundle['file.results.btn.sort.option.nameAZ']}"/>
                                     <f:param name="persistentId" value="#{DatasetPage.persistentId}"/>
                                     <f:param name="version" value="#{DatasetPage.version}"/>
@@ -288,7 +288,7 @@
                                     <f:param name="tagPresort" value="#{DatasetPage.tagPresort}"/>
                                     <f:param name="folderPresort" value="#{DatasetPage.folderPresort}"/>
                                 </h:outputLink></li>
-                            <li><h:outputLink value="/dataset.xhtml">
+                            <li><h:outputLink rel="nofollow" value="/dataset.xhtml">
                                     <h:outputText styleClass="#{(DatasetPage.fileSortField == 'name' and DatasetPage.fileSortOrder == 'desc') ? 'highlightBold' : ''}" value="#{bundle['file.results.btn.sort.option.nameZA']}"/>
                                     <f:param name="persistentId" value="#{DatasetPage.persistentId}"/>
                                     <f:param name="version" value="#{DatasetPage.version}"/>
@@ -300,7 +300,7 @@
                                     <f:param name="tagPresort" value="#{DatasetPage.tagPresort}"/>
                                     <f:param name="folderPresort" value="#{DatasetPage.folderPresort}"/>
                                 </h:outputLink></li>
-                            <li><h:outputLink value="/dataset.xhtml">
+                            <li><h:outputLink rel="nofollow" value="/dataset.xhtml">
                                     <h:outputText styleClass="#{(DatasetPage.fileSortField == 'date' and (empty DatasetPage.fileSortOrder)) ? 'highlightBold' : ''}" value="#{bundle['file.results.btn.sort.option.newest']}"/>
                                     <f:param name="persistentId" value="#{DatasetPage.persistentId}"/>
                                     <f:param name="version" value="#{DatasetPage.version}"/>
@@ -310,7 +310,7 @@
                                     <f:param name="fileSortField" value="date"/>
                                     <f:param name="tagPresort" value="#{DatasetPage.tagPresort}"/>
                                 </h:outputLink></li>
-                            <li><h:outputLink value="/dataset.xhtml">
+                            <li><h:outputLink rel="nofollow" value="/dataset.xhtml">
                                     <h:outputText styleClass="#{(DatasetPage.fileSortField == 'date' and DatasetPage.fileSortOrder == 'desc') ? 'highlightBold' : ''}" value="#{bundle['file.results.btn.sort.option.oldest']}"/>
                                     <f:param name="persistentId" value="#{DatasetPage.persistentId}"/>
                                     <f:param name="version" value="#{DatasetPage.version}"/>
@@ -321,7 +321,7 @@
                                     <f:param name="fileSortOrder" value="desc"/>
                                     <f:param name="tagPresort" value="#{DatasetPage.tagPresort}"/>
                                 </h:outputLink></li>
-                            <li><h:outputLink value="/dataset.xhtml">
+                            <li><h:outputLink rel="nofollow" value="/dataset.xhtml">
                                     <h:outputText styleClass="#{DatasetPage.fileSortField == 'size' ? 'highlightBold' : ''}" value="#{bundle['file.results.btn.sort.option.size']}"/>
                                     <f:param name="persistentId" value="#{DatasetPage.persistentId}"/>
                                     <f:param name="version" value="#{DatasetPage.version}"/>
@@ -331,7 +331,7 @@
                                     <f:param name="fileSortField" value="size"/>
                                     <f:param name="tagPresort" value="#{DatasetPage.tagPresort}"/>
                                 </h:outputLink></li>
-                            <li><h:outputLink value="/dataset.xhtml">
+                            <li><h:outputLink rel="nofollow" value="/dataset.xhtml">
                                     <h:outputText styleClass="#{DatasetPage.fileSortField == 'type' ? 'highlightBold' : ''}" value="#{bundle['file.results.btn.sort.option.type']}"/>
                                     <f:param name="persistentId" value="#{DatasetPage.persistentId}"/>
                                     <f:param name="version" value="#{DatasetPage.version}"/>


### PR DESCRIPTION
**What this PR does / why we need it**:
It fixes the missing filters for files in dataset page bug.

**Which issue(s) this PR closes**:

Closes #9647 

**Suggestions on how to test this**:
Open a dataset page for a dataset with more than 1 file, it should contain the facet filters (Filter by)

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
No, this is only a bugfix.

**Is there a release notes update needed for this change?**:
No.

**Additional documentation**:
![image](https://github.com/IQSS/dataverse/assets/101262459/8bd7117d-4a80-4127-b514-2336bbf87950)

