### PR TITLE
fix broken links to Containerization Working Group website

### DIFF
--- a/conf/docker-aio/readme.md
+++ b/conf/docker-aio/readme.md
@@ -1,7 +1,7 @@
 # Docker All-In-One
 
 > :information_source:  **NOTE: Sunsetting of this module is imminent.** There is no schedule yet, but expect it to go away.
-> Please let the [Dataverse Containerization Working Group](https://dc.wgs.gdcc.io) know if you are a user and
+> Please let the [Dataverse Containerization Working Group](https://ct.gdcc.io) know if you are a user and
 > what should be preserved.
 
 First pass docker all-in-one image, intended for running integration tests against.

--- a/doc/sphinx-guides/source/developers/testing.rst
+++ b/doc/sphinx-guides/source/developers/testing.rst
@@ -175,7 +175,7 @@ Running the full API test suite using Docker
 
 .. note::
     Sunsetting of this module is imminent.** There is no schedule yet, but expect it to go away.
-    Please let the `Dataverse Containerization Working Group <https://dc.wgs.gdcc.io>`_ know if you are a user and
+    Please let the `Dataverse Containerization Working Group <https://ct.gdcc.io>`_ know if you are a user and
     what should be preserved.
 
 To run the full suite of integration tests on your laptop, we recommend using the "all in one" Docker configuration described in ``conf/docker-aio/readme.md`` in the root of the repo.


### PR DESCRIPTION
**What this PR does / why we need it**:

https://ct.gdcc.io is the correct URL for the Containerization Working Group.

For a short time it was https://dc.wgs.gdcc.io but this URL is now a 404. I had made its way into the 5.14 release notes (which I fixed already) and into some docs, which I'm fixing in this PR.