### PR TITLE
mention requestHeaderSize increase

### DIFF
--- a/doc/release-notes/9260-solr930.md
+++ b/doc/release-notes/9260-solr930.md
@@ -25,6 +25,10 @@ We assume that you already have a user called "solr" (from the instructions abov
    cp /tmp/dvinstall/solrconfig.xml /usr/local/solr/solr-9.3.0/server/solr/collection1/conf
    ```
 
+1. A Dataverse installation requires a change to the jetty.xml file that ships with Solr.
+
+   Edit /usr/local/solr/solr-9.3.0/server/etc/jetty.xml , increasing `requestHeaderSize` from `8192` to `102400`
+
 1. Tell Solr to create the core "collection1" on startup.
 
    ```


### PR DESCRIPTION
**What this PR does / why we need it**:

The Solr 9.3.0 upgrade release notes omit the historically required modification of jetty.xml's `requestHeaderSize` setting. Adding this in per @pdurbin

**Which issue(s) this PR closes**:

Closes #9866

**Special notes for your reviewer**:

None

**Suggestions on how to test this**:

Standard Solr tests?

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No

**Is there a release notes update needed for this change?**:

Yes

**Additional documentation**:
