### PR TITLE
9667 - displayFormat added to DatasetFieldType API payload

### DIFF
--- a/doc/release-notes/9667-metadatablocks-api-extension.md
+++ b/doc/release-notes/9667-metadatablocks-api-extension.md
@@ -1,0 +1,1 @@
+DatasetFieldType attribute "displayFormat", is now returned by the API.

--- a/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
@@ -575,6 +575,7 @@ public class JsonPrinter {
         fieldsBld.add("description", fld.getDescription());
         fieldsBld.add("multiple", fld.isAllowMultiples());
         fieldsBld.add("isControlledVocabulary", fld.isControlledVocabulary());
+        fieldsBld.add("displayFormat", fld.getDisplayFormat());
         if (fld.isControlledVocabulary()) {
             // If the field has a controlled vocabulary,
             // add all values to the resulting JSON


### PR DESCRIPTION
## What this PR does / why we need it:

Add displayFormat to the metadata block fields payload, as required by https://github.com/IQSS/dataverse-client-javascript/issues/63

## Which issue(s) this PR closes:

- Closes #9667 

## Special notes for your reviewer:

N/A

## Suggestions on how to test this:

 New field retrieval can be tested via curl:

`curl -H "X-Dataverse-Key: <API_KEY>" -X GET http://localhost:8080/api/v1/metadatablocks/citation`

## Is there a release notes update needed for this change?:

Not sure, since it is a very simple addition. I have added a release note md, just in case.

## Additional documentation:

N/A