### PR TITLE
Add missing FK harvestingclient_id to dvobject

### DIFF
--- a/src/main/resources/db/migration/V6.1.0.1__9686-move-harvestingclient-id.sql
+++ b/src/main/resources/db/migration/V6.1.0.1__9686-move-harvestingclient-id.sql
@@ -1,5 +1,7 @@
 ALTER TABLE dvobject ADD COLUMN IF NOT EXISTS harvestingclient_id BIGINT;
 
+ALTER TABLE dvobject ADD CONSTRAINT fk_dvobject_harvestingclient_id FOREIGN KEY (harvestingclient_id) REFERENCES harvestingclient (id);
+
 --add harvesting client id to dvobject records of harvested datasets
 update dvobject dvo set harvestingclient_id = s.harvestingclient_id from
 (select id, harvestingclient_id from dataset d where d.harvestingclient_id is not null) s


### PR DESCRIPTION
**What this PR does / why we need it**:
I spoke with @landreev about the missing FK so we would need to add it to the FlyAway script 