### PR TITLE
Fix deploy beta testing action to enable api-session-auth feature flag

### DIFF
--- a/.github/workflows/deploy_beta_testing.yml
+++ b/.github/workflows/deploy_beta_testing.yml
@@ -18,6 +18,10 @@ jobs:
           distribution: 'zulu'
           java-version: '11'
 
+      - name: Enable API Session Auth feature flag
+        working-directory: src/main/resources/META-INF
+        run: echo -e "dataverse.feature.api-session-auth=true" >> microprofile-config.properties
+
       - name: Build application war
         run: mvn package
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a missing step to the beta testing environment deployment GitHub action.

**Which issue(s) this PR closes**:
N/A

**Special notes for your reviewer**:
The action worked before, but requests from the SPA to the backend were failing because the feature flag for the cookie authentication was not enabled.

## Suggestions on how to test this:

You can see how the action works in my fork repository, where I have committed several times in the develop branch, causing these events to trigger the action:
https://github.com/GPortas/dataverse/actions/runs/5749971477

These actions have updated the environment, available at the following URL:
https://beta.dataverse.org/

## Does this PR introduce a user interface change? If mockups are available, please link/include them here:
No

## Is there a release notes update needed for this change?:
Not sure.

## Additional documentation:
N/A

**Additional documentation**:
