### PR TITLE
Update issue template to set a default label

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,7 +3,7 @@ name: Bug report
 about: Did you encounter something unexpected or incorrect in the Dataverse software?
   We'd like to hear about it!
 title: ''
-labels: ''
+labels: 'Type: Bug'
 assignees: ''
 
 ---


### PR DESCRIPTION
**What this PR does / why we need it**:

It automatically adds the "Type: Bug" label to issues of type "bug report."

**Which issue(s) this PR closes**:

Closes #10065

**Special notes for your reviewer**:

N/A

**Suggestions on how to test this**:

Need to merge this PR and then try to create a new "bug report" issue to verify the proper label is added automatically.


**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No

**Is there a release notes update needed for this change?**:
No

**Additional documentation**:


N/A