### PR TITLE
IQSS/8889 - second try to limit file pids management

### DIFF
--- a/doc/release-notes/8889-2-filepids-in-collections-changes.md
+++ b/doc/release-notes/8889-2-filepids-in-collections-changes.md
@@ -1,0 +1,5 @@
+The default for whether PIDs are registerd for files or not is now false. For those who had file PIDs enabled by default, updating to this release will add the :FilePIDsEnabled = true setting to maintain your existing functionality.
+
+It is now possible to allow File PIDs to be enabled/disabled per collection. See the [:AllowEnablingFilePIDsPerCollection](https://guides.dataverse.org/en/latest/installation/config.html#filepidsenabled) section of the Configuration guide for details.
+
+For example, registration of PIDs for files can be enabled in a specific collection when it is disabled instance-wide. Or it can be disabled in specific collections where it is enabled by default. 

--- a/doc/release-notes/8889-2-filepids-in-collections-changes.md
+++ b/doc/release-notes/8889-2-filepids-in-collections-changes.md
@@ -1,5 +1,5 @@
-The default for whether PIDs are registerd for files or not is now false. For those who had file PIDs enabled by default, updating to this release will add the :FilePIDsEnabled = true setting to maintain your existing functionality.
+The default for whether PIDs are registered for files or not is now false. For those who had file PIDs enabled by default, updating to this release will automatically add the :FilePIDsEnabled = true setting to maintain your existing functionality.
 
-It is now possible to allow File PIDs to be enabled/disabled per collection. See the [:AllowEnablingFilePIDsPerCollection](https://guides.dataverse.org/en/latest/installation/config.html#filepidsenabled) section of the Configuration guide for details.
+It is now possible to allow File PIDs to be enabled/disabled per collection. See the [:AllowEnablingFilePIDsPerCollection](https://guides.dataverse.org/en/latest/installation/config.html#allowenablingfilepidspercollection) section of the Configuration guide for details.
 
-For example, registration of PIDs for files can be enabled in a specific collection when it is disabled instance-wide. Or it can be disabled in specific collections where it is enabled by default. 
+For example, registration of PIDs for files can now be enabled in a specific collection when it is disabled instance-wide. Or it can be disabled in specific collections where it is enabled by default. 

--- a/doc/release-notes/8889-2-filepids-in-collections-changes.md
+++ b/doc/release-notes/8889-2-filepids-in-collections-changes.md
@@ -1,5 +1,0 @@
-The default for whether PIDs are registerd for files or not is now false. For those who had file PIDs enabled by default, updating to this release will add the :FilePIDsEnabled = true setting to maintain your existing functionality.
-
-It is now possible to allow File PIDs to be enabled/disabled per collection. See the [:AllowEnablingFilePIDsPerCollection](https://guides.dataverse.org/en/latest/installation/config.html#filepidsenabled) section of the Configuration guide for details.
-
-For example, registration of PIDs for files can be enabled in a specific collection when it is disabled instance-wide. Or it can be disabled in specific collections where it is enabled by default. 

--- a/doc/release-notes/8889-2-filepids-in-collections-changes.md
+++ b/doc/release-notes/8889-2-filepids-in-collections-changes.md
@@ -1,4 +1,14 @@
-The default for whether PIDs are registered for files or not is now false. For those who had file PIDs enabled by default, updating to this release will automatically add the :FilePIDsEnabled = true setting to maintain your existing functionality.
+The default for whether PIDs are registered for files or not is now false.
+
+Installations where file PIDs were enabled by default will have to add the :FilePIDsEnabled = true setting to maintain the existing functionality.
+
+Add step to install:
+
+  If your installation did not have :FilePIDsEnabled set, you will need to set it to true to keep file PIDs enabled:
+
+  curl -X PUT -d 'true' http://localhost:8080/api/admin/settings/:FilePIDsEnabled
+
+
 
 It is now possible to allow File PIDs to be enabled/disabled per collection. See the [:AllowEnablingFilePIDsPerCollection](https://guides.dataverse.org/en/latest/installation/config.html#allowenablingfilepidspercollection) section of the Configuration guide for details.
 

--- a/doc/sphinx-guides/source/admin/dataverses-datasets.rst
+++ b/doc/sphinx-guides/source/admin/dataverses-datasets.rst
@@ -154,18 +154,15 @@ In the following example, the database id of the file is 42::
 
     export FILE_ID=42
     curl "http://localhost:8080/api/admin/$FILE_ID/registerDataFile"
-    
-This method will return a FORBIDDEN response if minting of file PIDs is not enabled for the collection the file is in. (Note that it is possible to have it enabled for a specific collection, even when it is disabled for the Dataverse installation as a whole. See :ref:`collection-attributes-api` in the Native API Guide.)
 
 Mint PIDs for all unregistered published files in the specified collection
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The following API will register the PIDs for all the yet unregistered published files in the datasets **directly within the collection** specified by its alias.::
+The following API will register the PIDs for all the yet unregistered published files in the datasets **directly within the collection** specified by its alias::
 
     curl "http://localhost:8080/api/admin/registerDataFiles/{collection_alias}"
 
-It will not attempt to register the datafiles in its sub-collections, so this call will need to be repeated on any sub-collections where files need to be registered as well.
-File-level PID registration must be enabled on the collection. (Note that it is possible to have it enabled for a specific collection, even when it is disabled for the Dataverse installation as a whole. See :ref:`collection-attributes-api` in the Native API Guide.)
+It will not attempt to register the datafiles in its sub-collections, so this call will need to be repeated on any sub-collections where files need to be registered as well. File-level PID registration must be enabled on the collection. (Note that it is possible to have it enabled for a specific collection, even when it is disabled for the Dataverse installation as a whole. See :ref:`collection-attributes-api` in the Native API Guide.)
 
 This API will sleep for 1 second between registration calls by default. A longer sleep interval can be specified with an optional ``sleep=`` parameter::
 
@@ -174,7 +171,7 @@ This API will sleep for 1 second between registration calls by default. A longer
 Mint PIDs for ALL unregistered files in the database
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The following API will attempt to register the PIDs for all the published files in your instance, in collections that allow file PIDs, that do not yet have them::
+The following API will attempt to register the PIDs for all the published files in your instance that do not yet have them::
 
     curl http://localhost:8080/api/admin/registerDataFileAll
 

--- a/doc/sphinx-guides/source/admin/dataverses-datasets.rst
+++ b/doc/sphinx-guides/source/admin/dataverses-datasets.rst
@@ -155,12 +155,12 @@ In the following example, the database id of the file is 42::
     export FILE_ID=42
     curl "http://localhost:8080/api/admin/$FILE_ID/registerDataFile"
     
-This method will return a FORBIDDEN response if minting of file PIDs is not enabled for the collection the file is in. (Note that it is possible to have it enabled for a specific collection, even when it is disabled for the Dataverse installation as a whole. See :ref:`collection-attributes-api` in the Native API Guide.)
+This method will return a FORBIDDEN response if minting of file PIDs is not enabled for the collection the file is in. (Note that it is possible to have file PIDs enabled for a specific collection, even when it is disabled for the Dataverse installation as a whole. See :ref:`collection-attributes-api` in the Native API Guide.)
 
 Mint PIDs for all unregistered published files in the specified collection
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The following API will register the PIDs for all the yet unregistered published files in the datasets **directly within the collection** specified by its alias.::
+The following API will register the PIDs for all the yet unregistered published files in the datasets **directly within the collection** specified by its alias::
 
     curl "http://localhost:8080/api/admin/registerDataFiles/{collection_alias}"
 

--- a/doc/sphinx-guides/source/admin/dataverses-datasets.rst
+++ b/doc/sphinx-guides/source/admin/dataverses-datasets.rst
@@ -154,15 +154,18 @@ In the following example, the database id of the file is 42::
 
     export FILE_ID=42
     curl "http://localhost:8080/api/admin/$FILE_ID/registerDataFile"
+    
+This method will return a FORBIDDEN response if minting of file PIDs is not enabled for the collection the file is in. (Note that it is possible to have it enabled for a specific collection, even when it is disabled for the Dataverse installation as a whole. See :ref:`collection-attributes-api` in the Native API Guide.)
 
 Mint PIDs for all unregistered published files in the specified collection
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The following API will register the PIDs for all the yet unregistered published files in the datasets **directly within the collection** specified by its alias::
+The following API will register the PIDs for all the yet unregistered published files in the datasets **directly within the collection** specified by its alias.::
 
     curl "http://localhost:8080/api/admin/registerDataFiles/{collection_alias}"
 
-It will not attempt to register the datafiles in its sub-collections, so this call will need to be repeated on any sub-collections where files need to be registered as well. File-level PID registration must be enabled on the collection. (Note that it is possible to have it enabled for a specific collection, even when it is disabled for the Dataverse installation as a whole. See :ref:`collection-attributes-api` in the Native API Guide.)
+It will not attempt to register the datafiles in its sub-collections, so this call will need to be repeated on any sub-collections where files need to be registered as well.
+File-level PID registration must be enabled on the collection. (Note that it is possible to have it enabled for a specific collection, even when it is disabled for the Dataverse installation as a whole. See :ref:`collection-attributes-api` in the Native API Guide.)
 
 This API will sleep for 1 second between registration calls by default. A longer sleep interval can be specified with an optional ``sleep=`` parameter::
 
@@ -171,7 +174,7 @@ This API will sleep for 1 second between registration calls by default. A longer
 Mint PIDs for ALL unregistered files in the database
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The following API will attempt to register the PIDs for all the published files in your instance that do not yet have them::
+The following API will attempt to register the PIDs for all the published files in your instance, in collections that allow file PIDs, that do not yet have them::
 
     curl http://localhost:8080/api/admin/registerDataFileAll
 

--- a/doc/sphinx-guides/source/api/native-api.rst
+++ b/doc/sphinx-guides/source/api/native-api.rst
@@ -753,7 +753,7 @@ The following attributes are supported:
 * ``name`` Name
 * ``description`` Description
 * ``affiliation`` Affiliation
-* ``filePIDsEnabled`` ("true" or "false") Enables or disables registration of file-level PIDs in datasets within the collection (overriding the instance-wide setting).
+* ``filePIDsEnabled`` ("true" or "false") Restricted to use by superusers and only when the :ref:`:AllowEnablingFilePIDsPerCollection <:AllowEnablingFilePIDsPerCollection>` setting is true. Enables or disables registration of file-level PIDs in datasets within the collection (overriding the instance-wide setting).
 
 
 Datasets

--- a/doc/sphinx-guides/source/api/native-api.rst
+++ b/doc/sphinx-guides/source/api/native-api.rst
@@ -753,7 +753,7 @@ The following attributes are supported:
 * ``name`` Name
 * ``description`` Description
 * ``affiliation`` Affiliation
-* ``filePIDsEnabled`` ("true" or "false") Restricted to use by superusers and only when the :ref:`:AllowEnablingFilePIDsPerCollection <:AllowEnablingFilePIDsPerCollection>` setting is true. Enables or disables registration of file-level PIDs in datasets within the collection (overriding the instance-wide setting).
+* ``filePIDsEnabled`` ("true" or "false") Enables or disables registration of file-level PIDs in datasets within the collection (overriding the instance-wide setting).
 
 
 Datasets

--- a/doc/sphinx-guides/source/installation/config.rst
+++ b/doc/sphinx-guides/source/installation/config.rst
@@ -2777,14 +2777,14 @@ timestamps.
 
 Toggles publishing of file-level PIDs for the entire installation. By default this setting is absent and Dataverse Software assumes it to be false. If enabled, the registration will be performed asynchronously (in the background) during publishing of a dataset.
 
-It is possible to override the installation-wide setting for specific collections, but only if it is set to true or false (and not left undefined). For example, registration of PIDs for files can be enabled in a specific collection when it is disabled instance-wide. Or it can be disabled in specific collections where it is enabled by default. See :ref:`collection-attributes-api` for details. 
+It is possible to override the installation-wide setting for specific collections, see :ref:`:AllowEnablingFilePIDsPerCollection <:AllowEnablingFilePIDsPerCollection>`. For example, registration of PIDs for files can be enabled in a specific collection when it is disabled instance-wide. Or it can be disabled in specific collections where it is enabled by default. See :ref:`collection-attributes-api` for details. 
 
 To enable file-level PIDs for the entire installation::
 
 ``curl -X PUT -d 'true' http://localhost:8080/api/admin/settings/:FilePIDsEnabled``
 
 
-If you don't want to register file-based PIDs for your entire installation, but do want to allow them to be enabled for a given collection set:
+If you don't want to register file-based PIDs for your entire installation::
 
 ``curl -X PUT -d 'false' http://localhost:8080/api/admin/settings/:FilePIDsEnabled``
 
@@ -2793,9 +2793,9 @@ If you don't want to register file-based PIDs for your entire installation, but 
 :AllowEnablingFilePIDsPerCollection
 +++++++++++++++++++++++++++++++++++
 
-Toggles whether superusers can change the File PIDs policy per collection. publishing of file-level PIDs for the entire installation. By default this setting is absent and Dataverse Software assumes it to be false. If enabled, the registration will be performed asynchronously (in the background) during publishing of a dataset.
+Toggles whether superusers can change the File PIDs policy per collection. By default this setting is absent and Dataverse Software assumes it to be false.
 
-For example, registration of PIDs for files can be enabled in a specific collection when it is disabled instance-wide. Or it can be disabled in specific collections where it is enabled by default. See :ref:`collection-attributes-api` for details. 
+For example, if this setting is true, registration of PIDs for files can be enabled in a specific collection when it is disabled instance-wide. Or it can be disabled in specific collections where it is enabled by default. See :ref:`collection-attributes-api` for details. 
 
 To enable setting file-level PIDs per collection::
 

--- a/doc/sphinx-guides/source/installation/config.rst
+++ b/doc/sphinx-guides/source/installation/config.rst
@@ -248,7 +248,7 @@ this provider.
 - :ref:`:Shoulder <:Shoulder>`
 - :ref:`:IdentifierGenerationStyle <:IdentifierGenerationStyle>` (optional)
 - :ref:`:DataFilePIDFormat <:DataFilePIDFormat>` (optional)
-- :ref:`:FilePIDsEnabled <:FilePIDsEnabled>` (optional, defaults to false)
+- :ref:`:FilePIDsEnabled <:FilePIDsEnabled>` (optional, defaults to true)
 
 .. _pids-handle-configuration:
 
@@ -297,7 +297,7 @@ Here are the configuration options for PermaLinks:
 - :ref:`:Shoulder <:Shoulder>`
 - :ref:`:IdentifierGenerationStyle <:IdentifierGenerationStyle>` (optional)
 - :ref:`:DataFilePIDFormat <:DataFilePIDFormat>` (optional)
-- :ref:`:FilePIDsEnabled <:FilePIDsEnabled>` (optional, defaults to false)
+- :ref:`:FilePIDsEnabled <:FilePIDsEnabled>` (optional, defaults to true)
 
 .. _auth-modes:
 
@@ -2775,35 +2775,14 @@ timestamps.
 :FilePIDsEnabled
 ++++++++++++++++
 
-Toggles publishing of file-level PIDs for the entire installation. By default this setting is absent and Dataverse Software assumes it to be false. If enabled, the registration will be performed asynchronously (in the background) during publishing of a dataset.
+Toggles publishing of file-level PIDs for the entire installation. By default this setting is absent and Dataverse Software assumes it to be true. If enabled, the registration will be performed asynchronously (in the background) during publishing of a dataset.
 
-It is possible to override the installation-wide setting for specific collections, but only if it is set to true or false (and not left undefined). For example, registration of PIDs for files can be enabled in a specific collection when it is disabled instance-wide. Or it can be disabled in specific collections where it is enabled by default. See :ref:`collection-attributes-api` for details. 
-
-To enable file-level PIDs for the entire installation::
-
-``curl -X PUT -d 'true' http://localhost:8080/api/admin/settings/:FilePIDsEnabled``
-
-
-If you don't want to register file-based PIDs for your entire installation, but do want to allow them to be enabled for a given collection set:
+If you don't want to register file-based PIDs for your installation, set:
 
 ``curl -X PUT -d 'false' http://localhost:8080/api/admin/settings/:FilePIDsEnabled``
 
-.. _:AllowEnablingFilePIDsPerCollection:
 
-:AllowEnablingFilePIDsPerCollection
-+++++++++++++++++++++++++++++++++++
-
-Toggles whether superusers can change the File PIDs policy per collection. publishing of file-level PIDs for the entire installation. By default this setting is absent and Dataverse Software assumes it to be false. If enabled, the registration will be performed asynchronously (in the background) during publishing of a dataset.
-
-For example, registration of PIDs for files can be enabled in a specific collection when it is disabled instance-wide. Or it can be disabled in specific collections where it is enabled by default. See :ref:`collection-attributes-api` for details. 
-
-To enable setting file-level PIDs per collection::
-
-``curl -X PUT -d 'true' http://localhost:8080/api/admin/settings/:AllowEnablingFilePIDsPerCollection``
-
-
-When :AllowEnablingFilePIDsPerCollection is true, setting File PIDs to be enabled/disabled for a given collection can be done via the Native API - see :ref:`collection-attributes-api` in the Native API Guide.
-
+It is possible to override the installation-wide setting for specific collections. For example, registration of PIDs for files can be enabled in a specific collection when it is disabled instance-wide. Or it can be disabled in specific collections where it is enabled by default. See :ref:`collection-attributes-api` for details. 
 
 .. _:IndependentHandleService:
 

--- a/doc/sphinx-guides/source/installation/config.rst
+++ b/doc/sphinx-guides/source/installation/config.rst
@@ -248,7 +248,7 @@ this provider.
 - :ref:`:Shoulder <:Shoulder>`
 - :ref:`:IdentifierGenerationStyle <:IdentifierGenerationStyle>` (optional)
 - :ref:`:DataFilePIDFormat <:DataFilePIDFormat>` (optional)
-- :ref:`:FilePIDsEnabled <:FilePIDsEnabled>` (optional, defaults to true)
+- :ref:`:FilePIDsEnabled <:FilePIDsEnabled>` (optional, defaults to false)
 
 .. _pids-handle-configuration:
 
@@ -297,7 +297,7 @@ Here are the configuration options for PermaLinks:
 - :ref:`:Shoulder <:Shoulder>`
 - :ref:`:IdentifierGenerationStyle <:IdentifierGenerationStyle>` (optional)
 - :ref:`:DataFilePIDFormat <:DataFilePIDFormat>` (optional)
-- :ref:`:FilePIDsEnabled <:FilePIDsEnabled>` (optional, defaults to true)
+- :ref:`:FilePIDsEnabled <:FilePIDsEnabled>` (optional, defaults to false)
 
 .. _auth-modes:
 
@@ -2775,14 +2775,35 @@ timestamps.
 :FilePIDsEnabled
 ++++++++++++++++
 
-Toggles publishing of file-level PIDs for the entire installation. By default this setting is absent and Dataverse Software assumes it to be true. If enabled, the registration will be performed asynchronously (in the background) during publishing of a dataset.
+Toggles publishing of file-level PIDs for the entire installation. By default this setting is absent and Dataverse Software assumes it to be false. If enabled, the registration will be performed asynchronously (in the background) during publishing of a dataset.
 
-If you don't want to register file-based PIDs for your installation, set:
+It is possible to override the installation-wide setting for specific collections, but only if it is set to true or false (and not left undefined). For example, registration of PIDs for files can be enabled in a specific collection when it is disabled instance-wide. Or it can be disabled in specific collections where it is enabled by default. See :ref:`collection-attributes-api` for details. 
+
+To enable file-level PIDs for the entire installation::
+
+``curl -X PUT -d 'true' http://localhost:8080/api/admin/settings/:FilePIDsEnabled``
+
+
+If you don't want to register file-based PIDs for your entire installation, but do want to allow them to be enabled for a given collection set:
 
 ``curl -X PUT -d 'false' http://localhost:8080/api/admin/settings/:FilePIDsEnabled``
 
+.. _:AllowEnablingFilePIDsPerCollection:
 
-It is possible to override the installation-wide setting for specific collections. For example, registration of PIDs for files can be enabled in a specific collection when it is disabled instance-wide. Or it can be disabled in specific collections where it is enabled by default. See :ref:`collection-attributes-api` for details. 
+:AllowEnablingFilePIDsPerCollection
++++++++++++++++++++++++++++++++++++
+
+Toggles whether superusers can change the File PIDs policy per collection. publishing of file-level PIDs for the entire installation. By default this setting is absent and Dataverse Software assumes it to be false. If enabled, the registration will be performed asynchronously (in the background) during publishing of a dataset.
+
+For example, registration of PIDs for files can be enabled in a specific collection when it is disabled instance-wide. Or it can be disabled in specific collections where it is enabled by default. See :ref:`collection-attributes-api` for details. 
+
+To enable setting file-level PIDs per collection::
+
+``curl -X PUT -d 'true' http://localhost:8080/api/admin/settings/:AllowEnablingFilePIDsPerCollection``
+
+
+When :AllowEnablingFilePIDsPerCollection is true, setting File PIDs to be enabled/disabled for a given collection can be done via the Native API - see :ref:`collection-attributes-api` in the Native API Guide.
+
 
 .. _:IndependentHandleService:
 

--- a/src/main/java/edu/harvard/iq/dataverse/api/Admin.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Admin.java
@@ -1514,6 +1514,9 @@ public class Admin extends AbstractApiBean {
             User u = getRequestUser(crc);
             DataverseRequest r = createDataverseRequest(u);
             DataFile df = findDataFileOrDie(id);
+            if(!systemConfig.isFilePIDsEnabledForCollection(df.getOwner().getOwner())) {
+                return forbidden("PIDs are not enabled for this file's collection.");
+            }
             if (df.getIdentifier() == null || df.getIdentifier().isEmpty()) {
                 execCommand(new RegisterDvObjectCommand(r, df));
             } else {
@@ -1537,11 +1540,18 @@ public class Admin extends AbstractApiBean {
         Integer alreadyRegistered = 0;
         Integer released = 0;
         Integer draft = 0;
+        Integer skipped = 0;
         logger.info("Starting to register: analyzing " + count + " files. " + new Date());
         logger.info("Only unregistered, published files will be registered.");
         for (DataFile df : fileService.findAll()) {
             try {
                 if ((df.getIdentifier() == null || df.getIdentifier().isEmpty())) {
+                    if(!systemConfig.isFilePIDsEnabledForCollection(df.getOwner().getOwner())) {
+                        skipped++;
+                        if (skipped % 100 == 0) {
+                            logger.info(skipped + " of  " + count + " files not in collections that allow file PIDs. " + new Date());
+                        }
+                    }
                     if (df.isReleased()) {
                         released++;
                         User u = getRequestAuthenticatedUserOrDie(crc);
@@ -1550,6 +1560,11 @@ public class Admin extends AbstractApiBean {
                         successes++;
                         if (successes % 100 == 0) {
                             logger.info(successes + " of  " + count + " files registered successfully. " + new Date());
+                        }
+                        try {
+                            Thread.sleep(1000);
+                        } catch (InterruptedException ie) {
+                            logger.warning("Interrupted Exception when attempting to execute Thread.sleep()!");
                         }
                     } else {
                         draft++;
@@ -1567,11 +1582,7 @@ public class Admin extends AbstractApiBean {
                 logger.info("Unexpected Exception: " + e.getMessage());
             }
             
-            try {
-                Thread.sleep(1000);
-            } catch (InterruptedException ie) {
-                logger.warning("Interrupted Exception when attempting to execute Thread.sleep()!");
-            }
+
         }
         logger.info("Final Results:");
         logger.info(alreadyRegistered + " of  " + count + " files were already registered. " + new Date());
@@ -1579,6 +1590,7 @@ public class Admin extends AbstractApiBean {
         logger.info(released + " of  " + count + " unregistered, published files to register. " + new Date());
         logger.info(successes + " of  " + released + " unregistered, published files registered successfully. "
                 + new Date());
+        logger.info(skipped + " of  " + count + " files not in collections that allow file PIDs. " + new Date());
 
         return ok("Datafile registration complete." + successes + " of  " + released
                 + " unregistered, published files registered successfully.");
@@ -1633,6 +1645,11 @@ public class Admin extends AbstractApiBean {
                         if (countSuccesses % 100 == 0) {
                             logger.info(countSuccesses + " out of " + count + " files registered successfully. " + new Date());
                         }
+                        try {
+                            Thread.sleep(sleepInterval * 1000);
+                        } catch (InterruptedException ie) {
+                            logger.warning("Interrupted Exception when attempting to execute Thread.sleep()!");
+                        }
                     } else {
                         countDrafts++;
                         logger.fine(countDrafts + " out of " + count + " files not yet published");
@@ -1647,12 +1664,6 @@ public class Admin extends AbstractApiBean {
                 Logger.getLogger(Datasets.class.getName()).log(Level.SEVERE, null, ex);
             } catch (Exception e) {
                 logger.info("Unexpected Exception: " + e.getMessage());
-            }
-            
-            try {
-                Thread.sleep(sleepInterval * 1000);
-            } catch (InterruptedException ie) {
-                logger.warning("Interrupted Exception when attempting to execute Thread.sleep()!");
             }
         }
         

--- a/src/main/java/edu/harvard/iq/dataverse/api/Admin.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Admin.java
@@ -1543,6 +1543,13 @@ public class Admin extends AbstractApiBean {
         Integer skipped = 0;
         logger.info("Starting to register: analyzing " + count + " files. " + new Date());
         logger.info("Only unregistered, published files will be registered.");
+        User u = null;
+        try {
+            u = getRequestAuthenticatedUserOrDie(crc);
+        } catch (WrappedResponse e1) {
+            return error(Status.UNAUTHORIZED, "api key required");
+        }
+        DataverseRequest r = createDataverseRequest(u);
         for (DataFile df : fileService.findAll()) {
             try {
                 if ((df.getIdentifier() == null || df.getIdentifier().isEmpty())) {
@@ -1553,8 +1560,6 @@ public class Admin extends AbstractApiBean {
                         }
                     } else if (df.isReleased()) {
                         released++;
-                        User u = getRequestAuthenticatedUserOrDie(crc);
-                        DataverseRequest r = createDataverseRequest(u);
                         execCommand(new RegisterDvObjectCommand(r, df));
                         successes++;
                         if (successes % 100 == 0) {

--- a/src/main/java/edu/harvard/iq/dataverse/api/Admin.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Admin.java
@@ -1578,7 +1578,9 @@ public class Admin extends AbstractApiBean {
                     }
                 } else {
                     alreadyRegistered++;
-                    logger.info(alreadyRegistered + " of  " + count + " files are already registered. " + new Date());
+                    if(alreadyRegistered % 100 == 0) {
+                      logger.info(alreadyRegistered + " of  " + count + " files are already registered. " + new Date());
+                    }
                 }
             } catch (WrappedResponse ex) {
                 logger.info("Failed to register file id: " + df.getId());

--- a/src/main/java/edu/harvard/iq/dataverse/api/Admin.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Admin.java
@@ -1514,9 +1514,6 @@ public class Admin extends AbstractApiBean {
             User u = getRequestUser(crc);
             DataverseRequest r = createDataverseRequest(u);
             DataFile df = findDataFileOrDie(id);
-            if(!systemConfig.isFilePIDsEnabledForCollection(df.getOwner().getOwner())) {
-                return forbidden("PIDs are not enabled for this file's collection.");
-            }
             if (df.getIdentifier() == null || df.getIdentifier().isEmpty()) {
                 execCommand(new RegisterDvObjectCommand(r, df));
             } else {
@@ -1540,18 +1537,11 @@ public class Admin extends AbstractApiBean {
         Integer alreadyRegistered = 0;
         Integer released = 0;
         Integer draft = 0;
-        Integer skipped = 0;
         logger.info("Starting to register: analyzing " + count + " files. " + new Date());
         logger.info("Only unregistered, published files will be registered.");
         for (DataFile df : fileService.findAll()) {
             try {
                 if ((df.getIdentifier() == null || df.getIdentifier().isEmpty())) {
-                    if(!systemConfig.isFilePIDsEnabledForCollection(df.getOwner().getOwner())) {
-                        skipped++;
-                        if (skipped % 100 == 0) {
-                            logger.info(skipped + " of  " + count + " files not in collections that allow file PIDs. " + new Date());
-                        }
-                    }
                     if (df.isReleased()) {
                         released++;
                         User u = getRequestAuthenticatedUserOrDie(crc);
@@ -1560,11 +1550,6 @@ public class Admin extends AbstractApiBean {
                         successes++;
                         if (successes % 100 == 0) {
                             logger.info(successes + " of  " + count + " files registered successfully. " + new Date());
-                        }
-                        try {
-                            Thread.sleep(1000);
-                        } catch (InterruptedException ie) {
-                            logger.warning("Interrupted Exception when attempting to execute Thread.sleep()!");
                         }
                     } else {
                         draft++;
@@ -1582,7 +1567,11 @@ public class Admin extends AbstractApiBean {
                 logger.info("Unexpected Exception: " + e.getMessage());
             }
             
-
+            try {
+                Thread.sleep(1000);
+            } catch (InterruptedException ie) {
+                logger.warning("Interrupted Exception when attempting to execute Thread.sleep()!");
+            }
         }
         logger.info("Final Results:");
         logger.info(alreadyRegistered + " of  " + count + " files were already registered. " + new Date());
@@ -1590,7 +1579,6 @@ public class Admin extends AbstractApiBean {
         logger.info(released + " of  " + count + " unregistered, published files to register. " + new Date());
         logger.info(successes + " of  " + released + " unregistered, published files registered successfully. "
                 + new Date());
-        logger.info(skipped + " of  " + count + " files not in collections that allow file PIDs. " + new Date());
 
         return ok("Datafile registration complete." + successes + " of  " + released
                 + " unregistered, published files registered successfully.");
@@ -1645,11 +1633,6 @@ public class Admin extends AbstractApiBean {
                         if (countSuccesses % 100 == 0) {
                             logger.info(countSuccesses + " out of " + count + " files registered successfully. " + new Date());
                         }
-                        try {
-                            Thread.sleep(sleepInterval * 1000);
-                        } catch (InterruptedException ie) {
-                            logger.warning("Interrupted Exception when attempting to execute Thread.sleep()!");
-                        }
                     } else {
                         countDrafts++;
                         logger.fine(countDrafts + " out of " + count + " files not yet published");
@@ -1664,6 +1647,12 @@ public class Admin extends AbstractApiBean {
                 Logger.getLogger(Datasets.class.getName()).log(Level.SEVERE, null, ex);
             } catch (Exception e) {
                 logger.info("Unexpected Exception: " + e.getMessage());
+            }
+            
+            try {
+                Thread.sleep(sleepInterval * 1000);
+            } catch (InterruptedException ie) {
+                logger.warning("Interrupted Exception when attempting to execute Thread.sleep()!");
             }
         }
         

--- a/src/main/java/edu/harvard/iq/dataverse/api/Admin.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Admin.java
@@ -1572,7 +1572,9 @@ public class Admin extends AbstractApiBean {
                         }
                     } else {
                         draft++;
-                        logger.info(draft + " of  " + count + " files not yet published");
+                        if (draft % 100 == 0) {
+                          logger.info(draft + " of  " + count + " files not yet published");
+                        }
                     }
                 } else {
                     alreadyRegistered++;

--- a/src/main/java/edu/harvard/iq/dataverse/api/Admin.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Admin.java
@@ -1551,8 +1551,7 @@ public class Admin extends AbstractApiBean {
                         if (skipped % 100 == 0) {
                             logger.info(skipped + " of  " + count + " files not in collections that allow file PIDs. " + new Date());
                         }
-                    }
-                    if (df.isReleased()) {
+                    } else if (df.isReleased()) {
                         released++;
                         User u = getRequestAuthenticatedUserOrDie(crc);
                         DataverseRequest r = createDataverseRequest(u);
@@ -1575,7 +1574,6 @@ public class Admin extends AbstractApiBean {
                     logger.info(alreadyRegistered + " of  " + count + " files are already registered. " + new Date());
                 }
             } catch (WrappedResponse ex) {
-                released++;
                 logger.info("Failed to register file id: " + df.getId());
                 Logger.getLogger(Datasets.class.getName()).log(Level.SEVERE, null, ex);
             } catch (Exception e) {

--- a/src/main/java/edu/harvard/iq/dataverse/api/Dataverses.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Dataverses.java
@@ -639,7 +639,7 @@ public class Dataverses extends AbstractApiBean {
                     if(!user.isSuperuser()) {
                         return forbidden("You must be a superuser to change this setting");
                     }
-                    if(settingsService.isTrueForKey(SettingsServiceBean.Key.AllowEnablingFilePIDsPerCollection, false)) {
+                    if(!settingsService.isTrueForKey(SettingsServiceBean.Key.AllowEnablingFilePIDsPerCollection, false)) {
                         return forbidden("Changing File PID policy per collection is not enabled on this server");
                     }
                     collection.setFilePIDsEnabled(parseBooleanOrDie(value));

--- a/src/main/java/edu/harvard/iq/dataverse/api/Dataverses.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Dataverses.java
@@ -636,6 +636,12 @@ public class Dataverses extends AbstractApiBean {
                     break;
                  */
                 case "filePIDsEnabled":
+                    if(!user.isSuperuser()) {
+                        return forbidden("You must be a superuser to change this setting");
+                    }
+                    if(settingsService.isTrueForKey(SettingsServiceBean.Key.AllowEnablingFilePIDsPerCollection, false)) {
+                        return forbidden("File PIDs are not enabled on this server");
+                    }
                     collection.setFilePIDsEnabled(parseBooleanOrDie(value));
                     break;
                 default:

--- a/src/main/java/edu/harvard/iq/dataverse/api/Dataverses.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Dataverses.java
@@ -640,7 +640,7 @@ public class Dataverses extends AbstractApiBean {
                         return forbidden("You must be a superuser to change this setting");
                     }
                     if(settingsService.isTrueForKey(SettingsServiceBean.Key.AllowEnablingFilePIDsPerCollection, false)) {
-                        return forbidden("File PIDs are not enabled on this server");
+                        return forbidden("Changing File PID policy per collection is not enabled on this server");
                     }
                     collection.setFilePIDsEnabled(parseBooleanOrDie(value));
                     break;

--- a/src/main/java/edu/harvard/iq/dataverse/api/Dataverses.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Dataverses.java
@@ -636,12 +636,6 @@ public class Dataverses extends AbstractApiBean {
                     break;
                  */
                 case "filePIDsEnabled":
-                    if(!user.isSuperuser()) {
-                        return forbidden("You must be a superuser to change this setting");
-                    }
-                    if(settingsService.isTrueForKey(SettingsServiceBean.Key.AllowEnablingFilePIDsPerCollection, false)) {
-                        return forbidden("File PIDs are not enabled on this server");
-                    }
                     collection.setFilePIDsEnabled(parseBooleanOrDie(value));
                     break;
                 default:

--- a/src/main/java/edu/harvard/iq/dataverse/batch/jobs/importer/filesystem/FileRecordWriter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/batch/jobs/importer/filesystem/FileRecordWriter.java
@@ -358,8 +358,9 @@ public class FileRecordWriter extends AbstractItemWriter {
         dataset.getLatestVersion().getFileMetadatas().add(fmd);
         fmd.setDatasetVersion(dataset.getLatestVersion());
         
-    if (commandEngine.getContext().systemConfig().isFilePIDsEnabledForCollection(dataset.getOwner())) {
-
+	String isFilePIDsEnabled = commandEngine.getContext().settings().getValueForKey(SettingsServiceBean.Key.FilePIDsEnabled, "true"); //default value for file PIDs is 'true'
+	if ("true".contentEquals( isFilePIDsEnabled )) {
+	
         GlobalIdServiceBean idServiceBean = GlobalIdServiceBean.getBean(packageFile.getProtocol(), commandEngine.getContext());
         if (packageFile.getIdentifier() == null || packageFile.getIdentifier().isEmpty()) {
             packageFile.setIdentifier(idServiceBean.generateDataFileIdentifier(packageFile));

--- a/src/main/java/edu/harvard/iq/dataverse/batch/jobs/importer/filesystem/FileRecordWriter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/batch/jobs/importer/filesystem/FileRecordWriter.java
@@ -358,9 +358,8 @@ public class FileRecordWriter extends AbstractItemWriter {
         dataset.getLatestVersion().getFileMetadatas().add(fmd);
         fmd.setDatasetVersion(dataset.getLatestVersion());
         
-	String isFilePIDsEnabled = commandEngine.getContext().settings().getValueForKey(SettingsServiceBean.Key.FilePIDsEnabled, "true"); //default value for file PIDs is 'true'
-	if ("true".contentEquals( isFilePIDsEnabled )) {
-	
+    if (commandEngine.getContext().systemConfig().isFilePIDsEnabledForCollection(dataset.getOwner())) {
+
         GlobalIdServiceBean idServiceBean = GlobalIdServiceBean.getBean(packageFile.getProtocol(), commandEngine.getContext());
         if (packageFile.getIdentifier() == null || packageFile.getIdentifier().isEmpty()) {
             packageFile.setIdentifier(idServiceBean.generateDataFileIdentifier(packageFile));

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/CreateDataverseCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/CreateDataverseCommand.java
@@ -97,6 +97,10 @@ public class CreateDataverseCommand extends AbstractCommand<Dataverse> {
         if (ctxt.dataverses().findByAlias(created.getAlias()) != null) {
             throw new IllegalCommandException("A dataverse with alias " + created.getAlias() + " already exists", this);
         }
+        
+        if(created.getFilePIDsEnabled()!=null && !ctxt.settings().isTrueForKey(SettingsServiceBean.Key.AllowEnablingFilePIDsPerCollection, false)) {
+            throw new IllegalCommandException("File PIDs cannot be enabled per collection", this);
+        }
 
         // Save the dataverse
         Dataverse managedDv = ctxt.dataverses().save(created);

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/CreateDataverseCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/CreateDataverseCommand.java
@@ -97,10 +97,6 @@ public class CreateDataverseCommand extends AbstractCommand<Dataverse> {
         if (ctxt.dataverses().findByAlias(created.getAlias()) != null) {
             throw new IllegalCommandException("A dataverse with alias " + created.getAlias() + " already exists", this);
         }
-        
-        if(created.getFilePIDsEnabled()!=null && !ctxt.settings().isTrueForKey(SettingsServiceBean.Key.AllowEnablingFilePIDsPerCollection, false)) {
-            throw new IllegalCommandException("File PIDs cannot be enabled per collection", this);
-        }
 
         // Save the dataverse
         Dataverse managedDv = ctxt.dataverses().save(created);

--- a/src/main/java/edu/harvard/iq/dataverse/settings/SettingsServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/settings/SettingsServiceBean.java
@@ -595,7 +595,11 @@ public class SettingsServiceBean {
          * True/false(default) option deciding whether the dataset file table display should include checkboxes
          * allowing users to dynamically turn folder and category ordering on/off.
          */
-        AllowUserManagementOfOrder
+        AllowUserManagementOfOrder,
+        /*
+         * True/false(default) option deciding whether file PIDs can be enabled per collection - using the Dataverse/collection set attribute API call.
+         */
+        AllowEnablingFilePIDsPerCollection
         ;
 
         @Override

--- a/src/main/java/edu/harvard/iq/dataverse/settings/SettingsServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/settings/SettingsServiceBean.java
@@ -595,11 +595,7 @@ public class SettingsServiceBean {
          * True/false(default) option deciding whether the dataset file table display should include checkboxes
          * allowing users to dynamically turn folder and category ordering on/off.
          */
-        AllowUserManagementOfOrder,
-        /*
-         * True/false(default) option deciding whether file PIDs can be enabled per collection - using the Dataverse/collection set attribute API call.
-         */
-        AllowEnablingFilePIDsPerCollection
+        AllowUserManagementOfOrder
         ;
 
         @Override

--- a/src/main/java/edu/harvard/iq/dataverse/util/SystemConfig.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/SystemConfig.java
@@ -1011,7 +1011,7 @@ public class SystemConfig {
                 // hasn't been explicitly enabled, therefore we presume that it is
                 // subject to how the registration is configured for the 
                 // entire instance:
-                return settingsService.isTrueForKey(SettingsServiceBean.Key.FilePIDsEnabled, false); 
+                return settingsService.isTrueForKey(SettingsServiceBean.Key.FilePIDsEnabled, true); 
             }
             thisCollection = thisCollection.getOwner();
         }

--- a/src/main/java/edu/harvard/iq/dataverse/util/SystemConfig.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/SystemConfig.java
@@ -1011,7 +1011,7 @@ public class SystemConfig {
                 // hasn't been explicitly enabled, therefore we presume that it is
                 // subject to how the registration is configured for the 
                 // entire instance:
-                return settingsService.isTrueForKey(SettingsServiceBean.Key.FilePIDsEnabled, true); 
+                return settingsService.isTrueForKey(SettingsServiceBean.Key.FilePIDsEnabled, false); 
             }
             thisCollection = thisCollection.getOwner();
         }

--- a/src/main/resources/db/migration/V5.13.0.3__8889-change-filepids-default.sql
+++ b/src/main/resources/db/migration/V5.13.0.3__8889-change-filepids-default.sql
@@ -1,3 +1,0 @@
-INSERT INTO setting(content, lang, name) VALUES
-              ('true', '', ':FilePIDsEnabled')
-       ON CONFLICT DO NOTHING;

--- a/src/main/resources/db/migration/V5.13.0.3__8889-change-filepids-default.sql
+++ b/src/main/resources/db/migration/V5.13.0.3__8889-change-filepids-default.sql
@@ -1,0 +1,3 @@
+INSERT INTO setting(content, lang, name) VALUES
+              ('true', '', ':FilePIDsEnabled')
+       ON CONFLICT DO NOTHING;

--- a/src/test/java/edu/harvard/iq/dataverse/api/FilesIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/FilesIT.java
@@ -2025,14 +2025,7 @@ public class FilesIT {
     @Test
     public void testFilePIDsBehavior() {
         // Create user
-        Response createUser = UtilIT.createRandomUser();
-        String apiToken = UtilIT.getApiTokenFromResponse(createUser);
-        String username = UtilIT.getUsernameFromResponse(createUser);
-        Response toggleSuperuser = UtilIT.makeSuperUser(username);
-        toggleSuperuser.then().assertThat()
-                .statusCode(OK.getStatusCode());
-        try {
-        UtilIT.enableSetting(SettingsServiceBean.Key.FilePIDsEnabled);
+        String apiToken = createUserGetToken();
 
         // Create Dataverse
         String collectionAlias = createDataverseGetAlias(apiToken);
@@ -2071,14 +2064,14 @@ public class FilesIT {
         assertNotNull("The file did not get a persistent identifier assigned (check that file PIDs are enabled instance-wide!)", origFilePersistentId);
 
         // Now change the file PIDs registration configuration for the collection:
-        UtilIT.enableSetting(SettingsServiceBean.Key.AllowEnablingFilePIDsPerCollection);
+        
         Response changeAttributeResp = UtilIT.setCollectionAttribute(collectionAlias, "filePIDsEnabled", "false", apiToken);
         
         // ... And do the whole thing with creating another dataset with a file:
         
         datasetId = createDatasetGetId(collectionAlias, apiToken);
         addResponse = UtilIT.uploadFileViaNative(datasetId.toString(), pathToFile, apiToken);
-        addResponse.then().assertThat().statusCode(OK.getStatusCode());
+        addResponse.then().assertThat().statusCode(OK.getStatusCode());                
         Long newFileId = JsonPath.from(addResponse.body().asString()).getLong("data.files[0].dataFile.id");
         
         // And publish this dataset:
@@ -2096,9 +2089,6 @@ public class FilesIT {
         msg(fileInfoResponseString);
         
         org.junit.Assert.assertEquals("The file was NOT supposed to be issued a PID", "", JsonPath.from(fileInfoResponseString).getString("data.dataFile.persistentId"));
-        } finally {
-            UtilIT.deleteSetting(SettingsServiceBean.Key.FilePIDsEnabled);
-            UtilIT.deleteSetting(SettingsServiceBean.Key.AllowEnablingFilePIDsPerCollection);
-        }
+      
     }
 }

--- a/src/test/java/edu/harvard/iq/dataverse/api/FilesIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/FilesIT.java
@@ -2032,70 +2032,70 @@ public class FilesIT {
         toggleSuperuser.then().assertThat()
                 .statusCode(OK.getStatusCode());
         try {
-        UtilIT.enableSetting(SettingsServiceBean.Key.FilePIDsEnabled);
+            UtilIT.enableSetting(SettingsServiceBean.Key.FilePIDsEnabled);
 
-        // Create Dataverse
-        String collectionAlias = createDataverseGetAlias(apiToken);
+            // Create Dataverse
+            String collectionAlias = createDataverseGetAlias(apiToken);
 
-        // Create Initial Dataset with 1 file:
-        Integer datasetId = createDatasetGetId(collectionAlias, apiToken);
-        String pathToFile = "scripts/search/data/replace_test/003.txt";
-        Response addResponse = UtilIT.uploadFileViaNative(datasetId.toString(), pathToFile, apiToken);
+            // Create Initial Dataset with 1 file:
+            Integer datasetId = createDatasetGetId(collectionAlias, apiToken);
+            String pathToFile = "scripts/search/data/replace_test/003.txt";
+            Response addResponse = UtilIT.uploadFileViaNative(datasetId.toString(), pathToFile, apiToken);
 
-        addResponse.then().assertThat()
-                .body("data.files[0].dataFile.contentType", equalTo("text/plain"))
-                .body("data.files[0].label", equalTo("003.txt"))
-                .statusCode(OK.getStatusCode());
-        
-        Long origFileId = JsonPath.from(addResponse.body().asString()).getLong("data.files[0].dataFile.id");
-        
-        // -------------------------
-        // Publish dataverse and dataset
-        // -------------------------
-        msg("Publish dataverse and dataset");
-        Response publishCollectionResp = UtilIT.publishDataverseViaSword(collectionAlias, apiToken);
-        publishCollectionResp.then().assertThat()
-                .statusCode(OK.getStatusCode());
-        
-        Response publishDatasetResp = UtilIT.publishDatasetViaNativeApi(datasetId, "major", apiToken);
-        publishDatasetResp.then().assertThat()
-                .statusCode(OK.getStatusCode());
-        
-        // The file in this dataset should have been assigned a PID when it was published:
-        Response fileInfoResponse = UtilIT.getFileData(origFileId.toString(), apiToken);
-        fileInfoResponse.then().assertThat().statusCode(OK.getStatusCode());
-        String fileInfoResponseString = fileInfoResponse.body().asString();
-        msg(fileInfoResponseString);
-        
-        String origFilePersistentId = JsonPath.from(fileInfoResponseString).getString("data.dataFile.persistentId");
-        assertNotNull("The file did not get a persistent identifier assigned (check that file PIDs are enabled instance-wide!)", origFilePersistentId);
+            addResponse.then().assertThat().body("data.files[0].dataFile.contentType", equalTo("text/plain"))
+                    .body("data.files[0].label", equalTo("003.txt")).statusCode(OK.getStatusCode());
 
-        // Now change the file PIDs registration configuration for the collection:
-        UtilIT.enableSetting(SettingsServiceBean.Key.AllowEnablingFilePIDsPerCollection);
-        Response changeAttributeResp = UtilIT.setCollectionAttribute(collectionAlias, "filePIDsEnabled", "false", apiToken);
-        
-        // ... And do the whole thing with creating another dataset with a file:
-        
-        datasetId = createDatasetGetId(collectionAlias, apiToken);
-        addResponse = UtilIT.uploadFileViaNative(datasetId.toString(), pathToFile, apiToken);
-        addResponse.then().assertThat().statusCode(OK.getStatusCode());
-        Long newFileId = JsonPath.from(addResponse.body().asString()).getLong("data.files[0].dataFile.id");
-        
-        // And publish this dataset:
-        msg("Publish second dataset");
-        
-        publishDatasetResp = UtilIT.publishDatasetViaNativeApi(datasetId, "major", apiToken);
-        publishDatasetResp.then().assertThat()
-                .statusCode(OK.getStatusCode());
-        
-        // And confirm that the file didn't get a PID:
-        
-        fileInfoResponse = UtilIT.getFileData(newFileId.toString(), apiToken);
-        fileInfoResponse.then().assertThat().statusCode(OK.getStatusCode());
-        fileInfoResponseString = fileInfoResponse.body().asString();
-        msg(fileInfoResponseString);
-        
-        org.junit.Assert.assertEquals("The file was NOT supposed to be issued a PID", "", JsonPath.from(fileInfoResponseString).getString("data.dataFile.persistentId"));
+            Long origFileId = JsonPath.from(addResponse.body().asString()).getLong("data.files[0].dataFile.id");
+
+            // -------------------------
+            // Publish dataverse and dataset
+            // -------------------------
+            msg("Publish dataverse and dataset");
+            Response publishCollectionResp = UtilIT.publishDataverseViaSword(collectionAlias, apiToken);
+            publishCollectionResp.then().assertThat().statusCode(OK.getStatusCode());
+
+            Response publishDatasetResp = UtilIT.publishDatasetViaNativeApi(datasetId, "major", apiToken);
+            publishDatasetResp.then().assertThat().statusCode(OK.getStatusCode());
+
+            // The file in this dataset should have been assigned a PID when it was
+            // published:
+            Response fileInfoResponse = UtilIT.getFileData(origFileId.toString(), apiToken);
+            fileInfoResponse.then().assertThat().statusCode(OK.getStatusCode());
+            String fileInfoResponseString = fileInfoResponse.body().asString();
+            msg(fileInfoResponseString);
+
+            String origFilePersistentId = JsonPath.from(fileInfoResponseString).getString("data.dataFile.persistentId");
+            assertNotNull(
+                    "The file did not get a persistent identifier assigned (check that file PIDs are enabled instance-wide!)",
+                    origFilePersistentId);
+
+            // Now change the file PIDs registration configuration for the collection:
+            UtilIT.enableSetting(SettingsServiceBean.Key.AllowEnablingFilePIDsPerCollection);
+            Response changeAttributeResp = UtilIT.setCollectionAttribute(collectionAlias, "filePIDsEnabled", "false",
+                    apiToken);
+
+            // ... And do the whole thing with creating another dataset with a file:
+
+            datasetId = createDatasetGetId(collectionAlias, apiToken);
+            addResponse = UtilIT.uploadFileViaNative(datasetId.toString(), pathToFile, apiToken);
+            addResponse.then().assertThat().statusCode(OK.getStatusCode());
+            Long newFileId = JsonPath.from(addResponse.body().asString()).getLong("data.files[0].dataFile.id");
+
+            // And publish this dataset:
+            msg("Publish second dataset");
+
+            publishDatasetResp = UtilIT.publishDatasetViaNativeApi(datasetId, "major", apiToken);
+            publishDatasetResp.then().assertThat().statusCode(OK.getStatusCode());
+
+            // And confirm that the file didn't get a PID:
+
+            fileInfoResponse = UtilIT.getFileData(newFileId.toString(), apiToken);
+            fileInfoResponse.then().assertThat().statusCode(OK.getStatusCode());
+            fileInfoResponseString = fileInfoResponse.body().asString();
+            msg(fileInfoResponseString);
+
+            org.junit.Assert.assertEquals("The file was NOT supposed to be issued a PID", "",
+                    JsonPath.from(fileInfoResponseString).getString("data.dataFile.persistentId"));
         } finally {
             UtilIT.deleteSetting(SettingsServiceBean.Key.FilePIDsEnabled);
             UtilIT.deleteSetting(SettingsServiceBean.Key.AllowEnablingFilePIDsPerCollection);

--- a/src/test/java/edu/harvard/iq/dataverse/api/FilesIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/FilesIT.java
@@ -2025,7 +2025,14 @@ public class FilesIT {
     @Test
     public void testFilePIDsBehavior() {
         // Create user
-        String apiToken = createUserGetToken();
+        Response createUser = UtilIT.createRandomUser();
+        String apiToken = UtilIT.getApiTokenFromResponse(createUser);
+        String username = UtilIT.getUsernameFromResponse(createUser);
+        Response toggleSuperuser = UtilIT.makeSuperUser(username);
+        toggleSuperuser.then().assertThat()
+                .statusCode(OK.getStatusCode());
+        try {
+        UtilIT.enableSetting(SettingsServiceBean.Key.FilePIDsEnabled);
 
         // Create Dataverse
         String collectionAlias = createDataverseGetAlias(apiToken);
@@ -2064,14 +2071,14 @@ public class FilesIT {
         assertNotNull("The file did not get a persistent identifier assigned (check that file PIDs are enabled instance-wide!)", origFilePersistentId);
 
         // Now change the file PIDs registration configuration for the collection:
-        
+        UtilIT.enableSetting(SettingsServiceBean.Key.AllowEnablingFilePIDsPerCollection);
         Response changeAttributeResp = UtilIT.setCollectionAttribute(collectionAlias, "filePIDsEnabled", "false", apiToken);
         
         // ... And do the whole thing with creating another dataset with a file:
         
         datasetId = createDatasetGetId(collectionAlias, apiToken);
         addResponse = UtilIT.uploadFileViaNative(datasetId.toString(), pathToFile, apiToken);
-        addResponse.then().assertThat().statusCode(OK.getStatusCode());                
+        addResponse.then().assertThat().statusCode(OK.getStatusCode());
         Long newFileId = JsonPath.from(addResponse.body().asString()).getLong("data.files[0].dataFile.id");
         
         // And publish this dataset:
@@ -2089,6 +2096,9 @@ public class FilesIT {
         msg(fileInfoResponseString);
         
         org.junit.Assert.assertEquals("The file was NOT supposed to be issued a PID", "", JsonPath.from(fileInfoResponseString).getString("data.dataFile.persistentId"));
-      
+        } finally {
+            UtilIT.deleteSetting(SettingsServiceBean.Key.FilePIDsEnabled);
+            UtilIT.deleteSetting(SettingsServiceBean.Key.AllowEnablingFilePIDsPerCollection);
+        }
     }
 }


### PR DESCRIPTION
**What this PR does / why we need it**: This PR replaces #9716 which was accidentally closed via a bad push to develop (see dv-tech slack channel). This PR recreates the prior one and adds additional changes to use a second :AllowEnablingFilePIDsPerCollection setting that enables/disables the API to change whether FIle PIDs are allowed per collection. (The :FilePIDsEnabled setting is now just a way to set the global default.)

**Which issue(s) this PR closes**:

Closes #8889

**Special notes for your reviewer**: I hopefully have cleaned up the develop branch and gotten everything in here correctly. I'll check again tomorrow morning and will scan the docs/code once more to see if I missed anything we talked about in slack and the old PR. (the https://github.com/IQSS/dataverse/commit/c6d42695585b1535df34c5a552dadcc0a99161af reverts the squash of all the commits that were reverted in develop).

**Suggestions on how to test this**: Setting :AllowEnablingFilePIDsPerCollection=true should enable the API call for superusers to set FilePIDs on/off per collection. Setting the global default via :FilePIDsEnabled should allow you to compare a collection using that global default and one where you've used the API to flip from true to false or vice versa. There is an automated test that verifies publishing a dataset after a collection has had its setting flipped does indeed have it's file PIDs handled correctly.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**: modified from the ones for the original PR - can be combined with those (I think it should be cut/paste to replace them).

**Additional documentation**:
