### PR TITLE
IQSS/10057 ddi export bugs

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/export/ddi/DdiExportUtil.java
+++ b/src/main/java/edu/harvard/iq/dataverse/export/ddi/DdiExportUtil.java
@@ -1824,7 +1824,7 @@ public class DdiExportUtil {
                 xmlw.writeCharacters(dvar.getString("label"));
                 xmlw.writeEndElement(); //labl
             }
-        } else if (vm != null && vm.containsKey("label")) {
+        } else {
             xmlw.writeStartElement("labl");
             writeAttribute(xmlw, "level", "variable");
             xmlw.writeCharacters(vm.getString("label"));

--- a/src/main/java/edu/harvard/iq/dataverse/export/ddi/DdiExportUtil.java
+++ b/src/main/java/edu/harvard/iq/dataverse/export/ddi/DdiExportUtil.java
@@ -1818,10 +1818,12 @@ public class DdiExportUtil {
 
         // labl
         if ((vm == null || !vm.containsKey("label"))) {
-            xmlw.writeStartElement("labl");
-            writeAttribute(xmlw, "level", "variable");
-            xmlw.writeCharacters(dvar.getString("label"));
-            xmlw.writeEndElement(); //labl
+            if(dvar.containsKey("label")) {
+                xmlw.writeStartElement("labl");
+                writeAttribute(xmlw, "level", "variable");
+                xmlw.writeCharacters(dvar.getString("label"));
+                xmlw.writeEndElement(); //labl
+            }
         } else if (vm != null && vm.containsKey("label")) {
             xmlw.writeStartElement("labl");
             writeAttribute(xmlw, "level", "variable");

--- a/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
@@ -796,9 +796,10 @@ public class JsonPrinter {
             JsonObjectBuilder catStatObj = Json.createObjectBuilder();
             catStatObj.add("label", stat.getLabel())
                       .add("value", stat.getValue())
-                      .add("isMissing", stat.isMissing())
-                      .add("frequency", stat.getFrequency())
-                    ;
+                      .add("isMissing", stat.isMissing());
+            if(stat.getFrequency()!=null){
+                catStatObj.add("frequency", stat.getFrequency());
+            }
             catArr.add(catStatObj);
         }
         return catArr;


### PR DESCRIPTION
**What this PR does / why we need it**: Fixes two bugs causing DDI metadata export to fail in some cases.

**Which issue(s) this PR closes**:

Closes #10057

**Special notes for your reviewer**: FWIW - there has been some slack discussion about whether this is worth a point release and/or if an external DDI exporter with the fixes could be built for 5.14/6.0. So far, these appear rare but Harvard hasn't analyzed its holding's export failures yet afaik.

**Suggestions on how to test this**:  The SPSS binary file in https://dataverse.theacss.org/dataset.xhtml?persistentId=doi:10.25825/FK2/4LAWJN has one bug and https://data.qdr.syr.edu/file.xhtml?persistentId=doi:10.5064/F6MW2F2K/V3SPLV&version=1.0 has the other. Verifying that you can get a DDI export from a dataset published with these files in it would prove the fixes work.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
