### PR TITLE
skip premature validation of required drop downs in metadata blocks

### DIFF
--- a/src/main/webapp/metadataFragment.xhtml
+++ b/src/main/webapp/metadataFragment.xhtml
@@ -285,7 +285,7 @@
                                                     <div class="form-group dataset-field-values">
                                                         <div class="form-col-container col-sm-9 edit-field">
                                                             <p:selectOneMenu value="#{dsf.singleControlledVocabularyValue}" converter="controlledVocabularyValueConverter" style="width: auto !important; max-width:100%; min-width:200px;" styleClass="form-control primitive"
-                                                                             id="unique1" required="#{dsf.required and datasetPage}" rendered="#{!dsf.datasetFieldType.allowMultiples}" filter="#{(dsf.datasetFieldType.controlledVocabularyValues.size() lt 10) ? 'false':'true'}" filterMatchMode="contains">
+                                                                             id="unique1" rendered="#{!dsf.datasetFieldType.allowMultiples}" filter="#{(dsf.datasetFieldType.controlledVocabularyValues.size() lt 10) ? 'false':'true'}" filterMatchMode="contains">
                                                                 <f:selectItem itemLabel="#{bundle.select}" itemValue="" noSelectionOption="true"/>
                                                                 <f:selectItems value="#{dsf.datasetFieldType.controlledVocabularyValues}" var="cvv" itemLabel="#{cvv.getLocaleStrValue(mdLangCode)}" itemValue="#{cvv}"/>
                                                             </p:selectOneMenu>


### PR DESCRIPTION
…mandatory

**What this PR does / why we need it**:

It skips a premature validation phase for a metadata block field with a mandatory drop down. This allows proper template change for a blank dataset and gives clearer error messages when saving.

**Which issue(s) this PR closes**:

Closes #10119

**Special notes for your reviewer**:

The HTML attribute `required` triggers a premature validation in metadata blocks. The db-table `datasetfieldtype` controls the desired validation phase.

**Suggestions on how to test this**:

* create a dataverse: https://demo.dataverse.org/ - add data - add dataverse
* select the dataverse - edit - general information
* make a field in a metadatablock required (e.g. _type of article_ in the journal block)
* create a custom template and set a field(s) in the citation block (e.g. title).
* Create a new dataset, set none of the fields and change to the custom template, the title should be applied. Save the blank dataset and a clear error message appears for the _type of article_.


**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

no

**Is there a release notes update needed for this change?**:

no

**Additional documentation**:
