### PR TITLE
no-op update to pom.xml to force Docker image build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
          In case the dependency is both transitive and direct (e. g. some common lib for logging),
          manage the version above and add the direct dependency here WITHOUT version tag, too.
     -->
-    <!-- TODO: Housekeeping is utterly needed. -->
+    <!-- TODO: Housekeeping is utterly needed! -->
     <dependencies>
 
         <!-- This dependency ensures the lib is on the classpath. That way, anything coming from


### PR DESCRIPTION
As described in .github/workflows/maven_unit_test.yml we need to touch Java files or pom.xml for this action (which pushes Docker images) to run.

This is just a no-op change to a comment.