### PR TITLE
10297 dataset metadata endpoint fix

### DIFF
--- a/doc/release-notes/10297-metadata-api-fix.md
+++ b/doc/release-notes/10297-metadata-api-fix.md
@@ -1,0 +1,1 @@
+The API endpoint `api/datasets/{id}/metadata` has been changed to default to the latest version of the dataset that the user has access.

--- a/src/main/java/edu/harvard/iq/dataverse/api/Datasets.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Datasets.java
@@ -778,7 +778,7 @@ public class Datasets extends AbstractApiBean {
     @Path("{id}/metadata")
     @Produces("application/ld+json, application/json-ld")
     public Response getVersionJsonLDMetadata(@Context ContainerRequestContext crc, @PathParam("id") String id, @Context UriInfo uriInfo, @Context HttpHeaders headers) {
-        return getVersionJsonLDMetadata(crc, id, DS_VERSION_DRAFT, uriInfo, headers);
+        return getVersionJsonLDMetadata(crc, id, DS_VERSION_LATEST, uriInfo, headers);
     }
 
     @PUT

--- a/src/test/java/edu/harvard/iq/dataverse/api/SearchIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/SearchIT.java
@@ -1202,7 +1202,7 @@ public class SearchIT {
                                                                                         .add("value", "42.33661")
                                                                                         .add("typeClass", "primitive")
                                                                                         .add("multiple", false)
-                                                                                        .add("typeName", "southLongitude")
+                                                                                        .add("typeName", "southLongitud e")
                                                                         )
                                                                         .add("eastLongitude",
                                                                                 Json.createObjectBuilder()

--- a/src/test/java/edu/harvard/iq/dataverse/api/SearchIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/SearchIT.java
@@ -1202,7 +1202,7 @@ public class SearchIT {
                                                                                         .add("value", "42.33661")
                                                                                         .add("typeClass", "primitive")
                                                                                         .add("multiple", false)
-                                                                                        .add("typeName", "southLongitud e")
+                                                                                        .add("typeName", "southLongitude")
                                                                         )
                                                                         .add("eastLongitude",
                                                                                 Json.createObjectBuilder()


### PR DESCRIPTION
**What this PR does / why we need it**:

When trying to access the endpoint api/datasets/{id}/metadata it will try by default to get the draft version and if this endpoint is used on a dataset with no draft it will return an error specifying that there is no draft version accompanied by an exception on the server side.

**Which issue(s) this PR closes**:

Closes #10297 

**Special notes for your reviewer**: It was discussed on slack that this was the intended behavior of the endpoint. Tests were added to validate when multiple versions of the dataset exist.

**Suggestions on how to test this**:
Try to access the endpoint at `api/datasets/{id}/metadata`

If a draft exists and the user has access to it it should be prioritized, otherwise, a published version will provided if exists.

**Is there a release notes update needed for this change?**:
Yes.


