### PR TITLE
feat(ct): add labels with service dependency versions to images #9928

### DIFF
--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -51,4 +51,6 @@ LABEL org.opencontainers.image.created="@git.build.time@" \
       org.opencontainers.image.vendor="Global Dataverse Community Consortium" \
       org.opencontainers.image.licenses="Apache-2.0" \
       org.opencontainers.image.title="Dataverse Application Image" \
-      org.opencontainers.image.description="This container image provides the research data repository software Dataverse in a box."
+      org.opencontainers.image.description="This container image provides the research data repository software Dataverse in a box." \
+      org.dataverse.deps.postgresql.version="@postgresql.server.version@" \
+      org.dataverse.deps.solr.version="@solr.version@"


### PR DESCRIPTION
**What this PR does / why we need it**:
Provide annotations/labels on Dataverse application container images carrying the information which PostgreSQL and Solr version is meant to be used with this image.

**Which issue(s) this PR closes**:

- Closes #9928

**Special notes for your reviewer**:
None. This is container metadata only, nothing else affected

**Suggestions on how to test this**:
Build the image, run `docker inspect -f '{{ index .Config.Labels "org.dataverse.deps.solr.version"}}' gdcc/dataverse:unstable` to see the label's content.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
Nope

**Is there a release notes update needed for this change?**:
Nope

**Additional documentation**:
None