### PR TITLE
Fix Datasets API getVersionFiles endpoint content type filtering

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DatasetVersionFilesServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetVersionFilesServiceBean.java
@@ -293,7 +293,7 @@ public class DatasetVersionFilesServiceBean implements Serializable {
                 query.orderBy(fileMetadata.dataFile.filesize.asc());
                 break;
             case Type:
-                query.orderBy(fileMetadata.dataFile.contentType.asc());
+                query.orderBy(fileMetadata.dataFile.contentType.asc(), fileMetadata.label.asc());
                 break;
             default:
                 query.orderBy(fileMetadata.label.asc());


### PR DESCRIPTION
**What this PR does / why we need it**:

DatasetsIT.getVersionFiles fails intermittently as it sometimes finds out unordered files when sorting by content type.

A second orderBy condition has been added to force that when sorting by content type, files are also sorted by name.

New order example:

- test_5.png
- test_1.txt
- test_2.txt
- test_3.txt

**Suggestions on how to test this**:

Get dataset files via curl using contentType query param:

`curl "https://demo.dataverse.org/api/datasets/24/versions/1.0/files?contentType=image/png"`