### PR TITLE
Add the .gitattributes file to set LF by default on .sh files on checkout

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# https://www.git-scm.com/docs/gitattributes
+
+# This set mandatory LF line endings for .sh files preventing from windows users to having to change the value of their git config --global core.autocrlf to 'false' or 'input'
+*.sh text eol=lf


### PR DESCRIPTION
**What this PR does / why we need it**:

Adding the .gitattributes file so it can make it easier for Windows users to get going on the code by just adding a file to the Git repository.

**Which issue(s) this PR closes**:

- Closes #9894

**Special notes for your reviewer**:

https://groups.google.com/g/dataverse-community/c/dGduT2T8F7Y 

**Suggestions on how to test this**:

Download the project from the original repo
Create a windows installation and set the core.autocrlf to false.
The development of the containers should fail. 
Delete the instalation
Set core.autocrlf=input to input or true
The development of the containers should be successful. 
set the core.autocrlf to false again
download from this fork
the development should be successful 

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
No

**Is there a release notes update needed for this change?**:
Change on the documentation at https://guides.dataverse.org/en/latest/developers/windows.html this step would not be necessary 

**Additional documentation**:
https://www.git-scm.com/docs/gitattributes

