### PR TITLE
descriptive labels for file stores

### DIFF
--- a/doc/sphinx-guides/source/installation/config.rst
+++ b/doc/sphinx-guides/source/installation/config.rst
@@ -539,6 +539,27 @@ If you wish to change which store is used by default, you'll need to delete the 
 
 It is also possible to set maximum file upload size limits per store. See the :ref:`:MaxFileUploadSizeInBytes` setting below.
 
+.. _labels-file-stores:
+
+Labels for File Stores
+++++++++++++++++++++++
+
+If you find yourself adding many file stores with various configurations such as per-file limits and direct upload, you might find it helpful to make the label descriptive.
+
+For example, instead of simply labeling an S3 store as "S3"...
+
+.. code-block:: none
+
+    ./asadmin create-jvm-options "\-Ddataverse.files.s3xl.label=S3"
+
+... you might want to include some extra information such as the example below.
+
+.. code-block:: none
+
+    ./asadmin create-jvm-options "\-Ddataverse.files.s3xl.label=S3XL, Filesize limit: 100GB, direct-upload"
+
+Please keep in mind that the UI will only show so many characters, so labels are best kept short.
+
 .. _storage-files-dir:
 
 File Storage


### PR DESCRIPTION
**What this PR does / why we need it**:

Superusers would like to know which file store is which

**Which issue(s) this PR closes**:

- Closes #9622

**Special notes for your reviewer**:

None.

**Suggestions on how to test this**:

Try the JVM options. See how the UI looks.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

Not really, longer labels.

![277493913-025f1b63-1aa6-495c-b0f2-c2835230f157](https://github.com/IQSS/dataverse/assets/21006/b1f0e7f4-c55b-4d91-8e57-5434dfc08e08)

**Is there a release notes update needed for this change?**:

No.

**Additional documentation**:

It is documentation.