### PR TITLE
Allows the dataverse administrator to set a dataverse user to respond to file access requests.

### DIFF
--- a/doc/sphinx-guides/source/installation/config.rst
+++ b/doc/sphinx-guides/source/installation/config.rst
@@ -3215,6 +3215,17 @@ This curl command...
 
 See also :doc:`oauth2`.
 
+.. _:DatasetManagerForFileAccessNotification
+
+:DatasetManagerForFileAccessNotification
+++++++++++++++++++++++++++++++++++++++++
+
+The identifier for the data manager's dataverse username. This is a dataverse account for the dataset manager of the organisation responsible
+for receiving file access requests. Use this in case owners of datasets are not responsible for approving access
+requests for file downloads. For example, if the mail address of the datamanager is "datasetmanager" set it to:
+
+``curl -X PUT -d 'datasetmanager' http://localhost:8080/api/admin/settings/:DatasetManagerForFileAccessNotification``
+
 .. _:FileFixityChecksumAlgorithm:
 
 :FileFixityChecksumAlgorithm

--- a/src/main/java/edu/harvard/iq/dataverse/FileDownloadServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/FileDownloadServiceBean.java
@@ -573,13 +573,18 @@ public class FileDownloadServiceBean implements java.io.Serializable {
     
     public void sendRequestFileAccessNotification(Dataset dataset, Long fileId, AuthenticatedUser requestor) {
         Timestamp ts = new Timestamp(new Date().getTime());
-        permissionService.getUsersWithPermissionOn(Permission.ManageDatasetPermissions, dataset).stream().forEach((au) -> {
+        final String datasetManagerForFileAccessNotification = settingsService.getValueForKey(SettingsServiceBean.Key.DatasetManagerForFileAccessNotification);
+        if (datasetManagerForFileAccessNotification == null ) {
+            permissionService.getUsersWithPermissionOn(Permission.ManageDatasetPermissions, dataset).stream().forEach((au) -> {
+                userNotificationService.sendNotification(au, ts, UserNotification.Type.REQUESTFILEACCESS, fileId, null, requestor, true);
+            });
+        } else {
+            final AuthenticatedUser au = authService.getAuthenticatedUser(datasetManagerForFileAccessNotification);
             userNotificationService.sendNotification(au, ts, UserNotification.Type.REQUESTFILEACCESS, fileId, null, requestor, true);
-        });
+        }
         //send the user that requested access a notification that they requested the access
         userNotificationService.sendNotification(requestor, ts, UserNotification.Type.REQUESTEDFILEACCESS, fileId, null, requestor, true);
-
-    } 
+    }
     
     public String generateServiceKey() {
         UUID uid = UUID.randomUUID();

--- a/src/main/java/edu/harvard/iq/dataverse/settings/SettingsServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/settings/SettingsServiceBean.java
@@ -53,6 +53,10 @@ public class SettingsServiceBean {
          */
         CustomDatasetSummaryFields,
         /**
+         * Dataverse user as an alternative address to send file download requests to.
+         */
+        DatasetManagerForFileAccessNotification,
+        /**
          * Defines a public installation -- all datafiles are unrestricted
          */
         PublicInstall,


### PR DESCRIPTION
Allows the dataverse administrator to set a dataverse user to respond to file access requests.

**What this PR does / why we need it**:
Sometimes employees to leave the organisation and no longer are able to approve access requests.
Or the organisation has entirely outsourced file approval tasks to a data officer.
In those cases, the organisational data manager needs to receive notifications.
This can be set with the DatasetManagerForFileAccessNotification set to the username of the 
datamanager's dataverse username.

**Which issue(s) this PR closes**:

Closes #

**Special notes for your reviewer**:

**Suggestions on how to test this**:
Default behavior: leave DatasetManagerForFileAccessNotification unset and there is no change for curent dataverse users.
Set DatasetManagerForFileAccessNotification to a dataverse username and make a file access request. Only this
user will then receive the access request.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
No

**Is there a release notes update needed for this change?**:

**Additional documentation**:
