### PR TITLE
9829 Use macos-latest runner for shellspec

### DIFF
--- a/.github/workflows/shellspec.yml
+++ b/.github/workflows/shellspec.yml
@@ -60,7 +60,7 @@ jobs:
                   shellspec
     shellspec-macos:
         name: "MacOS"
-        runs-on: macos-10.15
+        runs-on: macos-latest
         steps:
             - name: Install shellspec
               run: curl -fsSL https://git.io/shellspec | sh -s 0.28.1 --yes


### PR DESCRIPTION
**What this PR does / why we need it**:
It updates the Shellspec workflow to use the newer MacOS runners, since the `macos-10.15` are no longer available causing all Shellspec workflow to fail after being queued for a day.

**Which issue(s) this PR closes**:

Closes #9829

**Special notes for your reviewer**:
I assume that shellspec works the same on MacOS 11 and up as on MacOS 10.15. I have not tested this.

**Suggestions on how to test this**:
See that the new jobs pass.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
No.

**Is there a release notes update needed for this change?**:
Maybe; if release notes (should) include MacOS compatibility notes, then yes.

**Additional documentation**:
