### PR TITLE
Lookup dataverse by alias or ID when downloading guestbook responses via API

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/api/Dataverses.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Dataverses.java
@@ -1194,10 +1194,15 @@ public class Dataverses extends AbstractApiBean {
             public void write(OutputStream os) throws IOException,
                     WebApplicationException {
 
-                Dataverse dv = dataverseService.findByAlias(dvIdtf);
+                Dataverse dv;
+                try {
+                    dv = findDataverseOrDie(dvIdtf);
+                } catch (WrappedResponse wr) {
+                    throw new WebApplicationException(wr.getResponse());
+                }
                 Map<Integer, Object> customQandAs = guestbookResponseService.mapCustomQuestionAnswersAsStrings(dv.getId(), gbId);
                 Map<Integer, String> datasetTitles = guestbookResponseService.mapDatasetTitles(dv.getId());
-                
+
                 List<Object[]> guestbookResults = guestbookResponseService.getGuestbookResults(dv.getId(), gbId);
                 os.write("Guestbook, Dataset, Dataset PID, Date, Type, File Name, File Id, File PID, User Name, Email, Institution, Position, Custom Questions\n".getBytes());
                 for (Object[] result : guestbookResults) {

--- a/src/main/java/edu/harvard/iq/dataverse/api/Dataverses.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Dataverses.java
@@ -1173,8 +1173,9 @@ public class Dataverses extends AbstractApiBean {
     public Response getGuestbookResponsesByDataverse(@Context ContainerRequestContext crc, @PathParam("identifier") String dvIdtf,
             @QueryParam("guestbookId") Long gbId, @Context HttpServletResponse response) {
 
+        Dataverse dv;
         try {
-            Dataverse dv = findDataverseOrDie(dvIdtf);
+            dv = findDataverseOrDie(dvIdtf);
             User u = getRequestUser(crc);
             DataverseRequest req = createDataverseRequest(u);
             if (permissionSvc.request(req)
@@ -1194,12 +1195,6 @@ public class Dataverses extends AbstractApiBean {
             public void write(OutputStream os) throws IOException,
                     WebApplicationException {
 
-                Dataverse dv;
-                try {
-                    dv = findDataverseOrDie(dvIdtf);
-                } catch (WrappedResponse wr) {
-                    throw new WebApplicationException(wr.getResponse());
-                }
                 Map<Integer, Object> customQandAs = guestbookResponseService.mapCustomQuestionAnswersAsStrings(dv.getId(), gbId);
                 Map<Integer, String> datasetTitles = guestbookResponseService.mapDatasetTitles(dv.getId());
 
@@ -1208,7 +1203,6 @@ public class Dataverses extends AbstractApiBean {
                 for (Object[] result : guestbookResults) {
                     StringBuilder sb = guestbookResponseService.convertGuestbookResponsesToCSV(customQandAs, datasetTitles, result);
                     os.write(sb.toString().getBytes());
-
                 }
             }
         };

--- a/src/test/java/edu/harvard/iq/dataverse/api/DataversesIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/DataversesIT.java
@@ -17,11 +17,13 @@ import java.util.logging.Logger;
 import jakarta.json.Json;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonObjectBuilder;
-import static jakarta.ws.rs.core.Response.Status.CREATED;
-import static jakarta.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
 import jakarta.ws.rs.core.Response.Status;
-import static jakarta.ws.rs.core.Response.Status.BAD_REQUEST;
 import static jakarta.ws.rs.core.Response.Status.OK;
+import static jakarta.ws.rs.core.Response.Status.CREATED;
+import static jakarta.ws.rs.core.Response.Status.BAD_REQUEST;
+import static jakarta.ws.rs.core.Response.Status.FORBIDDEN;
+import static jakarta.ws.rs.core.Response.Status.NOT_FOUND;
+import static jakarta.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -144,23 +146,42 @@ public class DataversesIT {
         deleteDataverse.then().assertThat().statusCode(OK.getStatusCode());
     }
 
+    /**
+     * A regular user can create a Dataverse Collection and access its
+     * GuestbookResponses by DV alias or ID.
+     * A request for a non-existent Dataverse's GuestbookResponses returns
+     * Not Found.
+     * A regular user cannot access the guestbook responses for a Dataverse
+     * that they do not have permissions for, like the root Dataverse.
+     */
     @Test
     public void testGetGuestbookResponses() {
         Response createUser = UtilIT.createRandomUser();
         createUser.prettyPrint();
         String apiToken = UtilIT.getApiTokenFromResponse(createUser);
-        // Create a Dataverse
+
         Response create = UtilIT.createRandomDataverse(apiToken);
         create.prettyPrint();
         create.then().assertThat().statusCode(CREATED.getStatusCode());
         String alias = UtilIT.getAliasFromResponse(create);
         Integer dvId = UtilIT.getDataverseIdFromResponse(create);
-        // Get GuestbookResponses by Dataverse alias
+
+        logger.info("Request guestbook responses for non-existent Dataverse");
+        Response getResponsesByBadAlias = UtilIT.getGuestbookResponses("-1", null, apiToken);
+        getResponsesByBadAlias.then().assertThat().statusCode(NOT_FOUND.getStatusCode());
+
+        logger.info("Request guestbook responses for existent Dataverse by alias");
         Response getResponsesByAlias = UtilIT.getGuestbookResponses(alias, null, apiToken);
         getResponsesByAlias.then().assertThat().statusCode(OK.getStatusCode());
-        // Get GuestbookResponses by Dataverse ID
+
+        logger.info("Request guestbook responses for existent Dataverse by ID");
         Response getResponsesById = UtilIT.getGuestbookResponses(dvId.toString(), null, apiToken);
         getResponsesById.then().assertThat().statusCode(OK.getStatusCode());
+
+        logger.info("Request guestbook responses for root Dataverse by alias");
+        getResponsesById = UtilIT.getGuestbookResponses("root", null, apiToken);
+        getResponsesById.prettyPrint();
+        getResponsesById.then().assertThat().statusCode(FORBIDDEN.getStatusCode());
     }
 
     @Test

--- a/src/test/java/edu/harvard/iq/dataverse/api/DataversesIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/DataversesIT.java
@@ -145,6 +145,25 @@ public class DataversesIT {
     }
 
     @Test
+    public void testGetGuestbookResponses() {
+        Response createUser = UtilIT.createRandomUser();
+        createUser.prettyPrint();
+        String apiToken = UtilIT.getApiTokenFromResponse(createUser);
+        // Create a Dataverse
+        Response create = UtilIT.createRandomDataverse(apiToken);
+        create.prettyPrint();
+        create.then().assertThat().statusCode(CREATED.getStatusCode());
+        String alias = UtilIT.getAliasFromResponse(create);
+        Integer dvId = UtilIT.getDataverseIdFromResponse(create);
+        // Get GuestbookResponses by Dataverse alias
+        Response getResponsesByAlias = UtilIT.getGuestbookResponses(alias, null, apiToken);
+        getResponsesByAlias.then().assertThat().statusCode(OK.getStatusCode());
+        // Get GuestbookResponses by Dataverse ID
+        Response getResponsesById = UtilIT.getGuestbookResponses(dvId.toString(), null, apiToken);
+        getResponsesById.then().assertThat().statusCode(OK.getStatusCode());
+    }
+
+    @Test
     public void testNotEnoughJson() {
         Response createUser = UtilIT.createRandomUser();
         createUser.prettyPrint();

--- a/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
@@ -375,7 +375,7 @@ public class UtilIT {
 
     static Response getGuestbookResponses(String dataverseAlias, Long guestbookId, String apiToken) {
         RequestSpecification requestSpec = given()
-                .auth().basic(apiToken, EMPTY_STRING);
+                .header(API_TOKEN_HTTP_HEADER, apiToken);
         if (guestbookId != null) {
             requestSpec.queryParam("guestbookId", guestbookId);
         }

--- a/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
@@ -372,7 +372,16 @@ public class UtilIT {
                 .header(API_TOKEN_HTTP_HEADER, apiToken)
                 .when().get("/api/dataverses/" + alias + "/contents");
     }
-    
+
+    static Response getGuestbookResponses(String dataverseAlias, Long guestbookId, String apiToken) {
+        RequestSpecification requestSpec = given()
+                .auth().basic(apiToken, EMPTY_STRING);
+        if (guestbookId != null) {
+            requestSpec.queryParam("guestbookId", guestbookId);
+        }
+        return requestSpec.get("/api/dataverses/" + dataverseAlias + "/guestbookResponses/");
+    }
+
     static Response createRandomDatasetViaNativeApi(String dataverseAlias, String apiToken) {
         return createRandomDatasetViaNativeApi(dataverseAlias, apiToken, false);
     }

--- a/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
@@ -287,7 +287,7 @@ public class UtilIT {
     static Integer getDataverseIdFromResponse(Response createDataverseResponse) {
         JsonPath createdDataverse = JsonPath.from(createDataverseResponse.body().asString());
         int dataverseId = createdDataverse.getInt("data.id");
-        logger.info("Id found in create dataverse response: " + createdDataverse);
+        logger.info("Id found in create dataverse response: " + dataverseId);
         return dataverseId;
     }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Replaces a dataverse by-alias lookup with `findDataverseOrDie` to allow looking up a dataverse by both its alias and its ID, as the [documentation for 5.12.1](https://guides.dataverse.org/en/5.12.1/api/native-api.html#retrieve-guestbook-responses-for-a-dataverse-collection) mentions. The [same section for the latest version](https://guides.dataverse.org/en/latest/api/native-api.html#retrieve-guestbook-responses-for-a-dataverse-collection) says the same.

**Which issue(s) this PR closes**:

- Closes #9619 

**Special notes for your reviewer**: I would like this PR to count towards my Hacktoberfest goal, so if this is useful, please add the hacktoberfest-accepted label or an approving review.
My editor VSCodium with Java extensions made me handle the `WrappedResponse` that `findDataverseOrDie` may throw. Throwing a `WebApplicationException` is appropriate for the context, according to its Javadoc description.

**Suggestions on how to test this**: check that the commands in the issue work after applying the change.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: no

**Is there a release notes update needed for this change?**:
I suppose this may fix a bug in the API, but I don't consider this a big change otherwise.

**Additional documentation**:
