### PR TITLE
bump DuraCloud to 8.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -466,7 +466,7 @@
         <dependency>
             <groupId>org.duracloud</groupId>
             <artifactId>common</artifactId>
-            <version>7.1.1</version>
+            <version>8.0.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>
@@ -481,7 +481,7 @@
         <dependency>
             <groupId>org.duracloud</groupId>
             <artifactId>storeclient</artifactId>
-            <version>7.1.1</version>
+            <version>8.0.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>


### PR DESCRIPTION
**What this PR does / why we need it**:

See dataverse-security #93

**Which issue(s) this PR closes**:

Closes dataverse-security #93

**Special notes for your reviewer**:

Sorry to bump a major version, but 7.1.4 didn't address these.

**Suggestions on how to test this**:

Duracloud is only used by TDL. They have been alerted that this PR is getting merged and may impact their Duracloud archiving. Since IQSS doesn't have a Duracloud account/setup to test this, just regression testing is probably all that is needed.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No

**Is there a release notes update needed for this change?**:

No

**Additional documentation**:

None