### PR TITLE
Problem with long file stores ID in JVM options #8312

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/dataaccess/S3AccessIO.java
+++ b/src/main/java/edu/harvard/iq/dataverse/dataaccess/S3AccessIO.java
@@ -191,7 +191,7 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
                     }
                 } // else we're OK (assumes bucket name in storageidentifier matches the driver's bucketname)
             } else {
-                if(!storageIdentifier.substring((this.driverId + DataAccess.SEPARATOR).length()).contains(":")) {
+                if(!storageIdentifier.contains(":")) {
                     //No driver id or bucket 
                     newStorageIdentifier= this.driverId + DataAccess.SEPARATOR + bucketName + ":" + storageIdentifier;
                 } else {


### PR DESCRIPTION
Issue: Problem with long file stores ID in JVM options #8312

**What this PR does / why we need it**:
Feature: File Upload & Handling
Type: Bug
This PR addresses the issue reported in #8312, which pertains to a problem with long file store IDs in JVM options causing a "javax.ejb.EJBException: String index out of range: -3" error. The error was initially linked to a code issue in S3AccessIO.java.

This PR makes necessary code changes to [dataverse/src/main/java/edu/harvard/iq/dataverse/dataaccess/S3AccessIO.java](https://github.com/IQSS/dataverse/blob/0af5caf98bccf6a296e5ded3475519fd201e1ea2/src/main/java/edu/harvard/iq/dataverse/dataaccess/S3AccessIO.java#L194).

**Which issue(s) this PR closes**:
Closes #8312

