### PR TITLE
in README replace link to 404 with link to team

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Dataverse&#174;  
 ===============
 
-Dataverse is an [open source][] software platform for sharing, finding, citing, and preserving research data (developed by the [Data Science and Products team](https://www.iq.harvard.edu/people/people/data-science-products) at the [Institute for Quantitative Social Science](https://iq.harvard.edu/) and the [Dataverse community][]).
+Dataverse is an [open source][] software platform for sharing, finding, citing, and preserving research data (developed by the [Dataverse team](https://dataverse.org/about) at the [Institute for Quantitative Social Science](https://iq.harvard.edu/) and the [Dataverse community][]).
 
 [dataverse.org][] is our home on the web and shows a map of Dataverse installations around the world, a list of [features][], [integrations][] that have been made possible through [REST APIs][], our development [roadmap][], and more.
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Merging PR #9068 basically reverted PR #10051 so now we link to a 404 again.

That is to say, this is a 404: https://www.iq.harvard.edu/people/people/data-science-products

Instead, we want to link to https://dataverse.org/about

This PR is simply the same fix. Take 2.

**Which issue(s) this PR closes**:

- Closes #9267