### PR TITLE
Read zip file in try-with-resources

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/api/DatasetFieldServiceApi.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/DatasetFieldServiceApi.java
@@ -499,14 +499,21 @@ public class DatasetFieldServiceApi extends AbstractApiBean {
             {
                 ZipEntry entry = entries.nextElement();
                 String dataverseLangFileName = dataverseLangDirectory + "/" + entry.getName();
-                try (FileOutputStream fileOutput = new FileOutputStream(dataverseLangFileName)) {
+                File entryFile = new File(dataverseLangFileName);
+                String canonicalPath = entryFile.getCanonicalPath();
+                if (canonicalPath.startsWith(dataverseLangDirectory + "/")) {
+                    try (FileOutputStream fileOutput = new FileOutputStream(dataverseLangFileName)) {
 
-                    InputStream is = file.getInputStream(entry);
-                    BufferedInputStream bis = new BufferedInputStream(is);
+                        InputStream is = file.getInputStream(entry);
+                        BufferedInputStream bis = new BufferedInputStream(is);
 
-                    while (bis.available() > 0) {
-                        fileOutput.write(bis.read());
+                        while (bis.available() > 0) {
+                            fileOutput.write(bis.read());
+                        }
                     }
+                } else {
+                    logger.log(Level.SEVERE, "Zip Slip prevented: uploaded zip file tried to write to {}", canonicalPath);
+                    return Response.status(400).entity("The zip file includes an illegal file path").build();
                 }
             }
         }

--- a/src/main/java/edu/harvard/iq/dataverse/api/DatasetFieldServiceApi.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/DatasetFieldServiceApi.java
@@ -24,7 +24,6 @@ import jakarta.ejb.EJB;
 import jakarta.ejb.EJBException;
 import jakarta.json.Json;
 import jakarta.json.JsonArrayBuilder;
-import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
@@ -488,9 +487,7 @@ public class DatasetFieldServiceApi extends AbstractApiBean {
     @Consumes("application/zip")
     @Path("loadpropertyfiles")
     public Response loadLanguagePropertyFile(File inputFile) {
-        try
-        {
-            ZipFile file = new ZipFile(inputFile);
+        try (ZipFile file = new ZipFile(inputFile)) {
             //Get file entries
             Enumeration<? extends ZipEntry> entries = file.entries();
 
@@ -502,20 +499,19 @@ public class DatasetFieldServiceApi extends AbstractApiBean {
             {
                 ZipEntry entry = entries.nextElement();
                 String dataverseLangFileName = dataverseLangDirectory + "/" + entry.getName();
-                FileOutputStream fileOutput = new FileOutputStream(dataverseLangFileName);
+                try (FileOutputStream fileOutput = new FileOutputStream(dataverseLangFileName)) {
 
-                InputStream is = file.getInputStream(entry);
-                BufferedInputStream bis = new BufferedInputStream(is);
+                    InputStream is = file.getInputStream(entry);
+                    BufferedInputStream bis = new BufferedInputStream(is);
 
-                while (bis.available() > 0) {
-                    fileOutput.write(bis.read());
+                    while (bis.available() > 0) {
+                        fileOutput.write(bis.read());
+                    }
                 }
-                fileOutput.close();
             }
         }
-        catch(IOException e)
-        {
-            e.printStackTrace();
+        catch(IOException e) {
+            logger.log(Level.SEVERE, "Reading the language property zip file failed", e);
             return Response.status(500).entity("Internal server error. More details available at the server logs.").build();
         }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Use try-with-resources to prevent resource leaks when reading a zip file and writing `FileOutputStream`s in `DatasetFieldServiceApi.loadLanguagePropertyFile`.

It also prevents that paths in the zip file resolve to paths outside the `dataverseLangDirectory`, solving <https://sonarcloud.io/project/issues?open=AYpC3G9mQPYCEFsuVI2K&id=IQSS_dataverse>.

**Which issue(s) this PR closes**:

Closes #10055

**Special notes for your reviewer**:
The javadoc comments tell me that the `InputStream`s opened by `ZipFile.getInputStream(ZipEntry)` are closed when the zip file itself is closed (which is now handled through opening the zip file with try-with-resources), so I believe they don't need to be opened using try-with-resources.
Thank you!

**Suggestions on how to test this**:
To test that the zip slip fix works, we would need to try to upload a malicious zip file and see that an HTTP 400 response is returned.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
No

**Is there a release notes update needed for this change?**:
No

**Additional documentation**:
No