### PR TITLE
IQSS/9758 Fix Tabular Tag entry from file table kebab menu

### DIFF
--- a/src/main/webapp/editFilesFragment.xhtml
+++ b/src/main/webapp/editFilesFragment.xhtml
@@ -903,7 +903,7 @@
                                           filter="false">
                         <f:selectItems value="#{EditDatafilesPage.tabFileTags}" />
                         <p:ajax event="toggleSelect" listener="#{EditDatafilesPage.handleTabularTagsSelection}" update="tabularDataTags" />
-                        <p:ajax event="change" listener="#{EditDatafilesPage.TabularTagsSelection}" update="tabularDataTags" />
+                        <p:ajax event="change" listener="#{EditDatafilesPage.handleTabularTagsSelection}" update="tabularDataTags" />
                     </p:selectCheckboxMenu>
                     <p:message for="tabularDataTags" display="text" />
                 </div>


### PR DESCRIPTION
**What this PR does / why we need it**: This fixes a bug in the kebab menu

**Which issue(s) this PR closes**:

Closes #9758

**Special notes for your reviewer**: Fixed this just because it slowed me down in debugging the 5.14 DDI infinite loop issue...

**Suggestions on how to test this**: With a tabular file, click the kebab menu  metadata entry and try to add a tabular tag(s). Clicking save will often not work. (I've seen one change work I think - possibly after hitting the checkbox for one tag repeatedly.) With the PR, adding tabular tags should always work from the kebab menu. Regression test: this should not affect changing tabular tags by selecting a file row and using the file table's main Edit button to add a tabular tag.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
