### PR TITLE
IQSS/10324-fix granting file access w/o request

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/ManageFilePermissionsPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/ManageFilePermissionsPage.java
@@ -422,7 +422,10 @@ public class ManageFilePermissionsPage implements java.io.Serializable {
                     // set request(s) granted, if they exist
                     for (AuthenticatedUser au : roleAssigneeService.getExplicitUsers(roleAssignee)) {
                         FileAccessRequest far = file.getAccessRequestForAssignee(au);
-                        far.setStateGranted();
+                        //There may not be a request, so do the null check
+                        if (far != null) {
+                            far.setStateGranted();
+                        }
                     }
                     datafileService.save(file);
                 }


### PR DESCRIPTION
**What this PR does / why we need it**:  To fix granting file access when there was no access request.

At QDR, this appears to be due to an npe: ```
Caused by: java.lang.NullPointerException: Cannot invoke "edu.harvard.iq.dataverse.FileAccessRequest.setStateGranted()" because "far" is null
        at edu.harvard.iq.dataverse.ManageFilePermissionsPage.grantAccess(ManageFilePermissionsPage.java:425)

```

Digging in the code a bit, it looks like a bug introduced with the guestboook-at-request PR: As of that PR, requests are not deleted when granted, they are now given the state granted. At the line in question, the code is looking for a request in the created state associated with the file, so if no request exists, it fails. That should mean that when granting access for one file w/o a request existing (didn't test), it would succeed but the success message/page update would fail. With more than one file, the files after the first access isn't granted. 

**Which issue(s) this PR closes**:

Closes #10324

**Special notes for your reviewer**:

**Suggestions on how to test this**: See the issue and above. Regression testing - it should also work if someone requested access first.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
