### PR TITLE
Add direct upload to `getting-started` docs

### DIFF
--- a/doc/sphinx-guides/source/api/getting-started.rst
+++ b/doc/sphinx-guides/source/api/getting-started.rst
@@ -86,7 +86,7 @@ See :ref:`create-dataset-command`.
 Uploading Files
 ~~~~~~~~~~~~~~~
 
-See :ref:`add-file-api`.
+See :ref:`add-file-api`. In addition, when a Dataverse installation is configured to use S3 storage with direct upload enabled, there is API support to send a file directly to S3. This facilitates an efficient method to upload big files, but is more complex. The procedure is described in the :doc:`/developers/s3-direct-upload-api` guide.
 
 Publishing a Dataverse Collection
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/sphinx-guides/source/api/getting-started.rst
+++ b/doc/sphinx-guides/source/api/getting-started.rst
@@ -86,7 +86,7 @@ See :ref:`create-dataset-command`.
 Uploading Files
 ~~~~~~~~~~~~~~~
 
-See :ref:`add-file-api`. In addition, when a Dataverse installation is configured to use S3 storage with direct upload enabled, there is API support to send a file directly to S3. This facilitates an efficient method to upload big files, but is more complex. The procedure is described in the :doc:`/developers/s3-direct-upload-api` guide.
+See :ref:`add-file-api`. In addition, when a Dataverse installation is configured to use S3 storage with direct upload enabled, there is API support to send a file directly to S3. This facilitates an efficient method to upload big files, but is more complex. The procedure is described in the :doc:`/developers/s3-direct-upload-api` section of the Developer Guide.
 
 Publishing a Dataverse Collection
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/sphinx-guides/source/developers/s3-direct-upload-api.rst
+++ b/doc/sphinx-guides/source/developers/s3-direct-upload-api.rst
@@ -3,6 +3,12 @@ Direct DataFile Upload/Replace API
 
 The direct Datafile Upload API is used internally to support direct upload of files to S3 storage and by tools such as the DVUploader.
 
+.. contents:: |toctitle|
+	:local:
+
+Overview
+--------
+
 Direct upload involves a series of three activities, each involving interacting with the server for a Dataverse installation:
 
 * Requesting initiation of a transfer from the server
@@ -91,7 +97,7 @@ If the client is unable to complete the multipart upload, it should call the abo
   
 .. _direct-add-to-dataset-api:
 
-Adding the Uploaded file to the Dataset
+Adding the Uploaded File to the Dataset
 ---------------------------------------
 
 Once the file exists in the s3 bucket, a final API call is needed to add it to the Dataset. This call is the same call used to upload a file to a Dataverse installation but, rather than sending the file bytes, additional metadata is added using the "jsonData" parameter.
@@ -119,7 +125,7 @@ The allowed checksum algorithms are defined by the edu.harvard.iq.dataverse.Data
 Note that this API call can be used independently of the others, e.g. supporting use cases in which the file already exists in S3/has been uploaded via some out-of-band method. Enabling out-of-band uploads is described at :ref:`file-storage` in the Configuration Guide.
 With current S3 stores the object identifier must be in the correct bucket for the store, include the PID authority/identifier of the parent dataset, and be guaranteed unique, and the supplied storage identifier must be prefaced with the store identifier used in the Dataverse installation, as with the internally generated examples above.
 
-To add multiple Uploaded Files to the Dataset
+To Add Multiple Uploaded Files to the Dataset
 ---------------------------------------------
 
 Once the files exists in the s3 bucket, a final API call is needed to add all the files to the Dataset. In this API call, additional metadata is added using the "jsonData" parameter.
@@ -150,8 +156,7 @@ The allowed checksum algorithms are defined by the edu.harvard.iq.dataverse.Data
 Note that this API call can be used independently of the others, e.g. supporting use cases in which the files already exists in S3/has been uploaded via some out-of-band method. Enabling out-of-band uploads is described at :ref:`file-storage` in the Configuration Guide.
 With current S3 stores the object identifier must be in the correct bucket for the store, include the PID authority/identifier of the parent dataset, and be guaranteed unique, and the supplied storage identifier must be prefaced with the store identifier used in the Dataverse installation, as with the internally generated examples above.
 
-
-Replacing an existing file in the Dataset
+Replacing an Existing File in the Dataset
 -----------------------------------------
 
 Once the file exists in the s3 bucket, a final API call is needed to register it as a replacement of an existing file. This call is the same call used to replace a file to a Dataverse installation but, rather than sending the file bytes, additional metadata is added using the "jsonData" parameter.
@@ -180,7 +185,7 @@ Note that the API call does not validate that the file matches the hash value su
 Note that this API call can be used independently of the others, e.g. supporting use cases in which the file already exists in S3/has been uploaded via some out-of-band method. Enabling out-of-band uploads is described at :ref:`file-storage` in the Configuration Guide.
 With current S3 stores the object identifier must be in the correct bucket for the store, include the PID authority/identifier of the parent dataset, and be guaranteed unique, and the supplied storage identifier must be prefaced with the store identifier used in the Dataverse installation, as with the internally generated examples above.
 
-Replacing multiple existing files in the Dataset
+Replacing Multiple Existing Files in the Dataset
 ------------------------------------------------
 
 Once the replacement files exist in the s3 bucket, a final API call is needed to register them as replacements for existing files. In this API call, additional metadata is added using the "jsonData" parameter.


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR extends the getting started doc to reference the S3 direct upload documentation.
