### PR TITLE
Remove temporary additions to json export from #9175

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
@@ -654,7 +654,7 @@ public class JsonPrinter {
                 .add("categories", getFileCategories(fileMetadata))
                 .add("embargo", embargo)
                 //.add("released", df.isReleased())
-                .add("restricted", df.isRestricted())
+                //.add("restricted", df.isRestricted())
                 .add("storageIdentifier", df.getStorageIdentifier())
                 .add("originalFileFormat", df.getOriginalFileFormat())
                 .add("originalFormatLabel", df.getOriginalFormatLabel())
@@ -673,12 +673,8 @@ public class JsonPrinter {
                 //---------------------------------------------
                 .add("md5", getMd5IfItExists(df.getChecksumType(), df.getChecksumValue()))
                 .add("checksum", getChecksumTypeAndValue(df.getChecksumType(), df.getChecksumValue()))
-                .add("fileMetadataId", fileMetadata.getId())
                 .add("tabularTags", getTabularFileTags(df))
-                .add("creationDate",  df.getCreateDateFormattedYYYYMMDD())
-                .add("dataTables", df.getDataTables().isEmpty() ? null : JsonPrinter.jsonDT(df.getDataTables()))
-                .add("varGroups", fileMetadata.getVarGroups().isEmpty()
-                        ? null: JsonPrinter.jsonVarGroup(fileMetadata.getVarGroups()));
+                .add("creationDate",  df.getCreateDateFormattedYYYYMMDD());
     }
     
     //Started from https://github.com/RENCI-NRIG/dataverse/, i.e. https://github.com/RENCI-NRIG/dataverse/commit/2b5a1225b42cf1caba85e18abfeb952171c6754a


### PR DESCRIPTION
**What this PR does / why we need it**: In creating the ability to provide variable-level metadata in external exporters, I originally added the required info to the internal json representation. After confirming the approach would work, I created a separate 'fileDetails' json export and adapted the DDIExporter (actually DDIExportUtil class) to use it, but the forgot to restore the internal json representation to its original contents. The accidental additions to that json weren't noticed before the original PR was merged.

**Which issue(s) this PR closes**:

Closes #

**Special notes for your reviewer**:

**Suggestions on how to test this**: Verify that the default json export for a tabular file (with variable-level metadata) doesn't include elements for "restricted", "fileMetadataId", "dataTables", or "varGroups". (The develop branch would have these prior to this PR, but the version 5.13 release would not.)

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
