### PR TITLE
Make superuser API call idempotent

### DIFF
--- a/doc/release-notes/9887-superuser-api-is-now-idempotent.md
+++ b/doc/release-notes/9887-superuser-api-is-now-idempotent.md
@@ -1,4 +1,3 @@
-The Admin api to make/remove a user as superuser (`POST http://$SERVER/api/admin/superuser/$identifier`
-), which was previously toggle based, is now a idempotent or silent.
+The Admin api to make/remove a user as superuser (`POST http://$SERVER/api/admin/superuser/$identifier`), which was previously toggle based, is now a idempotent or silent.
 The api is now only to make a user as superuser.
 Calling the api multiple times or on already superuser user has no effect.

--- a/doc/release-notes/9887-superuser-api-is-now-idempotent.md
+++ b/doc/release-notes/9887-superuser-api-is-now-idempotent.md
@@ -1,3 +1,4 @@
-The Admin api to make/remove a user as superuser (`POST http://$SERVER/api/admin/superuser/$identifier`), which was previously toggle based, is now idempotent or silent call.
-The api is now only to make user as superuser.
-Calling the api multiple times or on already superuser user has no effect.
+The admin api to make/remove a user as superuser (`POST http://$SERVER/api/admin/superuser/$identifier`), which was previously toggle based, is now idempotent or silent call.
+
+- The api is now only to make user as superuser.
+- Calling the api multiple times or on already superuser user has no effect.

--- a/doc/release-notes/9887-superuser-api-is-now-idempotent.md
+++ b/doc/release-notes/9887-superuser-api-is-now-idempotent.md
@@ -1,3 +1,3 @@
-The Admin api to make/remove a user as superuser (`POST http://$SERVER/api/admin/superuser/$identifier`), which was previously toggle based, is now a idempotent or silent.
-The api is now only to make a user as superuser.
+The Admin api to make/remove a user as superuser (`POST http://$SERVER/api/admin/superuser/$identifier`), which was previously toggle based, is now idempotent or silent call.
+The api is now only to make user as superuser.
 Calling the api multiple times or on already superuser user has no effect.

--- a/doc/release-notes/9887-superuser-api-is-now-idempotent.md
+++ b/doc/release-notes/9887-superuser-api-is-now-idempotent.md
@@ -1,0 +1,4 @@
+The Admin api to make/remove a user as superuser (`POST http://$SERVER/api/admin/superuser/$identifier`
+), which was previously toggle based, is now a idempotent or silent.
+The api is now only to make a user as superuser.
+Calling the api multiple times or on already superuser user has no effect.

--- a/doc/sphinx-guides/source/api/native-api.rst
+++ b/doc/sphinx-guides/source/api/native-api.rst
@@ -4880,7 +4880,7 @@ This action changes the identifier of user johnsmith to jsmith.
 Make User a SuperUser
 ~~~~~~~~~~~~~~~~~~~~~
 
-Toggles superuser mode on the ``AuthenticatedUser`` whose ``identifier`` (without the ``@`` sign) is passed. ::
+Sets superuser mode on the ``AuthenticatedUser`` whose ``identifier`` (without the ``@`` sign) is passed. ::
 
     POST http://$SERVER/api/admin/superuser/$identifier
 

--- a/src/main/java/edu/harvard/iq/dataverse/api/Admin.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Admin.java
@@ -1037,8 +1037,7 @@ public class Admin extends AbstractApiBean {
 
 			user.setSuperuser(true);
 
-			return ok("User " + user.getIdentifier() + " " + (user.isSuperuser() ? "set" : "removed")
-					+ " as a superuser.");
+			return ok("User " + user.getIdentifier() + " set as a superuser.");
 		} catch (Exception e) {
 			alr.setActionResult(ActionLogRecord.Result.InternalError);
 			alr.setInfo(alr.getInfo() + "// " + e.getMessage());

--- a/src/main/java/edu/harvard/iq/dataverse/api/Admin.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Admin.java
@@ -1035,7 +1035,7 @@ public class Admin extends AbstractApiBean {
                             return error(Status.BAD_REQUEST, "You cannot make a deactivated user a superuser.");
                         }
 
-			user.setSuperuser(!user.isSuperuser());
+			user.setSuperuser(true);
 
 			return ok("User " + user.getIdentifier() + " " + (user.isSuperuser() ? "set" : "removed")
 					+ " as a superuser.");


### PR DESCRIPTION
**What this PR does / why we need it**:
The api to make user a superuser is currently toggle based. The changes will make it a silent call.

**Which issue(s) this PR closes**:

Closes #9887 

**Suggestions on how to test this**:
`POST http://$SERVER/api/admin/superuser/$identifier` will make normal user a superuser but no effect on already superuser

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
No

**Is there a release notes update needed for this change?**:
Yes

**Additional documentation**:
Related issue https://github.com/IQSS/dataverse-docker/issues/78