### PR TITLE
update "making releases" after 6.1

### DIFF
--- a/doc/sphinx-guides/source/developers/making-releases.rst
+++ b/doc/sphinx-guides/source/developers/making-releases.rst
@@ -67,6 +67,19 @@ Once important tests have passed (compile, unit tests, etc.), merge the pull req
 
 If this is a hotfix release, skip this whole "merge develop to master" step (the "develop" branch is not involved until later).
 
+(Optional) Test Docker Images
+-----------------------------
+
+After the "master" branch has been updated and the GitHub Action to build and push Docker images has run (see `PR #9776 <https://github.com/IQSS/dataverse/pull/9776>`_), go to https://hub.docker.com/u/gdcc and make sure the "alpha" tag for the following images has been updated:
+
+- https://hub.docker.com/r/gdcc/base
+- https://hub.docker.com/r/gdcc/dataverse
+- https://hub.docker.com/r/gdcc/configbaker
+
+To test these images against our API test suite, go to the "alpha" workflow at https://github.com/gdcc/api-test-runner/actions/workflows/alpha.yml and run it.
+
+If there are failures, additional dependencies or settings may have been added to the "develop" workflow. Copy them over and try again.
+
 Build the Guides for the Release
 --------------------------------
 

--- a/doc/sphinx-guides/source/developers/making-releases.rst
+++ b/doc/sphinx-guides/source/developers/making-releases.rst
@@ -125,9 +125,11 @@ Go to https://jenkins.dataverse.org/job/IQSS_Dataverse_Internal/ and make the fo
 
 Click "Save" then "Build Now".
 
-The build number will appear in ``/api/info/version`` (along with the commit mentioned above) from a running installation (e.g. ``{"version":"5.10.1","build":"907-b844672``).
+This will build the war file, and then automatically deploy it on dataverse-internal. Verify that the application has deployed successfully. 
 
-Note that the build number comes from script in an early build step...
+The build number will appear in ``/api/info/version`` (along with the commit mentioned above) from a running installation (e.g. ``{"version":"5.10.1","build":"907-b844672``). 
+
+Note that the build number comes from the following script in an early Jenkins build step...
 
 .. code-block:: bash
 
@@ -142,11 +144,15 @@ Build Installer (dvinstall.zip)
 ssh into the dataverse-internal server and do the following:
 
 - In a git checkout of the dataverse source switch to the master branch and pull the latest.
-- Copy the war file from the previous step to the ``target`` directory in the root of the repo (create it, if necessary).
+- Copy the war file from the previous step to the ``target`` directory in the root of the repo (create it, if necessary):
+- ``mkdir target``
+- ``cp /tmp/dataverse-5.10.1.war target``
 - ``cd scripts/installer``
 - ``make``
 
 A zip file called ``dvinstall.zip`` should be produced.
+
+Alternatively, you can build the installer on your own dev. instance. But make sure you use the war file produced in the step above, not a war file build from master on your own system! That's because we want the released application war file to contain the build number described above. Download the war file directly from Jenkins, or from dataverse-internal. 
 
 Make Artifacts Available for Download
 -------------------------------------
@@ -161,6 +167,11 @@ Upload the following artifacts to the draft release you created:
   - metadata block tsv files
   - config files
 
+Deploy on Demo
+--------------
+
+Now that you have the release ready to go, give it one final test by deploying it on demo. Note that this is also an opportunity to re-test the upgrade checklist as described in the release note. 
+
 Publish the Release
 -------------------
 
@@ -171,7 +182,14 @@ Update Guides Link
 
 "latest" at https://guides.dataverse.org/en/latest/ is a symlink to the directory with the latest release. That directory (e.g. ``5.10.1``) was put into place by the Jenkins "guides" job described above.
 
-ssh into the guides server and update the symlink to point to the latest release.
+ssh into the guides server and update the symlink to point to the latest release, as in the example below.
+
+.. code-block:: bash
+
+  cd /var/www/html/en
+  ln -s 5.10.1 latest
+
+
 
 Close Milestone on GitHub and Create a New One
 ----------------------------------------------

--- a/doc/sphinx-guides/source/developers/making-releases.rst
+++ b/doc/sphinx-guides/source/developers/making-releases.rst
@@ -170,7 +170,7 @@ Upload the following artifacts to the draft release you created:
 Deploy on Demo
 --------------
 
-Now that you have the release ready to go, give it one final test by deploying it on demo. Note that this is also an opportunity to re-test the upgrade checklist as described in the release note. 
+Now that you have the release ready to go, give it one final test by deploying it on https://demo.dataverse.org . Note that this is also an opportunity to re-test the upgrade checklist as described in the release note. 
 
 Publish the Release
 -------------------

--- a/doc/sphinx-guides/source/developers/making-releases.rst
+++ b/doc/sphinx-guides/source/developers/making-releases.rst
@@ -24,6 +24,7 @@ The task at or near release time is to collect these notes into a single doc.
 - Create an issue in GitHub to track the work of creating release notes for the upcoming release.
 - Create a branch, add a .md file for the release (ex. 5.10.1 Release Notes) in ``/doc/release-notes`` and write the release notes, making sure to pull content from the issue-specific release notes mentioned above.
 - Delete the previously-created, issue-specific release notes as the content is added to the main release notes file.
+- Include instructions to describe the steps required to upgrade the application from the previous version. These must be customized for release numbers and special circumstances such as changes to metadata blocks and infrastructure.
 - Take the release notes .md through the regular Code Review and QA process.
 
 Create a GitHub Issue and Branch for the Release


### PR DESCRIPTION
The [making releases](https://guides.dataverse.org/en/6.0/developers/making-releases.html) page for 6.0 isn't perfect.

This PR makes some updates based on what we've learned from releasing 6.1.

Preview the changes at https://dataverse-guide--10180.org.readthedocs.build/en/10180/developers/making-releases.html