### PR TITLE
reduce logging and fix typo

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
@@ -1891,7 +1891,7 @@ public class DatasetPage implements java.io.Serializable {
                 //retrieveDatasetVersionResponse = datasetVersionService.retrieveDatasetVersionById(dataset.getId(), version);
                 retrieveDatasetVersionResponse = datasetVersionService.selectRequestedVersion(dataset.getVersions(), version);
                 this.workingVersion = retrieveDatasetVersionResponse.getDatasetVersion();
-                logger.info("retreived version: id: " + workingVersion.getId() + ", state: " + this.workingVersion.getVersionState());
+                logger.fine("retrieved version: id: " + workingVersion.getId() + ", state: " + this.workingVersion.getVersionState());
 
             } else if (versionId != null) {
                 // TODO: 4.2.1 - this method is broken as of now!


### PR DESCRIPTION
**What this PR does / why we need it**:

Logs are too chatty after #9558 was merged. See https://iqss.slack.com/archives/C010LA04BCG/p1689620939737689

**Which issue(s) this PR closes**:

None

**Special notes for your reviewer**:

Found during perf testing:

- #9672

The logging was added a looong time ago: a129c9a. I assume it was just for troubleshooting.

Why is it different now that 5.14? If you look at 5.14 at https://github.com/IQSS/dataverse/blob/v5.13/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java#L1871 you'll see that `if (persistentId != null) {` was the first in a series of `if else` clauses. Presumably that first `if` was executed a lot.

Now instead of `} else if (this.getId() != null) {`...
... we have `if (this.getId() != null) {` with no `else` so it gets executed a lot more.  This change was made in 64743bf as part of this PR:

- #9558

**Suggestions on how to test this**:

In Docker, without the reduced logging, I see this when I load a dataset:

```
dev_dataverse>  retreived version: id: 1, state: RELEASED|#]
```

I've been testing by loading a published dataset landing page.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No

**Is there a release notes update needed for this change?**:

No

**Additional documentation**:

None.