### PR TITLE
Rewrite DatasetVersionFilesServiceBean QueryDSL queries using JPA Criteria and remove the QueryDSL library from the application dependencies

### DIFF
--- a/modules/dataverse-parent/pom.xml
+++ b/modules/dataverse-parent/pom.xml
@@ -200,9 +200,6 @@
         
         <!-- Container related -->
         <fabric8-dmp.version>0.43.4</fabric8-dmp.version>
-
-        <!-- Persistence -->
-        <querydsl.version>5.0.0</querydsl.version>
     </properties>
     
     <pluginRepositories>

--- a/pom.xml
+++ b/pom.xml
@@ -252,20 +252,6 @@
             <artifactId>expressly</artifactId>
             <scope>provided</scope>
         </dependency>
-
-        <dependency>
-            <groupId>com.querydsl</groupId>
-            <artifactId>querydsl-apt</artifactId>
-            <version>${querydsl.version}</version>
-            <classifier>jakarta</classifier>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.querydsl</groupId>
-            <artifactId>querydsl-jpa</artifactId>
-            <version>${querydsl.version}</version>
-            <classifier>jakarta</classifier>
-        </dependency>
         
         <dependency>
             <groupId>commons-io</groupId>


### PR DESCRIPTION
**What this PR does / why we need it**:

As decided at the frontend weekly meeting on 19th October, DatasetVersionFilesServiceBean has been rewritten using JPA Criteria instead of QueryDSL. The QueryDSL library has been removed.

**Which issue(s) this PR closes**:

- Closes #10028
- Closes https://github.com/IQSS/dataverse/issues/9990

**Suggestions on how to test this**:

The following API endpoints use the rewritten queries:

- getVersionFiles _/datasets/{id}/versions/{versionId}/files_ (https://github.com/IQSS/dataverse/blob/develop/doc/sphinx-guides/source/api/native-api.rst#list-files-in-a-dataset)
 
- getVersionFileCounts _/datasets/{id}/versions/{versionId}/files/counts_ (https://github.com/IQSS/dataverse/blob/develop/doc/sphinx-guides/source/api/native-api.rst#get-file-counts-in-a-dataset)

- getDownloadSize _/datasets/{id}/versions/{versionId}/downloadsize_ (https://github.com/IQSS/dataverse/blob/develop/doc/sphinx-guides/source/api/native-api.rst#get-the-size-of-downloading-all-the-files-of-a-dataset-version)

Despite we can test manual curl calls to these endpoints by sending different combinations of parameters (Described in the Native API documentation) and verify that they work correctly, testing all cases is extensive. Integration tests mainly cover all possible scenarios, so to verify the new implementation we can check that all test cases still pass as they did with the previous QueryDSL implementation.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No

**Is there a release notes update needed for this change?**:

No