### PR TITLE
increase configbaker timeout

### DIFF
--- a/modules/container-configbaker/scripts/bootstrap.sh
+++ b/modules/container-configbaker/scripts/bootstrap.sh
@@ -13,7 +13,7 @@ function usage() {
   echo ""
   echo "Parameters:"
   echo "instanceUrl - Location on container network where to reach your instance. Default: 'http://dataverse:8080'"
-  echo "    timeout - Provide how long to wait for the instance to become available (using wait4x). Default: '2m'"
+  echo "    timeout - Provide how long to wait for the instance to become available (using wait4x). Default: '3m'"
   echo "    persona - Configure persona to execute. Calls ${BOOTSTRAP_DIR}/<persona>/init.sh. Default: 'base'"
   echo ""
   echo "Note: This script will wait for the Dataverse instance to be available before executing the bootstrapping."
@@ -24,7 +24,7 @@ function usage() {
 
 # Set some defaults as documented
 DATAVERSE_URL=${DATAVERSE_URL:-"http://dataverse:8080"}
-TIMEOUT=${TIMEOUT:-"2m"}
+TIMEOUT=${TIMEOUT:-"3m"}
 
 while getopts "u:t:h" OPTION
 do


### PR DESCRIPTION
**What this PR does / why we need it**:

@nightowlaz was brave enough to try `docker compose -f docker-compose-dev.yml up` from https://guides.dataverse.org/en/5.14/container/dev-usage.html#running BUT it didn't work! :homer-doh:

In this thread we figured out the a 3 minute time out is better than 2 (so I'm bumping it):

https://dataverse.zulipchat.com/#narrow/stream/375812-containers/topic/running.20using.20compose

**Which issue(s) this PR closes**:

None

**Special notes for your reviewer**:

This issue is related:

- #5593

**Suggestions on how to test this**:

Try the docker compose command above. Does it work? In the before/failure case you might see this:

```
dev_bootstrap         | Error: context deadline exceeded
```

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No

**Is there a release notes update needed for this change?**:

No

**Additional documentation**:

No