### PR TITLE
New API option to get the download size of the dataset version files without the original tabular files size

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DatasetServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetServiceBean.java
@@ -788,13 +788,13 @@ public class DatasetServiceBean implements java.io.Serializable {
                 }
             }
         }
-        
+
     }
 
     //get a string to add to save success message
     //depends on page (dataset/file) and user privleges
     public String getReminderString(Dataset dataset, boolean canPublishDataset, boolean filePage, boolean isValid) {
-       
+
         String reminderString;
 
         if (canPublishDataset) {
@@ -1015,12 +1015,12 @@ public class DatasetServiceBean implements java.io.Serializable {
     }
 
     public long findStorageSize(Dataset dataset) throws IOException {
-        return findStorageSize(dataset, false, GetDatasetStorageSizeCommand.Mode.STORAGE, null);
+        return findStorageSize(dataset, false, true, GetDatasetStorageSizeCommand.Mode.STORAGE, null);
     }
 
 
     public long findStorageSize(Dataset dataset, boolean countCachedExtras) throws IOException {
-        return findStorageSize(dataset, countCachedExtras, GetDatasetStorageSizeCommand.Mode.STORAGE, null);
+        return findStorageSize(dataset, countCachedExtras, true, GetDatasetStorageSizeCommand.Mode.STORAGE, null);
     }
 
     /**
@@ -1028,6 +1028,7 @@ public class DatasetServiceBean implements java.io.Serializable {
      *
      * @param dataset
      * @param countCachedExtras boolean indicating if the cached disposable extras should also be counted
+     * @param countOriginalTabularSize boolean indicating if the size of the stored original tabular files should also be counted, in addition to the main tab-delimited file size
      * @param mode String indicating whether we are getting the result for storage (entire dataset) or download version based
      * @param version optional param for dataset version
      * @return total size
@@ -1036,7 +1037,7 @@ public class DatasetServiceBean implements java.io.Serializable {
      * default mode, the method doesn't need to access the storage system, as the
      * sizes of the main files are recorded in the database)
      */
-    public long findStorageSize(Dataset dataset, boolean countCachedExtras, GetDatasetStorageSizeCommand.Mode mode, DatasetVersion version) throws IOException {
+    public long findStorageSize(Dataset dataset, boolean countCachedExtras, boolean countOriginalTabularSize, GetDatasetStorageSizeCommand.Mode mode, DatasetVersion version) throws IOException {
         long total = 0L;
 
         if (dataset.isHarvested()) {
@@ -1062,7 +1063,7 @@ public class DatasetServiceBean implements java.io.Serializable {
                 total += datafile.getFilesize();
 
                 if (!countCachedExtras) {
-                    if (datafile.isTabularData()) {
+                    if (datafile.isTabularData() && countOriginalTabularSize) {
                         // count the size of the stored original, in addition to the main tab-delimited file:
                         Long originalFileSize = datafile.getDataTable().getOriginalFileSize();
                         if (originalFileSize != null) {

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/GetDataverseStorageSizeCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/GetDataverseStorageSizeCommand.java
@@ -59,7 +59,7 @@ public class GetDataverseStorageSizeCommand extends AbstractCommand<Long> {
             }
             
             try {
-                total += ctxt.datasets().findStorageSize(dataset, countCachedFiles, GetDatasetStorageSizeCommand.Mode.STORAGE, null);
+                total += ctxt.datasets().findStorageSize(dataset, countCachedFiles, true, GetDatasetStorageSizeCommand.Mode.STORAGE, null);
             } catch (IOException ex) {
                 throw new CommandException(BundleUtil.getStringFromBundle("dataverse.datasize.ioerror"), this);
             }

--- a/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
@@ -3409,4 +3409,11 @@ public class UtilIT {
                 .body(jsonString)
                 .put("/api/datasets/" + datasetId + "/versions/" + version + "/deaccession");
     }
+
+    static Response getDownloadSize(Integer datasetId, String version, boolean ignoreOriginalTabularSize, String apiToken) {
+        return given()
+                .header(API_TOKEN_HTTP_HEADER, apiToken)
+                .queryParam("ignoreOriginalTabularSize", ignoreOriginalTabularSize)
+                .get("/api/datasets/" + datasetId + "/versions/" + version + "/downloadsize");
+    }
 }


### PR DESCRIPTION
…oadSize datasets API endpoint

**What this PR does / why we need it**:

**Which issue(s) this PR closes**:

Closes #

**Special notes for your reviewer**:

**Suggestions on how to test this**:

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
