### PR TITLE
Update the beta-testing deploy GitHub action to use "flat" GitHub secrets

### DIFF
--- a/.github/workflows/deploy_beta_testing.yml
+++ b/.github/workflows/deploy_beta_testing.yml
@@ -8,7 +8,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    environment: beta-testing
 
     steps:
       - uses: actions/checkout@v3
@@ -38,7 +37,6 @@ jobs:
   deploy-to-payara:
     needs: build
     runs-on: ubuntu-latest
-    environment: beta-testing
 
     steps:
       - uses: actions/checkout@v3
@@ -55,11 +53,11 @@ jobs:
       - name: Copy war file to remote instance
         uses: appleboy/scp-action@master
         with:
-          host: ${{ secrets.PAYARA_INSTANCE_HOST }}
-          username: ${{ secrets.PAYARA_INSTANCE_USERNAME }}
-          key: ${{ secrets.PAYARA_INSTANCE_SSH_PRIVATE_KEY }}
+          host: ${{ secrets.BETA_PAYARA_INSTANCE_HOST }}
+          username: ${{ secrets.BETA_PAYARA_INSTANCE_USERNAME }}
+          key: ${{ secrets.BETA_PAYARA_INSTANCE_SSH_PRIVATE_KEY }}
           source: './${{ env.war_file }}'
-          target: '/home/${{ secrets.PAYARA_INSTANCE_USERNAME }}'
+          target: '/home/${{ secrets.BETA_PAYARA_INSTANCE_USERNAME }}'
           overwrite: true
 
       - name: Execute payara war deployment remotely
@@ -67,17 +65,17 @@ jobs:
         env:
           INPUT_WAR_FILE: ${{ env.war_file }}
         with:
-          host: ${{ secrets.PAYARA_INSTANCE_HOST }}
-          username: ${{ secrets.PAYARA_INSTANCE_USERNAME }}
-          key: ${{ secrets.PAYARA_INSTANCE_SSH_PRIVATE_KEY }}
+          host: ${{ secrets.BETA_PAYARA_INSTANCE_HOST }}
+          username: ${{ secrets.BETA_PAYARA_INSTANCE_USERNAME }}
+          key: ${{ secrets.BETA_PAYARA_INSTANCE_SSH_PRIVATE_KEY }}
           envs: INPUT_WAR_FILE
           script: |
             APPLICATION_NAME=dataverse-backend
-            ASADMIN='/usr/local/payara5/bin/asadmin --user admin'
+            ASADMIN='/usr/local/payara6/bin/asadmin --user admin'
             $ASADMIN undeploy $APPLICATION_NAME
             $ASADMIN stop-domain
-            rm -rf /usr/local/payara5/glassfish/domains/domain1/generated
-            rm -rf /usr/local/payara5/glassfish/domains/domain1/osgi-cache
+            rm -rf /usr/local/payara6/glassfish/domains/domain1/generated
+            rm -rf /usr/local/payara6/glassfish/domains/domain1/osgi-cache
             $ASADMIN start-domain
             $ASADMIN deploy --name $APPLICATION_NAME $INPUT_WAR_FILE
             $ASADMIN stop-domain


### PR DESCRIPTION
## What this PR does / why we need it:

Updates the beta-testing deploy GitHub action to use "flat" GitHub secrets instead of GitHub environments with secrets, since the GitHub organization does not support that feature.

Also updates the action to use payara6 commands.

## Which issue(s) this PR closes:

- Closes #9784 

## Special notes for your reviewer:

New GitHub secrets are already configured by myself in the IQSS/dataverse repository.

## Suggestions on how to test this:

You can see how my fork correctly deploys the application using the implemented changes:
https://github.com/GPortas/dataverse/actions/runs/5892650217/job/15982711141

## Does this PR introduce a user interface change? If mockups are available, please link/include them here:

N/A

## Is there a release notes update needed for this change?:

No

## Additional documentation:

N/A
