### PR TITLE
DANS - Add embargo info to ORE map (and therefore bag export)

### DIFF
--- a/doc/release-notes/9698-embargo-info-in-ORE.md
+++ b/doc/release-notes/9698-embargo-info-in-ORE.md
@@ -1,0 +1,1 @@
+The OAI_ORE metadata export (and hence the archival Bag for a dataset) now includes information about file embargoes

--- a/src/main/java/edu/harvard/iq/dataverse/util/bagit/OREMap.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/bagit/OREMap.java
@@ -10,6 +10,7 @@ import edu.harvard.iq.dataverse.DatasetFieldType;
 import edu.harvard.iq.dataverse.DatasetVersion;
 import edu.harvard.iq.dataverse.Dataverse;
 import edu.harvard.iq.dataverse.DvObjectContainer;
+import edu.harvard.iq.dataverse.Embargo;
 import edu.harvard.iq.dataverse.FileMetadata;
 import edu.harvard.iq.dataverse.TermsOfUseAndAccess;
 import edu.harvard.iq.dataverse.branding.BrandingUtil;
@@ -193,6 +194,17 @@ public class OREMap {
                 }
                 addIfNotNull(aggRes, JsonLDTerm.schemaOrg("name"), fileName); 
                 addIfNotNull(aggRes, JsonLDTerm.restricted, fmd.isRestricted());
+                Embargo embargo=df.getEmbargo(); 
+                if(embargo!=null) {
+                    String date = embargo.getFormattedDateAvailable();
+                    String reason= embargo.getReason();
+                    JsonObjectBuilder embargoObject = Json.createObjectBuilder();
+                    embargoObject.add(JsonLDTerm.DVCore("dateAvailable").getLabel(), date);
+                    if(reason!=null) {
+                        embargoObject.add(JsonLDTerm.DVCore("reason").getLabel(), reason);
+                    }
+                    aggRes.add(JsonLDTerm.DVCore("embargoed").getLabel(), embargoObject);
+                }
                 addIfNotNull(aggRes, JsonLDTerm.directoryLabel, fmd.getDirectoryLabel());
                 addIfNotNull(aggRes, JsonLDTerm.schemaOrg("version"), fmd.getVersion());
                 addIfNotNull(aggRes, JsonLDTerm.datasetVersionId, fmd.getDatasetVersion().getId());

--- a/src/main/java/edu/harvard/iq/dataverse/util/json/JsonLDTerm.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/json/JsonLDTerm.java
@@ -29,6 +29,9 @@ public class JsonLDTerm {
     public static JsonLDTerm studyCompletion = JsonLDTerm.DVCore("studyCompletion");
 
     public static JsonLDTerm restricted = JsonLDTerm.DVCore("restricted");
+    public static JsonLDTerm embargoed = JsonLDTerm.DVCore("embargoed");
+    public static JsonLDTerm embargoDateAvailable = JsonLDTerm.DVCore("dateAvailable");
+    public static JsonLDTerm embargoReason = JsonLDTerm.DVCore("reason");
     public static JsonLDTerm directoryLabel = JsonLDTerm.DVCore("directoryLabel");
     public static JsonLDTerm datasetVersionId = JsonLDTerm.DVCore("datasetVersionId");
     public static JsonLDTerm categories = JsonLDTerm.DVCore("categories");


### PR DESCRIPTION
**What this PR does / why we need it**: The original work to add embargoes did not include adding information about the embargo to the OAI_ORE export and therefore the exported archival Bags. (I think I was hoping to find existing semantic terms to reuse, which hasn't happened. http://purl.org/spar/fabio/hasEmbargoDate could be used but there's no equivalent for reason). This PR adds embargo info to the OAI_ORE file using new terms for "embargoed", "dateAvailable", and "reason" in the DVCore namespace (https://dataverse.org/schema/core#). This will allow DANS (and others) to move forward in using embargoes with archiving.

**Which issue(s) this PR closes**:

Closes #

**Special notes for your reviewer**:

**Suggestions on how to test this**: Add embargoes to files - with/without optional reasons and verify that after publication the OAI_ORE file has their date and optional reason formatted like
```
"dvcore:embargoed": {
    "dvcore:dateAvailable": "2023-08-17",
    "dvcore:reason": "super secret stuff in here"
}

```
**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**: yes

**Additional documentation**:
