### PR TITLE
Fix the issues with the permissions of the Docker scripts on Windows

### DIFF
--- a/modules/container-configbaker/Dockerfile
+++ b/modules/container-configbaker/Dockerfile
@@ -26,8 +26,12 @@ RUN true && \
   # Make our working directories
   mkdir -p ${SCRIPT_DIR} ${SECRETS_DIR} ${SOLR_TEMPLATE}
 
-# Get in the scripts and make them executable (just in case...)
+# Get in the scripts 
 COPY maven/scripts maven/solr/update-fields.sh ${SCRIPT_DIR}/
+# Copy the data from scripts/api that provide the common base setup you'd get from the installer.
+# ".dockerignore" will take care of taking only the bare necessities
+COPY maven/setup ${SCRIPT_DIR}/bootstrap/base/
+# Make the scripts executable
 RUN chmod +x ${SCRIPT_DIR}/*.sh ${BOOTSTRAP_DIR}/*/*.sh
 
 # Copy the Solr config bits
@@ -35,10 +39,8 @@ COPY --from=solr /opt/solr/server/solr/configsets/_default ${SOLR_TEMPLATE}/
 COPY maven/solr/*.xml ${SOLR_TEMPLATE}/conf/
 RUN rm ${SOLR_TEMPLATE}/conf/managed-schema.xml
 
-# Copy the data from scripts/api that provide the common base setup you'd get from the installer.
-# ".dockerignore" will take care of taking only the bare necessities
-COPY maven/setup ${SCRIPT_DIR}/bootstrap/base/
-RUN chmod +x ${BOOTSTRAP_DIR}/*/*.sh
+
+
 
 # Set the entrypoint to tini (as a process supervisor)
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]

--- a/modules/container-configbaker/Dockerfile
+++ b/modules/container-configbaker/Dockerfile
@@ -38,6 +38,7 @@ RUN rm ${SOLR_TEMPLATE}/conf/managed-schema.xml
 # Copy the data from scripts/api that provide the common base setup you'd get from the installer.
 # ".dockerignore" will take care of taking only the bare necessities
 COPY maven/setup ${SCRIPT_DIR}/bootstrap/base/
+RUN chmod +x ${BOOTSTRAP_DIR}/*/*.sh
 
 # Set the entrypoint to tini (as a process supervisor)
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]

--- a/modules/container-configbaker/Dockerfile
+++ b/modules/container-configbaker/Dockerfile
@@ -40,8 +40,6 @@ COPY maven/solr/*.xml ${SOLR_TEMPLATE}/conf/
 RUN rm ${SOLR_TEMPLATE}/conf/managed-schema.xml
 
 
-
-
 # Set the entrypoint to tini (as a process supervisor)
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 # By default run a script that will print a help message and terminate


### PR DESCRIPTION
**What this PR does / why we need it**:

When starting the containers on Windows configbaker-1 is able to connect to the DV-API and retrieve the version at "dataverse:8080/api/info/version" but when it tries to run the init.sh script it shows the following error:

"/scripts/bootstrap/dev/init.sh: line 10: /scripts/bootstrap/base/setup-all.sh: Permission denied"

**Which issue(s) this PR closes**:

- Closes #9904

**Special notes for your reviewer**:

The first solution was to add the chmod to the init.sh script, this also works but I consider this being a better solution since:

1. The permissions are done before execution
2. There is already logic setting permissions on this file, so it makes sense to put them in the same place.

There is a line that set up permissions for scripts before this, but I didn't want to modify or move it since it is not clear that these permissions are necessary before the point the scripts are copied to ${SCRIPT_DIR}/bootstrap/base/. I left this code intact and added RUN chmod +x ${BOOTSTRAP_DIR}/*/*.sh after the scripts were copied into the base folder. 

**Suggestions on how to test this**:

Download the original version on windows (tested and working on windows 10).

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No

**Is there a release notes update needed for this change?**:

N/A

**Additional documentation**:

N/A
