### PR TITLE
IQSS/10200 - Create dirs needed for Globus transfer to managed stores

### DIFF
--- a/doc/sphinx-guides/source/developers/globus-api.rst
+++ b/doc/sphinx-guides/source/developers/globus-api.rst
@@ -168,7 +168,7 @@ In the managed case, once a Globus transfer has been initiated a final API call 
                     "files": [{"description":"My description.","directoryLabel":"data/subdir1","categories":["Data"], "restrict":"false", "storageIdentifier":"globusm://18b3972213f-f6b5c2221423", "fileName":"file1.txt", "mimeType":"text/plain", "checksum": {"@type": "MD5", "@value": "1234"}}, \
                     {"description":"My description.","directoryLabel":"data/subdir1","categories":["Data"], "restrict":"false", "storageIdentifier":"globusm://18b39722140-50eb7d3c5ece", "fileName":"file2.txt", "mimeType":"text/plain", "checksum": {"@type": "MD5", "@value": "2345"}}]}'
 
-  curl -H "X-Dataverse-key:$API_TOKEN" -H "Content-type:multipart/form-data" -X POST "$SERVER_URL/api/datasets/:persistentId/addGlobusFiles -F "jsonData=$JSON_DATA"
+  curl -H "X-Dataverse-key:$API_TOKEN" -H "Content-type:multipart/form-data" -X POST "$SERVER_URL/api/datasets/:persistentId/addGlobusFiles" -F "jsonData=$JSON_DATA"
 
 Note that the mimetype is multipart/form-data, matching the /addFiles API call. Also note that the API_TOKEN is not needed when using a signed URL.
 

--- a/doc/sphinx-guides/source/developers/globus-api.rst
+++ b/doc/sphinx-guides/source/developers/globus-api.rst
@@ -170,7 +170,7 @@ In the managed case, once a Globus transfer has been initiated a final API call 
 
   curl -H "X-Dataverse-key:$API_TOKEN" -H "Content-type:multipart/form-data" -X POST "$SERVER_URL/api/datasets/:persistentId/addGlobusFiles -F "jsonData=$JSON_DATA"
 
-Note that the mimetype is multipart/form-data, matching the /addFiles API call. ALso note that the API_TOKEN is not needed when using a signed URL.
+Note that the mimetype is multipart/form-data, matching the /addFiles API call. Also note that the API_TOKEN is not needed when using a signed URL.
 
 With this information, Dataverse will begin to monitor the transfer and when it completes, will add all files for which the transfer succeeded.
 As the transfer can take significant time and the API call is asynchronous, the only way to determine if the transfer succeeded via API is to use the standard calls to check the dataset lock state and contents.

--- a/doc/sphinx-guides/source/developers/globus-api.rst
+++ b/doc/sphinx-guides/source/developers/globus-api.rst
@@ -157,7 +157,7 @@ In the remote/reference case, the map is from the initially supplied endpoint/pa
 Adding Files to the Dataset
 ---------------------------
 
-In the managed case, once a Globus transfer has been initiated a final API call is made to Dataverse to provide it with the task identifier of the transfer and information about the files being transferred:
+In the managed case, you must initiate a Globus transfer and take note of its task identifier. As in the JSON example below, you will pass it as ``taskIdentifier`` along with details about the files you are transferring:
 
 .. code-block:: bash
 

--- a/doc/sphinx-guides/source/developers/globus-api.rst
+++ b/doc/sphinx-guides/source/developers/globus-api.rst
@@ -102,7 +102,7 @@ Once the user identifies which files are to be added, the requestGlobusTransferP
   export PERSISTENT_IDENTIFIER=doi:10.5072/FK27U7YBV
   export LOCALE=en-US
  
-  curl -H "X-Dataverse-key:$API_TOKEN" -H "Content-type:application/json" -X POST "$SERVER_URL/api/datasets/:persistentId/requestGlobusUpload"
+  curl -H "X-Dataverse-key:$API_TOKEN" -H "Content-type:application/json" -X POST "$SERVER_URL/api/datasets/:persistentId/requestGlobusUploadPaths"
 
 Note that when using the dataverse-globus app or the return from the previous call, the URL for this call will be signed and no API_TOKEN is needed. 
   

--- a/doc/sphinx-guides/source/developers/globus-api.rst
+++ b/doc/sphinx-guides/source/developers/globus-api.rst
@@ -72,7 +72,7 @@ The response includes the id for the Globus endpoint to use along with several s
 
 The getDatasetMetadata and getFileListing URLs are just signed versions of the standard Dataset metadata and file listing API calls. The other two are Globus specific.
 
-If called for a dataset using a store that is configured with a remote Globus endpoint(s), the return response is similar but the response includes a
+If called for, a dataset using a store that is configured with a remote Globus endpoint(s), the return response is similar but the response includes a
 the "managed" parameter will be false, the "endpoint" parameter is replaced with a JSON array of "referenceEndpointsWithPaths" and the
 requestGlobusTransferPaths and addGlobusFiles URLs are replaced with ones for requestGlobusReferencePaths and addFiles. All of these calls are
 described further below.
@@ -91,7 +91,7 @@ The returned response includes the same getDatasetMetadata and getFileListing UR
 Performing an Upload/Transfer In
 --------------------------------
 
-The information from the API call above can be used to provide a user with information about the dataset and to prepare to transfer or to reference files (based on the "managed" parameter). 
+The information from the API call above can be used to provide a user with information about the dataset and to prepare to transfer (managed=true) or to reference files (managed=false).
 
 Once the user identifies which files are to be added, the requestGlobusTransferPaths or requestGlobusReferencePaths URLs can be called. These both reference the same API call but must be used with different entries in the JSON body sent:
 

--- a/doc/sphinx-guides/source/developers/globus-api.rst
+++ b/doc/sphinx-guides/source/developers/globus-api.rst
@@ -1,6 +1,9 @@
 Globus Transfer API
 ===================
 
+.. contents:: |toctitle|
+        :local:
+
 The Globus API addresses three use cases:
 
 * Transfer to a Dataverse-managed Globus endpoint (File-based or using the Globus S3 Connector)

--- a/doc/sphinx-guides/source/developers/globus-api.rst
+++ b/doc/sphinx-guides/source/developers/globus-api.rst
@@ -2,6 +2,7 @@ Globus Transfer API
 ===================
 
 The Globus API addresses three use cases:
+
 * Transfer to a Dataverse-managed Globus endpoint (File-based or using the Globus S3 Connector)
 * Reference of files that will remain in a remote Globus endpoint
 * Transfer from a Dataverse-managed Globus endpoint

--- a/src/main/java/edu/harvard/iq/dataverse/globus/GlobusServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/globus/GlobusServiceBean.java
@@ -240,7 +240,7 @@ public class GlobusServiceBean implements java.io.Serializable {
         MakeRequestResponse result = null;
         String body = "{\"DATA_TYPE\":\"mkdir\",\"path\":\"" + dir + "\"}";
         try {
-            logger.info(body);
+            logger.fine(body);
             URL url = new URL(
                     "https://transfer.api.globusonline.org/v0.10/operation/endpoint/" + endpoint.getId() + "/mkdir");
             result = makeRequest(url, "Bearer", endpoint.getClientToken(), "POST", body);

--- a/src/main/java/edu/harvard/iq/dataverse/globus/GlobusServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/globus/GlobusServiceBean.java
@@ -134,7 +134,7 @@ public class GlobusServiceBean implements java.io.Serializable {
      * @param globusLogger - a separate logger instance, may be null
      */
     public void deletePermission(String ruleId, Dataset dataset, Logger globusLogger) {
-        globusLogger.info("Start deleting rule " + ruleId + " for dataset " + dataset.getId());
+        globusLogger.fine("Start deleting rule " + ruleId + " for dataset " + dataset.getId());
         if (ruleId.length() > 0) {
             if (dataset != null) {
                 GlobusEndpoint endpoint = getGlobusEndpoint(dataset);
@@ -179,25 +179,95 @@ public class GlobusServiceBean implements java.io.Serializable {
         permissions.setPrincipal(principal);
         permissions.setPath(endpoint.getBasePath() + "/");
         permissions.setPermissions("rw");
-
+        
         JsonObjectBuilder response = Json.createObjectBuilder();
-        response.add("status", requestPermission(endpoint, dataset, permissions));
-        String driverId = dataset.getEffectiveStorageDriverId();
-        JsonObjectBuilder paths = Json.createObjectBuilder();
-        for (int i = 0; i < numberOfPaths; i++) {
-            String storageIdentifier = DataAccess.getNewStorageIdentifier(driverId);
-            int lastIndex = Math.max(storageIdentifier.lastIndexOf("/"), storageIdentifier.lastIndexOf(":"));
-            paths.add(storageIdentifier, endpoint.getBasePath() + "/" + storageIdentifier.substring(lastIndex + 1));
-
+        //Try to create the directory (202 status) if it does not exist (502-already exists)
+        int mkDirStatus = makeDirs(endpoint, dataset);
+        if (!(mkDirStatus== 202 || mkDirStatus == 502)) {
+            return response.add("status", mkDirStatus).build();
         }
-        response.add("paths", paths.build());
+        //The dir for the dataset's data exists, so try to request permission for the principal
+        int requestPermStatus = requestPermission(endpoint, dataset, permissions);
+        response.add("status", requestPermStatus);
+        if (requestPermStatus == 201) {
+            String driverId = dataset.getEffectiveStorageDriverId();
+            JsonObjectBuilder paths = Json.createObjectBuilder();
+            for (int i = 0; i < numberOfPaths; i++) {
+                String storageIdentifier = DataAccess.getNewStorageIdentifier(driverId);
+                int lastIndex = Math.max(storageIdentifier.lastIndexOf("/"), storageIdentifier.lastIndexOf(":"));
+                paths.add(storageIdentifier, endpoint.getBasePath() + "/" + storageIdentifier.substring(lastIndex + 1));
+
+            }
+            response.add("paths", paths.build());
+        }
         return response.build();
     }
 
+    /**
+     * Call to create the directories for the specified dataset.
+     * 
+     * @param dataset
+     * @return - an error status at whichever subdir the process fails at or the
+     *         final success status
+     */
+    private int makeDirs(GlobusEndpoint endpoint, Dataset dataset) {
+        logger.fine("Creating dirs: " + endpoint.getBasePath());
+        int index = endpoint.getBasePath().lastIndexOf(dataset.getAuthorityForFileStorage())
+                + dataset.getAuthorityForFileStorage().length();
+        String nextDir = endpoint.getBasePath().substring(0, index);
+        int response = makeDir(endpoint, nextDir);
+        String identifier = dataset.getIdentifierForFileStorage();
+        //Usually identifiers will have 0 or 1 slashes (e.g. FK2/ABCDEF) but the while loop will handle any that could have more
+        //Will skip if the first makeDir above failed
+        while ((identifier.length() > 0) && ((response == 202 || response == 502))) {
+            index = identifier.indexOf('/');
+            if (index == -1) {
+                //Last dir to create
+                response = makeDir(endpoint, nextDir + "/" + identifier);
+                identifier = "";
+            } else {
+                //The next dir to create
+                nextDir = nextDir + "/" + identifier.substring(0, index);
+                response = makeDir(endpoint, nextDir);
+                //The rest of the identifier
+                identifier = identifier.substring(index + 1);
+            }
+        }
+        return response;
+    }
+    
+    private int makeDir(GlobusEndpoint endpoint, String dir) {
+        MakeRequestResponse result = null;
+        String body = "{\"DATA_TYPE\":\"mkdir\",\"path\":\"" + dir + "\"}";
+        try {
+            logger.info(body);
+            URL url = new URL(
+                    "https://transfer.api.globusonline.org/v0.10/operation/endpoint/" + endpoint.getId() + "/mkdir");
+            result = makeRequest(url, "Bearer", endpoint.getClientToken(), "POST", body);
+
+            switch (result.status) {
+            case 202:
+                logger.fine("Dir " + dir + " was created successfully.");
+                break;
+            case 502:
+                logger.fine("Dir " + dir + " already exists.");
+                break;
+            default:
+                logger.warning("Status " + result.status + " received when creating dir " + dir);
+                logger.fine("Response: " + result.jsonResponse);
+            }
+        } catch (MalformedURLException ex) {
+            // Misconfiguration
+            logger.warning("Failed to create dir on " + endpoint.getId());
+            return 500;
+        }
+        return result.status;
+    }
+    
     private int requestPermission(GlobusEndpoint endpoint, Dataset dataset, Permissions permissions) {
         Gson gson = new GsonBuilder().create();
         MakeRequestResponse result = null;
-        logger.info("Start creating the rule");
+        logger.fine("Start creating the rule");
 
         try {
             URL url = new URL("https://transfer.api.globusonline.org/v0.10/endpoint/" + endpoint.getId() + "/access");
@@ -218,7 +288,7 @@ public class GlobusServiceBean implements java.io.Serializable {
                 if (globusResponse != null && globusResponse.containsKey("access_id")) {
                     permissions.setId(globusResponse.getString("access_id"));
                     monitorTemporaryPermissions(permissions.getId(), dataset.getId());
-                    logger.info("Access rule " + permissions.getId() + " was created successfully");
+                    logger.fine("Access rule " + permissions.getId() + " was created successfully");
                 } else {
                     // Shouldn't happen!
                     logger.warning("Access rule id not returned for dataset " + dataset.getId());
@@ -363,7 +433,6 @@ public class GlobusServiceBean implements java.io.Serializable {
         try {
             connection = (HttpURLConnection) url.openConnection();
             // Basic
-            logger.info(authType + " " + authCode);
             logger.fine("For URL: " + url.toString());
             connection.setRequestProperty("Authorization", authType + " " + authCode);
             // connection.setRequestProperty("Content-Type",
@@ -713,7 +782,7 @@ public class GlobusServiceBean implements java.io.Serializable {
                                 .mapToObj(index -> ((JsonObject) newfilesJsonArray.get(index)).getJsonObject(fileId))
                                 .filter(Objects::nonNull).collect(Collectors.toList());
                         if (newfileJsonObject != null) {
-                            logger.info("List Size: " + newfileJsonObject.size());
+                            logger.fine("List Size: " + newfileJsonObject.size());
                             // if (!newfileJsonObject.get(0).getString("hash").equalsIgnoreCase("null")) {
                             JsonPatch path = Json.createPatchBuilder()
                                     .add("/md5Hash", newfileJsonObject.get(0).getString("hash")).build();
@@ -884,7 +953,7 @@ public class GlobusServiceBean implements java.io.Serializable {
         String taskIdentifier = jsonObject.getString("taskIdentifier");
 
         GlobusEndpoint endpoint = getGlobusEndpoint(dataset);
-        logger.info("Endpoint path: " + endpoint.getBasePath());
+        logger.fine("Endpoint path: " + endpoint.getBasePath());
 
         // If the rules_cache times out, the permission will be deleted. Presumably that
         // doesn't affect a
@@ -892,10 +961,10 @@ public class GlobusServiceBean implements java.io.Serializable {
         GlobusTask task = getTask(endpoint.getClientToken(), taskIdentifier, globusLogger);
         String ruleId = getRuleId(endpoint, task.getOwner_id(), "r");
         if (ruleId != null) {
-            logger.info("Found rule: " + ruleId);
+            logger.fine("Found rule: " + ruleId);
             Long datasetId = rulesCache.getIfPresent(ruleId);
             if (datasetId != null) {
-                logger.info("Deleting from cache: rule: " + ruleId);
+                logger.fine("Deleting from cache: rule: " + ruleId);
                 // Will not delete rule
                 rulesCache.invalidate(ruleId);
             }
@@ -909,7 +978,7 @@ public class GlobusServiceBean implements java.io.Serializable {
 
         // Transfer is done (success or failure) so delete the rule
         if (ruleId != null) {
-            logger.info("Deleting: rule: " + ruleId);
+            logger.fine("Deleting: rule: " + ruleId);
             deletePermission(ruleId, dataset, globusLogger);
         }
 
@@ -1032,7 +1101,6 @@ public class GlobusServiceBean implements java.io.Serializable {
     }
 
     private CompletableFuture<FileDetailsHolder> calculateDetailsAsync(String id, Logger globusLogger) {
-        // logger.info(" calcualte additional details for these globus id ==== " + id);
 
         return CompletableFuture.supplyAsync(() -> {
             try {
@@ -1071,7 +1139,7 @@ public class GlobusServiceBean implements java.io.Serializable {
                 count = 3;
             } catch (IOException ioex) {
                 count = 3;
-                logger.info(ioex.getMessage());
+                logger.fine(ioex.getMessage());
                 globusLogger.info(
                         "DataFile (fullPath " + fullPath + ") does not appear to be accessible within Dataverse: ");
             } catch (Exception ex) {

--- a/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
@@ -3718,4 +3718,12 @@ public class UtilIT {
                 .post("/api/datasets/" + datasetId + "/requestGlobusDownload");
     }
 
+    static Response requestGlobusUploadPaths(Integer datasetId, JsonObject body, String apiToken) {
+        return given()
+                .header(API_TOKEN_HTTP_HEADER, apiToken)
+                .body(body.toString())
+                .contentType("application/json")
+                .post("/api/datasets/" + datasetId + "/requestGlobusUploadPaths");
+    }
+
 }


### PR DESCRIPTION
**What this PR does / why we need it**: Creates/verifies the existence of the required directories on a managed Globus endpoint for data files to be added to a dataset. 

**Which issue(s) this PR closes**:

- Closes #10200

**Special notes for your reviewer**: FWIW - I've verified that Globus will not create parent dirs if they are missing, so the code tries to create the dir for the authority and then the subdir(s) for the dataset identifier, e.g. the path 10.5072/FK2/ABCDEF. If the dirs exist, Globus responds with 502. If not a 202 indicates successful creation. 

**Suggestions on how to test this**: Perform the manual testing associated with the initial Globus PR #10162, assuring that you're using a new dataset and using a Globus principal that does not have any permissions on the endpoint.  Could test variants where the authority/shoulder dirs already exist (or not). Tests can be repeated on the same dataset by using a privileged principal to delete dirs. On the test instance I have set up, there are endpoints where I can grant others permission to be able to do this or I can help with resetting.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: no

**Is there a release notes update needed for this change?**:

**Additional documentation**:
