### PR TITLE
Update file-edit-button-fragment.xhtml

### DIFF
--- a/src/main/webapp/file-edit-button-fragment.xhtml
+++ b/src/main/webapp/file-edit-button-fragment.xhtml
@@ -95,8 +95,7 @@
             <p:commandLink      update="@([id$=fileEmbargoPopup])" 
                                 onclick="if (!(#{fileMetadata!=null} || testFilesSelected()))
                                             return false;" 
-                                oncomplete="PF('fileEmbargoPopup').show();"
-                                action="#{bean[refreshEmbargoPopoupAction]()}">
+                                oncomplete="PF('fileEmbargoPopup').show();">
                                 <f:setPropertyActionListener target="#{fileMetadataForAction}" value="#{fileMetadata}" />
                 <h:outputText value="#{bundle['file.embargo']}"/>
             </p:commandLink> 


### PR DESCRIPTION
What this PR does / why we need it:

fixes the issue with embargo on Payara6

Which issue(s) this PR closes:

Closes https://github.com/IQSS/dataverse/issues/9773

Special notes for your reviewer:

note that the deleted action was never defined in the .xhtml files that included this fragment nor did any refresh Embargo methods ever exist in the associated java classes (likely that was copied from refreshTags and erroneously left behind)

refreshTags does have some logic that may be desired for embargo, but that is out of scope as it dod not exist in 5.14 (or ever) and we can handle in the SPA

Suggestions on how to test this:

Make sure embargo now works as expected (including not allowing for published files)

Does this PR introduce a user interface change? If mockups are available, please link/include them here:

no

Is there a release notes update needed for this change?:

no

Additional documentation: