### PR TITLE
bump DuraCloud to current version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -480,7 +480,7 @@
         <dependency>
             <groupId>org.duracloud</groupId>
             <artifactId>common</artifactId>
-            <version>7.1.1</version>
+            <version>7.1.4</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>
@@ -495,7 +495,7 @@
         <dependency>
             <groupId>org.duracloud</groupId>
             <artifactId>storeclient</artifactId>
-            <version>7.1.1</version>
+            <version>7.1.4</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>


### PR DESCRIPTION
**What this PR does / why we need it**:

cuts the list of known vulnerabilities in the Dataverse warfile from 62 to 24.

**Which issue(s) this PR closes**:

Closes https://github.com/IQSS/dataverse-security/issues/93

**Special notes for your reviewer**:

None

**Suggestions on how to test this**:

Test DuraCloud exporter

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No

**Is there a release notes update needed for this change?**:

No

**Additional documentation**:

None