### PR TITLE
update configbaker to included recent version of ed

### DIFF
--- a/modules/container-configbaker/Dockerfile
+++ b/modules/container-configbaker/Dockerfile
@@ -18,7 +18,7 @@ ENV SCRIPT_DIR="/scripts" \
 ENV PATH="${PATH}:${SCRIPT_DIR}" \
     BOOTSTRAP_DIR="${SCRIPT_DIR}/bootstrap"
 
-ARG APK_PACKAGES="curl bind-tools netcat-openbsd jq bash dumb-init wait4x"
+ARG APK_PACKAGES="curl bind-tools netcat-openbsd jq bash dumb-init wait4x ed"
 
 RUN true && \
   # Install necessary software and tools


### PR DESCRIPTION

**What this PR does / why we need it**:
The config baker image is unable to execute the `update-fields.sh` without the updated dependency.
**Which issue(s) this PR closes**:
```
# curl "http://${DATAVERSE_HOSTNAME}:8080/api/admin/index/solr/schema" | /scripts/update-fields.sh /template/conf/schema.xml
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 23010    0 23010    0     0   313k      0 --:--:-- --:--:-- --:--:--  316k
ed: unimplemented command
ed: can't find string "SCHEMA-FIELDS::BEGIN"
ed: can't find string "SCHEMA-FIELDS::END"
ed: bad line range for delete
ed: unimplemented command
ed: can't find string "SCHEMA-COPY-FIELDS::BEGIN"
ed: can't find string "SCHEMA-COPY-FIELDS::END"
ed: bad line range for delete
```
**Suggestions on how to test this**: Execute 
**Is there a release notes update needed for this change?**: No
**Additional documentation**: No
