### PR TITLE
9650 list linked dataverses in link edit form

### DIFF
--- a/doc/sphinx-guides/source/admin/dataverses-datasets.rst
+++ b/doc/sphinx-guides/source/admin/dataverses-datasets.rst
@@ -121,7 +121,7 @@ Creates a link between a dataset and a Dataverse collection (see the :ref:`datas
 List Dataverses that are linked from a Dataset
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Creates a link between a dataset and a Dataverse collection (see the :ref:`dataset-linking` section of the User Guide for more information). ::
+Lists the link(s) created between a dataset and a Dataverse collection (see the :ref:`dataset-linking` section of the User Guide for more information). ::
 
     curl -H "X-Dataverse-key: $API_TOKEN" -X PUT http://$SERVER/api/datasets/$linked-dataset-id/links
 

--- a/doc/sphinx-guides/source/admin/dataverses-datasets.rst
+++ b/doc/sphinx-guides/source/admin/dataverses-datasets.rst
@@ -118,6 +118,26 @@ Creates a link between a dataset and a Dataverse collection (see the :ref:`datas
 
     curl -H "X-Dataverse-key: $API_TOKEN" -X PUT http://$SERVER/api/datasets/$linked-dataset-id/link/$linking-dataverse-alias
 
+List Dataverses that are linked from a Dataset
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Creates a link between a dataset and a Dataverse collection (see the :ref:`dataset-linking` section of the User Guide for more information). ::
+
+    curl -H "X-Dataverse-key: $API_TOKEN" -X PUT http://$SERVER/api/datasets/$linked-dataset-id/links
+
+It returns a list in the following format:
+
+.. code-block:: json
+
+  {
+    "status": "OK",
+    "data": {
+      "dataverses that link to dataset id 56782": [
+        "crc990 (id 18802)"
+      ]
+    }
+  }
+
 .. _unlink-a-dataset:
 
 Unlink a Dataset


### PR DESCRIPTION
**What this PR does / why we need it**:

With this changes the user can see the list of linked dataverses at the dataset page's link edit form.

**Which issue(s) this PR closes**:

It is one step towards #9650 

**Special notes for your reviewer**:

It contains a UI change, but I am not an expert of Dataverse's stylesheet classes. I have created some rough direct formatting via the "style" attribute of HTML elements. A UI expert might give suggestions how to improve it.

**Suggestions on how to test this**:

1. run `mvn clean package` and deploy the war file  to the test environment
2. if you do not have a dataset which is already linked to a dataverse, create a link
3. open the "Link Dataset" form at the dataset page, and check what is below the "Save Linked Dataset" button

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

Here you can find the result:
![Screenshot from 2023-06-19 23-15-07](https://github.com/IQSS/dataverse/assets/218218/c4cc4b7b-b45f-4b53-b0b0-80345f7558ad)

**Is there a release notes update needed for this change?**:
It might worth to mention it that the user now can list the linked dataverses from the dataset page as well.

**Additional documentation**:
