### PR TITLE
Equals method fix

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DatasetFieldDefaultValue.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetFieldDefaultValue.java
@@ -113,7 +113,7 @@ public class DatasetFieldDefaultValue implements Serializable {
 
     @Override
     public boolean equals(Object object) {
-        if (!(object instanceof DatasetField)) {
+        if (!(object instanceof DatasetFieldDefaultValue)) {
             return false;
         }
         DatasetFieldDefaultValue other = (DatasetFieldDefaultValue) object;

--- a/src/main/java/edu/harvard/iq/dataverse/DataverseContact.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DataverseContact.java
@@ -99,7 +99,7 @@ public class DataverseContact implements Serializable {
 
     @Override
     public boolean equals(Object object) {
-        if (!(object instanceof DatasetFieldType)) {
+        if (!(object instanceof DataverseContact)) {
             return false;
         }
         DataverseContact other = (DataverseContact) object;

--- a/src/main/java/edu/harvard/iq/dataverse/DataverseFacet.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DataverseFacet.java
@@ -93,7 +93,7 @@ public class DataverseFacet implements Serializable {
 
     @Override
     public boolean equals(Object object) {
-        if (!(object instanceof DatasetFieldType)) {
+        if (!(object instanceof DataverseFacet)) {
             return false;
         }
         DataverseFacet other = (DataverseFacet) object;

--- a/src/main/java/edu/harvard/iq/dataverse/DataverseFeaturedDataverse.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DataverseFeaturedDataverse.java
@@ -85,7 +85,7 @@ public class DataverseFeaturedDataverse implements Serializable {
 
     @Override
     public boolean equals(Object object) {
-        if (!(object instanceof DatasetFieldType)) {
+        if (!(object instanceof DataverseFeaturedDataverse)) {
             return false;
         }
         DataverseFeaturedDataverse other = (DataverseFeaturedDataverse) object;

--- a/src/main/java/edu/harvard/iq/dataverse/DataverseTheme.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DataverseTheme.java
@@ -181,7 +181,7 @@ public class DataverseTheme implements Serializable {
 
     @Override
     public boolean equals(Object object) {
-        if (!(object instanceof DatasetFieldType)) {
+        if (!(object instanceof DataverseTheme)) {
             return false;
         }
         DataverseTheme other = (DataverseTheme) object;

--- a/src/test/java/edu/harvard/iq/dataverse/DatasetFieldDefaultValueTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/DatasetFieldDefaultValueTest.java
@@ -1,0 +1,47 @@
+package edu.harvard.iq.dataverse;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import org.junit.jupiter.api.BeforeEach;
+
+public class DatasetFieldDefaultValueTest {
+    private DatasetFieldDefaultValue dataverseContact;
+
+    @BeforeEach
+    public void before() {
+        this.dataverseContact = new DatasetFieldDefaultValue();
+        this.dataverseContact.setId(1L);
+    }
+
+    @Test
+    public void testEqualsWithNull() {
+        assertFalse(this.dataverseContact.equals(null));
+    }
+
+    @Test
+    public void testEqualsWithDifferentClass() {
+        DatasetField datasetField = new DatasetField();
+
+        assertFalse(this.dataverseContact.equals(datasetField));
+    }
+
+    @Test
+    public void testEqualsWithSameClassSameId() {
+        DatasetFieldDefaultValue dataverseContact1 = new DatasetFieldDefaultValue();
+        dataverseContact1.setId(1L);
+
+        assertTrue(this.dataverseContact.equals(dataverseContact1));
+    }
+
+    @Test
+    public void testEqualsWithSameClassDifferentId() {
+        DatasetFieldDefaultValue dataverseContact1 = new DatasetFieldDefaultValue();
+        dataverseContact1.setId(2L);
+
+        assertFalse(this.dataverseContact.equals(dataverseContact1));
+    }
+}

--- a/src/test/java/edu/harvard/iq/dataverse/DataverseContactTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/DataverseContactTest.java
@@ -1,0 +1,47 @@
+package edu.harvard.iq.dataverse;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import org.junit.jupiter.api.BeforeEach;
+
+public class DataverseContactTest {
+    private DataverseContact dataverseContact;
+
+    @BeforeEach
+    public void before() {
+        this.dataverseContact = new DataverseContact();
+        this.dataverseContact.setId(1L);
+    }
+
+    @Test
+    public void testEqualsWithNull() {
+        assertFalse(this.dataverseContact.equals(null));
+    }
+
+    @Test
+    public void testEqualsWithDifferentClass() {
+        DatasetFieldType datasetFieldType = new DatasetFieldType();
+
+        assertFalse(this.dataverseContact.equals(datasetFieldType));
+    }
+
+    @Test
+    public void testEqualsWithSameClassSameId() {
+        DataverseContact dataverseContact1 = new DataverseContact();
+        dataverseContact1.setId(1L);
+
+        assertTrue(this.dataverseContact.equals(dataverseContact1));
+    }
+
+    @Test
+    public void testEqualsWithSameClassDifferentId() {
+        DataverseContact dataverseContact1 = new DataverseContact();
+        dataverseContact1.setId(2L);
+
+        assertFalse(this.dataverseContact.equals(dataverseContact1));
+    }
+}

--- a/src/test/java/edu/harvard/iq/dataverse/DataverseFacetTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/DataverseFacetTest.java
@@ -1,0 +1,47 @@
+package edu.harvard.iq.dataverse;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import org.junit.jupiter.api.BeforeEach;
+
+public class DataverseFacetTest {
+    private DataverseFacet dataverseFacet;
+
+    @BeforeEach
+    public void before() {
+        this.dataverseFacet = new DataverseFacet();
+        this.dataverseFacet.setId(1L);
+    }
+
+    @Test
+    public void testEqualsWithNull() {
+        assertFalse(this.dataverseFacet.equals(null));
+    }
+
+    @Test
+    public void testEqualsWithDifferentClass() {
+        DatasetFieldType datasetFieldType = new DatasetFieldType();
+
+        assertFalse(this.dataverseFacet.equals(datasetFieldType));
+    }
+
+    @Test
+    public void testEqualsWithSameClassSameId() {
+        DataverseFacet dataverseFacet1 = new DataverseFacet();
+        dataverseFacet1.setId(1L);
+
+        assertTrue(this.dataverseFacet.equals(dataverseFacet1));
+    }
+
+    @Test
+    public void testEqualsWithSameClassDifferentId() {
+        DataverseFacet dataverseFacet1 = new DataverseFacet();
+        dataverseFacet1.setId(2L);
+
+        assertFalse(this.dataverseFacet.equals(dataverseFacet1));
+    }
+}

--- a/src/test/java/edu/harvard/iq/dataverse/DataverseFeaturedDataverseTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/DataverseFeaturedDataverseTest.java
@@ -1,0 +1,47 @@
+package edu.harvard.iq.dataverse;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import org.junit.jupiter.api.BeforeEach;
+
+public class DataverseFeaturedDataverseTest {
+    private DataverseFeaturedDataverse dataverseFeaturedDataverse;
+
+    @BeforeEach
+    public void before() {
+        this.dataverseFeaturedDataverse = new DataverseFeaturedDataverse();
+        this.dataverseFeaturedDataverse.setId(1L);
+    }
+
+    @Test
+    public void testEqualsWithNull() {
+        assertFalse(this.dataverseFeaturedDataverse.equals(null));
+    }
+
+    @Test
+    public void testEqualsWithDifferentClass() {
+        DatasetFieldType datasetFieldType = new DatasetFieldType();
+
+        assertFalse(this.dataverseFeaturedDataverse.equals(datasetFieldType));
+    }
+
+    @Test
+    public void testEqualsWithSameClassSameId() {
+        DataverseFeaturedDataverse dataverseFeaturedDataverse1 = new DataverseFeaturedDataverse();
+        dataverseFeaturedDataverse1.setId(1L);
+
+        assertTrue(this.dataverseFeaturedDataverse.equals(dataverseFeaturedDataverse1));
+    }
+
+    @Test
+    public void testEqualsWithSameClassDifferentId() {
+        DataverseFeaturedDataverse dataverseFeaturedDataverse1 = new DataverseFeaturedDataverse();
+        dataverseFeaturedDataverse1.setId(2L);
+
+        assertFalse(this.dataverseFeaturedDataverse.equals(dataverseFeaturedDataverse1));
+    }
+}

--- a/src/test/java/edu/harvard/iq/dataverse/DataverseThemeTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/DataverseThemeTest.java
@@ -1,0 +1,47 @@
+package edu.harvard.iq.dataverse;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import org.junit.jupiter.api.BeforeEach;
+
+public class DataverseThemeTest {
+    private DataverseTheme dataverseTheme;
+
+    @BeforeEach
+    public void before() {
+        this.dataverseTheme = new DataverseTheme();
+        this.dataverseTheme.setId(1L);
+    }
+
+    @Test
+    public void testEqualsWithNull() {
+        assertFalse(this.dataverseTheme.equals(null));
+    }
+
+    @Test
+    public void testEqualsWithDifferentClass() {
+        DatasetFieldType datasetFieldType = new DatasetFieldType();
+
+        assertFalse(this.dataverseTheme.equals(datasetFieldType));
+    }
+
+    @Test
+    public void testEqualsWithSameClassSameId() {
+        DataverseTheme dataverseTheme1 = new DataverseTheme();
+        dataverseTheme1.setId(1L);
+
+        assertTrue(this.dataverseTheme.equals(dataverseTheme1));
+    }
+
+    @Test
+    public void testEqualsWithSameClassDifferentId() {
+        DataverseTheme dataverseTheme1 = new DataverseTheme();
+        dataverseTheme1.setId(2L);
+
+        assertFalse(this.dataverseTheme.equals(dataverseTheme1));
+    }
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the equals method in the following classes:
1. DataverseFacet.java
2. DatasetFieldDefaultValue.java
3. DataverseContact.java
4. DataverseFeaturedDataverse.java
5. DataverseTheme.java
This PR also includes unit tests for these fixed equals methods.

**Which issue(s) this PR closes**: 

Closes #9951 

**Special notes for your reviewer**:
NA

**Suggestions on how to test this**:
NA

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
NA

**Is there a release notes update needed for this change?**:
NA

**Additional documentation**:
NA
