### PR TITLE
CVOC 9276 Initializing integration of ontoportal

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
@@ -3766,10 +3766,11 @@ public class DatasetPage implements java.io.Serializable {
                 ((UpdateDatasetVersionCommand) cmd).setValidateLenient(true);
             }
             dataset = commandEngine.submit(cmd);
-            for (DatasetField df : dataset.getLatestVersion().getFlatDatasetFields()) {
+            List<DatasetField> flatDatasetFields = dataset.getLatestVersion().getFlatDatasetFields();
+            for (DatasetField df : flatDatasetFields) {
                 logger.fine("Found id: " + df.getDatasetFieldType().getId());
                 if (fieldService.getCVocConf(true).containsKey(df.getDatasetFieldType().getId())) {
-                    fieldService.registerExternalVocabValues(df);
+                    fieldService.registerExternalVocabValues(df, flatDatasetFields);
                 }
             }
             if (editMode == EditMode.CREATE) {

--- a/src/main/webapp/datasetFieldForEditFragment.xhtml
+++ b/src/main/webapp/datasetFieldForEditFragment.xhtml
@@ -42,6 +42,8 @@
             </c:if>
             <f:passThroughAttribute name="lang" value="#{DatasetPage.getFieldLanguage(cvoc.getString('languages'))}"/>
             <f:passThroughAttribute name="data-cvoc-service-url" value="#{cvoc.getString('cvoc-url','')}"/>
+            <f:passThroughAttribute name="data-cvoc-ui-url" value="#{cvoc.getString('cvoc-ui-url','')}"/>
+            <f:passThroughAttribute name="data-cvoc-headers" value="#{cvoc.containsKey('headers')? cvoc.get('headers').toString() : '{}' }"/>
             <f:passThroughAttribute name="data-cvoc-protocol" value="#{cvoc.getString('protocol','')}"/>
             <f:passThroughAttribute name="data-cvoc-filter" value="#{cvoc.getString('term-parent-uri','')}"/>
             <f:passThroughAttribute name="data-cvoc-vocabs" value="#{cvoc.get('vocabs').toString()}"/>

--- a/src/main/webapp/metadataFragment.xhtml
+++ b/src/main/webapp/metadataFragment.xhtml
@@ -88,6 +88,8 @@
                                                     escape="#{dsf.datasetFieldType.isEscapeOutputText()}">
                                                     <f:passThroughAttribute name="lang" value="#{DatasetPage.getFieldLanguage(cvocConf.get(dsf.datasetFieldType.id).getString('languages'))}" />
                                                     <f:passThroughAttribute name="data-cvoc-service-url" value="#{cvocConf.get(dsf.datasetFieldType.id).getString('cvoc-url','')}" />
+                                                    <f:passThroughAttribute name="data-cvoc-ui-url" value="#{cvocConf.get(dsf.datasetFieldType.id).getString('cvoc-ui-url','')}" />
+                                                    <f:passThroughAttribute name="data-cvoc-headers" value="#{cvocConf.get(dsf.datasetFieldType.id).containsKey('headers')? cvocConf.get(dsf.datasetFieldType.id).get('headers').toString() : '{}' }" />
                                                     <f:passThroughAttribute name="data-cvoc-protocol" value="#{cvocConf.get(dsf.datasetFieldType.id).getString('protocol','')}" />
                                                     <f:passThroughAttribute name="data-cvoc-managedfields" value="#{cvocConf.get(dsf.datasetFieldType.id).get('managedfields').toString()}" />
                                                 </h:outputText>
@@ -100,6 +102,8 @@
                                                                   escape="#{dsf.datasetFieldType.isEscapeOutputText()}">
                                                         <f:passThroughAttribute name="lang" value="#{DatasetPage.getFieldLanguage(cvocConf.get(dsf.datasetFieldType.id).getString('languages'))}" />
                                                         <f:passThroughAttribute name="data-cvoc-service-url" value="#{cvocConf.get(dsf.datasetFieldType.id).getString('cvoc-url','')}" />
+                                                        <f:passThroughAttribute name="data-cvoc-ui-url" value="#{cvocConf.get(dsf.datasetFieldType.id).getString('cvoc-ui-url','')}" />
+                                                        <f:passThroughAttribute name="data-cvoc-headers" value="#{cvocConf.get(dsf.datasetFieldType.id).containsKey('headers')? cvocConf.get(dsf.datasetFieldType.id).get('headers').toString() : '{}' }" />
                                                         <f:passThroughAttribute name="data-cvoc-protocol" value="#{cvocConf.get(dsf.datasetFieldType.id).getString('protocol','')}" />
                                                         <f:passThroughAttribute name="data-cvoc-managedfields" value="#{cvocConf.get(dsf.datasetFieldType.id).get('managedfields').toString()}" />
                                                     </h:outputText>
@@ -146,6 +150,8 @@
                                                                       rendered="${cvocOnCvPart and cvPart.key.datasetFieldType.name.equals(cvocConf.get(cvPart.key.datasetFieldType.id).getString('term-uri-field'))}">
                                                                       <f:passThroughAttribute name="lang" value="#{DatasetPage.getFieldLanguage(cvocConf.get(cvPart.key.datasetFieldType.id).getString('languages'))}" />
                                                                       <f:passThroughAttribute name="data-cvoc-service-url" value="#{cvocConf.get(cvPart.key.datasetFieldType.id).getString('cvoc-url','')}" />
+                                                                      <f:passThroughAttribute name="data-cvoc-ui-url" value="#{cvocConf.get(cvPart.key.datasetFieldType.id).getString('cvoc-ui-url','')}" />
+                                                                      <f:passThroughAttribute name="data-cvoc-headers" value="#{cvocConf.get(cvPart.key.datasetFieldType.id).containsKey('headers')? cvocConf.get(cvPart.key.datasetFieldType.id).get('headers').toString() : '{}' }" />
                                                                       <f:passThroughAttribute name="data-cvoc-protocol" value="#{cvocConf.get(cvPart.key.datasetFieldType.id).getString('protocol','')}" />
                                                                       <!-- unlikely to be used in this case -->
                                                                       <f:passThroughAttribute name="data-cvoc-managedfields" value="#{cvocConf.get(cvPart.key.datasetFieldType.id).get('managedfields').toString()}" />
@@ -156,6 +162,8 @@
                                                                       rendered="${cvocOnDsf and cvPart.key.datasetFieldType.name.equals(cvocConf.get(dsf.datasetFieldType.id).getString('term-uri-field'))}">
                                                                       <f:passThroughAttribute name="lang" value="#{DatasetPage.getFieldLanguage(cvocConf.get(dsf.datasetFieldType.id).getString('languages'))}" />
                                                                       <f:passThroughAttribute name="data-cvoc-service-url" value="#{cvocConf.get(dsf.datasetFieldType.id).getString('cvoc-url','')}" />
+                                                                      <f:passThroughAttribute name="data-cvoc-ui-url" value="#{cvocConf.get(dsf.datasetFieldType.id).getString('cvoc-ui-url','')}" />
+                                                                      <f:passThroughAttribute name="data-cvoc-headers" value="#{cvocConf.get(dsf.datasetFieldType.id).containsKey('headers')? cvocConf.get(dsf.datasetFieldType.id).get('headers').toString() : '{}' }" />
                                                                       <f:passThroughAttribute name="data-cvoc-protocol" value="#{cvocConf.get(dsf.datasetFieldType.id).getString('protocol','')}" />
                                                                       <f:passThroughAttribute name="data-cvoc-managedfields" value="#{cvocConf.get(dsf.datasetFieldType.id).get('managedfields').toString()}" />
                                                         </h:outputText>

--- a/src/main/webapp/search-include-fragment.xhtml
+++ b/src/main/webapp/search-include-fragment.xhtml
@@ -202,6 +202,8 @@
                                 <c:if test="#{!cvocConf.isEmpty()}">
                                     <f:passThroughAttribute name="lang" value="#{DatasetPage.getFieldLanguage(cvocConf.get(facetCategory.datasetFieldTypeId).getString('languages'))}" />
                                     <f:passThroughAttribute name="data-cvoc-service-url" value="#{cvocConf.get(facetCategory.datasetFieldTypeId).getString('cvoc-url','')}" />
+                                    <f:passThroughAttribute name="data-cvoc-ui-url" value="#{cvocConf.get(facetCategory.datasetFieldTypeId).getString('cvoc-ui-url','')}" />
+                                    <f:passThroughAttribute name="data-cvoc-headers" value="#{cvocConf.get(facetCategory.datasetFieldTypeId).containsKey('headers')? cvocConf.get(facetCategory.datasetFieldTypeId).get('headers').toString() : '{}' }" />
                                     <f:passThroughAttribute name="data-cvoc-protocol" value="#{cvocConf.get(facetCategory.datasetFieldTypeId).getString('protocol','')}" />
                                 </c:if>
                             </h:outputText>
@@ -223,6 +225,8 @@
                                 <c:if test="#{!cvocConf.isEmpty()}">
                                     <f:passThroughAttribute name="lang" value="#{DatasetPage.getFieldLanguage(cvocConf.get(facetCategory.datasetFieldTypeId).getString('languages'))}" />
                                     <f:passThroughAttribute name="data-cvoc-service-url" value="#{cvocConf.get(facetCategory.datasetFieldTypeId).getString('cvoc-url','')}" />
+                                    <f:passThroughAttribute name="data-cvoc-ui-url" value="#{cvocConf.get(facetCategory.datasetFieldTypeId).getString('cvoc-ui-url','')}" />
+                                    <f:passThroughAttribute name="data-cvoc-headers" value="#{cvocConf.get(facetCategory.datasetFieldTypeId).containsKey('headers')? cvocConf.get(facetCategory.datasetFieldTypeId).get('headers').toString() : '{}' }" />
                                     <f:passThroughAttribute name="data-cvoc-protocol" value="#{cvocConf.get(facetCategory.datasetFieldTypeId).getString('protocol','')}" />
                                 </c:if>
                             </h:outputText>
@@ -367,6 +371,8 @@
                         <h:outputText value="#{friendlyNames.get(1)}">
                                 <f:passThroughAttribute name="lang" value="#{DatasetPage.getFieldLanguage(cvocConf.get(SearchIncludeFragment.getFieldTypeId(friendlyNames.get(0))).getString('languages'))}" />
                                 <f:passThroughAttribute name="data-cvoc-service-url" value="#{cvocConf.get(SearchIncludeFragment.getFieldTypeId(friendlyNames.get(0))).getString('cvoc-url','')}" />
+                                <f:passThroughAttribute name="data-cvoc-ui-url" value="#{cvocConf.get(SearchIncludeFragment.getFieldTypeId(friendlyNames.get(0))).getString('cvoc-ui-url','')}" />
+                                <f:passThroughAttribute name="data-cvoc-headers" value="#{cvocConf.get(SearchIncludeFragment.getFieldTypeId(friendlyNames.get(0))).containsKey('headers')? cvocConf.get(SearchIncludeFragment.getFieldTypeId(friendlyNames.get(0))).get('headers').toString() : '{}' }" />
                                 <f:passThroughAttribute name="data-cvoc-protocol" value="#{cvocConf.get(SearchIncludeFragment.getFieldTypeId(friendlyNames.get(0))).getString('protocol','')}" />
                         </h:outputText>
                         <span class="glyphicon glyphicon-remove"></span>
@@ -604,6 +610,8 @@
                                         <c:if test="#{!cvocConf.isEmpty()}">
                                             <f:passThroughAttribute name="lang" value="#{DatasetPage.getFieldLanguage(cvocConf.get(datasetFieldServiceBean.findByName(highlight.solrField.nameSearchable).id).getString('languages'))}" />
                                             <f:passThroughAttribute name="data-cvoc-service-url" value="#{cvocConf.get(datasetFieldServiceBean.findByName(highlight.solrField.nameSearchable).id).getString('cvoc-url','')}" />
+                                            <f:passThroughAttribute name="data-cvoc-ui-url" value="#{cvocConf.get(datasetFieldServiceBean.findByName(highlight.solrField.nameSearchable).id).getString('cvoc-ui-url','')}" />
+                                            <f:passThroughAttribute name="data-cvoc-headers" value="#{cvocConf.get(datasetFieldServiceBean.findByName(highlight.solrField.nameSearchable).id).containsKey('headers')? cvocConf.get(datasetFieldServiceBean.findByName(highlight.solrField.nameSearchable).id).get('headers').toString() : '{}' }" />
                                             <f:passThroughAttribute name="data-cvoc-protocol" value="#{cvocConf.get(datasetFieldServiceBean.findByName(highlight.solrField.nameSearchable).id).getString('protocol','')}" />
                                         </c:if>
                                     </h:outputText>

--- a/src/main/webapp/search/advanced.xhtml
+++ b/src/main/webapp/search/advanced.xhtml
@@ -121,6 +121,8 @@
                                                     <p:inputText id="searchValue2" styleClass="form-control" value="#{item.searchValue}" rendered="#{empty item.controlledVocabularyValues}">
                                                         <f:passThroughAttribute name="lang" value="#{AdvancedSearchPage.getFieldLanguage(cvoc.getString('languages'))}"/>
                                                         <f:passThroughAttribute name="data-cvoc-service-url" value="#{cvoc.getString('cvoc-url','')}"/>
+                                                        <f:passThroughAttribute name="data-cvoc-ui-url" value="#{cvoc.getString('cvoc-ui-url','')}"/>
+                                                        <f:passThroughAttribute name="data-cvoc-headers" value="#{cvoc.containsKey('headers')? cvoc.get('headers').toString() : '{}' }"/>
                                                         <f:passThroughAttribute name="data-cvoc-protocol" value="#{cvoc.getString('protocol','')}"/>
                                                         <f:passThroughAttribute name="data-cvoc-filter" value="#{cvoc.getString('term-parent-uri','')}"/>
                                                         <f:passThroughAttribute name="data-cvoc-vocabs" value="#{cvoc.get('vocabs').toString()}"/>


### PR DESCRIPTION
**What this PR does / why we need it**:

The PR is set as draft as it's a first part of a long development and discussion with Dataverse members.

This PR is the result of tests, work on a Proof of Concept to support [Agroportal](https://agroportal.lirmm.fr/) (one instance of Ontoportal). 
The goal was to try to implement Ontoportal using [Ontoportal API](https://data.agroportal.lirmm.fr/documentation)  + apikey (required by Ontoportal API Endpoints) starting from [skosmos.js](https://github.com/gdcc/dataverse-external-vocab-support/blob/main/scripts/skosmos.js) and [cvoc-conf.json](https://github.com/gdcc/dataverse-external-vocab-support/blob/main/examples/config/cvoc-conf.json). 
We decided to try to hide as possible the apikey and share not API but rather UI Urls for `keywordTermURL` and `keywordVocabularyURI`.

This PR adds some external controlled vocabulary configuration options in order to support ontoportal service.
Options are :
- `cvoc-ui-url` a url of human interface where `cvoc-url` is the api url
- `headers` that allows to add some headers required by the `cvoc-url`, in Ontoportal case the apikey.

`headers` option may not be enough on security matter, an idea is to have a proxy application that is used just to hide the apikey (as a java http request with apikey in header cannot be seen).
For example : `cvoc-url=https://demo.dataverse.org/ontoportal_proxy` that will request API enpoints of `https://data.agroportal.lirmm.fr`. Such a proxy must handle good CORS parameters.

**Which issue(s) this PR closes**:

Starts developments for #9276

**Suggestions on how to test this**:

Here are the files that have been used to make it work under `develop` branch : 

- [ontoportal.js](https://github.com/Recherche-Data-Gouv/dataverse-external-vocab-support/blob/poc_ontoportal/scripts/ontoportal.js)
- [cvoc-agroportal-ontoportal-conf.json](https://github.com/Recherche-Data-Gouv/dataverse-external-vocab-support/blob/poc_ontoportal/examples/config/cvoc-agroportal-ontoportal-conf.json)
- [schema.xml + citation.tsv](https://github.com/IQSS/dataverse/files/13478133/schema_xml_citation_tsv.zip)

**Demo**:

https://github.com/IQSS/dataverse/assets/83018819/9c81bafa-cc11-40f2-8e45-c5040f56b3d3

**Other informations**:

@DS-INRA will reach out soon to ask for a meeting 
PR description will be improved every time possible.