### PR TITLE
get FITS metadata extraction working again post PR 9841

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -294,7 +294,7 @@
         <dependency>
             <groupId>gov.nasa.gsfc.heasarc</groupId>
             <artifactId>nom-tam-fits</artifactId>
-            <version>1.18.0</version>
+            <version>1.12.0</version>
         </dependency>
         <dependency>
             <groupId>net.handle</groupId>

--- a/src/test/java/edu/harvard/iq/dataverse/api/FitsIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/FitsIT.java
@@ -60,6 +60,7 @@ public class FitsIT {
         getJson.prettyPrint();
         getJson.then().assertThat()
                 .statusCode(OK.getStatusCode())
+                .body("data.latestVersion.files[0].description", equalTo("FITS file, 2 HDUs total:\nThe primary HDU; 1 Table HDU(s) 1 Image HDU(s); \nThe following recognized metadata keys have been found in the FITS file:\nCRVAL2; NAXIS; INSTRUME; NAXIS1; NAXIS0; EXPTIME; CD1_1; CRVAL1; TARGNAME; DATE-OBS; \n"))
                 .body("data.latestVersion.metadataBlocks.astrophysics.fields[0].value[0]", equalTo("Image"));
 
         // a bit more precise than the check for "Image" above (but annoyingly fiddly)


### PR DESCRIPTION
**What this PR does / why we need it**:

The following PR broke FITS metadata extraction (sorry)...

- #9841

... as judged by the FitsIT test. Right now develop has FITS version 1.18.0.

**Which issue(s) this PR closes**:

- Closes #9808

**Special notes for your reviewer**:

I went for the oldest version, 1.12.0 (dated Feb 21, 2015),  to be closest to the jar we were using (fits-2012-10-25-generated.jar).

I did try 1.17.1 and 1.17.0 but FitsIT fails with this (undefined instead of image):

```
Expected: FITS file, 2 HDUs total:\nThe primary HDU; 1 Table HDU(s) 1 Image HDU(s); \nThe following recognized metadata keys have been found in the FITS file:\nCRVAL2; NAXIS; INSTRUME; NAXIS1; NAXIS0; EXPTIME; CD1_1; CRVAL1; TARGNAME; DATE-OBS; \n
  Actual: FITS file, 2 HDUs total:\nThe primary HDU; 1 Image HDU(s); 1 undefined HDU(s); \nThe following recognized metadata keys have been found in the FITS file:\nCRVAL2; NAXIS; INSTRUME; NAXIS1; NAXIS0; EXPTIME; CD1_1; CRVAL1; TARGNAME; DATE-OBS; \n
```

I'm willing the try other versions. Let me know. Here is the list of versions: https://mvnrepository.com/artifact/gov.nasa.gsfc.heasarc/nom-tam-fits

**Suggestions on how to test this**:

Make sure FitsIT is passing in Jenkins.

From [Slack](https://iqss.slack.com/archives/C010LA04BCG/p1693342065698989):

"So I guess it was still extracting to the file description ok.

The test in FitsIT enabled the astro block and checks if fields are populated from the file. That’s the part that was failing."

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No.

**Is there a release notes update needed for this change?**:

No.

**Additional documentation**:

None.