### PR TITLE
#9748 delete tools only added by tests

### DIFF
--- a/src/test/java/edu/harvard/iq/dataverse/api/ExternalToolsIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/ExternalToolsIT.java
@@ -40,21 +40,6 @@ public class ExternalToolsIT {
     @Test
     public void testFileLevelTool1() {
 
-        // Delete all external tools before testing.
-        Response getTools = UtilIT.getExternalTools();
-        getTools.prettyPrint();
-        getTools.then().assertThat()
-                .statusCode(OK.getStatusCode());
-        String body = getTools.getBody().asString();
-        JsonReader bodyObject = Json.createReader(new StringReader(body));
-        JsonArray tools = bodyObject.readObject().getJsonArray("data");
-        for (int i = 0; i < tools.size(); i++) {
-            JsonObject tool = tools.getJsonObject(i);
-            int id = tool.getInt("id");
-            Response deleteExternalTool = UtilIT.deleteExternalTool(id);
-            deleteExternalTool.prettyPrint();
-        }
-
         Response createUser = UtilIT.createRandomUser();
         createUser.prettyPrint();
         createUser.then().assertThat()
@@ -145,25 +130,13 @@ public class ExternalToolsIT {
                 .statusCode(OK.getStatusCode())
                 // No tools for this file type.
                 .body("data", Matchers.hasSize(0));
+        
+        //Delete the tool added by this test...
+        Response deleteExternalTool = UtilIT.deleteExternalTool(toolId);
     }
 
     @Test
     public void testDatasetLevelTool1() {
-
-        // Delete all external tools before testing.
-        Response getTools = UtilIT.getExternalTools();
-        getTools.prettyPrint();
-        getTools.then().assertThat()
-                .statusCode(OK.getStatusCode());
-        String body = getTools.getBody().asString();
-        JsonReader bodyObject = Json.createReader(new StringReader(body));
-        JsonArray tools = bodyObject.readObject().getJsonArray("data");
-        for (int i = 0; i < tools.size(); i++) {
-            JsonObject tool = tools.getJsonObject(i);
-            int id = tool.getInt("id");
-            Response deleteExternalTool = UtilIT.deleteExternalTool(id);
-            deleteExternalTool.prettyPrint();
-        }
 
         Response createUser = UtilIT.createRandomUser();
         createUser.prettyPrint();
@@ -184,7 +157,6 @@ public class ExternalToolsIT {
         createDataset.then().assertThat()
                 .statusCode(CREATED.getStatusCode());
 
-//        Integer datasetId = UtilIT.getDatasetIdFromResponse(createDataset);
         Integer datasetId = JsonPath.from(createDataset.getBody().asString()).getInt("data.id");
         String datasetPid = JsonPath.from(createDataset.getBody().asString()).getString("data.persistentId");
 
@@ -219,6 +191,8 @@ public class ExternalToolsIT {
         addExternalTool.then().assertThat()
                 .statusCode(OK.getStatusCode())
                 .body("data.displayName", CoreMatchers.equalTo("DatasetTool1"));
+        
+        long toolId = JsonPath.from(addExternalTool.getBody().asString()).getLong("data.id");
 
         Response getExternalToolsByDatasetIdInvalidType = UtilIT.getExternalToolsForDataset(datasetId.toString(), "invalidType", apiToken);
         getExternalToolsByDatasetIdInvalidType.prettyPrint();
@@ -233,26 +207,15 @@ public class ExternalToolsIT {
                 .body("data[0].scope", CoreMatchers.equalTo("dataset"))
                 .body("data[0].toolUrlWithQueryParams", CoreMatchers.equalTo("http://datasettool1.com?datasetPid=" + datasetPid + "&key=" + apiToken))
                 .statusCode(OK.getStatusCode());
-
+        
+        //Delete the tool added by this test...
+        Response deleteExternalTool = UtilIT.deleteExternalTool(toolId);
+        deleteExternalTool.then().assertThat()
+                .statusCode(OK.getStatusCode());
     }
 
     @Test
     public void testDatasetLevelToolConfigure() {
-
-        // Delete all external tools before testing.
-        Response getTools = UtilIT.getExternalTools();
-        getTools.prettyPrint();
-        getTools.then().assertThat()
-                .statusCode(OK.getStatusCode());
-        String body = getTools.getBody().asString();
-        JsonReader bodyObject = Json.createReader(new StringReader(body));
-        JsonArray tools = bodyObject.readObject().getJsonArray("data");
-        for (int i = 0; i < tools.size(); i++) {
-            JsonObject tool = tools.getJsonObject(i);
-            int id = tool.getInt("id");
-            Response deleteExternalTool = UtilIT.deleteExternalTool(id);
-            deleteExternalTool.prettyPrint();
-        }
 
         Response createUser = UtilIT.createRandomUser();
         createUser.prettyPrint();
@@ -302,6 +265,8 @@ public class ExternalToolsIT {
         addExternalTool.then().assertThat()
                 .statusCode(OK.getStatusCode())
                 .body("data.displayName", CoreMatchers.equalTo("Dataset Configurator"));
+        
+        long toolId = JsonPath.from(addExternalTool.getBody().asString()).getLong("data.id");
 
         Response getExternalToolsByDatasetId = UtilIT.getExternalToolsForDataset(datasetId.toString(), "configure", apiToken);
         getExternalToolsByDatasetId.prettyPrint();
@@ -310,6 +275,11 @@ public class ExternalToolsIT {
                 .body("data[0].scope", CoreMatchers.equalTo("dataset"))
                 .body("data[0].types[0]", CoreMatchers.equalTo("configure"))
                 .body("data[0].toolUrlWithQueryParams", CoreMatchers.equalTo("https://datasetconfigurator.com?datasetPid=" + datasetPid))
+                .statusCode(OK.getStatusCode());
+        
+        //Delete the tool added by this test...
+        Response deleteExternalTool = UtilIT.deleteExternalTool(toolId);
+        deleteExternalTool.then().assertThat()
                 .statusCode(OK.getStatusCode());
 
     }
@@ -400,12 +370,13 @@ public class ExternalToolsIT {
         String body = getTools.getBody().asString();
         JsonReader bodyObject = Json.createReader(new StringReader(body));
         JsonArray tools = bodyObject.readObject().getJsonArray("data");
+        /*
         for (int i = 0; i < tools.size(); i++) {
             JsonObject tool = tools.getJsonObject(i);
             int id = tool.getInt("id");
             Response deleteExternalTool = UtilIT.deleteExternalTool(id);
             deleteExternalTool.prettyPrint();
-        }
+        }*/
     }
 
     // preview only
@@ -446,6 +417,13 @@ public class ExternalToolsIT {
         addExternalTool.prettyPrint();
         addExternalTool.then().assertThat()
                 .statusCode(OK.getStatusCode());
+        
+        long toolId = JsonPath.from(addExternalTool.getBody().asString()).getLong("data.id");
+        
+        //Delete the tool added by this test...
+        Response deleteExternalTool = UtilIT.deleteExternalTool(toolId);
+        deleteExternalTool.then().assertThat()
+                .statusCode(OK.getStatusCode());
     }
 
     // explore only
@@ -478,6 +456,13 @@ public class ExternalToolsIT {
         Response addExternalTool = UtilIT.addExternalTool(job.build());
         addExternalTool.prettyPrint();
         addExternalTool.then().assertThat()
+                .statusCode(OK.getStatusCode());
+        
+        long toolId = JsonPath.from(addExternalTool.getBody().asString()).getLong("data.id");
+        
+        //Delete the tool added by this test...
+        Response deleteExternalTool = UtilIT.deleteExternalTool(toolId);
+        deleteExternalTool.then().assertThat()
                 .statusCode(OK.getStatusCode());
     }
 
@@ -526,21 +511,6 @@ public class ExternalToolsIT {
 
     @Test
     public void testFileLevelToolWithAuxFileReq() throws IOException {
-
-        // Delete all external tools before testing.
-        Response getTools = UtilIT.getExternalTools();
-        getTools.prettyPrint();
-        getTools.then().assertThat()
-                .statusCode(OK.getStatusCode());
-        String body = getTools.getBody().asString();
-        JsonReader bodyObject = Json.createReader(new StringReader(body));
-        JsonArray tools = bodyObject.readObject().getJsonArray("data");
-        for (int i = 0; i < tools.size(); i++) {
-            JsonObject tool = tools.getJsonObject(i);
-            int id = tool.getInt("id");
-            Response deleteExternalTool = UtilIT.deleteExternalTool(id);
-            deleteExternalTool.prettyPrint();
-        }
 
         Response createUser = UtilIT.createRandomUser();
         createUser.prettyPrint();
@@ -640,6 +610,12 @@ public class ExternalToolsIT {
                 .body("data[0].displayName", CoreMatchers.equalTo("HDF5 Tool"))
                 .body("data[0].scope", CoreMatchers.equalTo("file"))
                 .body("data[0].contentType", CoreMatchers.equalTo("application/x-hdf5"));
+        
+        //Delete the tool added by this test...
+        Response deleteExternalTool = UtilIT.deleteExternalTool(toolId);
+        deleteExternalTool.then().assertThat()
+                .statusCode(OK.getStatusCode());
+        
     }
 
 }

--- a/src/test/java/edu/harvard/iq/dataverse/api/ExternalToolsIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/ExternalToolsIT.java
@@ -101,7 +101,7 @@ public class ExternalToolsIT {
                 .statusCode(OK.getStatusCode())
                 .body("data.displayName", CoreMatchers.equalTo("AwesomeTool"));
 
-        long toolId = JsonPath.from(addExternalTool.getBody().asString()).getLong("data.id");
+        Long toolId = JsonPath.from(addExternalTool.getBody().asString()).getLong("data.id");
 
         Response getTool = UtilIT.getExternalTool(toolId);
         getTool.prettyPrint();
@@ -115,14 +115,17 @@ public class ExternalToolsIT {
                 .statusCode(BAD_REQUEST.getStatusCode())
                 .body("message", CoreMatchers.equalTo("Type must be one of these values: [explore, configure, preview, query]."));
 
-        Response getExternalToolsForTabularFiles = UtilIT.getExternalToolsForFile(tabularFileId.toString(), "explore", apiToken);
+       // Getting tool by tool Id to avoid issue where there are existing tools
+        String toolIdString = toolId.toString();
+        Response getExternalToolsForTabularFiles = UtilIT.getExternalToolForFileById(tabularFileId.toString(), "explore", apiToken, toolIdString);
         getExternalToolsForTabularFiles.prettyPrint();
+        
         getExternalToolsForTabularFiles.then().assertThat()
                 .statusCode(OK.getStatusCode())
-                .body("data[0].displayName", CoreMatchers.equalTo("AwesomeTool"))
-                .body("data[0].scope", CoreMatchers.equalTo("file"))
-                .body("data[0].contentType", CoreMatchers.equalTo("text/tab-separated-values"))
-                .body("data[0].toolUrlWithQueryParams", CoreMatchers.equalTo("http://awesometool.com?fileid=" + tabularFileId + "&key=" + apiToken));
+                .body("data.displayName", CoreMatchers.equalTo("AwesomeTool"))
+                .body("data.scope", CoreMatchers.equalTo("file"))
+                .body("data.contentType", CoreMatchers.equalTo("text/tab-separated-values"))
+                .body("data.toolUrlWithQueryParams", CoreMatchers.equalTo("http://awesometool.com?fileid=" + tabularFileId + "&key=" + apiToken));
 
         Response getExternalToolsForJuptyerNotebooks = UtilIT.getExternalToolsForFile(jupyterNotebookFileId.toString(), "explore", apiToken);
         getExternalToolsForJuptyerNotebooks.prettyPrint();

--- a/src/test/java/edu/harvard/iq/dataverse/api/ExternalToolsIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/ExternalToolsIT.java
@@ -133,6 +133,8 @@ public class ExternalToolsIT {
         
         //Delete the tool added by this test...
         Response deleteExternalTool = UtilIT.deleteExternalTool(toolId);
+        deleteExternalTool.then().assertThat()
+                .statusCode(OK.getStatusCode());
     }
 
     @Test

--- a/src/test/java/edu/harvard/iq/dataverse/api/ExternalToolsIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/ExternalToolsIT.java
@@ -432,6 +432,7 @@ public class ExternalToolsIT {
     @Disabled
     @Test
     public void createToolDataExplorer() {
+    /*    
         JsonObjectBuilder job = Json.createObjectBuilder();
         job.add("displayName", "Data Explorer");
         job.add("description", "");
@@ -466,6 +467,7 @@ public class ExternalToolsIT {
         Response deleteExternalTool = UtilIT.deleteExternalTool(toolId);
         deleteExternalTool.then().assertThat()
                 .statusCode(OK.getStatusCode());
+        */
     }
 
     // both preview and explore

--- a/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
@@ -2354,6 +2354,21 @@ public class UtilIT {
         }
         return requestSpecification.get("/api/admin/test/files/" + idInPath + "/externalTools?type=" + type + optionalQueryParam);
     }
+    
+    static Response getExternalToolForFileById(String idOrPersistentIdOfFile, String type, String apiToken, String toolId) {
+        String idInPath = idOrPersistentIdOfFile; // Assume it's a number.
+        String optionalQueryParam = ""; // If idOrPersistentId is a number we'll just put it in the path.
+        if (!NumberUtils.isCreatable(idOrPersistentIdOfFile)) {
+            idInPath = ":persistentId";
+            optionalQueryParam = "&persistentId=" + idOrPersistentIdOfFile;
+        }
+        RequestSpecification requestSpecification = given();
+        if (apiToken != null) {
+            requestSpecification = given()
+                    .header(UtilIT.API_TOKEN_HTTP_HEADER, apiToken);
+        }
+        return requestSpecification.get("/api/admin/test/files/" + idInPath + "/externalTool/" + toolId + "?type=" + type + optionalQueryParam);
+    }
 
     static Response submitFeedback(JsonObjectBuilder job) {
         return given()


### PR DESCRIPTION
**What this PR does / why we need it**: Updates ExternalToolsIT so that existing tools are not deleted

**Which issue(s) this PR closes**:

Closes #9748 Installed External tools deleted by running ExternalToolsIT

**Special notes for your reviewer**: Going in I thought that deleting the tools was a requirement to get the tests to pass. That turned out not to be the case which made the fix easier. The tests were modified to delete only those tools added via the tests.

**Suggestions on how to test this**: Install an external tool in your test environment. Run ExternalToolsIT
verify that your pre-installed tool(s) exist after running the test. And that there are no additional tools.
api for getting a list of installed tools:
 curl http://localhost:8080/api/admin/externalTools

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: no

**Is there a release notes update needed for this change?**: no

**Additional documentation**: none
