### PR TITLE
Update to Maven Docker Plugin 0.43.4

### DIFF
--- a/modules/dataverse-parent/pom.xml
+++ b/modules/dataverse-parent/pom.xml
@@ -198,7 +198,7 @@
         <pomchecker-maven-plugin.version>1.7.0</pomchecker-maven-plugin.version>
         
         <!-- Container related -->
-        <fabric8-dmp.version>0.43.0</fabric8-dmp.version>
+        <fabric8-dmp.version>0.43.3</fabric8-dmp.version>
     </properties>
     
     <pluginRepositories>

--- a/modules/dataverse-parent/pom.xml
+++ b/modules/dataverse-parent/pom.xml
@@ -198,7 +198,7 @@
         <pomchecker-maven-plugin.version>1.7.0</pomchecker-maven-plugin.version>
         
         <!-- Container related -->
-        <fabric8-dmp.version>0.43.3</fabric8-dmp.version>
+        <fabric8-dmp.version>0.43.4</fabric8-dmp.version>
     </properties>
     
     <pluginRepositories>


### PR DESCRIPTION
**What this PR does / why we need it**:
With this new version, a problem on M1 MACs not being able to build with Docker because of a non-existing config file was worked around by the DMP devs.

**Which issue(s) this PR closes**:

- Closes #9771 

**Special notes for your reviewer**:
There is a [bug report](https://github.com/fabric8io/docker-maven-plugin/issues/1698) that 0.43.2 was no longer allowing to push images. We'll see if this works again with this version.

**Suggestions on how to test this**:
@sekmiller is the one having the troubles. Hard to test.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
