### PR TITLE
fix command for only building configbaker image

### DIFF
--- a/doc/sphinx-guides/source/container/configbaker-image.rst
+++ b/doc/sphinx-guides/source/container/configbaker-image.rst
@@ -86,7 +86,7 @@ Maven modules packaging target with activated "container" profile from the proje
 
 If you specifically want to build a config baker image *only*, try
 
-``mvn -Pct package -Ddocker.filter=dev_bootstrap``
+``mvn -Pct docker:build -Ddocker.filter=dev_bootstrap``
 
 The build of config baker involves copying Solr configset files. The Solr version used is inherited from Maven,
 acting as the single source of truth. Also, the tag of the image should correspond the application image, as


### PR DESCRIPTION
**What this PR does / why we need it**:

As discussed at [#containers > ✔ iterating on configbaker @ 💬](https://dataverse.zulipchat.com/#narrow/channel/375812-containers/topic/.E2.9C.94.20iterating.20on.20configbaker/near/385284844) the current command for building just the configbaker images doesn't work. This PR corrects the docs.

Building configbaker separately from Dataverse is much, much faster.

**Which issue(s) this PR closes**:

None

**Special notes for your reviewer**:

None.

**Suggestions on how to test this**:

I edited `modules/container-configbaker/scripts/bootstrap.sh` (to increase the timeout) but any configbaker script on config would do.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No.

**Is there a release notes update needed for this change?**:

No

**Additional documentation**:

None.