### PR TITLE
VarMetadata fixes for #9175

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/export/ddi/DdiExportUtil.java
+++ b/src/main/java/edu/harvard/iq/dataverse/export/ddi/DdiExportUtil.java
@@ -1750,7 +1750,7 @@ public class DdiExportUtil {
                 if (vars != null) {
                     for (int j = 0; j < vars.size(); j++) {
                         createVarDDI(xmlw, vars.getJsonObject(j), fileJson.getJsonNumber("id").toString(),
-                                fileJson.getString("fileMetadataId"));
+                                fileJson.getJsonNumber("fileMetadataId").toString());
                     }
                 }
             }
@@ -1797,7 +1797,7 @@ public class DdiExportUtil {
         }
 
         if (dvar.containsKey("numberOfDecimalPoints")) {
-            writeAttribute(xmlw, "dcml", dvar.getString("numberOfDecimalPoints"));
+            writeAttribute(xmlw, "dcml", dvar.getJsonNumber("numberOfDecimalPoints").toString());
         }
 
         if (dvar.getBoolean("isOrderedCategorical")) {
@@ -1820,13 +1820,13 @@ public class DdiExportUtil {
         // location
         xmlw.writeEmptyElement("location");
         if (dvar.containsKey("fileStartPosition")) {
-            writeAttribute(xmlw, "StartPos", dvar.getString("fileStartPosition"));
+            writeAttribute(xmlw, "StartPos", dvar.getJsonNumber("fileStartPosition").toString());
         }
         if (dvar.containsKey("fileEndPosition")) {
-            writeAttribute(xmlw, "EndPos", dvar.getString("fileEndPosition"));
+            writeAttribute(xmlw, "EndPos", dvar.getJsonNumber("fileEndPosition").toString());
         }
         if (dvar.containsKey("recordSegmentNumber")) {
-            writeAttribute(xmlw, "RecSegNo", dvar.getString("recordSegmentNumber"));
+            writeAttribute(xmlw, "RecSegNo", dvar.getJsonNumber("recordSegmentNumber").toString());
         }
 
         writeAttribute(xmlw, "fileid", "f" + fileId);
@@ -1867,38 +1867,41 @@ public class DdiExportUtil {
         }
 
         // invalrng
-        boolean invalrngAdded = false;
-        JsonArray ranges = dvar.getJsonArray("invalidRanges");
-        for (int i=0;i<ranges.size();i++) {
-            JsonObject range = ranges.getJsonObject(0); 
-            //if (range.getBeginValueType() != null && range.getBeginValueType().getName().equals(DB_VAR_RANGE_TYPE_POINT)) {
-            if (range.getBoolean("hasBeginValueType") && range.getBoolean("isBeginValueTypePoint")) {
-                if (range.containsKey("beginValue")) {
-                    invalrngAdded = checkParentElement(xmlw, "invalrng", invalrngAdded);
-                    xmlw.writeEmptyElement("item");
-                    writeAttribute(xmlw, "VALUE", range.getString("beginValue"));
-                }
-            } else {
-                invalrngAdded = checkParentElement(xmlw, "invalrng", invalrngAdded);
-                xmlw.writeEmptyElement("range");
-                if (range.getBoolean("hasBeginValueType") && range.containsKey("beginValue")) {
-                    if (range.getBoolean("isBeginValueTypeMin")) {
-                        writeAttribute(xmlw, "min", range.getString("beginValue"));
-                    } else if (range.getBoolean("isBeginValueTypeMinExcl")) {
-                        writeAttribute(xmlw, "minExclusive", range.getString("beginValue"));
+        if (dvar.containsKey("invalidRanges")) {
+            boolean invalrngAdded = false;
+            JsonArray ranges = dvar.getJsonArray("invalidRanges");
+            for (int i = 0; i < ranges.size(); i++) {
+                JsonObject range = ranges.getJsonObject(0);
+                // if (range.getBeginValueType() != null &&
+                // range.getBeginValueType().getName().equals(DB_VAR_RANGE_TYPE_POINT)) {
+                if (range.getBoolean("hasBeginValueType") && range.getBoolean("isBeginValueTypePoint")) {
+                    if (range.containsKey("beginValue")) {
+                        invalrngAdded = checkParentElement(xmlw, "invalrng", invalrngAdded);
+                        xmlw.writeEmptyElement("item");
+                        writeAttribute(xmlw, "VALUE", range.getString("beginValue"));
                     }
-                }
-                if (range.getBoolean("hasEndValueType") && range.containsKey("endValue")) {
-                    if (range.getBoolean("isEndValueTypeMax")) {
-                        writeAttribute(xmlw, "max", range.getString("endValue"));
-                    } else if (range.getBoolean("isEndValueTypeMaxExcl")) {
-                        writeAttribute(xmlw, "maxExclusive", range.getString("endValue"));
+                } else {
+                    invalrngAdded = checkParentElement(xmlw, "invalrng", invalrngAdded);
+                    xmlw.writeEmptyElement("range");
+                    if (range.getBoolean("hasBeginValueType") && range.containsKey("beginValue")) {
+                        if (range.getBoolean("isBeginValueTypeMin")) {
+                            writeAttribute(xmlw, "min", range.getString("beginValue"));
+                        } else if (range.getBoolean("isBeginValueTypeMinExcl")) {
+                            writeAttribute(xmlw, "minExclusive", range.getString("beginValue"));
+                        }
+                    }
+                    if (range.getBoolean("hasEndValueType") && range.containsKey("endValue")) {
+                        if (range.getBoolean("isEndValueTypeMax")) {
+                            writeAttribute(xmlw, "max", range.getString("endValue"));
+                        } else if (range.getBoolean("isEndValueTypeMaxExcl")) {
+                            writeAttribute(xmlw, "maxExclusive", range.getString("endValue"));
+                        }
                     }
                 }
             }
-        }
-        if (invalrngAdded) {
-            xmlw.writeEndElement(); // invalrng
+            if (invalrngAdded) {
+                xmlw.writeEndElement(); // invalrng
+            }
         }
 
         //universe
@@ -1910,67 +1913,72 @@ public class DdiExportUtil {
             }
         }
 
-        //sum stats
-        for (Entry<String, JsonValue> sumStat : dvar.getJsonObject("summaryStatistics").entrySet()) {
-            xmlw.writeStartElement("sumStat");
-            writeAttribute(xmlw, "type", sumStat.getKey());
-            xmlw.writeCharacters(sumStat.getValue().toString());
-            xmlw.writeEndElement(); //sumStat
+        // sum stats
+        if (dvar.containsKey("summaryStatistics")) {
+            for (Entry<String, JsonValue> sumStat : dvar.getJsonObject("summaryStatistics").entrySet()) {
+                xmlw.writeStartElement("sumStat");
+                writeAttribute(xmlw, "type", sumStat.getKey());
+                xmlw.writeCharacters(sumStat.getValue().toString());
+                xmlw.writeEndElement(); // sumStat
+            }
         }
 
         // categories
-        JsonArray varCats = dvar.getJsonArray("variableCategories");
-        for (int i=0;i<varCats.size();i++) {
-            JsonObject varCat = varCats.getJsonObject(i);
-            xmlw.writeStartElement("catgry");
-            if (varCat.getBoolean("isMissing")) {
-                writeAttribute(xmlw, "missing", "Y");
-            }
-
-            // catValu
-            xmlw.writeStartElement("catValu");
-            xmlw.writeCharacters(varCat.getString("value"));
-            xmlw.writeEndElement(); //catValu
-
-            // label
-            if (varCat.containsKey("label")) {
-                xmlw.writeStartElement("labl");
-                writeAttribute(xmlw, "level", "category");
-                xmlw.writeCharacters(varCat.getString("label"));
-                xmlw.writeEndElement(); //labl
-            }
-
-            // catStat
-            if (varCat.containsKey("frequency")) {
-                xmlw.writeStartElement("catStat");
-                writeAttribute(xmlw, "type", "freq");
-                Double freq = Double.parseDouble(varCat.getString("frequency"));
-                // if frequency is actually a long value, we want to write "100" instead of "100.0"
-                if (Math.floor(freq) == freq) {
-                    xmlw.writeCharacters(Long.valueOf(freq.longValue()).toString());
-                } else {
-                    xmlw.writeCharacters(freq.toString());
+        if (dvar.containsKey("variableCategories")) {
+            JsonArray varCats = dvar.getJsonArray("variableCategories");
+            for (int i = 0; i < varCats.size(); i++) {
+                JsonObject varCat = varCats.getJsonObject(i);
+                xmlw.writeStartElement("catgry");
+                if (varCat.getBoolean("isMissing")) {
+                    writeAttribute(xmlw, "missing", "Y");
                 }
-                xmlw.writeEndElement(); //catStat
-            }
 
-            //catStat weighted freq
-            if (vm != null && vm.getBoolean("isWeighted")) {
-                JsonArray catMetas = vm.getJsonArray("categoryMetadatas");
-                for (int j=0;i<catMetas.size();j++) {
-                    JsonObject cm = catMetas.getJsonObject(j);
-                    if (cm.getString("categoryValue").equals(varCat.getString("value"))) {
-                        xmlw.writeStartElement("catStat");
-                        writeAttribute(xmlw, "wgtd", "wgtd");
-                        writeAttribute(xmlw, "type", "freq");
-                        xmlw.writeCharacters(cm.getString("wFreq"));
-                        xmlw.writeEndElement(); //catStat
-                        break;
+                // catValu
+                xmlw.writeStartElement("catValu");
+                xmlw.writeCharacters(varCat.getString("value"));
+                xmlw.writeEndElement(); // catValu
+
+                // label
+                if (varCat.containsKey("label")) {
+                    xmlw.writeStartElement("labl");
+                    writeAttribute(xmlw, "level", "category");
+                    xmlw.writeCharacters(varCat.getString("label"));
+                    xmlw.writeEndElement(); // labl
+                }
+
+                // catStat
+                if (varCat.containsKey("frequency")) {
+                    xmlw.writeStartElement("catStat");
+                    writeAttribute(xmlw, "type", "freq");
+                    Double freq = varCat.getJsonNumber("frequency").doubleValue();
+                    // if frequency is actually a long value, we want to write "100" instead of
+                    // "100.0"
+                    if (Math.floor(freq) == freq) {
+                        xmlw.writeCharacters(Long.valueOf(freq.longValue()).toString());
+                    } else {
+                        xmlw.writeCharacters(freq.toString());
+                    }
+                    xmlw.writeEndElement(); // catStat
+                }
+
+                // catStat weighted freq
+                if (vm != null && vm.getBoolean("isWeighted")) {
+                    JsonArray catMetas = vm.getJsonArray("categoryMetadatas");
+                    for (int j = 0; i < catMetas.size(); j++) {
+                        JsonObject cm = catMetas.getJsonObject(j);
+                        if (cm.getString("categoryValue").equals(varCat.getString("value"))) {
+                            xmlw.writeStartElement("catStat");
+                            writeAttribute(xmlw, "wgtd", "wgtd");
+                            writeAttribute(xmlw, "type", "freq");
+                            xmlw.writeCharacters(cm.getJsonNumber("wFreq").toString());
+                            xmlw.writeEndElement(); // catStat
+                            break;
+                        }
                     }
                 }
-            }
 
-            xmlw.writeEndElement(); //catgry
+                xmlw.writeEndElement(); // catgry
+            }
         }
 
 
@@ -1981,9 +1989,13 @@ public class DdiExportUtil {
         } else {
             throw new XMLStreamException("Illegal Variable Format Type!");
         }
-        writeAttribute(xmlw, "formatname", dvar.getString("format"));
+        if(dvar.containsKey("format")) {
+            writeAttribute(xmlw, "formatname", dvar.getString("format"));
+        }
         //experiment writeAttribute(xmlw, "schema", dv.getFormatSchema());
-        writeAttribute(xmlw, "category", dvar.getString("formatCategory"));
+        if(dvar.containsKey("formatCategory")) {
+            writeAttribute(xmlw, "category", dvar.getString("formatCategory"));
+        }
 
         // notes
         if (dvar.containsKey("UNF") && !dvar.getString("UNF").isBlank()) {
@@ -2031,19 +2043,19 @@ public class DdiExportUtil {
 
                     if (dt.containsKey("caseQuantity")) {
                         xmlw.writeStartElement("caseQnty");
-                        xmlw.writeCharacters(dt.getString("caseQuantity"));
+                        xmlw.writeCharacters(dt.getJsonNumber("caseQuantity").toString());
                         xmlw.writeEndElement(); // caseQnty
                     }
 
                     if (dt.containsKey("varQuantity")) {
                         xmlw.writeStartElement("varQnty");
-                        xmlw.writeCharacters(dt.getString("varQuantity"));
+                        xmlw.writeCharacters(dt.getJsonNumber("varQuantity").toString());
                         xmlw.writeEndElement(); // varQnty
                     }
 
                     if (dt.containsKey("recordsPerCase")) {
                         xmlw.writeStartElement("recPrCas");
-                        xmlw.writeCharacters(dt.getString("recordsPerCase"));
+                        xmlw.writeCharacters(dt.getJsonNumber("recordsPerCase").toString());
                         xmlw.writeEndElement(); // recPrCas
                     }
 

--- a/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
@@ -678,8 +678,7 @@ public class JsonPrinter {
                 .add("creationDate",  df.getCreateDateFormattedYYYYMMDD())
                 .add("dataTables", df.getDataTables().isEmpty() ? null : JsonPrinter.jsonDT(df.getDataTables()))
                 .add("varGroups", fileMetadata.getVarGroups().isEmpty()
-                        ? JsonPrinter.jsonVarGroup(fileMetadata.getVarGroups())
-                        : null);
+                        ? null: JsonPrinter.jsonVarGroup(fileMetadata.getVarGroups()));
     }
     
     //Started from https://github.com/RENCI-NRIG/dataverse/, i.e. https://github.com/RENCI-NRIG/dataverse/commit/2b5a1225b42cf1caba85e18abfeb952171c6754a

--- a/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
@@ -685,7 +685,7 @@ public class JsonPrinter {
     public static JsonArrayBuilder jsonDT(List<DataTable> ldt) {
         JsonArrayBuilder ldtArr = Json.createArrayBuilder();
         for(DataTable dt: ldt){
-            ldtArr.add(jsonObjectBuilder().add("dataTable", JsonPrinter.json(dt)));
+            ldtArr.add(JsonPrinter.json(dt));
         }
         return ldtArr;
     }
@@ -713,6 +713,7 @@ public class JsonPrinter {
     // TODO: add sumstat and variable categories, check formats
     public static JsonObjectBuilder json(DataVariable dv) {
     return jsonObjectBuilder()
+            .add("id", dv.getId())
             .add("name", dv.getName())
             .add("label", dv.getLabel())
             .add("weighted", dv.isWeighted())
@@ -728,9 +729,9 @@ public class JsonPrinter {
             .add("recordSegmentNumber", dv.getRecordSegmentNumber())
             .add("numberOfDecimalPoints",dv.getNumberOfDecimalPoints())
             .add("variableMetadata",jsonVarMetadata(dv.getVariableMetadatas()))
-            .add("invalidRanges", dv.getInvalidRanges().isEmpty() ? JsonPrinter.jsonInvalidRanges(dv.getInvalidRanges()) : null)
-            .add("summaryStatistics", dv.getSummaryStatistics().isEmpty() ? JsonPrinter.jsonSumStat(dv.getSummaryStatistics()) : null)
-            .add("variableCategories", dv.getCategories().isEmpty() ? JsonPrinter.jsonCatStat(dv.getCategories()) : null) 
+            .add("invalidRanges", dv.getInvalidRanges().isEmpty() ? null : JsonPrinter.jsonInvalidRanges(dv.getInvalidRanges()))
+            .add("summaryStatistics", dv.getSummaryStatistics().isEmpty() ? null : JsonPrinter.jsonSumStat(dv.getSummaryStatistics()))
+            .add("variableCategories", dv.getCategories().isEmpty() ? null : JsonPrinter.jsonCatStat(dv.getCategories())) 
             ;
     }
 


### PR DESCRIPTION
**What this PR does / why we need it**: Per discussion in #9481, a more complex example files showed additional bugs in the updated DDI exporter. This PR fixes those errors. 

**Which issue(s) this PR closes**:

Closes #

**Special notes for your reviewer**:

**Suggestions on how to test this**: Use the [file from #9481](https://github.com/IQSS/dataverse/files/11771812/cora-efc2000-E-2000-4_F1.txt) renamed with a .sav extension and verify that the DDI metadata export exists and includes a <dataDscr> section. The file should nominally be the same as for v5.13 except for minor ordering differences, e.g. between the <catgry> entries. An example DDI export output for this file is attached below.

From @landreev: I would also confirm that the resulting DDI is valid against the schema. I like to use CESSDA Metadata Validator (https://cmv.cessda.eu/#!validation). 

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
