### PR TITLE
Update Kanban Board URL

### DIFF
--- a/doc/sphinx-guides/source/developers/intro.rst
+++ b/doc/sphinx-guides/source/developers/intro.rst
@@ -40,7 +40,7 @@ For the Dataverse Software development roadmap, please see https://www.iq.harvar
 Kanban Board
 ------------
 
-You can get a sense of what's currently in flight (in dev, in QA, etc.) by looking at https://github.com/orgs/IQSS/projects/2
+You can get a sense of what's currently in flight (in dev, in QA, etc.) by looking at https://github.com/orgs/IQSS/projects/34
 
 Issue Tracker
 -------------


### PR DESCRIPTION
The URL was pointing to the old board.

**What this PR does / why we need it**:
The URL on the documentation was pointing to the old board. 
