### PR TITLE
clarify "Set Citation Data Field Type for a Dataset" in API Guide

### DIFF
--- a/doc/sphinx-guides/source/api/native-api.rst
+++ b/doc/sphinx-guides/source/api/native-api.rst
@@ -1572,8 +1572,8 @@ The fully expanded example above (without environment variables) looks like this
 Set Citation Date Field Type for a Dataset
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Sets the dataset citation date field type for a given dataset. ``:publicationDate`` is the default.
-Note that the dataset citation date field type must be a date field.
+Sets the dataset citation date field type for a given dataset. ``:publicationDate`` is the default. 
+Note that the dataset citation date field type must be a date field. This change applies to all versions of the dataset that have an entry for the new date field. It also applies to all file citations in the dataset. 
 
 .. code-block:: bash
 


### PR DESCRIPTION
Added clarification to what is affected in Set Citation Data Field Type for a Dataset

**What this PR does / why we need it**: Adds some additional information about how the endpoint affects dataset versions and files. 

**Which issue(s) this PR closes**: https://github.com/IQSS/dataverse/issues/10227#issuecomment-1894132363 

- Closes #10227

**Special notes for your reviewer**:

**Suggestions on how to test this**: Created a demo dataset to test the changes to each version here: https://demo.dataverse.org/dataset.xhtml?persistentId=doi:10.70122/FK2/X5GFFN. 

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
