### PR TITLE
Disabling quotas checks for direct uploads via API

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/CreateNewDataFilesCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/CreateNewDataFilesCommand.java
@@ -657,7 +657,8 @@ public class CreateNewDataFilesCommand extends AbstractCommand<CreateDataFileRes
             if (newFileSize != null) {
                 fileSize = newFileSize;
             } else {
-                throw new CommandExecutionException("File size must be explicitly specified when creating DataFiles with Direct Upload", this);
+                // This is a direct upload via the API (DVUploader, etc.) 
+                //throw new CommandExecutionException("File size must be explicitly specified when creating DataFiles with Direct Upload", this);
             }
         }
         
@@ -696,7 +697,7 @@ public class CreateNewDataFilesCommand extends AbstractCommand<CreateDataFileRes
             datafiles.add(datafile);
 
             // Update quota (may not be necessary in the context of direct upload - ?)
-            if (quota != null) {
+            if (fileSize > 0 && quota != null) {
                 quota.setTotalUsageInBytes(quota.getTotalUsageInBytes() + fileSize);
             }
             return CreateDataFileResult.success(fileName, finalType, datafiles);


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a quick workaround for direct uploads-via-api broken in the dev. branch, rolling back the check added in #9361. 
Longer term solution coming as part of #8549. 

**Which issue(s) this PR closes**:

Closes #10080

**Special notes for your reviewer**:

Feeling super confident about merging this without any further ado. Should not affect any existing functionality or break anything.

**Suggestions on how to test this**:

DVUploader should be failing on a direct-enabled store (either with the `-directupload` option; or in its default mode, starting w/ `v1.2.0beta3`) in the dev. branch as of now; should be working after this PR is merged. 

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
