### PR TITLE
add note about :MDCLogPath, Payara 5 vs 6 #9822

### DIFF
--- a/doc/release-notes/9340-payara5to6.md
+++ b/doc/release-notes/9340-payara5to6.md
@@ -76,6 +76,10 @@
 
    `sudo -u dataverse vi /usr/local/payara6/glassfish/domains/domain1/config/jhove.conf`
 
+1. If you are using Make Data Count (MDC), edit :MDCLogPath
+
+   Your `:MDCLogPath` database setting might be pointing to a Payara 5 directory such as `/usr/local/payara5/glassfish/domains/domain1/logs`. If so, edit this to be Payara 6. You'll probably want to copy your logs over as well.
+
 1. Update systemd unit file (or other init system) from `/usr/local/payara5` to `/usr/local/payara6`, if applicable.
 
 1. Start Payara:

--- a/doc/release-notes/9340-payara5to6.md
+++ b/doc/release-notes/9340-payara5to6.md
@@ -76,6 +76,12 @@
 
    `sudo -u dataverse vi /usr/local/payara6/glassfish/domains/domain1/config/jhove.conf`
 
+1. Copy logos from Payara 5 to Payara 6
+
+   These logos are for collections (dataverses).
+
+   `sudo -u dataverse cp -r /usr/local/payara5/glassfish/domains/domain1/docroot/logos /usr/local/payara6/glassfish/domains/domain1/docroot`
+
 1. If you are using Make Data Count (MDC), edit :MDCLogPath
 
    Your `:MDCLogPath` database setting might be pointing to a Payara 5 directory such as `/usr/local/payara5/glassfish/domains/domain1/logs`. If so, edit this to be Payara 6. You'll probably want to copy your logs over as well.


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR lets people upgrading to Payara 6 know that :MDCLogPath might be pointing at their old Payara 5 directory.

**Which issue(s) this PR closes**:

- Closes #9822

**Special notes for your reviewer**:

I poked around in the docs and couldn't find other cases of this.

**Suggestions on how to test this**:

Nothing to test, really. It's just a note.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No.

**Is there a release notes update needed for this change?**:

No, this edit is part of the main Payara 6 release note.

**Additional documentation**:

None.