### PR TITLE
IQSS/10095-download estimate bug fix

### DIFF
--- a/src/main/resources/db/migration/V6.0.0.3__10095-guestbook-at-request2.sql
+++ b/src/main/resources/db/migration/V6.0.0.3__10095-guestbook-at-request2.sql
@@ -1,0 +1,34 @@
+-- This creates a function that ESTIMATES the size of the
+-- GuestbookResponse table (for the metrics display), instead
+-- of relying on straight "SELECT COUNT(*) ..."
+-- It uses statistics to estimate the number of guestbook entries
+-- and the fraction of them related to downloads,
+-- i.e. those that weren't created for 'AccessRequest' events.
+-- Significant potential savings for an active installation.
+-- See https://github.com/IQSS/dataverse/issues/8840 and 
+-- https://github.com/IQSS/dataverse/pull/8972 for more details
+
+CREATE OR REPLACE FUNCTION estimateGuestBookResponseTableSize()
+RETURNS bigint AS $$
+DECLARE
+  estimatedsize bigint;
+BEGIN
+  SELECT CASE WHEN relpages<10 THEN 0
+              ELSE ((reltuples / relpages)
+               * (pg_relation_size('public.guestbookresponse') / current_setting('block_size')::int))::bigint
+               * (SELECT CASE WHEN ((select count(*) from pg_stats where tablename='guestbookresponse') = 0 
+                   OR (select array_position(most_common_vals::text::text[], 'AccessRequest') 
+                       FROM pg_stats WHERE tablename='guestbookresponse' AND attname='eventtype') IS NULL) THEN 1
+                   ELSE 1 - (SELECT (most_common_freqs::text::text[])[array_position(most_common_vals::text::text[], 'AccessRequest')]::float
+                       FROM pg_stats WHERE tablename='guestbookresponse' and attname='eventtype') END)
+         END
+     FROM   pg_class
+     WHERE  oid = 'public.guestbookresponse'::regclass INTO estimatedsize;
+
+     if estimatedsize = 0 then
+     SELECT COUNT(id) FROM guestbookresponse WHERE eventtype!= 'AccessRequest' INTO estimatedsize;
+     END if;   
+
+  RETURN estimatedsize;
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;


### PR DESCRIPTION
**What this PR does / why we need it**: As described in the issue, the prior method tried to assign a fraction to a bigint, causing  a failure. This fixes the issue by using the type float

**Which issue(s) this PR closes**:

Closes #10095

**Special notes for your reviewer**: The bug is only in the dev branch. The PR adds a new flyway script rather than replacing the old one. Just changing the old one would work except for developers having to remove the last couple of flyway entries. I can change the PR to that if it is desirable (avoids recording the bug in every flyway table forever.)

**Suggestions on how to test this**: This only appears once the table size is large enough (relpages >10), guestbook-at-request has been enabled somewhere and a response for an at-request guestbook has been entered, and table stats are up to date. I'm not sure what the best way to recreate that is although I expect using a copy of the real Harvard DB and setting up a guestbook-at-request and using it would work. Nominally all of the select statements in the query could be performed manually to verify that the test case is hitting the changed line. Happy to discuss. I can confirm that the new query is working at QDR (and that the old one was failing/same conditions).

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
