### PR TITLE
bump solrj per qqmyers to address zookeeper dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -283,7 +283,7 @@
         <dependency>
             <groupId>org.apache.solr</groupId>
             <artifactId>solr-solrj</artifactId>
-            <version>9.3.0</version>
+            <version>9.4.1</version>
         </dependency>
         <dependency>
             <groupId>colt</groupId>


### PR DESCRIPTION
**What this PR does / why we need it**:

Bumps solr-solrj version to address dataverse-security #95

**Which issue(s) this PR closes**:

Closes dataverse-security #95

**Special notes for your reviewer**:

per @qqmyers `According to Apache, solrj is usually cross-compatible with solr, so it sounds like solrj 9.4.1 would work with solr 9.3. So it looks like we could update solrj w/o requiring an update to solr itself. (From QDR, I know that solr 9.4.0 works with solrj 9.3 - the other direction.)`

**Suggestions on how to test this**:

standard integration tests?

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

no

**Is there a release notes update needed for this change?**:

no

**Additional documentation**:

none