### PR TITLE
Minor improvements for the external metadata filtering

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/dataset/DatasetUtil.java
+++ b/src/main/java/edu/harvard/iq/dataverse/dataset/DatasetUtil.java
@@ -524,7 +524,7 @@ public class DatasetUtil {
             jsonMetadata = json(ds).add("datasetVersion", json(ds.getLatestVersion()))
                     .add("sourceAddress", sourceAddressLabel)
                     .add("userIdentifier", userIdentifier)
-                    .add("colAlias", ds.getOwner().getAlias())
+                    .add("parentAlias", ds.getOwner().getAlias())
                     .build().toString();
         } catch (Exception ex) {
             logger.warning("Failed to export dataset metadata as json; "+ex.getMessage() == null ? "" : ex.getMessage());

--- a/src/main/java/edu/harvard/iq/dataverse/dataset/DatasetUtil.java
+++ b/src/main/java/edu/harvard/iq/dataverse/dataset/DatasetUtil.java
@@ -38,7 +38,6 @@ import edu.harvard.iq.dataverse.settings.SettingsServiceBean;
 import edu.harvard.iq.dataverse.util.StringUtil;
 import static edu.harvard.iq.dataverse.util.json.JsonPrinter.json;
 import static edu.harvard.iq.dataverse.util.json.NullSafeJsonBuilder.jsonObjectBuilder;
-import java.math.BigDecimal;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.EnumUtils;

--- a/src/main/java/edu/harvard/iq/dataverse/dataverse/DataverseUtil.java
+++ b/src/main/java/edu/harvard/iq/dataverse/dataverse/DataverseUtil.java
@@ -39,6 +39,7 @@ public class DataverseUtil {
 
         String sourceAddressLabel = "0.0.0.0";
         String userIdentifier = "guest";
+        String parentAlias = dv.getOwner() == null ? "" : dv.getOwner().getAlias();
 
         if (request != null) {
             IpAddress sourceAddress = request.getSourceAddress();
@@ -51,16 +52,17 @@ public class DataverseUtil {
                 userIdentifier = user.getUserIdentifier();
             }
         }
-
+        
         // We are sending the collection metadata encoded in our standard json 
         // format, with a couple of extra elements added, such as the id of 
-        // the user sending the request and the source address, in order to make 
-        // it easier for the filter to whitelist users. 
+        // the user sending the request and the alias of the parent collection, 
+        // in order to make it easier for the filter to manage whitelisting. 
         
         try {
             jsonMetadata = json(dv)
                     .add("sourceAddress", sourceAddressLabel)
                     .add("userIdentifier", userIdentifier)
+                    .add("parentAlias", parentAlias)
                     .build().toString();
         } catch (Exception ex) {
             logger.warning(

--- a/src/main/java/edu/harvard/iq/dataverse/dataverse/DataverseUtil.java
+++ b/src/main/java/edu/harvard/iq/dataverse/dataverse/DataverseUtil.java
@@ -4,6 +4,7 @@ import edu.harvard.iq.dataverse.Dataset;
 import edu.harvard.iq.dataverse.Dataverse;
 import edu.harvard.iq.dataverse.DvObjectContainer;
 import edu.harvard.iq.dataverse.authorization.groups.impl.ipaddress.ip.IpAddress;
+import edu.harvard.iq.dataverse.authorization.users.AuthenticatedUser;
 import edu.harvard.iq.dataverse.authorization.users.User;
 import edu.harvard.iq.dataverse.engine.command.DataverseRequest;
 import edu.harvard.iq.dataverse.util.BundleUtil;
@@ -37,16 +38,30 @@ public class DataverseUtil {
         String jsonMetadata;
 
         String sourceAddressLabel = "0.0.0.0";
+        String userIdentifier = "guest";
 
         if (request != null) {
             IpAddress sourceAddress = request.getSourceAddress();
             if (sourceAddress != null) {
                 sourceAddressLabel = sourceAddress.toString();
             }
+            AuthenticatedUser user = request.getAuthenticatedUser();
+            
+            if (user != null) {
+                userIdentifier = user.getUserIdentifier();
+            }
         }
 
+        // We are sending the collection metadata encoded in our standard json 
+        // format, with a couple of extra elements added, such as the id of 
+        // the user sending the request and the source address, in order to make 
+        // it easier for the filter to whitelist users. 
+        
         try {
-            jsonMetadata = json(dv).add("sourceAddress", sourceAddressLabel).build().toString();
+            jsonMetadata = json(dv)
+                    .add("sourceAddress", sourceAddressLabel)
+                    .add("userIdentifier", userIdentifier)
+                    .build().toString();
         } catch (Exception ex) {
             logger.warning(
                     "Failed to export dataverse metadata as json; " + ex.getMessage() == null ? "" : ex.getMessage());


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds a couple of extra bits of information to the json that the application passes to the external metadata filter. This is for better record keeping and managing white lists on the filter side. 

**Which issue(s) this PR closes**:

Closes #9727

**Special notes for your reviewer**:

**Suggestions on how to test this**:

All this PR does is add 2 extra fields to the json exports for datasets and collections that are generated for the external filter. 
The easiest way to test would be to configure the filtering by setting both `:DataverseMetadataValidatorScript` and `:DatasetMetadataValidatorScript` to `/usr/bin/true`; then publish a collection and a dataset, and inspect the metadata exports left in `/tmp`. Both should have the 2 extra fields at the end: `userIdentifier` and `parentAlias`. 


**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
