### PR TITLE
Switching to gdcc/xoai v5.2.0 (9910)

### DIFF
--- a/modules/dataverse-parent/pom.xml
+++ b/modules/dataverse-parent/pom.xml
@@ -165,7 +165,7 @@
         <apache.httpcomponents.core.version>4.4.14</apache.httpcomponents.core.version>
         
         <!-- NEW gdcc XOAI library implementation -->
-        <gdcc.xoai.version>5.1.0</gdcc.xoai.version>
+        <gdcc.xoai.version>5.2.0</gdcc.xoai.version>
     
         <!-- Testing dependencies -->
         <testcontainers.version>1.19.0</testcontainers.version>


### PR DESCRIPTION
**What this PR does / why we need it**:

This pr contains no code changes in the Dataverse source, but changes the dataverse-parent pom file switching to the newly released v. 5.2 of the gdcc/xoai library. This fixes the problem affecting (some) OAI records with utf8 characters. (see the original issue; the actual problem is described in detail in an issue in the [gdcc/xoai](https://github.com/gdcc/xoai) repo). 

**Which issue(s) this PR closes**:

Closes #9910

**Special notes for your reviewer**:

**Suggestions on how to test this**:

The condition is somewhat tricky to reproduce on purpose. But can be very easily tested using a known affected export and some cheating; I will provide the details. 

The bug is triggered when a multi-byte utf8 character is split in 2 at the exact offset of 1024 bytes in the harvestable metadata export. Even if you create a test dataset with all the metadata encoded in some multi-byte utf8 (Chinese, etc.), there will still be a chance that this condition will not be met. It could then be triggered by padding the export with extra characters, but it's easier to cheat as follows. 

You need an exported dataset that's part of an OAI set. It helps if the dataset is stored on a filesystem; s3 will work too, but fs is easier. `doi:10.70122/FK2/9TZE9Y` is used below since that was the dataset I used on my local instance. 

Verify that the dataset is exported, and can be accessed via OAI: 

```
curl "http://localhost:8080/api/datasets/export?exporter=oai_dc&persistentId=doi:10.70122/FK2/9TZE9Y"

curl "http://localhost:8080/oai?verb=GetRecord&metadataPrefix=oai_dc&identifier=doi:10.70122/FK2/9TZE9Y"
```

Now replace the cached oai_dc export for the dataset with the attached known problematic export (`export_oai_dc.cached.txt`; adjust the path as needed as well): 

```
cp export_oai_dc.cached.txt /usr/local/payara6/glassfish/domains/domain1/files/10.70122/FK2/9TZE9Y/export_oai_dc.cached
``` 

Verify that the error condition is now met, by looking at the 1024 byte offset:

```
curl "http://localhost:8080/api/datasets/export?exporter=oai_dc&persistentId=doi:10.70122/FK2/9TZE9Y"  | head -c1024
```

the end of the record should look like this: `The experiments were carried out on farmer?` - i.e., we get the question mark instead of the fancy utf8 apostrophe in the word "farmer’s". 

To test the "before" state, in develop branch, look at the OAI record above - `/oai?verb=GetRecord&metadataPrefix=oai_dc&identifier=doi:10.70122/FK2/9TZE9Y` in firefox. It should refuse to render the response complaining about invalid xml. 

The OAI record should be rendered properly once the build from this branch is deployed. 

[export_oai_dc.cached.txt](https://github.com/IQSS/dataverse/files/12919957/export_oai_dc.cached.txt)


**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
