### PR TITLE
Containers: set autodeploy-enabled=true for ENABLE_RELOAD

### DIFF
--- a/modules/container-base/src/main/docker/scripts/init_1_generate_devmode_commands.sh
+++ b/modules/container-base/src/main/docker/scripts/init_1_generate_devmode_commands.sh
@@ -56,6 +56,7 @@ fi
 if [ "${ENABLE_RELOAD}" = "1" ]; then
   echo "Enabling hot reload of deployments."
   echo "set configs.config.server-config.admin-service.das-config.dynamic-reload-enabled=true" >> "${DV_PREBOOT}"
+  echo "set configs.config.server-config.admin-service.das-config.autodeploy-enabled=true" >> "${DV_PREBOOT}"
 fi
 
 # 4. Add the commands to the existing preboot file, but insert BEFORE deployment


### PR DESCRIPTION
**What this PR does / why we need it**:

We want the base image to support the autodeploy directory when ENABLE_RELOAD is true.

**Which issue(s) this PR closes**:

- Closes #10099

**Suggestions on how to test this**:

Try `cp path/to/myapp.war /opt/payara/appserver/glassfish/domains/domain1/autodeploy` with and without this fix.