### PR TITLE
disable loading of metadata blocks in API tests, more sleep

### DIFF
--- a/src/test/java/edu/harvard/iq/dataverse/api/AdminIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/AdminIT.java
@@ -734,6 +734,13 @@ public class AdminIT {
                 .statusCode(OK.getStatusCode());
     }
 
+    /**
+     * Disabled because once there are new fields in the database that Solr
+     * doesn't know about, dataset creation could be prevented, or at least
+     * subsequent search operations could fail because the dataset can't be
+     * indexed.
+     */
+    @Disabled
     @Test
     public void testLoadMetadataBlock_NoErrorPath() {
         Response createUser = UtilIT.createRandomUser();
@@ -778,6 +785,13 @@ public class AdminIT {
         assertEquals(244, (int) statistics.get("Controlled Vocabulary"));
     }
 
+    /**
+     * Disabled because once there are new fields in the database that Solr
+     * doesn't know about, dataset creation could be prevented, or at least
+     * subsequent search operations could fail because the dataset can't be
+     * indexed.
+     */
+    @Disabled
     @Test
     public void testLoadMetadataBlock_ErrorHandling() {
         Response createUser = UtilIT.createRandomUser();

--- a/src/test/java/edu/harvard/iq/dataverse/api/MoveIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/MoveIT.java
@@ -300,7 +300,7 @@ public class MoveIT {
                 .statusCode(OK.getStatusCode())
                 .body("feed.entry[0].id", CoreMatchers.endsWith(datasetPid));
 
-        UtilIT.sleepForReindex(datasetPid, superuserApiToken, 10);
+        UtilIT.sleepForReindex(datasetPid, superuserApiToken, 20);
         Response getLinksAfter = UtilIT.getDatasetLinks(datasetPid, superuserApiToken);
         getLinksAfter.prettyPrint();
         getLinksAfter.then().assertThat()

--- a/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
@@ -563,7 +563,14 @@ public class UtilIT {
                 .post("/api/datasets/:persistentId/modifyRegistrationMetadata/?persistentId=" + persistentId);
         return response;
     }
-    
+
+    /**
+     * Deprecated because once there are new fields in the database that Solr
+     * doesn't know about, dataset creation could be prevented, or at least
+     * subsequent search operations could fail because the dataset can't be
+     * indexed.
+     */
+    @Deprecated    
     static Response loadMetadataBlock(String apiToken, byte[] body) {
         return given()
           .header(API_TOKEN_HTTP_HEADER, apiToken)


### PR DESCRIPTION
**What this PR does / why we need it**:

We can't ship 6.0 with failing tests.

**Which issue(s) this PR closes**:

- Closes #9868

**Special notes for your reviewer**:

During the containerization meeting yesterday we talked about why tests are failing at https://github.com/gdcc/api-test-runner . (This was about 20 minutes in at https://harvard.zoom.us/rec/share/Nsm8SZgE05wuziNoGPA9fYNCPoYH1sKqvgS7omn-nclo6qFTsAn-qu-pqF4JnFuZ.joqMRTV6SqSf5gMl ). One avenue to explore is how we load metadata blocks (added in PR #6921) but don't update the Solr schema. Is this a problem?

I disabled two tests with this note: `Disabled because once there are new fields in the database that Solr doesn't know about, dataset creation could be prevented, or at least subsequent search operations could fail because the dataset can't be indexed.`

It's somewhat mysterious why GitHub Actions is more sensitive to the loading of a metadata block than Jenkins is. Jenkins can be fixed with more sleep in #9874.

See test results below.

**Suggestions on how to test this**:

Check Jenkins and GitHub Actions.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No.

**Is there a release notes update needed for this change?**:

No.

**Additional documentation**:

None.