### PR TITLE
Container Guide: shorten redeploy section to what works

### DIFF
--- a/doc/sphinx-guides/source/container/dev-usage.rst
+++ b/doc/sphinx-guides/source/container/dev-usage.rst
@@ -150,16 +150,6 @@ by recreating the container(s). In the future, more options may be added here.
 If you started your containers in foreground, just stop them and follow the steps for building and running again.
 The same goes for using Maven to start the containers in the background.
 
-In case of using Docker Compose and starting the containers in the background, you can use a workaround to only
-restart the application container:
-
-.. code-block::
-
-  # First rebuild the container (will complain about an image still in use, this is fine.)
-  mvn -Pct package
-  # Then re-create the container (will automatically restart the container for you)
-  docker compose -f docker-compose-dev.yml create dev_dataverse
-
 Using ``docker container inspect dev_dataverse | grep Image`` you can verify the changed checksums.
 
 Using a Debugger


### PR DESCRIPTION
Remove the instructions related to the re-deploy of containers in the background as of 11/02/2023 these instructions didn't work with the current containers.

**What this PR does / why we need it**:

The instructions provided don't work with the current containers:

In case of using Docker Compose and starting the containers in the background, you can use a workaround to only restart the application container:

# First rebuild the container (will complain about an image still in use, this is fine.)
mvn -Pct package
# Then re-create the container (will automatically restart the container for you)
docker compose -f docker-compose-dev.yml create dev_dataverse

**Which issue(s) this PR closes**:
N/A
Closes #

**Special notes for your reviewer**:

**Suggestions on how to test this**:

-Install Dataverse on containers
-Run them on the background with mvn -Pct docker:star
-Make a change to the code
-Follow the instructions on the documentation

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
N/A
**Is there a release notes update needed for this change?**:
N/A
**Additional documentation**:
N/A