### PR TITLE
switch to SWORD 2.0.0 non-snapshot

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
         <dependency>
             <groupId>io.gdcc</groupId>
             <artifactId>sword2-server</artifactId>
-            <version>2.0.0-SNAPSHOT</version>
+            <version>2.0.0</version>
         </dependency>
         <!-- Dependency to use sword2-server in our codebase -->
         <dependency>


### PR DESCRIPTION
**What this PR does / why we need it**:

Snapshot releases can change under our feet. @poikilotherm and I released 2.0.0 of our SWORD library today. This pull request switches us to it.

**Which issue(s) this PR closes**:

- Closes #9801

**Special notes for your reviewer**:

The only changes in the SWORD library since the most recent snapshot we've all been using from the Payara 6 branch are a few dependabot pull requests I merged:

- https://github.com/gdcc/sword2-server/pull/80
- https://github.com/gdcc/sword2-server/pull/152
- pomchecker: https://github.com/gdcc/sword2-server/commit/7b0c9c0e933d57c138c2a23dc2b9c63658a84b82

**Suggestions on how to test this**:

SwordIT should pass.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No.

**Is there a release notes update needed for this change?**:

No.

**Additional documentation**:

None.