### PR TITLE
bump google.library.version to 26.30.0

### DIFF
--- a/modules/dataverse-parent/pom.xml
+++ b/modules/dataverse-parent/pom.xml
@@ -152,7 +152,7 @@
         <postgresql.version>42.6.0</postgresql.version>
         <solr.version>9.3.0</solr.version>
         <aws.version>1.12.290</aws.version>
-        <google.library.version>26.29.0</google.library.version>
+        <google.library.version>26.30.0</google.library.version>
     
         <!-- Basic libs, logging -->
         <jakartaee-api.version>8.0.0</jakartaee-api.version>

--- a/modules/dataverse-parent/pom.xml
+++ b/modules/dataverse-parent/pom.xml
@@ -152,7 +152,7 @@
         <postgresql.version>42.6.0</postgresql.version>
         <solr.version>9.3.0</solr.version>
         <aws.version>1.12.290</aws.version>
-        <google.cloud.version>0.177.0</google.cloud.version>
+        <google.cloud.version>0.209.0</google.cloud.version>
     
         <!-- Basic libs, logging -->
         <jakartaee-api.version>8.0.0</jakartaee-api.version>

--- a/modules/dataverse-parent/pom.xml
+++ b/modules/dataverse-parent/pom.xml
@@ -40,8 +40,8 @@
             </dependency>
             <dependency>
                 <groupId>com.google.cloud</groupId>
-                <artifactId>google-cloud-bom</artifactId>
-                <version>${google.cloud.version}</version>
+                <artifactId>libraries-bom</artifactId>
+                <version>${google.library.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -152,7 +152,7 @@
         <postgresql.version>42.6.0</postgresql.version>
         <solr.version>9.3.0</solr.version>
         <aws.version>1.12.290</aws.version>
-        <google.cloud.version>0.209.0</google.cloud.version>
+        <google.library.version>26.29.0</google.library.version>
     
         <!-- Basic libs, logging -->
         <jakartaee-api.version>8.0.0</jakartaee-api.version>

--- a/src/test/java/edu/harvard/iq/dataverse/api/SwordIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/SwordIT.java
@@ -855,7 +855,7 @@ public class SwordIT {
         List<String> oneFileLeftInV2Draft = statement3.getBody().xmlPath().getList("feed.entry.id");
         logger.info("Number of files remaining in this post version 1 draft:" + oneFileLeftInV2Draft.size());
         assertEquals(1, oneFileLeftInV2Draft.size());
-
+        UtilIT.sleepForLock(datasetPersistentId, "EditInProgress", apiToken, UtilIT.MAXIMUM_PUBLISH_LOCK_DURATION);
         Response deleteIndex1b = UtilIT.deleteFile(Integer.parseInt(index1b), apiToken);
         deleteIndex1b.then().assertThat()
                 .statusCode(NO_CONTENT.getStatusCode());


### PR DESCRIPTION
**What this PR does / why we need it**:

Switches to the latest version of a more focused bom as a way to address the issue. See the changed file.

**Which issue(s) this PR closes**:

dataverse-security #75

**Special notes for your reviewer**:

None

**Suggestions on how to test this**:

test Google Cloud preservation workflow. Unless IQSS wants to set up for this, @qqmyers can tested it at QDR (where v26.28 of the library has already been tested. Beyond that, general regression testing is needed.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No

**Is there a release notes update needed for this change?**:

No

**Additional documentation**:

None