### PR TITLE
Fix code coverage reports after introducing QueryDSL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -252,14 +252,7 @@
             <artifactId>expressly</artifactId>
             <scope>provided</scope>
         </dependency>
-
-        <dependency>
-            <groupId>com.querydsl</groupId>
-            <artifactId>querydsl-apt</artifactId>
-            <version>${querydsl.version}</version>
-            <classifier>jakarta</classifier>
-            <scope>provided</scope>
-        </dependency>
+        
         <dependency>
             <groupId>com.querydsl</groupId>
             <artifactId>querydsl-jpa</artifactId>
@@ -709,7 +702,29 @@
                 <configuration>
                     <release>${target.java.version}</release>
                     <!-- for use with `mvn -DcompilerArgument=-Xlint:unchecked compile` -->
-                    <compilerArgument>${compilerArgument}</compilerArgument>
+                    <compilerArgs>
+                        <arg>${compilerArgument}</arg>
+                        <!--
+                            See APT options table for more:
+                            https://querydsl.com/static/querydsl/latest/reference/html/ch03s03.html
+                        -->
+                        <arg>-Aquerydsl.generatedAnnotationClass=com.querydsl.core.annotations.Generated</arg>
+                    </compilerArgs>
+                    <!-- Extracted from https://github.com/querydsl/querydsl/issues/3131#issuecomment-1549255382 -->
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>com.querydsl</groupId>
+                            <artifactId>querydsl-apt</artifactId>
+                            <version>${querydsl.version}</version>
+                            <classifier>jakarta</classifier>
+                        </path>
+                        <path>
+                            <groupId>jakarta.persistence</groupId>
+                            <artifactId>jakarta.persistence-api</artifactId>
+                            <!-- Cannot be inherited from Payara BOM. Needs manual adaption. -->
+                            <version>3.1.0</version>
+                        </path>
+                    </annotationProcessorPaths>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
**What this PR does / why we need it**:
The Coveralls report is broken because JaCoCo's XML report file contains generated source files (and cannot be made to exclude them). The Coveralls Maven Plugin does not skip these classes and breaks of trying to read nonexisting source files.

**Which issue(s) this PR closes**:

Closes #9990

**Special notes for your reviewer**:
- [ ] Figure out a way how to either exclude the class references or
- [ ] Figure out a way how to make Coveralls skip ignored files (that have been excluded by some JaCoCo mechanism) or
- [ ] Migrate to some other reporting of coverage that is compatible with this...

**Suggestions on how to test this**:
None

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
Nope

**Is there a release notes update needed for this change?**:
Nope

**Additional documentation**:
None
