### PR TITLE
release note for archivers

### DIFF
--- a/doc/release-notes/9812-archiver-warnings.md
+++ b/doc/release-notes/9812-archiver-warnings.md
@@ -1,0 +1,7 @@
+# Potential Archiver Incompatibilities with Payara6
+The Google Cloud and DuraCloud Archivers (see https://guides.dataverse.org/en/latest/installation/config.html#bagit-export) may not work in v6.0.
+This is due to their dependence on libraries that include classes in javax.* packages that are no longer available.
+If these classes are actually used when the archivers run, the archivers would fail.
+As these two archivers require additional setup, they have not been tested in v6.0.
+Community members using these archivers or considering their use are encouraged to test them with v6.0 and report any errors and/or provide fixes for them that can be included in future releases.
+


### PR DESCRIPTION
**What this PR does / why we need it**: adds a release note about the potential incompatibility of the Google Cloud and DuraCloud Archivers/BagIt Exporters with v6.0.

**Which issue(s) this PR closes**:

Closes #9812
Closes #9811 

**Special notes for your reviewer**: Closing the issues as I expect a new post 6.0 issue can be opened with more details about any specific issues that arise.

**Suggestions on how to test this**:

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**: That's all this is.

**Additional documentation**:
