### PR TITLE
Iqss/8889 limit file pids management

### DIFF
--- a/doc/sphinx-guides/source/admin/dataverses-datasets.rst
+++ b/doc/sphinx-guides/source/admin/dataverses-datasets.rst
@@ -154,15 +154,18 @@ In the following example, the database id of the file is 42::
 
     export FILE_ID=42
     curl "http://localhost:8080/api/admin/$FILE_ID/registerDataFile"
+    
+This method will return a FORBIDDEN response if minting of file PIDs is not enabled for the collection the file is in. (Note that it is possible to have it enabled for a specific collection, even when it is disabled for the Dataverse installation as a whole. See :ref:`collection-attributes-api` in the Native API Guide.)
 
 Mint PIDs for all unregistered published files in the specified collection
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The following API will register the PIDs for all the yet unregistered published files in the datasets **directly within the collection** specified by its alias::
+The following API will register the PIDs for all the yet unregistered published files in the datasets **directly within the collection** specified by its alias.::
 
     curl "http://localhost:8080/api/admin/registerDataFiles/{collection_alias}"
 
-It will not attempt to register the datafiles in its sub-collections, so this call will need to be repeated on any sub-collections where files need to be registered as well. File-level PID registration must be enabled on the collection. (Note that it is possible to have it enabled for a specific collection, even when it is disabled for the Dataverse installation as a whole. See :ref:`collection-attributes-api` in the Native API Guide.)
+It will not attempt to register the datafiles in its sub-collections, so this call will need to be repeated on any sub-collections where files need to be registered as well.
+File-level PID registration must be enabled on the collection. (Note that it is possible to have it enabled for a specific collection, even when it is disabled for the Dataverse installation as a whole. See :ref:`collection-attributes-api` in the Native API Guide.)
 
 This API will sleep for 1 second between registration calls by default. A longer sleep interval can be specified with an optional ``sleep=`` parameter::
 
@@ -171,7 +174,7 @@ This API will sleep for 1 second between registration calls by default. A longer
 Mint PIDs for ALL unregistered files in the database
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The following API will attempt to register the PIDs for all the published files in your instance that do not yet have them::
+The following API will attempt to register the PIDs for all the published files in your instance, in collections that allow file PIDs, that do not yet have them::
 
     curl http://localhost:8080/api/admin/registerDataFileAll
 

--- a/doc/sphinx-guides/source/api/native-api.rst
+++ b/doc/sphinx-guides/source/api/native-api.rst
@@ -753,7 +753,7 @@ The following attributes are supported:
 * ``name`` Name
 * ``description`` Description
 * ``affiliation`` Affiliation
-* ``filePIDsEnabled`` ("true" or "false") Enables or disables registration of file-level PIDs in datasets within the collection (overriding the instance-wide setting).
+* ``filePIDsEnabled`` ("true" or "false") Restricted to use by superusers and only when the global :ref:`:FilePIDsEnabled <:FilePIDsEnabled>` is set. Enables or disables registration of file-level PIDs in datasets within the collection (overriding the instance-wide setting).
 
 
 Datasets

--- a/doc/sphinx-guides/source/installation/config.rst
+++ b/doc/sphinx-guides/source/installation/config.rst
@@ -248,7 +248,7 @@ this provider.
 - :ref:`:Shoulder <:Shoulder>`
 - :ref:`:IdentifierGenerationStyle <:IdentifierGenerationStyle>` (optional)
 - :ref:`:DataFilePIDFormat <:DataFilePIDFormat>` (optional)
-- :ref:`:FilePIDsEnabled <:FilePIDsEnabled>` (optional, defaults to true)
+- :ref:`:FilePIDsEnabled <:FilePIDsEnabled>` (optional, defaults to false)
 
 .. _pids-handle-configuration:
 
@@ -297,7 +297,7 @@ Here are the configuration options for PermaLinks:
 - :ref:`:Shoulder <:Shoulder>`
 - :ref:`:IdentifierGenerationStyle <:IdentifierGenerationStyle>` (optional)
 - :ref:`:DataFilePIDFormat <:DataFilePIDFormat>` (optional)
-- :ref:`:FilePIDsEnabled <:FilePIDsEnabled>` (optional, defaults to true)
+- :ref:`:FilePIDsEnabled <:FilePIDsEnabled>` (optional, defaults to false)
 
 .. _auth-modes:
 
@@ -2775,14 +2775,20 @@ timestamps.
 :FilePIDsEnabled
 ++++++++++++++++
 
-Toggles publishing of file-level PIDs for the entire installation. By default this setting is absent and Dataverse Software assumes it to be true. If enabled, the registration will be performed asynchronously (in the background) during publishing of a dataset.
+Toggles publishing of file-level PIDs for the entire installation. By default this setting is absent and Dataverse Software assumes it to be false. If enabled, the registration will be performed asynchronously (in the background) during publishing of a dataset.
 
-If you don't want to register file-based PIDs for your installation, set:
+It is possible to override the installation-wide setting for specific collections, but only if it is set to true or false (and not left undefined). For example, registration of PIDs for files can be enabled in a specific collection when it is disabled instance-wide. Or it can be disabled in specific collections where it is enabled by default. See :ref:`collection-attributes-api` for details. 
+
+To enable file-level PIDs for the entire installation::
+
+``curl -X PUT -d 'true' http://localhost:8080/api/admin/settings/:FilePIDsEnabled``
+
+
+If you don't want to register file-based PIDs for your entire installation, but do want to allow them to be enabled for a given collection set:
 
 ``curl -X PUT -d 'false' http://localhost:8080/api/admin/settings/:FilePIDsEnabled``
 
 
-It is possible to override the installation-wide setting for specific collections. For example, registration of PIDs for files can be enabled in a specific collection when it is disabled instance-wide. Or it can be disabled in specific collections where it is enabled by default. See :ref:`collection-attributes-api` for details. 
 
 .. _:IndependentHandleService:
 

--- a/src/main/java/edu/harvard/iq/dataverse/api/Admin.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Admin.java
@@ -1514,6 +1514,9 @@ public class Admin extends AbstractApiBean {
             User u = getRequestUser(crc);
             DataverseRequest r = createDataverseRequest(u);
             DataFile df = findDataFileOrDie(id);
+            if(!systemConfig.isFilePIDsEnabledForCollection(df.getOwner().getOwner())) {
+                return forbidden("PIDs are not enabled for this file's collection.");
+            }
             if (df.getIdentifier() == null || df.getIdentifier().isEmpty()) {
                 execCommand(new RegisterDvObjectCommand(r, df));
             } else {
@@ -1537,11 +1540,18 @@ public class Admin extends AbstractApiBean {
         Integer alreadyRegistered = 0;
         Integer released = 0;
         Integer draft = 0;
+        Integer skipped = 0;
         logger.info("Starting to register: analyzing " + count + " files. " + new Date());
         logger.info("Only unregistered, published files will be registered.");
         for (DataFile df : fileService.findAll()) {
             try {
                 if ((df.getIdentifier() == null || df.getIdentifier().isEmpty())) {
+                    if(!systemConfig.isFilePIDsEnabledForCollection(df.getOwner().getOwner())) {
+                        skipped++;
+                        if (skipped % 100 == 0) {
+                            logger.info(skipped + " of  " + count + " files not in collections that allow file PIDs. " + new Date());
+                        }
+                    }
                     if (df.isReleased()) {
                         released++;
                         User u = getRequestAuthenticatedUserOrDie(crc);
@@ -1550,6 +1560,11 @@ public class Admin extends AbstractApiBean {
                         successes++;
                         if (successes % 100 == 0) {
                             logger.info(successes + " of  " + count + " files registered successfully. " + new Date());
+                        }
+                        try {
+                            Thread.sleep(1000);
+                        } catch (InterruptedException ie) {
+                            logger.warning("Interrupted Exception when attempting to execute Thread.sleep()!");
                         }
                     } else {
                         draft++;
@@ -1567,11 +1582,7 @@ public class Admin extends AbstractApiBean {
                 logger.info("Unexpected Exception: " + e.getMessage());
             }
             
-            try {
-                Thread.sleep(1000);
-            } catch (InterruptedException ie) {
-                logger.warning("Interrupted Exception when attempting to execute Thread.sleep()!");
-            }
+
         }
         logger.info("Final Results:");
         logger.info(alreadyRegistered + " of  " + count + " files were already registered. " + new Date());
@@ -1579,6 +1590,7 @@ public class Admin extends AbstractApiBean {
         logger.info(released + " of  " + count + " unregistered, published files to register. " + new Date());
         logger.info(successes + " of  " + released + " unregistered, published files registered successfully. "
                 + new Date());
+        logger.info(skipped + " of  " + count + " files not in collections that allow file PIDs. " + new Date());
 
         return ok("Datafile registration complete." + successes + " of  " + released
                 + " unregistered, published files registered successfully.");

--- a/src/main/java/edu/harvard/iq/dataverse/api/Dataverses.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Dataverses.java
@@ -636,6 +636,12 @@ public class Dataverses extends AbstractApiBean {
                     break;
                  */
                 case "filePIDsEnabled":
+                    if(!user.isSuperuser()) {
+                        return forbidden("You must be a superuser to change this setting");
+                    }
+                    if(settingsService.getValueForKey(SettingsServiceBean.Key.FilePIDsEnabled)==null) {
+                        return forbidden("File PIDs are not enabled on this server");
+                    }
                     collection.setFilePIDsEnabled(parseBooleanOrDie(value));
                     break;
                 default:


### PR DESCRIPTION
**What this PR does / why we need it**: This PR adds restriction to who can enable file PIDs for a given collection and when. Changing the setting via the API now requires a superuser and is only allowed if the global :FilePIDsEnabled setting is set (to true or false, but not undefined/non-existent).

The PR also tightens the admin API calls to register a file, all files in a collection, or all files globally to follow the per-collection setting for file PIDs.

Docs have been updated.

Also one minor change to the batch file PID calls - the sleep now only applies when a file is registered (when the register command is called) and not for files that are skipped/in a draft version, etc.

**Which issue(s) this PR closes**:

Closes #8889 

**Special notes for your reviewer**:

**Suggestions on how to test this**: Regression testing should assure the collection-level file PID functionality still works. The changes here can be tested by calling the change collection attributes API call to change the file pids setting - as a superuser/normal user, when the :FilePIDsEnabled setting is set (true or false)/isn't set. (The former in each pair should succeed, the latter should not.)

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**: I think the release notes are generic w.r.t. these changes, - could possibly say the new collection-level file pid functionlity is optional (versus always enabled).

**Additional documentation**:
