### PR TITLE
Disable TC when no Docker around

### DIFF
--- a/doc/sphinx-guides/source/developers/testing.rst
+++ b/doc/sphinx-guides/source/developers/testing.rst
@@ -316,7 +316,7 @@ Please make sure to:
    .. code:: java
 
        /** A very minimal example for a Testcontainers integration test class. */
-       @Testcontainers
+       @Testcontainers(disabledWithoutDocker = true)
        @Tag(edu.harvard.iq.dataverse.util.testing.Tags.INTEGRATION_TEST)
        @Tag(edu.harvard.iq.dataverse.util.testing.Tags.USES_TESTCONTAINERS)
        class MyExampleIT { /* ... */ }

--- a/src/test/java/edu/harvard/iq/dataverse/authorization/providers/oauth2/oidc/OIDCAuthenticationProviderFactoryIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/authorization/providers/oauth2/oidc/OIDCAuthenticationProviderFactoryIT.java
@@ -54,7 +54,7 @@ import static org.mockito.Mockito.when;
 
 @Tag(Tags.INTEGRATION_TEST)
 @Tag(Tags.USES_TESTCONTAINERS)
-@Testcontainers
+@Testcontainers(disabledWithoutDocker = true)
 @ExtendWith(MockitoExtension.class)
 // NOTE: order is important here - Testcontainers must be first, otherwise it's not ready when we call getAuthUrl()
 @LocalJvmSettings


### PR DESCRIPTION
**What this PR does / why we need it**:
Disabling Testcontainers tests when no Docker is available unblocks devs that don't run these tests locally.

**Which issue(s) this PR closes**:

Closes #9974

**Special notes for your reviewer**:
None

**Suggestions on how to test this**:
Run `mvn install` on a machine without Docker, see it *not* fail.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
Nope

**Is there a release notes update needed for this change?**:
Nope

**Additional documentation**:
None
