### PR TITLE
9773 - fix embargo for Payara 6

### DIFF
--- a/src/main/webapp/file-edit-button-fragment.xhtml
+++ b/src/main/webapp/file-edit-button-fragment.xhtml
@@ -83,8 +83,7 @@
         <li>
             <p:commandLink      update="@([id$=fileTagsPopup])" 
                                 onclick="if (!testTermsOfAccess() || !(#{fileMetadata!=null} || testFilesSelected()))
-                                            return false;"                                 
-                                action="#{bean[refreshTagsPopoupAction]()}">            
+                                            return false;">            
                 <h:outputText value="#{bundle['file.tags']}"/>
             </p:commandLink>    
         </li>  


### PR DESCRIPTION
**What this PR does / why we need it**:

fixes the issue with embargo on Payara6

**Which issue(s) this PR closes**:

Closes #9773

**Special notes for your reviewer**:

note that the deleted action was never defined in the .xhtml files that included this fragment nor did any refresh Embargo methods ever exist in the associated java classes (likely that was copied from refreshTags and erroneously left behind) 

refreshTags does have some logic that may be desired for embargo, but that is out of scope as it dod not exist in 5.14 (or ever) and we can handle in the SPA

**Suggestions on how to test this**:

Make sure embargo now works as expected (including not allowing for published files)

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

no

**Is there a release notes update needed for this change?**:

no

**Additional documentation**:
