### PR TITLE
get tests passing in Jenkins

### DIFF
--- a/src/test/java/edu/harvard/iq/dataverse/api/DataversesIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/DataversesIT.java
@@ -372,7 +372,7 @@ public class DataversesIT {
         while (checkIndex) {
             try {   
                     try {
-                        Thread.sleep(2000);
+                        Thread.sleep(4000);
                     } catch (InterruptedException ex) {
                     }                
                 Response search = UtilIT.search("id:dataverse_" + dataverseId + "&subtree=" + dataverseAlias2, apiToken);

--- a/src/test/java/edu/harvard/iq/dataverse/api/FilesIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/FilesIT.java
@@ -1107,7 +1107,7 @@ public class FilesIT {
         Response addResponse = UtilIT.uploadFileViaNative(datasetId.toString(), pathToFile, apiToken);
         
         // Wait a little while for the index to pick up the file, otherwise timing issue with searching for it.
-        UtilIT.sleepForReindex(datasetId.toString(), apiToken, 2);
+        UtilIT.sleepForReindex(datasetId.toString(), apiToken, 4);
 
         String successMsgAdd = BundleUtil.getStringFromBundle("file.addreplace.success.add");
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Before we release 6.0, all tests should be passing on https://jenkins.dataverse.org/job/IQSS-dataverse-develop/

**Which issue(s) this PR closes**:

- Closes #9848

**Special notes for your reviewer**:

Just some more sleep. 😴 

As I mentioned at standup, I'm also concerned that sometimes Dataverse won't deploy in 90 seconds. Here's a related issue:

- #5593

We may need to bump up the value in Ansible from 90 seconds.

Also, please note that I didn't fix FitsIT in this PR. The fix for that is over here:

- #9849

The first commit on this PR passed except for FitsIT: https://jenkins.dataverse.org/job/IQSS-Dataverse-Develop-PR/job/PR-9855/1/testReport/

I followed up with another pre-emptive doubling of sleep in a second commit for a test that failed previously.

**Suggestions on how to test this**:

Check Jenkins. Are the tests passing?

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No.

**Is there a release notes update needed for this change?**:

No.

**Additional documentation**:

None.