### PR TITLE
A quick xhtml-only fix for the "template with custom terms of use" bug

### DIFF
--- a/src/main/webapp/file-download-popup-fragment.xhtml
+++ b/src/main/webapp/file-download-popup-fragment.xhtml
@@ -8,6 +8,8 @@
                 xmlns:jsf="http://xmlns.jcp.org/jsf"
                 xmlns:iqbs="http://xmlns.jcp.org/jsf/composite/iqbs">
 
+    <ui:fragment rendered="#{DatasetPage.editMode != 'CREATE'}">
+
         <o:importFunctions type="edu.harvard.iq.dataverse.util.MarkupChecker" />
         <p:focus context="guestbookUIFragment"/>
         <p class="help-block">
@@ -51,6 +53,7 @@
                 </p>
             </div>
         </div>
+        
 
         <ui:fragment rendered="#{empty workingVersion.termsOfUseAndAccess.license}">
             <div class="form-group"
@@ -297,4 +300,5 @@
                 #{bundle.cancel}
             </button>
         </div>
+    </ui:fragment>
 </ui:composition>


### PR DESCRIPTION
**What this PR does / why we need it**:

This fixes, or works around the bug by disabling **everything** inside the file-download-popup-fragment when the page is in CREATE mode. 

**Which issue(s) this PR closes**:

Closes #9825

**Special notes for your reviewer**:

Going forward, we may want to consider adding some null checks inside the java code to prevent this; it's not entirely impossible that another developer will add some code that will try to call this method on a dataset that doesn't yet have a persistent id for whatever reason - ?

**Suggestions on how to test this**:

see the linked issue for the steps to reproduce the bug. 

edit: would also be prudent to confirm that the file download popup is still working when you are actually downloading files from a dataset that has terms of use. I have tested - but worth confirming. 

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
