### PR TITLE
#9650 list the linked dataverse in the link edit form

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
@@ -3341,6 +3341,14 @@ public class DatasetPage implements java.io.Serializable {
         }
     }
 
+    public List<Dataverse> getLinkedDataverses() {
+        List<Dataverse> linkedDataverses = new ArrayList<>();
+        if (session.getUser().isAuthenticated()) {
+            linkedDataverses = dataverseService.findDataversesThatLinkToThisDatasetId(dataset.getId());
+        }
+        return linkedDataverses;
+    }
+
     public List<Dataverse> completeHostDataverseMenuList(String query) {
         if (session.getUser().isAuthenticated()) {
             return dataverseService.filterDataversesForHosting(query, dvRequestService.getDataverseRequest());

--- a/src/main/java/propertyFiles/Bundle.properties
+++ b/src/main/java/propertyFiles/Bundle.properties
@@ -1470,6 +1470,7 @@ dataset.viewVersion.unpublished=View Unpublished Version
 dataset.viewVersion.published=View Published Version
 dataset.link.title=Link Dataset
 dataset.link.save=Save Linked Dataset
+dataset.link.list=List of linked dataverses
 dataset.link.not.to.owner=Can't link a dataset to its dataverse
 dataset.link.not.to.parent.dataverse=Can't link a dataset to its parent dataverses
 dataset.link.not.published=Can't link a dataset that has not been published

--- a/src/main/webapp/dataset.xhtml
+++ b/src/main/webapp/dataset.xhtml
@@ -1612,6 +1612,18 @@
                                 #{bundle.cancel}
                             </button>
                         </div>
+                        <p:fragment id="linkedDataversesList" rendered="#{!empty DatasetPage.linkedDataverses}">
+                            <p style="margin-top: 10px; margin-bottom: 0;"><strong><h:outputText value="#{bundle['dataset.link.list']}" escape="false" /></strong></p>
+                            <ul style="margin-top: 0; padding-top: 0;">
+                                <ui:repeat value="#{DatasetPage.linkedDataverses}" var="linkedDataverse">
+                                    <li>
+                                        <a href="/dataverse/#{linkedDataverse.alias}">
+                                            <h:outputText value="#{linkedDataverse.displayName}" />
+                                        </a>
+                                    </li>
+                                </ui:repeat>
+                            </ul>
+                        </p:fragment>
                     </p:dialog>
                     <p:remoteCommand name="linkDatasetCommand" oncomplete="PF('linkDatasetForm').hide();" update=":messagePanel  @([id$=Messages])" actionListener="#{DatasetPage.saveLinkingDataverses}"/>
                     <p:dialog id="computeBatchListPopup" header="#{bundle['dataset.compute.computeBatchListHeader']}" widgetVar="computeBatchListPopup" modal="true">


### PR DESCRIPTION
**What this PR does / why we need it**:

With this changes the user can see the list of linked dataverses at the dataset page's link edit form.

**Which issue(s) this PR closes**:

It is one step towards #9650 

**Special notes for your reviewer**:

It contains a UI change, but I am not an expert of Dataverse's stylesheet classes. I have created some rough direct formatting via the "style" attribute of HTML elements. A UI expert might give suggestions how to improve it.

**Suggestions on how to test this**:

1. run `mvn clean package` and deploy the war file  to the test environment
2. if you do not have a dataset which is already linked to a dataverse, create a link
3. open the "Link Dataset" form at the dataset page, and check what is below the "Save Linked Dataset" button

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

Here you can find the result:
![Screenshot from 2023-06-19 23-15-07](https://github.com/IQSS/dataverse/assets/218218/c4cc4b7b-b45f-4b53-b0b0-80345f7558ad)

**Is there a release notes update needed for this change?**:
It might worth to mention it that the user now can list the linked dataverses from the dataset page as well.

**Additional documentation**:
