### PR TITLE
#10271 fix tool tests w/arrays

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/api/TestApi.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/TestApi.java
@@ -44,6 +44,34 @@ public class TestApi extends AbstractApiBean {
             return wr.getResponse();
         }
     }
+    
+    @GET
+    @Path("datasets/{id}/externalTool/{toolId}")
+    public Response getExternalToolforDatasetById(@PathParam("id") String idSupplied, @PathParam("toolId") String toolId, @QueryParam("type") String typeSupplied) {
+        ExternalTool.Type type;
+        try {
+            type = ExternalTool.Type.fromString(typeSupplied);
+        } catch (IllegalArgumentException ex) {
+            return error(BAD_REQUEST, ex.getLocalizedMessage());
+        }
+        Dataset dataset;
+        try {
+            dataset = findDatasetOrDie(idSupplied);
+            JsonArrayBuilder tools = Json.createArrayBuilder();
+            List<ExternalTool> datasetTools = externalToolService.findDatasetToolsByType(type);
+            for (ExternalTool tool : datasetTools) {
+                ApiToken apiToken = externalToolService.getApiToken(getRequestApiKey());
+                ExternalToolHandler externalToolHandler = new ExternalToolHandler(tool, dataset, apiToken, null);
+                JsonObjectBuilder toolToJson = externalToolService.getToolAsJsonWithQueryParameters(externalToolHandler);
+                if (tool.getId().toString().equals(toolId)) {
+                    return ok(toolToJson);
+                }
+            }
+        } catch (WrappedResponse wr) {
+            return wr.getResponse();
+        }
+        return error(BAD_REQUEST, "Could not find external tool with id of " + toolId);
+    }
 
     @Path("files/{id}/externalTools")
     @GET

--- a/src/test/java/edu/harvard/iq/dataverse/api/ExternalToolsIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/ExternalToolsIT.java
@@ -197,7 +197,7 @@ public class ExternalToolsIT {
                 .statusCode(OK.getStatusCode())
                 .body("data.displayName", CoreMatchers.equalTo("DatasetTool1"));
         
-        long toolId = JsonPath.from(addExternalTool.getBody().asString()).getLong("data.id");
+        Long toolId = JsonPath.from(addExternalTool.getBody().asString()).getLong("data.id");
 
         Response getExternalToolsByDatasetIdInvalidType = UtilIT.getExternalToolsForDataset(datasetId.toString(), "invalidType", apiToken);
         getExternalToolsByDatasetIdInvalidType.prettyPrint();
@@ -205,12 +205,12 @@ public class ExternalToolsIT {
                 .statusCode(BAD_REQUEST.getStatusCode())
                 .body("message", CoreMatchers.equalTo("Type must be one of these values: [explore, configure, preview, query]."));
 
-        Response getExternalToolsByDatasetId = UtilIT.getExternalToolsForDataset(datasetId.toString(), "explore", apiToken);
+        Response getExternalToolsByDatasetId = UtilIT.getExternalToolForDatasetById(datasetId.toString(), "explore", apiToken, toolId.toString());
         getExternalToolsByDatasetId.prettyPrint();
         getExternalToolsByDatasetId.then().assertThat()
-                .body("data[0].displayName", CoreMatchers.equalTo("DatasetTool1"))
-                .body("data[0].scope", CoreMatchers.equalTo("dataset"))
-                .body("data[0].toolUrlWithQueryParams", CoreMatchers.equalTo("http://datasettool1.com?datasetPid=" + datasetPid + "&key=" + apiToken))
+                .body("data.displayName", CoreMatchers.equalTo("DatasetTool1"))
+                .body("data.scope", CoreMatchers.equalTo("dataset"))
+                .body("data.toolUrlWithQueryParams", CoreMatchers.equalTo("http://datasettool1.com?datasetPid=" + datasetPid + "&key=" + apiToken))
                 .statusCode(OK.getStatusCode());
         
         //Delete the tool added by this test...
@@ -271,15 +271,14 @@ public class ExternalToolsIT {
                 .statusCode(OK.getStatusCode())
                 .body("data.displayName", CoreMatchers.equalTo("Dataset Configurator"));
         
-        long toolId = JsonPath.from(addExternalTool.getBody().asString()).getLong("data.id");
-
-        Response getExternalToolsByDatasetId = UtilIT.getExternalToolsForDataset(datasetId.toString(), "configure", apiToken);
+        Long toolId = JsonPath.from(addExternalTool.getBody().asString()).getLong("data.id");
+        Response getExternalToolsByDatasetId = UtilIT.getExternalToolForDatasetById(datasetId.toString(), "configure", apiToken, toolId.toString());
         getExternalToolsByDatasetId.prettyPrint();
         getExternalToolsByDatasetId.then().assertThat()
-                .body("data[0].displayName", CoreMatchers.equalTo("Dataset Configurator"))
-                .body("data[0].scope", CoreMatchers.equalTo("dataset"))
-                .body("data[0].types[0]", CoreMatchers.equalTo("configure"))
-                .body("data[0].toolUrlWithQueryParams", CoreMatchers.equalTo("https://datasetconfigurator.com?datasetPid=" + datasetPid))
+                .body("data.displayName", CoreMatchers.equalTo("Dataset Configurator"))
+                .body("data.scope", CoreMatchers.equalTo("dataset"))
+                .body("data.types[0]", CoreMatchers.equalTo("configure"))
+                .body("data.toolUrlWithQueryParams", CoreMatchers.equalTo("https://datasetconfigurator.com?datasetPid=" + datasetPid))
                 .statusCode(OK.getStatusCode());
         
         //Delete the tool added by this test...
@@ -594,7 +593,7 @@ public class ExternalToolsIT {
                 .statusCode(OK.getStatusCode())
                 .body("data.displayName", CoreMatchers.equalTo("HDF5 Tool"));
 
-        long toolId = JsonPath.from(addExternalTool.getBody().asString()).getLong("data.id");
+        Long toolId = JsonPath.from(addExternalTool.getBody().asString()).getLong("data.id");
 
         Response getTool = UtilIT.getExternalTool(toolId);
         getTool.prettyPrint();
@@ -610,13 +609,13 @@ public class ExternalToolsIT {
                 .body("data", Matchers.hasSize(0));
 
         // The tool shows for a true HDF5 file. The NcML aux file is available. Requirements met.
-        Response getToolsForTrueHdf5 = UtilIT.getExternalToolsForFile(trueHdf5.toString(), "preview", apiToken);
+        Response getToolsForTrueHdf5 = UtilIT.getExternalToolForFileById(trueHdf5.toString(), "preview", apiToken, toolId.toString());
         getToolsForTrueHdf5.prettyPrint();
         getToolsForTrueHdf5.then().assertThat()
                 .statusCode(OK.getStatusCode())
-                .body("data[0].displayName", CoreMatchers.equalTo("HDF5 Tool"))
-                .body("data[0].scope", CoreMatchers.equalTo("file"))
-                .body("data[0].contentType", CoreMatchers.equalTo("application/x-hdf5"));
+                .body("data.displayName", CoreMatchers.equalTo("HDF5 Tool"))
+                .body("data.scope", CoreMatchers.equalTo("file"))
+                .body("data.contentType", CoreMatchers.equalTo("application/x-hdf5"));
         
         //Delete the tool added by this test...
         Response deleteExternalTool = UtilIT.deleteExternalTool(toolId);

--- a/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
@@ -2339,6 +2339,21 @@ public class UtilIT {
         }
         return requestSpecification.get("/api/admin/test/datasets/" + idInPath + "/externalTools?type=" + type + optionalQueryParam);
     }
+    
+    static Response getExternalToolForDatasetById(String idOrPersistentIdOfDataset, String type, String apiToken, String toolId) {
+        String idInPath = idOrPersistentIdOfDataset; // Assume it's a number.
+        String optionalQueryParam = ""; // If idOrPersistentId is a number we'll just put it in the path.
+        if (!NumberUtils.isCreatable(idOrPersistentIdOfDataset)) {
+            idInPath = ":persistentId";
+            optionalQueryParam = "&persistentId=" + idOrPersistentIdOfDataset;
+        }
+        RequestSpecification requestSpecification = given();
+        if (apiToken != null) {
+            requestSpecification = given()
+                    .header(UtilIT.API_TOKEN_HTTP_HEADER, apiToken);
+        }
+        return requestSpecification.get("/api/admin/test/datasets/" + idInPath + "/externalTool/" + toolId + "?type=" + type + optionalQueryParam);
+    }
 
     static Response getExternalToolsForFile(String idOrPersistentIdOfFile, String type, String apiToken) {
         String idInPath = idOrPersistentIdOfFile; // Assume it's a number.


### PR DESCRIPTION
**What this PR does / why we need it**: Some tests were failing in external tools because they return an array of tools and assume that the first tool in the array is the one they want to validate/verify. The tests have been updated to retrieve the test subject tool by its id.

**Which issue(s) this PR closes**:

Closes #10271 API Tests Failing 

**Special notes for your reviewer**:

**Suggestions on how to test this**:  mvn test -Dtest=ExternalToolsIT

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**: no 

**Additional documentation**: none
