### PR TITLE
IQSS/10018-Check driver type not id

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/dataaccess/StorageIO.java
+++ b/src/main/java/edu/harvard/iq/dataverse/dataaccess/StorageIO.java
@@ -606,7 +606,7 @@ public abstract class StorageIO<T extends DvObject> {
     }
     
     public static boolean isDirectUploadEnabled(String driverId) {
-        return (DataAccess.S3.equals(driverId) && Boolean.parseBoolean(System.getProperty("dataverse.files." + DataAccess.S3 + ".upload-redirect"))) ||
+        return (System.getProperty("dataverse.files." + driverId + ".type").equals(DataAccess.S3) && Boolean.parseBoolean(System.getProperty("dataverse.files." + driverId + ".upload-redirect"))) ||
             Boolean.parseBoolean(System.getProperty("dataverse.files." + driverId + ".upload-out-of-band"));
     }
     


### PR DESCRIPTION
**What this PR does / why we need it**: Fixes a bug introduced in #9003 that broken direct upload for stores that didn't have id='s3' / used that store's settings for all stores of type 's3'. This PR restores direct upload as an option for stores with type='s3'

**Which issue(s) this PR closes**:

Closes #9003

**Special notes for your reviewer**: issue only exists in develop so far.

**Suggestions on how to test this**: Create an s3 store that doesn't have the id 's3' and verify that direct upload works. (Do not have a store with id 's3' that allows direct upload.)

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
