### PR TITLE
JQ has moved, both RPM repo and GH source

### DIFF
--- a/doc/sphinx-guides/source/installation/prerequisites.rst
+++ b/doc/sphinx-guides/source/installation/prerequisites.rst
@@ -276,17 +276,11 @@ jq
 Installing jq
 =============
 
-``jq`` is a command line tool for parsing JSON output that is used by the Dataverse Software installation script. It is available in the EPEL repository::
+``jq`` is a command line tool for parsing JSON output that is used by the Dataverse Software installation script. It is available in the ``appstream`` repository::
 
-	# yum install epel-release
-	# yum install jq
+	# dnf install jq
 
-or you may install it manually::
-
-        # cd /usr/bin
-        # wget https://stedolan.github.io/jq/download/linux64/jq
-        # chmod +x jq
-        # jq --version
+or you may install the latest binary for your OS and platform, available from https://github.com/jqlang/jq/releases
 
 .. _install-imagemagick:
 


### PR DESCRIPTION
**What this PR does / why we need it**:

JQ is now in the appstream repo on RHEL releases, point users at pre-built binaries from official GH repo

**Which issue(s) this PR closes**:

Closes #10355

**Special notes for your reviewer**:

None

**Suggestions on how to test this**:

Attempt to install via RPM and using a pre-built binary.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No

**Is there a release notes update needed for this change?**:

No

**Additional documentation**:

None