### PR TITLE
fix S3 provider priorities

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/dataaccess/S3AccessIO.java
+++ b/src/main/java/edu/harvard/iq/dataverse/dataaccess/S3AccessIO.java
@@ -1209,22 +1209,20 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
                 allowInstanceCredentials = false;
                 AWSStaticCredentialsProvider staticCredentials = new AWSStaticCredentialsProvider(
                         new BasicAWSCredentials(
-                                accessKey.orElse(""),
-                                secretKey.orElse("")));
+                                accessKey.get(),
+                                secretKey.get()));
                 providers.add(staticCredentials);
             } else if (s3profile == null) {
                 //Only use the default profile when it isn't explicitly set for this store when there are no static creds (otherwise it will be preferred).
                 s3profile = "default";
             }
             if (s3profile != null) {
-                ProfileCredentialsProvider profileCredentials = new ProfileCredentialsProvider(s3profile);
-                providers.add(profileCredentials);
+                providers.add(new ProfileCredentialsProvider(s3profile));
             }
 
             if (allowInstanceCredentials) {
                 // Add role-based provider as in the default provider chain
-                InstanceProfileCredentialsProvider instanceCredentials = InstanceProfileCredentialsProvider.getInstance();
-                providers.add(instanceCredentials);
+                providers.add(InstanceProfileCredentialsProvider.getInstance());
             }
             // Add all providers to chain - the first working provider will be used
             // (role-based is first in the default cred provider chain (if no profile or

--- a/src/main/java/edu/harvard/iq/dataverse/dataaccess/S3AccessIO.java
+++ b/src/main/java/edu/harvard/iq/dataverse/dataaccess/S3AccessIO.java
@@ -108,14 +108,13 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
             if(!StringUtil.isEmpty(proxy)&&StringUtil.isEmpty(endpoint)) {
                 logger.severe(driverId + " config error: Must specify a custom-endpoint-url if proxy-url is specified");
             }
-            //Not sure this is needed but moving it from the open method for now since it definitely doesn't need to run every time an object is opened.
-            try {
-                if (bucketName == null || !s3.doesBucketExistV2(bucketName)) {
-                    throw new IOException("ERROR: S3AccessIO - You must create and configure a bucket before creating datasets.");
-                }
-            } catch (SdkClientException sce) {
-                throw new IOException("ERROR: S3AccessIO - Failed to look up bucket "+bucketName+" (is AWS properly configured?): " + sce.getMessage());
-            }
+
+            // FWIW: There used to be a check here to see if the bucket exists.
+            // It was very redundant (checking every time we access any file) and didn't do
+            // much but potentially make the failure (in the unlikely case a bucket doesn't
+            // exist/just disappeared) happen slightly earlier (here versus at the first
+            // file/metadata access).
+                    
         } catch (Exception e) {
             throw new AmazonClientException(
                         "Cannot instantiate a S3 client; check your AWS credentials and region",


### PR DESCRIPTION
**What this PR does / why we need it**: This PR addresses priority issues that existed between the 3 types of credential providers used by S3 stores. Before - the global role-based creds, if set, would override the per store profile or instance credentials. Now they do not, and static creds won't be ignored if/when a default profile exists in the Unix account running Payara.
The PR also includes removal of a redundant check that the bucket exists that would run for every file access.

**Which issue(s) this PR closes**:

Closes #10003 

**Special notes for your reviewer**: New priority rules are listed in a source comment. As this is a bug fix, it looks to me like the current guides say the right thing about priorities. So I don't see anything to change in the docs (without doing a big rewrite of the whole S3 setup section!). Similarly, since this is a bug fix for a reasonably rare case (role-based access was broken from 4.20 to 5.13, and you have to be using two different S3 providers), I don't know that anything is needed in the release notes.

**Suggestions on how to test this**:
Regression testing that S3 setup works. Depending on how far you want to go, you could check all the combinations of EC2 role based access is/isn't set, the S3 store has a .profile set or not, (the profile actually exists in the .aws/credentials file or not), and the static microprofile config is/isn't set and verify that setting a profile or static creds wins over the role based method, profile wins over static when both are set, setting nothing results in the default profile in the .aws/credentials file being used, etc. (I have tested at QDR that this fix works in the case where role-based creds exist and we have an S3 store that has to use a non-default profile instead.)

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
