### PR TITLE
support Postgres versions 14 and 15

### DIFF
--- a/doc/sphinx-guides/source/installation/prerequisites.rst
+++ b/doc/sphinx-guides/source/installation/prerequisites.rst
@@ -97,10 +97,14 @@ Also note that Payara may utilize more than the default number of file descripto
 PostgreSQL
 ----------
 
+PostgreSQL 13 is recommended because it's the version we test against. Version 10 or higher is required because that's what's `supported by Flyway <https://documentation.red-gate.com/fd/postgresql-184127604.html>`_, which we use for database migrations.
+
+You are welcome to experiment with newer versions of PostgreSQL, but please note that as of PostgreSQL 15, permissions have been restricted on the ``public`` schema (`release notes <https://www.postgresql.org/docs/release/15.0/>`_, `EDB blog post <https://www.enterprisedb.com/blog/new-public-schema-permissions-postgresql-15>`_, `Crunchy Data blog post <https://www.crunchydata.com/blog/be-ready-public-schema-changes-in-postgres-15>`_). The Dataverse installer has been updated to restore the old permissions, but this may not be a long term solution.
+
 Installing PostgreSQL
 =====================
 
-The application has been tested with PostgreSQL versions up to 13 and version 10+ is required. We recommend installing the latest version that is available for your OS distribution. *For example*, to install PostgreSQL 13 under RHEL7/derivative::
+*For example*, to install PostgreSQL 13 under RHEL7/derivative::
 
 	# yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm
 	# yum makecache fast

--- a/modules/dataverse-parent/pom.xml
+++ b/modules/dataverse-parent/pom.xml
@@ -149,7 +149,7 @@
     
         <!-- Major system components and dependencies -->
         <payara.version>6.2023.8</payara.version>
-        <postgresql.version>42.5.1</postgresql.version>
+        <postgresql.version>42.6.0</postgresql.version>
         <solr.version>9.3.0</solr.version>
         <aws.version>1.12.290</aws.version>
         <google.cloud.version>0.177.0</google.cloud.version>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <packaging.type>war</packaging.type>
         
         <reload4j.version>1.2.18.4</reload4j.version>
-        <flyway.version>8.5.10</flyway.version>
+        <flyway.version>9.21.2</flyway.version>
         <jhove.version>1.20.1</jhove.version>
         <jacoco.version>0.8.7</jacoco.version>
         <poi.version>5.2.1</poi.version>

--- a/scripts/installer/install.py
+++ b/scripts/installer/install.py
@@ -423,15 +423,15 @@ if podName != "start-glassfish" and podName != "dataverse-glassfish-0" and not s
 
    if int(pg_major_version) >= 15:
       conn_cmd = "GRANT ALL ON SCHEMA public TO "+pgUser+";"
-   try:
-      cur.execute(conn_cmd)
-   except:
-      if force:
-         print("WARNING: failed to grant permissions on schema public - continuing, since the --force option was specified")
-      else:
-         sys.exit("Couldn't grant privileges on schema public to "+pgUser)
-   cur.close()
-   conn.close()
+      try:
+         cur.execute(conn_cmd)
+      except:
+         if force:
+            print("WARNING: failed to grant permissions on schema public - continuing, since the --force option was specified")
+         else:
+            sys.exit("Couldn't grant privileges on schema public to "+pgUser)
+      cur.close()
+      conn.close()
 
    print("Database and role created!")
    if pgOnly:

--- a/scripts/installer/install.py
+++ b/scripts/installer/install.py
@@ -413,7 +413,7 @@ if podName != "start-glassfish" and podName != "dataverse-glassfish-0" and not s
 
    # 3e. set permissions:
 
-   conn_cmd = "GRANT ALL PRIVILEGES on DATABASE "+pgDb+" to "+pgUser+";"
+   conn_cmd = "GRANT CREATE PRIVILEGES on DATABASE "+pgDb+" to "+pgUser+";"
    try:
       cur.execute(conn_cmd)
    except:

--- a/scripts/installer/install.py
+++ b/scripts/installer/install.py
@@ -423,6 +423,7 @@ if podName != "start-glassfish" and podName != "dataverse-glassfish-0" and not s
 
    if int(pg_major_version) >= 15:
       conn_cmd = "GRANT ALL ON SCHEMA public TO "+pgUser+";"
+      print("PostgreSQL 15 or higher detected. Running " + conn_cmd)
       try:
          cur.execute(conn_cmd)
       except:

--- a/scripts/installer/install.py
+++ b/scripts/installer/install.py
@@ -380,12 +380,13 @@ if podName != "start-glassfish" and podName != "dataverse-glassfish-0" and not s
       print("Can't connect to PostgresQL as the admin user.\n")
       sys.exit("Is the server running, have you adjusted pg_hba.conf, etc?")
 
-   # 3b. get the Postgres version (do we need it still?)
+   # 3b. get the Postgres version for new permissions model in versions 15+
    try:
-      pg_full_version = conn.server_version
-      print("PostgresQL version: "+str(pg_full_version))
+      pg_full_version = str(conn.server_version)
+      pg_major_version = pg_full_version[0:2]
+      print("PostgreSQL version: "+pg_major_version)
    except:
-      print("Warning: Couldn't determine PostgresQL version.")
+      print("Warning: Couldn't determine PostgreSQL version.")
    conn.close()
 
    # 3c. create role:
@@ -410,11 +411,25 @@ if podName != "start-glassfish" and podName != "dataverse-glassfish-0" and not s
       else:
          sys.exit("Couldn't create database or database already exists.\n")
 
+   # 3e. set permissions:
+
    conn_cmd = "GRANT ALL PRIVILEGES on DATABASE "+pgDb+" to "+pgUser+";"
    try:
       cur.execute(conn_cmd)
    except:
       sys.exit("Couldn't grant privileges on "+pgDb+" to "+pgUser)
+   cur.close()
+   conn.close()
+
+   if int(pg_major_version) >= 15:
+      conn_cmd = "GRANT ALL ON SCHEMA public TO "+pgUser+";"
+   try:
+      cur.execute(conn_cmd)
+   except:
+      if force:
+         print("WARNING: failed to grant permissions on schema public - continuing, since the --force option was specified")
+      else:
+         sys.exit("Couldn't grant privileges on schema public to "+pgUser)
    cur.close()
    conn.close()
 


### PR DESCRIPTION
**What this PR does / why we need it**:

add flyway and installer support for Postgres versions 14 and 15

**Which issue(s) this PR closes**:

- Closes #9717 

**Special notes for your reviewer**:

None

**Suggestions on how to test this**:

Install Dataverse using installer and warfile built from branch, run E2E tests.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No

**Is there a release notes update needed for this change?**:

Perhaps, to explain the support (but not requirement) of the newer Postgres versions.

**Additional documentation**:

Added: https://dataverse-guide--9877.org.readthedocs.build/en/9877/installation/prerequisites.html#postgresql