### PR TITLE
Add .qpj and .qmd Extensions to Shapefile Handling #8134

### DIFF
--- a/doc/release-notes/8134-add-qpj-qmd-extensions.md
+++ b/doc/release-notes/8134-add-qpj-qmd-extensions.md
@@ -1,3 +1,3 @@
 Add .qpj and .qmd Extensions to Shapefile Handling
 
-- Support for `.qpj` and `.qmd` files in shapefile uploads has been introduced, ensuring that these files are properly recognized and handled as part of geospatial data sets in Dataverse.
+- Support for `.qpj` and `.qmd` files in shapefile uploads has been introduced, ensuring that these files are properly recognized and handled as part of geospatial datasets in Dataverse.

--- a/doc/release-notes/8134-add-qpj-qmd-extensions.md
+++ b/doc/release-notes/8134-add-qpj-qmd-extensions.md
@@ -1,0 +1,3 @@
+Add .qpj and .qmd Extensions to Shapefile Handling
+
+- Support for `.qpj` and `.qmd` files in shapefile uploads has been introduced, ensuring that these files are properly recognized and handled as part of geospatial data sets in Dataverse.

--- a/doc/sphinx-guides/source/developers/geospatial.rst
+++ b/doc/sphinx-guides/source/developers/geospatial.rst
@@ -34,7 +34,7 @@ For example:
 Upon recognition of the four required files, the Dataverse installation will group them as well as any other relevant files into a shapefile set. Files with these extensions will be included in the shapefile set:
 
 - Required: ``.shp``, ``.shx``, ``.dbf``, ``.prj``
-- Optional: ``.sbn``, ``.sbx``, ``.fbn``, ``.fbx``, ``.ain``, ``.aih``, ``.ixs``, ``.mxs``, ``.atx``, ``.cpg``, ``shp.xml``
+- Optional: ``.sbn``, ``.sbx``, ``.fbn``, ``.fbx``, ``.ain``, ``.aih``, ``.ixs``, ``.mxs``, ``.atx``, ``.cpg``, ``.qpj``, ``.qmd``, ``shp.xml``
 
 Then the Dataverse installation creates a new ``.zip`` with mimetype as a shapefile. The shapefile set will persist as this new ``.zip``.
 

--- a/src/main/java/edu/harvard/iq/dataverse/util/ShapefileHandler.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/ShapefileHandler.java
@@ -72,7 +72,7 @@ public class ShapefileHandler{
     public final static List<String> SHAPEFILE_MANDATORY_EXTENSIONS = Arrays.asList("shp", "shx", "dbf", "prj");
     public final static String SHP_XML_EXTENSION = "shp.xml";
     public final static String BLANK_EXTENSION = "__PLACEHOLDER-FOR-BLANK-EXTENSION__";
-    public final static List<String> SHAPEFILE_ALL_EXTENSIONS = Arrays.asList("shp", "shx", "dbf", "prj", "sbn", "sbx", "fbn", "fbx", "ain", "aih", "ixs", "mxs", "atx", "cpg", SHP_XML_EXTENSION);  
+    public final static List<String> SHAPEFILE_ALL_EXTENSIONS = Arrays.asList("shp", "shx", "dbf", "prj", "sbn", "sbx", "fbn", "fbx", "ain", "aih", "ixs", "mxs", "atx", "cpg", "qpj", "qmd", SHP_XML_EXTENSION);
     
     public boolean DEBUG = false;
         

--- a/src/test/java/edu/harvard/iq/dataverse/util/shapefile/ShapefileHandlerTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/util/shapefile/ShapefileHandlerTest.java
@@ -144,9 +144,40 @@ public class ShapefileHandlerTest {
         
         msg("Passed!");
     }
-    
-    
-        
+
+
+    @Test
+    public void testShapefileWithQpjAndQmd() throws IOException {
+        msgt("(4) testShapefileWithQpjAndQmd");
+
+        // Create mock files for the new extensions
+        List<String> fileNames = Arrays.asList("testShape.shp", "testShape.shx", "testShape.dbf", "testShape.prj", "testShape.qpj", "testShape.qmd");
+
+        // Create a zip file with these files
+        File zipFile = createAndZipFiles(fileNames, "testShapeWithNewExtensions.zip");
+
+        // Pass the zip to the ShapefileHandler
+        ShapefileHandler shpHandler = new ShapefileHandler(new FileInputStream(zipFile));
+        shpHandler.DEBUG = true;
+
+        // Check if it is recognized as a shapefile
+        assertTrue(shpHandler.containsShapefile(), "The zip should contain a shapefile with the new extensions");
+
+        // Get file groups map and verify presence
+        Map<String, List<String>> fileGroups = shpHandler.getFileGroups();
+        assertFalse(fileGroups.isEmpty(), "The file groups map should not be empty");
+
+        // Ensure the specific extensions are present
+        assertTrue(fileGroups.containsKey("testShape"), "The file group should contain the key 'testShape'");
+        assertTrue(fileGroups.get("testShape").containsAll(Arrays.asList("shp", "shx", "dbf", "prj", "qpj", "qmd")), "The file group should include the new extensions .qpj and .qmd");
+
+        // Delete the test zip file
+        zipFile.delete();
+
+        msg("Test passed successfully!");
+    }
+
+
     @Test
     public void testZippedTwoShapefiles() throws IOException{
         msgt("(2) testZippedTwoShapefiles");


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR includes `.qpj` and `.qmd` in the list of file extensions handled by `ShapefileHandler`, ensuring that QGIS project files and metadata are correctly processed and included in the zipped shapefile packages. The documentation has been updated to reflect these changes, and a new test has been added to confirm the proper handling of these file types.

**Which issue(s) this PR closes**:

- Closes #8134

**Special notes for your reviewer**:

Please note that `.qpj` files are crucial for QGIS users as they contain projection information.

**Suggestions on how to test this**:

1. Upload a [zipped shapefile](https://github.com/IQSS/dataverse/issues/8134#issuecomment-1273259369) containing `.qpj` and `.qmd` files.
2. Ensure the files remain within the zip after upload and are not extracted.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

N/A

**Is there a release notes update needed for this change?**:

Yes, it has been noted that Dataverse now retains `.qpj` and `.qmd` files in zipped shapefile uploads.

**Additional documentation**:

https://dataverse-guide--10305.org.readthedocs.build/en/10305/developers/geospatial.html
