### PR TITLE
Remove the authentication annotation from info API

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/api/AbstractApiBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/AbstractApiBean.java
@@ -636,6 +636,16 @@ public abstract class AbstractApiBean {
         }
     }
 
+    /***
+     * The preferred way of handling a request from an open API.
+     *
+     * @param hdl handling code block.
+     * @return HTTP Response appropriate for the way {@code hdl} executed.
+     */
+    protected Response response(DataverseRequestHandler hdl) {
+        return response(hdl, null);
+    }
+
     private Response handleDataverseRequestHandlerException(Exception ex) {
         String incidentId = UUID.randomUUID().toString();
         logger.log(Level.SEVERE, "API internal error " + incidentId +": " + ex.getMessage(), ex);

--- a/src/main/java/edu/harvard/iq/dataverse/api/AbstractApiBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/AbstractApiBean.java
@@ -636,16 +636,6 @@ public abstract class AbstractApiBean {
         }
     }
 
-    /***
-     * The preferred way of handling a request from an open API.
-     *
-     * @param hdl handling code block.
-     * @return HTTP Response appropriate for the way {@code hdl} executed.
-     */
-    protected Response response(DataverseRequestHandler hdl) {
-        return response(hdl, null);
-    }
-
     private Response handleDataverseRequestHandlerException(Exception ex) {
         String incidentId = UUID.randomUUID().toString();
         logger.log(Level.SEVERE, "API internal error " + incidentId +": " + ex.getMessage(), ex);

--- a/src/main/java/edu/harvard/iq/dataverse/api/Info.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Info.java
@@ -35,30 +35,27 @@ public class Info extends AbstractApiBean {
     }
 
     @GET
-    @AuthRequired
     @Path("version")
-    public Response getInfo(@Context ContainerRequestContext crc) {
+    public Response getInfo() {
         String versionStr = systemConfig.getVersion(true);
         String[] comps = versionStr.split("build",2);
         String version = comps[0].trim();
         JsonValue build = comps.length > 1 ? Json.createArrayBuilder().add(comps[1].trim()).build().get(0) : JsonValue.NULL;
 
         return response( req -> ok( Json.createObjectBuilder().add("version", version)
-                                                              .add("build", build)), getRequestUser(crc));
+                                                              .add("build", build)));
     }
 
     @GET
-    @AuthRequired
     @Path("server")
-    public Response getServer(@Context ContainerRequestContext crc) {
-        return response( req -> ok(JvmSettings.FQDN.lookup()), getRequestUser(crc));
+    public Response getServer() {
+        return response( req -> ok(JvmSettings.FQDN.lookup()));
     }
 
     @GET
-    @AuthRequired
     @Path("apiTermsOfUse")
-    public Response getTermsOfUse(@Context ContainerRequestContext crc) {
-        return response( req -> ok(systemConfig.getApiTermsOfUse()), getRequestUser(crc));
+    public Response getTermsOfUse() {
+        return response( req -> ok(systemConfig.getApiTermsOfUse()));
     }
 
     @GET

--- a/src/main/java/edu/harvard/iq/dataverse/api/Info.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Info.java
@@ -38,21 +38,21 @@ public class Info extends AbstractApiBean {
         String[] comps = versionStr.split("build",2);
         String version = comps[0].trim();
         JsonValue build = comps.length > 1 ? Json.createArrayBuilder().add(comps[1].trim()).build().get(0) : JsonValue.NULL;
-
-        return response( req -> ok( Json.createObjectBuilder().add("version", version)
-                                                              .add("build", build)));
+        return ok(Json.createObjectBuilder()
+                .add("version", version)
+                .add("build", build));
     }
 
     @GET
     @Path("server")
     public Response getServer() {
-        return response( req -> ok(JvmSettings.FQDN.lookup()));
+        return ok(JvmSettings.FQDN.lookup());
     }
 
     @GET
     @Path("apiTermsOfUse")
     public Response getTermsOfUse() {
-        return response( req -> ok(systemConfig.getApiTermsOfUse()));
+        return ok(systemConfig.getApiTermsOfUse());
     }
 
     @GET

--- a/src/main/java/edu/harvard/iq/dataverse/api/Info.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Info.java
@@ -1,6 +1,5 @@
 package edu.harvard.iq.dataverse.api;
 
-import edu.harvard.iq.dataverse.api.auth.AuthRequired;
 import edu.harvard.iq.dataverse.settings.JvmSettings;
 import edu.harvard.iq.dataverse.settings.SettingsServiceBean;
 import edu.harvard.iq.dataverse.util.SystemConfig;
@@ -9,8 +8,6 @@ import jakarta.json.Json;
 import jakarta.json.JsonValue;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
-import jakarta.ws.rs.container.ContainerRequestContext;
-import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.Response;
 
 @Path("info")


### PR DESCRIPTION
**What this PR does / why we need it**:

After the changes that happened on #9303 and #9360  the `@AuthenticationRequired` was present on some API methods that are public and some additional code that is not required, this change:

-Overloads `AbstractAPIBean.response` requiring only a `DataverseRequestHandler` and passing a null `User`. 
-Removes the `@AuthenticationRequired` from the following info endpoints: {`version, server and apiTermsOfUse`}
-it also removes the `@Context ContainerRequestContext` from the signature of the method and makes a new call to the new re-introduced signature. This signature was deprecated on #9303 and removed on #9360.

**Which issue(s) this PR closes**:

Closes #9466 

**Special notes for your reviewer**:
This method signature was marked as deprecated on #9303, probably the intention of the author was to deprecate it while the functionality was migrated to the new authentication mechanism and removed once all the changes were done. 

**Suggestions on how to test this**:
-Run the APIs and integration tests.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
N/A

**Is there a release notes update needed for this change?**:
N/A

**Additional documentation**:
N/A