### PR TITLE
Single retry when datafile checksum validation fails

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/util/FileUtil.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/FileUtil.java
@@ -1504,20 +1504,12 @@ public class FileUtil implements java.io.Serializable  {
             boolean fixed = false;
             if (!dataFile.isTabularData() && dataFile.getIngestReport() != null) {
                 // try again, see if the .orig file happens to be there:
-                InputStream in = null;
-                try {
-                    in = storage.getAuxFileAsInputStream(FileUtil.SAVED_ORIGINAL_FILENAME_EXTENSION);
-                } catch (IOException ioex) {
-                    in = null;
+                try (InputStream in = storage.getAuxFileAsInputStream(FileUtil.SAVED_ORIGINAL_FILENAME_EXTENSION)) {
+                    recalculatedChecksum = FileUtil.calculateChecksum(in, checksumType);
+                } catch (RuntimeException rte) {
+                    recalculatedChecksum = null;
                 }
-                if (in != null) {
-                    try {
-                        recalculatedChecksum = FileUtil.calculateChecksum(in, checksumType);
-                    } catch (RuntimeException rte) {
-                        recalculatedChecksum = null;
-                    } finally {
-                        IOUtils.closeQuietly(in);
-                    }
+                if (recalculatedChecksum != null) {
                     // try again:
                     if (recalculatedChecksum.equals(dataFile.getChecksumValue())) {
                         fixed = true;

--- a/src/main/java/edu/harvard/iq/dataverse/util/FileUtil.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/FileUtil.java
@@ -1449,7 +1449,8 @@ public class FileUtil implements java.io.Serializable  {
     	return s3io;
     }
     
-    private static InputStream getInputStream(StorageIO<DataFile> storage, boolean isTabularData) throws IOException {
+    private static InputStream getOriginalFileInputStream(StorageIO<DataFile> storage, boolean isTabularData) throws IOException {
+        storage.open(DataAccessOption.READ_ACCESS);
         if (!isTabularData) {
             return storage.getInputStream();
         } else {
@@ -1471,8 +1472,7 @@ public class FileUtil implements java.io.Serializable  {
         InputStream in = null;
 
         try {
-            storage.open(DataAccessOption.READ_ACCESS);
-            in = getInputStream(storage, dataFile.isTabularData());
+            in = getOriginalFileInputStream(storage, dataFile.isTabularData());
         } catch (IOException ioex) {
             in = null;
         }
@@ -1492,8 +1492,7 @@ public class FileUtil implements java.io.Serializable  {
             IOUtils.closeQuietly(in);
             storage = dataFile.getStorageIO();
             try {
-                storage.open(DataAccessOption.READ_ACCESS);
-                in = getInputStream(storage, dataFile.isTabularData());
+                in = getOriginalFileInputStream(storage, dataFile.isTabularData());
                 recalculatedChecksum = FileUtil.calculateChecksum(in, checksumType);
             } catch (RuntimeException rte2) {
                 logger.log(Level.SEVERE, "failed to calculated checksum, no retry", rte2);

--- a/src/main/java/edu/harvard/iq/dataverse/util/FileUtil.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/FileUtil.java
@@ -1504,6 +1504,7 @@ public class FileUtil implements java.io.Serializable  {
             boolean fixed = false;
             if (!dataFile.isTabularData() && dataFile.getIngestReport() != null) {
                 // try again, see if the .orig file happens to be there:
+                InputStream in = null;
                 try {
                     in = storage.getAuxFileAsInputStream(FileUtil.SAVED_ORIGINAL_FILENAME_EXTENSION);
                 } catch (IOException ioex) {


### PR DESCRIPTION
**What this PR does / why we need it**:
It fixes the problem when publishing large datasets, and the s3 server closes the connection. On some installations, this happens every 20 to 30 minutes. In that case, publishing of large datasets is not possible without disabling the validation.

**Which issue(s) this PR closes**:

Closes #10114 

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
No

**Is there a release notes update needed for this change?**:
No

**Additional documentation**:
The fix implements a single retry when datafile validation fails. If the fail was due to a lost connection, the checksum gets recomputed and the publishing succeeds.