### PR TITLE
#3702 - Returning to author now requires a commented reason that is sent by email to the author

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
@@ -701,6 +701,16 @@ public class DatasetPage implements java.io.Serializable {
         this.numberOfFilesToShow = numberOfFilesToShow;
     }
 
+    private String returnReason = "";
+
+    public String getReturnReason() {
+        return returnReason;
+    }
+
+    public void setReturnReason(String returnReason) {
+        this.returnReason = returnReason;
+    }
+
     public void showAll(){
         setNumberOfFilesToShow(new Long(fileMetadatasSearch.size()));
     }
@@ -2601,8 +2611,7 @@ public class DatasetPage implements java.io.Serializable {
 
     public String sendBackToContributor() {
         try {
-            //FIXME - Get Return Comment from sendBackToContributor popup
-            Command<Dataset> cmd = new ReturnDatasetToAuthorCommand(dvRequestService.getDataverseRequest(), dataset, "");
+            Command<Dataset> cmd = new ReturnDatasetToAuthorCommand(dvRequestService.getDataverseRequest(), dataset, returnReason);
             dataset = commandEngine.submit(cmd);
             JsfHelper.addSuccessMessage(BundleUtil.getStringFromBundle("dataset.reject.success"));
         } catch (CommandException ex) {

--- a/src/main/java/edu/harvard/iq/dataverse/MailServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/MailServiceBean.java
@@ -467,14 +467,11 @@ public class MailServiceBean implements java.io.Serializable {
                 version =  (DatasetVersion) targetObject;
                 pattern = BundleUtil.getStringFromBundle("notification.email.wasReturnedByReviewer");
                 String optionalReturnReason = "";
-                /*
-                FIXME
-                Setting up to add single comment when design completed
-                optionalReturnReason = ".";
+
                 if (comment != null && !comment.isEmpty()) {
-                    optionalReturnReason = ".\n\n" + BundleUtil.getStringFromBundle("wasReturnedReason") + "\n\n" + comment;
+                    optionalReturnReason = ".\n\n" + MessageFormat.format(BundleUtil.getStringFromBundle("notification.email.wasReturnedByReviewerReason"), comment);
                 }
-                */
+
                 String[] paramArrayReturnedDataset = {version.getDataset().getDisplayName(), getDatasetDraftLink(version.getDataset()), 
                     version.getDataset().getOwner().getDisplayName(),  getDataverseLink(version.getDataset().getOwner()), optionalReturnReason};
                 messageText += MessageFormat.format(pattern, paramArrayReturnedDataset);

--- a/src/main/java/edu/harvard/iq/dataverse/api/Notifications.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Notifications.java
@@ -55,7 +55,6 @@ public class Notifications extends AbstractApiBean {
             notificationObjectBuilder.add("id", notification.getId());
             notificationObjectBuilder.add("type", type.toString());
             /* FIXME - Re-add reasons for return if/when they are added to the notifications page.
-            
             if (Type.RETURNEDDS.equals(type) || Type.SUBMITTEDDS.equals(type)) {
                 JsonArrayBuilder reasons = getReasonsForReturn(notification);
                 for (JsonValue reason : reasons.build()) {

--- a/src/main/java/propertyFiles/Bundle.properties
+++ b/src/main/java/propertyFiles/Bundle.properties
@@ -781,7 +781,8 @@ notification.email.createDataverse=Your new dataverse named {0} (view at {1} ) w
 # Bundle file editors, please note that "notification.email.createDataset" is used in a unit test
 notification.email.createDataset=Your new dataset named {0} (view at {1} ) was created in {2} (view at {3} ). To learn more about what you can do with a dataset, check out the Dataset Management - User Guide at {4}/{5}/user/dataset-management.html .
 notification.email.wasSubmittedForReview={0} (view at {1} ) was submitted for review to be published in {2} (view at {3} ). Don''t forget to publish it or send it back to the contributor, {4} ({5})\!
-notification.email.wasReturnedByReviewer={0} (view at {1} ) was returned by the curator of {2} (view at {3} ).
+notification.email.wasReturnedByReviewer={0} (view at {1} ) was returned by the curator of {2} (view at {3} ).{4}
+notification.email.wasReturnedByReviewerReason=See the curator comment : {0}
 notification.email.wasPublished={0} (view at {1} ) was published in {2} (view at {3} ).
 notification.email.publishFailedPidReg={0} (view at {1} ) in {2} (view at {3} ) could not be published due to a failure to register, or update the Global Identifier for the dataset or one of the files in it. Contact support if this continues to happen. 
 notification.email.closing=\n\nYou may contact us for support at {0}.\n\nThank you,\n{1}

--- a/src/main/webapp/dataset.xhtml
+++ b/src/main/webapp/dataset.xhtml
@@ -1810,27 +1810,30 @@
                         <p class="text-warning">
                             <span class="glyphicon glyphicon-warning-sign"/> #{bundle['dataset.rejectMessage']}
                         </p>
-                        <ui:remove>
-                            <!--FIXME update for new comments table -->
-                            <p:inputTextarea id="returnReason" rows="3" value="#{DatasetPage.workingVersion.returnReason}" title="#{bundle['dataset.rejectMessage.label']}" maxlength="200" widgetVar="returnReason"
-                                             cols="70" counter="display" counterTemplate="{0} characters remaining." autoResize="false"
-                                             requiredMessage="#{bundle['dataset.reject.enterReason.error']}"/>
-                            <!--FIXME validation error msg for returnReason was in confirmDialog using testReturnReason() in commandButton below but all that was removed
-                                      as it did not look like the usual validation method, added preferred requiredMessage attribute to inputTextarea above, need wiring #5717-->
-                            <p>
-                                <h:outputText id="display"/>
-                            </p>
-                            <p:watermark for="returnReason" value="#{bundle['dataset.rejectWatermark']}" id="returnReasonwatermark"/>
-                        </ui:remove>
+
+                        <p:inputTextarea id="returnReason" rows="3" value="#{DatasetPage.returnReason}" title="#{bundle['dataset.rejectMessage.label']}" maxlength="200" widgetVar="returnReason"
+                                         cols="70" counter="display" counterTemplate="{0} characters remaining." autoResize="false"
+                                         required="#{param['DO_RETURN_TO_AUTHOR_VALIDATION']}"
+                                         requiredMessage="#{bundle['dataset.reject.enterReason.error']}"/>
+                        <p>
+                            <h:outputText id="display"/>
+                        </p>
+                        <p:watermark for="returnReason" value="#{bundle['dataset.rejectWatermark']}" id="returnReasonWatermark"/>
+                        <h:message for="returnReason" styleClass="bg-danger text-danger"/>
+                        
                         <div class="button-block">
-                            <p:commandButton styleClass="btn btn-default" value="#{bundle.continue}" onclick="PF('sendBackToContributor').hide()" action="#{DatasetPage.sendBackToContributor}"/>
+                            <p:commandButton styleClass="btn btn-default" value="#{bundle.continue}"
+                                             update="@form"
+                                             oncomplete="PF('sendBackToContributor').show();if (args &amp;&amp; !args.validationFailed) returnToAuthorCommand();">
+                                <f:param name="DO_RETURN_TO_AUTHOR_VALIDATION" value="true"/>
+                            </p:commandButton>
                             <button class="btn btn-link" onclick="PF('sendBackToContributor').hide();
                                     PF('blockDatasetForm').hide();" type="button">
                                 #{bundle.cancel}
                             </button>
                         </div>
                     </p:dialog>
-                    <p:remoteCommand name="returnToAuthorCommand" action="#{DatasetPage.sendBackToContributor}"/>
+                    <p:remoteCommand name="returnToAuthorCommand" oncomplete="PF('sendBackToContributor').hide();" update=":messagePanel" actionListener="#{DatasetPage.sendBackToContributor}"/>
                     <p:remoteCommand name="linkEditTerms"   actionListener="#{DatasetPage.edit('LICENSE')}" update="@form,:datasetForm,:messagePanel">
                         <f:setPropertyActionListener target="#{DatasetPage.selectedTabIndex}" value="0" />
                     </p:remoteCommand>

--- a/src/main/webapp/dataverseuser.xhtml
+++ b/src/main/webapp/dataverseuser.xhtml
@@ -178,9 +178,6 @@
                                                         <o:param>
                                                             #{DataverseUserPage.getRequestorEmail(item)}
                                                         </o:param>
-                                                        <o:param>
-                                                            #{DataverseUserPage.getReasonForReturn(item.theObject)}
-                                                        </o:param>
                                                     </h:outputFormat>
                                                 </ui:fragment>
                                                 <ui:fragment rendered="#{item.type == 'RETURNEDDS'}">


### PR DESCRIPTION
**What this PR does / why we need it**:

It displays a required textarea inside the "return to author" popup that is used to comment the reason of the return. This comment is sent by email to the author.

**Which issue(s) this PR closes**:

Might close #3702 

**Special notes for your reviewer**:

This PR does not cover the management of displaying reasons of return in notification page.
`Notification` does not share the same architecture as `WorkflowComment` on a `DatasetVersion`, so it's not easy to join on comment to a notification in case there is multiple return to the author on the same Dataset version.

`Bundle.properties` new values must be arbitrated, as the closing of #3702

**Suggestions on how to test this**:

All the XHTML part with `required` field and `remoteCommand` seems really "delicate", an attention must be paid to the other commands in the dataset (like editing/saving a dataset).
Also, validation message seems to be removed a bit too fast when tags are updated, it might need a little improvement.

**Does this PR introduce a user interface change? 

https://github.com/IQSS/dataverse/assets/83018819/e2c16c0c-ef7d-4017-9e59-afe70ab41a93

**Is there a release notes update needed for this change?**:

Definitely yes.

