### PR TITLE
MDC Legacy counts: Remove duplicate elements from bad merge

### DIFF
--- a/src/main/webapp/file.xhtml
+++ b/src/main/webapp/file.xhtml
@@ -284,6 +284,7 @@
                                                     data-trigger="focus" data-html="true" data-content="#{bundle['metrics.file.tip.makedatacount']}"></a>
                                             </ui:fragment>
                                         </div>
+                                        <!-- END DATASET CITATION -->
                                         <div id="metrics-body">
                                             <!-- Classic downloads -->
                                             <div class="metrics-count-block" jsf:rendered="#{!settingsWrapper.makeDataCountDisplayEnabled}">

--- a/src/main/webapp/file.xhtml
+++ b/src/main/webapp/file.xhtml
@@ -284,39 +284,22 @@
                                                     data-trigger="focus" data-html="true" data-content="#{bundle['metrics.file.tip.makedatacount']}"></a>
                                             </ui:fragment>
                                         </div>
-                                        <!-- END DATASET CITATION -->
-                                        <!-- Metrics -->
-                                        <div class="col-sm-3">
-                                            <div id="metrics-block" jsf:rendered="#{!(widgetWrapper.widgetView or FilePage.fileMetadata.dataFile.filePackage or FilePage.fileMetadata.datasetVersion.deaccessioned)}">
-                                                <div id="metrics-heading">
-                                                    #{bundle['metrics.file.title']}
-                                                    <ui:fragment rendered="#{!settingsWrapper.makeDataCountDisplayEnabled}">
-                                                        <span class="glyphicon glyphicon-question-sign tooltip-icon" data-toggle="tooltip" data-placement="auto top" 
-                                                            data-trigger="hover" data-original-title="#{bundle['metrics.dataset.tip.default']}"></span>
-                                                    </ui:fragment>
-                                                    <ui:fragment rendered="#{settingsWrapper.makeDataCountDisplayEnabled}">
-                                                        <a tabindex="0" role="button" class="glyphicon glyphicon-question-sign tooltip-icon" data-toggle="popover" data-placement="auto top" 
-                                                            data-trigger="focus" data-html="true" data-content="#{bundle['metrics.dataset.tip.makedatacount']}"></a>
-                                                    </ui:fragment>
-                                                </div>
-                                                <div id="metrics-body">
-                                                    <!-- Classic downloads -->
-                                                    <div class="metrics-count-block" jsf:rendered="#{!settingsWrapper.makeDataCountDisplayEnabled}">
-                                                        <h:outputFormat value="{0} #{bundle['metrics.downloads']}">
-                                                            <f:param value="#{guestbookResponseServiceBean.getCountGuestbookResponsesByDataFileId(FilePage.fileId)}"/>
-                                                        </h:outputFormat>
-                                                        <span class="glyphicon glyphicon-question-sign tooltip-icon"
-                                                              data-toggle="tooltip" data-placement="auto top" data-original-title="#{bundle['metrics.file.downloads.tip']}"></span>
-                                                    </div>
-                                                    <!-- Make Data Count downloads -->
-                                                    <div class="metrics-count-block" jsf:rendered="#{settingsWrapper.makeDataCountDisplayEnabled}">
-                                                        <h:outputFormat value="{0} #{bundle['metrics.downloads']}">
-                                                            <f:param value="#{guestbookResponseServiceBean.getCountGuestbookResponsesByDataFileId(FilePage.fileId)}"/>
-                                                        </h:outputFormat>
-                                                        <span class="glyphicon glyphicon-question-sign tooltip-icon"
-                                                                data-toggle="tooltip" data-placement="auto top" data-original-title="#{bundle['metrics.file.downloads.nonmdc.tip']}"></span>
-                                                    </div>
-                                                </div>
+                                        <div id="metrics-body">
+                                            <!-- Classic downloads -->
+                                            <div class="metrics-count-block" jsf:rendered="#{!settingsWrapper.makeDataCountDisplayEnabled}">
+                                                <h:outputFormat value="{0} #{bundle['metrics.downloads']}">
+                                                    <f:param value="#{guestbookResponseServiceBean.getCountGuestbookResponsesByDataFileId(FilePage.fileId)}"/>
+                                                </h:outputFormat>
+                                                <span class="glyphicon glyphicon-question-sign tooltip-icon"
+                                                      data-toggle="tooltip" data-placement="auto top" data-original-title="#{bundle['metrics.file.downloads.tip']}"></span>
+                                            </div>
+                                            <!-- Make Data Count downloads -->
+                                            <div class="metrics-count-block" jsf:rendered="#{settingsWrapper.makeDataCountDisplayEnabled}">
+                                                <h:outputFormat value="{0} #{bundle['metrics.downloads']}">
+                                                    <f:param value="#{guestbookResponseServiceBean.getCountGuestbookResponsesByDataFileId(FilePage.fileId)}"/>
+                                                </h:outputFormat>
+                                                <span class="glyphicon glyphicon-question-sign tooltip-icon"
+                                                        data-toggle="tooltip" data-placement="auto top" data-original-title="#{bundle['metrics.file.downloads.nonmdc.tip']}"></span>
                                             </div>
                                         </div>
                                     </div>


### PR DESCRIPTION
**What this PR does / why we need it**: #6543 has duplicate file page elements for the metrics-block - probably due to a bad merge at some point. 

![image](https://github.com/IQSS/dataverse/assets/6731983/1477f5b3-3061-4ed9-bf0d-be59371d90b1)

This PR corrects the block so that there is only one block showing.

**Which issue(s) this PR closes**:

Closes #

**Special notes for your reviewer**:

**Suggestions on how to test this**: Look at the file page and verify only one metadata block, and that the size ~fills the area in that part of the page (and doesn't look like the image here).

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
