### PR TITLE
10168 fix api error response for getDatasetVersionArchivalStatus

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/api/Datasets.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Datasets.java
@@ -4288,7 +4288,7 @@ public class Datasets extends AbstractApiBean {
                     headers);
 
             if (dsv.getArchivalCopyLocation() == null) {
-                return error(Status.NO_CONTENT, "This dataset version has not been archived");
+                return error(Status.NOT_FOUND, "This dataset version has not been archived");
             } else {
                 JsonObject status = JsonUtil.getJsonObject(dsv.getArchivalCopyLocation());
                 return ok(status);

--- a/src/test/java/edu/harvard/iq/dataverse/api/DatasetsIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/DatasetsIT.java
@@ -3291,7 +3291,8 @@ createDataset = UtilIT.createRandomDatasetViaNativeApi(dataverse1Alias, apiToken
 
         //Verify the status is empty
         Response nullStatus = UtilIT.getDatasetVersionArchivalStatus(datasetId, "1.0", apiToken);
-        nullStatus.then().assertThat().statusCode(NO_CONTENT.getStatusCode());
+        nullStatus.prettyPrint();
+        nullStatus.then().assertThat().statusCode(NOT_FOUND.getStatusCode());
 
         //Set it
         Response setStatus = UtilIT.setDatasetVersionArchivalStatus(datasetId, "1.0", apiToken, "pending",
@@ -3309,7 +3310,7 @@ createDataset = UtilIT.createRandomDatasetViaNativeApi(dataverse1Alias, apiToken
 
         //Make sure it's gone
         Response nullStatus2 = UtilIT.getDatasetVersionArchivalStatus(datasetId, "1.0", apiToken);
-        nullStatus2.then().assertThat().statusCode(NO_CONTENT.getStatusCode());
+        nullStatus2.then().assertThat().statusCode(NOT_FOUND.getStatusCode());
 
     }
 


### PR DESCRIPTION
**What this PR does / why we need it**: Fixes the error response to the api that calls getDatasetVersionArchivalStatus when there's no archived version. It should return an error response to let the user know that the dataset version has not been archived.

**Which issue(s) this PR closes**:

Closes #10168 getDatasetVersionArchivalStatus returns a blank response when there's no archived version.

**Special notes for your reviewer**:

**Suggestions on how to test this**: Call the api with a dataset version that isn't archived and verify that you get a proper error response. 

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**: No

**Additional documentation**: None
