### PR TITLE
Adds GitHub action for deploying to beta testing environment

### DIFF
--- a/.github/workflows/deploy_beta_testing.yml
+++ b/.github/workflows/deploy_beta_testing.yml
@@ -1,0 +1,80 @@
+name: 'Deploy to Beta Testing'
+
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    environment: beta-testing
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '11'
+
+      - name: Build application war
+        run: mvn package
+
+      - name: Get war file name
+        working-directory: target
+        run: echo "war_file=$(ls *.war | head -1)">> $GITHUB_ENV
+
+      - name: Upload war artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: built-app
+          path: ./target/${{ env.war_file }}
+
+  deploy-to-payara:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: beta-testing
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Download war artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: built-app
+          path: ./
+
+      - name: Get war file name
+        run: echo "war_file=$(ls *.war | head -1)">> $GITHUB_ENV
+
+      - name: Copy war file to remote instance
+        uses: appleboy/scp-action@master
+        with:
+          host: ${{ secrets.PAYARA_INSTANCE_HOST }}
+          username: ${{ secrets.PAYARA_INSTANCE_USERNAME }}
+          key: ${{ secrets.PAYARA_INSTANCE_SSH_PRIVATE_KEY }}
+          source: './${{ env.war_file }}'
+          target: '/home/${{ secrets.PAYARA_INSTANCE_USERNAME }}'
+          overwrite: true
+
+      - name: Execute payara war deployment remotely
+        uses: appleboy/ssh-action@v1.0.0
+        env:
+          INPUT_WAR_FILE: ${{ env.war_file }}
+        with:
+          host: ${{ secrets.PAYARA_INSTANCE_HOST }}
+          username: ${{ secrets.PAYARA_INSTANCE_USERNAME }}
+          key: ${{ secrets.PAYARA_INSTANCE_SSH_PRIVATE_KEY }}
+          envs: INPUT_WAR_FILE
+          script: |
+            APPLICATION_NAME=dataverse-backend
+            ASADMIN='/usr/local/payara5/bin/asadmin --user admin'
+            $ASADMIN undeploy $APPLICATION_NAME
+            $ASADMIN stop-domain
+            rm -rf /usr/local/payara5/glassfish/domains/domain1/generated
+            rm -rf /usr/local/payara5/glassfish/domains/domain1/osgi-cache
+            $ASADMIN start-domain
+            $ASADMIN deploy --name $APPLICATION_NAME $INPUT_WAR_FILE
+            $ASADMIN stop-domain
+            $ASADMIN start-domain


### PR DESCRIPTION
## What this PR does / why we need it:

Adds a GitHub action that is executed on any push event in the develop branch and deploys the application to the remote Beta Testing environment.

## Which issue(s) this PR closes:

- Closes #9746 

## Special notes for your reviewer:

We need to create the GitHub environment in this repository with the secrets corresponding to the credentials to allow the GitHub action to access and update the Beta Testing instance.

The PR reviewer / QA should contact me to set up this environment, since I have the secrets.

## Suggestions on how to test this:

You can see how the action works in my fork repository, where I have committed several times in the develop branch, causing these events to trigger the action:
https://github.com/GPortas/dataverse/actions/runs/5741044286

These actions have updated the environment, available at the following URL:
https://beta.dataverse.org/

## Does this PR introduce a user interface change? If mockups are available, please link/include them here:
No

## Is there a release notes update needed for this change?:
Not sure.

## Additional documentation:
N/A