### PR TITLE
Update for #9677

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/export/InternalExportDataProvider.java
+++ b/src/main/java/edu/harvard/iq/dataverse/export/InternalExportDataProvider.java
@@ -77,7 +77,7 @@ public class InternalExportDataProvider implements ExportDataProvider {
         JsonArrayBuilder jab = Json.createArrayBuilder();
         for (FileMetadata fileMetadata : dv.getFileMetadatas()) {
             DataFile dataFile = fileMetadata.getDataFile();
-            jab.add(JsonPrinter.json(dataFile, fileMetadata));
+            jab.add(JsonPrinter.json(dataFile, fileMetadata, true));
         }
         return jab.build();
     }

--- a/src/main/java/edu/harvard/iq/dataverse/export/ddi/DdiExportUtil.java
+++ b/src/main/java/edu/harvard/iq/dataverse/export/ddi/DdiExportUtil.java
@@ -2074,7 +2074,7 @@ public class DdiExportUtil {
                 // various notes:
                 // this specially formatted note section is used to store the UNF
                 // (Universal Numeric Fingerprint) signature:
-                if (dt.containsKey("UNF") && !dt.getString("UNF").isBlank()) {
+                if ((dt!=null) && (dt.containsKey("UNF") && !dt.getString("UNF").isBlank())) {
                     xmlw.writeStartElement("notes");
                     writeAttribute(xmlw, "level", LEVEL_FILE);
                     writeAttribute(xmlw, "type", NOTE_TYPE_UNF);

--- a/src/main/java/edu/harvard/iq/dataverse/export/ddi/DdiExportUtil.java
+++ b/src/main/java/edu/harvard/iq/dataverse/export/ddi/DdiExportUtil.java
@@ -1733,8 +1733,8 @@ public class DdiExportUtil {
              }
             }
         
-
-            if (fileJson.containsKey("dataTables")) {
+            // originalFileFormat is one of several keys that only exist for tabular data
+            if (fileJson.containsKey("originalFileFormat")) {
                 if (!tabularData) {
                     xmlw.writeStartElement("dataDscr");
                     tabularData = true;
@@ -1745,12 +1745,14 @@ public class DdiExportUtil {
                         createVarGroupDDI(xmlw, varGroups.getJsonObject(j));
                     }
                 }
-                JsonObject dataTable = fileJson.getJsonArray("dataTables").getJsonObject(0);
-                JsonArray vars = dataTable.getJsonArray("dataVariables");
-                if (vars != null) {
-                    for (int j = 0; j < vars.size(); j++) {
-                        createVarDDI(xmlw, vars.getJsonObject(j), fileJson.getJsonNumber("id").toString(),
-                                fileJson.getJsonNumber("fileMetadataId").toString());
+                if (fileJson.containsKey("dataTables")) {
+                    JsonObject dataTable = fileJson.getJsonArray("dataTables").getJsonObject(0);
+                    JsonArray vars = dataTable.getJsonArray("dataVariables");
+                    if (vars != null) {
+                        for (int j = 0; j < vars.size(); j++) {
+                            createVarDDI(xmlw, vars.getJsonObject(j), fileJson.getJsonNumber("id").toString(),
+                                    fileJson.getJsonNumber("fileMetadataId").toString());
+                        }
                     }
                 }
             }

--- a/src/main/java/edu/harvard/iq/dataverse/export/ddi/DdiExportUtil.java
+++ b/src/main/java/edu/harvard/iq/dataverse/export/ddi/DdiExportUtil.java
@@ -1712,7 +1712,7 @@ public class DdiExportUtil {
         // we're not writing the opening <dataDscr> tag until we find an actual 
         // tabular datafile.
         for (int i=0;i<fileDetails.size();i++) {
-            JsonObject fileJson = fileDetails.getJsonObject(0);
+            JsonObject fileJson = fileDetails.getJsonObject(i);
 
             /**
              * Previously (in Dataverse 5.3 and below) the dataDscr section was
@@ -1721,7 +1721,7 @@ public class DdiExportUtil {
              * should instead use the "Data Variable Metadata Access" endpoint.)
              * These days we skip restricted files to avoid this exposure.
              */
-            if (fileJson.getBoolean("restricted")) {
+            if (fileJson.containsKey("restricted") && fileJson.getBoolean("restricted")) {
                 continue;
             }
             if(fileJson.containsKey("embargo")) {

--- a/src/main/java/edu/harvard/iq/dataverse/export/ddi/DdiExportUtil.java
+++ b/src/main/java/edu/harvard/iq/dataverse/export/ddi/DdiExportUtil.java
@@ -1733,8 +1733,7 @@ public class DdiExportUtil {
              }
             }
         
-            // originalFileFormat is one of several keys that only exist for tabular data
-            if (fileJson.containsKey("originalFileFormat")) {
+            if (fileJson.containsKey("dataTables")) {
                 if (!tabularData) {
                     xmlw.writeStartElement("dataDscr");
                     tabularData = true;
@@ -1745,14 +1744,12 @@ public class DdiExportUtil {
                         createVarGroupDDI(xmlw, varGroups.getJsonObject(j));
                     }
                 }
-                if (fileJson.containsKey("dataTables")) {
-                    JsonObject dataTable = fileJson.getJsonArray("dataTables").getJsonObject(0);
-                    JsonArray vars = dataTable.getJsonArray("dataVariables");
-                    if (vars != null) {
-                        for (int j = 0; j < vars.size(); j++) {
-                            createVarDDI(xmlw, vars.getJsonObject(j), fileJson.getJsonNumber("id").toString(),
-                                    fileJson.getJsonNumber("fileMetadataId").toString());
-                        }
+                JsonObject dataTable = fileJson.getJsonArray("dataTables").getJsonObject(0);
+                JsonArray vars = dataTable.getJsonArray("dataVariables");
+                if (vars != null) {
+                    for (int j = 0; j < vars.size(); j++) {
+                        createVarDDI(xmlw, vars.getJsonObject(j), fileJson.getJsonNumber("id").toString(),
+                                fileJson.getJsonNumber("fileMetadataId").toString());
                     }
                 }
             }
@@ -2027,9 +2024,12 @@ public class DdiExportUtil {
         String dataverseUrl = SystemConfig.getDataverseSiteUrlStatic();
         for (int i =0;i<fileDetails.size();i++) {
             JsonObject fileJson = fileDetails.getJsonObject(i);
-
-            if (fileJson.containsKey("dataTables")) {
-                JsonObject dt = fileJson.getJsonArray("dataTables").getJsonObject(0);
+            //originalFileFormat is one of several keys that only exist for tabular data
+            if (fileJson.containsKey("originalFileFormat")) {
+                JsonObject dt = null;
+                if (fileJson.containsKey("dataTables")) {
+                    dt = fileJson.getJsonArray("dataTables").getJsonObject(0);
+                }
                 xmlw.writeStartElement("fileDscr");
                 String fileId = fileJson.getJsonNumber("id").toString();
                 writeAttribute(xmlw, "ID", "f" + fileId);
@@ -2040,7 +2040,8 @@ public class DdiExportUtil {
                 xmlw.writeCharacters(fileJson.getString("filename"));
                 xmlw.writeEndElement(); // fileName
 
-                if (dt.containsKey("caseQuantity") || dt.containsKey("varQuantity") || dt.containsKey("recordsPerCase")) {
+                if (dt != null && (dt.containsKey("caseQuantity") || dt.containsKey("varQuantity")
+                        || dt.containsKey("recordsPerCase"))) {
                     xmlw.writeStartElement("dimensns");
 
                     if (dt.containsKey("caseQuantity")) {

--- a/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
@@ -617,7 +617,7 @@ public class JsonPrinter {
                 .add("version", fmd.getVersion())
                 .add("datasetVersionId", fmd.getDatasetVersion().getId())
                 .add("categories", getFileCategories(fmd))
-                .add("dataFile", JsonPrinter.json(fmd.getDataFile(), fmd));
+                .add("dataFile", JsonPrinter.json(fmd.getDataFile(), fmd, false));
     }
 
       public static JsonObjectBuilder json(AuxiliaryFile auxFile) {
@@ -633,10 +633,10 @@ public class JsonPrinter {
                 .add("dataFile", JsonPrinter.json(auxFile.getDataFile()));
     }
     public static JsonObjectBuilder json(DataFile df) {
-        return JsonPrinter.json(df, null);
+        return JsonPrinter.json(df, null, false);
     }
     
-    public static JsonObjectBuilder json(DataFile df, FileMetadata fileMetadata) {
+    public static JsonObjectBuilder json(DataFile df, FileMetadata fileMetadata, boolean forExportDataProvider) {
         // File names are no longer stored in the DataFile entity; 
         // (they are instead in the FileMetadata (as "labels") - this way 
         // the filename can change between versions... 
@@ -661,7 +661,7 @@ public class JsonPrinter {
 
         JsonObjectBuilder embargo = df.getEmbargo() != null ? JsonPrinter.json(df.getEmbargo()) : null;
 
-        return jsonObjectBuilder()
+        NullSafeJsonBuilder builder = jsonObjectBuilder()
                 .add("id", df.getId())
                 .add("persistentId", pidString)
                 .add("pidURL", pidURL)
@@ -672,7 +672,6 @@ public class JsonPrinter {
                 .add("categories", getFileCategories(fileMetadata))
                 .add("embargo", embargo)
                 //.add("released", df.isReleased())
-                //.add("restricted", df.isRestricted())
                 .add("storageIdentifier", df.getStorageIdentifier())
                 .add("originalFileFormat", df.getOriginalFileFormat())
                 .add("originalFormatLabel", df.getOriginalFormatLabel())
@@ -692,7 +691,16 @@ public class JsonPrinter {
                 .add("md5", getMd5IfItExists(df.getChecksumType(), df.getChecksumValue()))
                 .add("checksum", getChecksumTypeAndValue(df.getChecksumType(), df.getChecksumValue()))
                 .add("tabularTags", getTabularFileTags(df))
-                .add("creationDate",  df.getCreateDateFormattedYYYYMMDD());
+                .add("creationDate", df.getCreateDateFormattedYYYYMMDD());
+        /*
+         * The restricted state was not included prior to #9175 so to avoid backward
+         * incompatability, it is now only added when generating json for the
+         * InternalExportDataProvider fileDetails.
+         */
+        if (forExportDataProvider) {
+            builder.add("restricted", df.isRestricted());
+        }
+        return builder;
     }
     
     //Started from https://github.com/RENCI-NRIG/dataverse/, i.e. https://github.com/RENCI-NRIG/dataverse/commit/2b5a1225b42cf1caba85e18abfeb952171c6754a


### PR DESCRIPTION
**What this PR does / why we need it**: The fix from #9677 removed the "restricted" key from the dataset fileDetails provided via the InternalExportDataProvider. Since this detail is not available via the DataFileDTO used in DdiExporterUtil, this PR adds the restricted key back but only when the JsonPrinter method is called from the InternalExportDataProvider. This maintains backward compatibility while fixing the issue. (Further refactoring/updating the DTOs, etc. might be cleaner - e.g. in the context of #9463)


**Which issue(s) this PR closes**:

Closes #

**Special notes for your reviewer**:

**Suggestions on how to test this**:

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
