### PR TITLE
9769 fix docker push

### DIFF
--- a/.github/workflows/container_app_push.yml
+++ b/.github/workflows/container_app_push.yml
@@ -99,8 +99,12 @@ jobs:
         name: "Package & Publish"
         runs-on: ubuntu-latest
         # Only run this job if we have access to secrets. This is true for events like push/schedule which run in
-        # context of main repo, but for PRs only true if coming from the main repo! Forks have no secret access.
-        if: needs.check-secrets.outputs.available == 'true'
+        # context of the main repo, but for PRs only true if coming from the main repo! Forks have no secret access.
+        #
+        # Note: The team's decision was to not auto-deploy an image on any git push where no PR exists (yet).
+        #       Accordingly, only run for push events on branches develop and master.
+        if: needs.check-secrets.outputs.available == 'true' &&
+            ( github.event_name != 'push' || ( github.event_name == 'push' && contains(fromJSON('["develop", "master"]'), github.ref_name)))
         steps:
             - uses: actions/checkout@v3
             - uses: actions/setup-java@v3
@@ -109,7 +113,7 @@ jobs:
                   distribution: temurin
 
             # Depending on context, we push to different targets. Login accordingly.
-            - if: ${{ github.event_name != 'pull_request' }}
+            - if: github.event_name != 'pull_request'
               name: Log in to Docker Hub registry
               uses: docker/login-action@v2
               with:

--- a/.github/workflows/spi_release.yml
+++ b/.github/workflows/spi_release.yml
@@ -2,12 +2,12 @@ name: Dataverse SPI
 
 on:
     push:
-        branch:
+        branches:
             - "develop"
         paths:
             - "modules/dataverse-spi/**"
     pull_request:
-        branch:
+        branches:
             - "develop"
         paths:
             - "modules/dataverse-spi/**"


### PR DESCRIPTION
**What this PR does / why we need it**:
This fixes the container push workflow, sending feature branch preview images to Docker Hub, breaking workflows for many.

**Which issue(s) this PR closes**:

Closes #9769 

**Special notes for your reviewer**:
None

**Suggestions on how to test this**:
Must be merged to see effect. Push a commit to a feature branch (updated to latest develop) and see how the image deployment is skipped. Cannot be seen from this PR as from a forked repo, could be tested from cloning the branch into an upstream repo one.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
No

**Is there a release notes update needed for this change?**:
No

**Additional documentation**:
None