### PR TITLE
Add displayOrder, typeClass and isRequired fields to DatasetFieldType payload

### DIFF
--- a/doc/release-notes/10216-metadatablocks.md
+++ b/doc/release-notes/10216-metadatablocks.md
@@ -1,4 +1,5 @@
 The API endpoint `/api/metadatablocks/{block_id}` has been extended to include the following fields:
 
-- `isRequired` - Whether or not this field is required
-- `displayOrder`:  The display order of the field in create/edit forms
+- `isRequired`: Whether or not this field is required
+- `displayOrder`: The display order of the field in create/edit forms
+- `typeClass`: The type class of this field ("controlledVocabulary", "compound", or "primitive")

--- a/doc/release-notes/10216-metadatablocks.md
+++ b/doc/release-notes/10216-metadatablocks.md
@@ -1,0 +1,4 @@
+The API endpoint `/api/metadatablocks/{block_id}` has been extended to include the following fields:
+
+- `isRequired` - Wether or not this field is required
+- `displayOrder`:  The display order of the field in create/edit forms

--- a/doc/release-notes/10216-metadatablocks.md
+++ b/doc/release-notes/10216-metadatablocks.md
@@ -1,4 +1,4 @@
 The API endpoint `/api/metadatablocks/{block_id}` has been extended to include the following fields:
 
-- `isRequired` - Wether or not this field is required
+- `isRequired` - Whether or not this field is required
 - `displayOrder`:  The display order of the field in create/edit forms

--- a/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
@@ -570,6 +570,8 @@ public class JsonPrinter {
         fieldsBld.add("multiple", fld.isAllowMultiples());
         fieldsBld.add("isControlledVocabulary", fld.isControlledVocabulary());
         fieldsBld.add("displayFormat", fld.getDisplayFormat());
+        fieldsBld.add("isRequired", fld.isRequired());
+        fieldsBld.add("displayOrder", fld.getDisplayOrder());
         if (fld.isControlledVocabulary()) {
             // If the field has a controlled vocabulary,
             // add all values to the resulting JSON

--- a/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
@@ -565,6 +565,7 @@ public class JsonPrinter {
         fieldsBld.add("displayName", fld.getDisplayName());
         fieldsBld.add("title", fld.getTitle());
         fieldsBld.add("type", fld.getFieldType().toString());
+        fieldsBld.add("typeClass", typeClassString(fld));
         fieldsBld.add("watermark", fld.getWatermark());
         fieldsBld.add("description", fld.getDescription());
         fieldsBld.add("multiple", fld.isAllowMultiples());

--- a/src/test/java/edu/harvard/iq/dataverse/api/MetadataBlocksIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/MetadataBlocksIT.java
@@ -25,7 +25,9 @@ public class MetadataBlocksIT {
         getCitationBlock.prettyPrint();
         getCitationBlock.then().assertThat()
                 .statusCode(OK.getStatusCode())
-                .body("data.fields.subject.controlledVocabularyValues[0]", CoreMatchers.is("Agricultural Sciences"));
+                .body("data.fields.subject.controlledVocabularyValues[0]", CoreMatchers.is("Agricultural Sciences"))
+                .body("data.fields.title.displayOrder", CoreMatchers.is(0))
+                .body("data.fields.title.isRequired", CoreMatchers.is(true));
     }
     
     @Test
@@ -37,18 +39,18 @@ public class MetadataBlocksIT {
             ", response=" + createUser.prettyPrint());
         String apiToken = UtilIT.getApiTokenFromResponse(createUser);
         assumeFalse(apiToken == null || apiToken.isBlank());
-        
+
         Response createCollection = UtilIT.createRandomDataverse(apiToken);
         assumeTrue(createCollection.statusCode() < 300,
             "code=" + createCollection.statusCode() +
             ", response=" + createCollection.prettyPrint());
         String dataverseAlias = UtilIT.getAliasFromResponse(createCollection);
         assumeFalse(dataverseAlias == null || dataverseAlias.isBlank());
-        
+
         // when
         String pathToJsonFile = "scripts/api/data/dataset-create-new-all-default-fields.json";
         Response createDataset = UtilIT.createDatasetViaNativeApi(dataverseAlias, pathToJsonFile, apiToken);
-        
+
         // then
         assertEquals(CREATED.getStatusCode(), createDataset.statusCode(),
            "code=" + createDataset.statusCode() +

--- a/src/test/java/edu/harvard/iq/dataverse/api/MetadataBlocksIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/MetadataBlocksIT.java
@@ -27,6 +27,7 @@ public class MetadataBlocksIT {
                 .statusCode(OK.getStatusCode())
                 .body("data.fields.subject.controlledVocabularyValues[0]", CoreMatchers.is("Agricultural Sciences"))
                 .body("data.fields.title.displayOrder", CoreMatchers.is(0))
+                .body("data.fields.title.typeClass", CoreMatchers.is("primitive"))
                 .body("data.fields.title.isRequired", CoreMatchers.is(true));
     }
     


### PR DESCRIPTION
**What this PR does / why we need it**:

The API endpoint `/api/metadatablocks/{block_id}` has been extended to include the following fields:

- `isRequired` - Wether or not this field is required
- `displayOrder`:  The display order of the field in create/edit forms
- `typeClass`: The type class of this field ("controlledVocabulary", "compound", or "primitive")

**Which issue(s) this PR closes**:

- Closes #10216

**Suggestions on how to test this**:

`curl http://localhost:8080/api/v1/metadatablocks/citation`

See how citation fields subJson contains the new 'isRequired' and 'displayOrder' fields.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No

**Is there a release notes update needed for this change?**:

Yes.
