### PR TITLE
Suggested changes to OpenAPI PR

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,10 +32,12 @@
         <poi.version>5.2.1</poi.version>
         <tika.version>2.4.1</tika.version>
         <netcdf.version>5.5.3</netcdf.version>
-
-        <smallrye.schemaFilename>dataverse_openapi</smallrye.schemaFilename>
-        <smallrye.infoTitle>Dataverse API</smallrye.infoTitle>
-        <smallrye.outputDirectory>src/main/resources/edu/harvard/iq/dataverse/openapi</smallrye.outputDirectory>
+        
+        <openapi.infoTitle>Dataverse API</openapi.infoTitle>
+        <openapi.infoVersion>${project.version}</openapi.infoVersion>
+        <openapi.infoDescription>Dataverse is an open source publication repository software with an API first approach.</openapi.infoDescription>
+        <!-- https://download.eclipse.org/microprofile/microprofile-open-api-3.1.1/microprofile-openapi-spec-3.1.1.html#_location_and_formats -->
+        <openapi.outputDirectory>${project.build.outputDirectory}/META-INF</openapi.outputDirectory>
     </properties>
     
     <!-- Versions of dependencies used both directly and transitive are managed here.
@@ -686,7 +688,6 @@
                     <include>**/firstNames/*.*</include>
                     <include>**/*.xsl</include>
                     <include>**/services/*</include>
-                    <include>**/openapi/*</include>
                 </includes>
             </resource>
             <resource>
@@ -699,22 +700,6 @@
             </resource>
         </resources>
         <plugins>
-            <plugin>
-                <artifactId>smallrye-open-api-maven-plugin</artifactId>
-                <groupId>io.smallrye</groupId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>generate-schema</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <schemaFilename>${smallrye.schemaFilename}</schemaFilename>
-                    <infoTitle>${smallrye.infoTitle}</infoTitle>
-                    <outputDirectory>${smallrye.outputDirectory}</outputDirectory>
-                </configuration>
-            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
@@ -906,6 +891,30 @@
                     <encoding>UTF-8</encoding>
                     <consoleOutput>true</consoleOutput>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>io.smallrye</groupId>
+                <artifactId>smallrye-open-api-maven-plugin</artifactId>
+                <version>3.10.0</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>generate-schema</goal>
+                        </goals>
+                        <!-- Plugin scans class files, not sources. Execute after compile phase but before package -->
+                        <phase>prepare-package</phase>
+                        <configuration>
+                            <outputDirectory>${openapi.outputDirectory}</outputDirectory>
+                            <schemaFilename>openapi</schemaFilename>
+                            <infoTitle>${openapi.infoTitle}</infoTitle>
+                            <infoVersion>${openapi.infoVersion}</infoVersion>
+                            <infoDescription>${openapi.infoDescription}</infoDescription>
+                            <operationIdStrategy>CLASS_METHOD</operationIdStrategy>
+                            <scanPackages>edu.harvard.iq.dataverse</scanPackages>
+                            <scanDependenciesDisable>true</scanDependenciesDisable>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
We will need to change some method signatures to avoid the duplications.

Simply run `mvn clean package -DskipTests` to generate the files.

```
[INFO] --- smallrye-open-api:3.10.0:generate-schema (default) @ dataverse ---
März 11, 2024 10:29:18 PM io.smallrye.openapi.runtime.scanner.spi.AnnotationScanner processOperation
WARN: SROAP07903: Duplicate operationId: Admin_putSetting produced by Class: edu.harvard.iq.dataverse.api.Admin, Method: jakarta.ws.rs.core.Response putSetting(java.lang.String name, java.lang.String content) and Class: edu.harvard.iq.dataverse.api.Admin, Method: jakarta.ws.rs.core.Response putSetting(java.lang.String name, java.lang.String lang, java.lang.String content)
März 11, 2024 10:29:18 PM io.smallrye.openapi.runtime.scanner.spi.AnnotationScanner processOperation
WARN: SROAP07903: Duplicate operationId: Admin_deleteSetting produced by Class: edu.harvard.iq.dataverse.api.Admin, Method: jakarta.ws.rs.core.Response deleteSetting(java.lang.String name) and Class: edu.harvard.iq.dataverse.api.Admin, Method: jakarta.ws.rs.core.Response deleteSetting(java.lang.String name, java.lang.String lang)
März 11, 2024 10:29:18 PM io.smallrye.openapi.runtime.scanner.spi.AnnotationScanner processOperation
WARN: SROAP07903: Duplicate operationId: BuiltinUsers_create produced by Class: edu.harvard.iq.dataverse.api.BuiltinUsers, Method: jakarta.ws.rs.core.Response create(edu.harvard.iq.dataverse.authorization.providers.builtin.BuiltinUser user, java.lang.String password, java.lang.String key) and Class: edu.harvard.iq.dataverse.api.BuiltinUsers, Method: jakarta.ws.rs.core.Response create(edu.harvard.iq.dataverse.authorization.providers.builtin.BuiltinUser user, java.lang.String password, java.lang.String key, java.lang.Boolean sendEmailNotification)
März 11, 2024 10:29:18 PM io.smallrye.openapi.runtime.scanner.spi.AnnotationScanner processOperation
WARN: SROAP07903: Duplicate operationId: Datasets_getVersionJsonLDMetadata produced by Class: edu.harvard.iq.dataverse.api.Datasets, Method: jakarta.ws.rs.core.Response getVersionJsonLDMetadata(jakarta.ws.rs.container.ContainerRequestContext crc, java.lang.String id, jakarta.ws.rs.core.UriInfo uriInfo, jakarta.ws.rs.core.HttpHeaders headers) and Class: edu.harvard.iq.dataverse.api.Datasets, Method: jakarta.ws.rs.core.Response getVersionJsonLDMetadata(jakarta.ws.rs.container.ContainerRequestContext crc, java.lang.String id, java.lang.String versionId, jakarta.ws.rs.core.UriInfo uriInfo, jakarta.ws.rs.core.HttpHeaders headers)
März 11, 2024 10:29:19 PM io.smallrye.openapi.runtime.scanner.spi.AnnotationScanner processOperation
WARN: SROAP07903: Duplicate operationId: Files_getFileData produced by Class: edu.harvard.iq.dataverse.api.Files, Method: jakarta.ws.rs.core.Response getFileData(jakarta.ws.rs.container.ContainerRequestContext crc, java.lang.String fileIdOrPersistentId, boolean includeDeaccessioned, boolean returnDatasetVersion, boolean returnOwners, jakarta.ws.rs.core.UriInfo uriInfo, jakarta.ws.rs.core.HttpHeaders headers) and Class: edu.harvard.iq.dataverse.api.Files, Method: jakarta.ws.rs.core.Response getFileData(jakarta.ws.rs.container.ContainerRequestContext crc, java.lang.String fileIdOrPersistentId, java.lang.String datasetVersionId, boolean includeDeaccessioned, boolean returnDatasetVersion, boolean returnOwners, jakarta.ws.rs.core.UriInfo uriInfo, jakarta.ws.rs.core.HttpHeaders headers)
März 11, 2024 10:29:19 PM io.smallrye.openapi.runtime.scanner.spi.AnnotationScanner processOperation
WARN: SROAP07903: Duplicate operationId: Users_getTraces produced by Class: edu.harvard.iq.dataverse.api.Users, Method: jakarta.ws.rs.core.Response getTraces(jakarta.ws.rs.container.ContainerRequestContext crc, jakarta.ws.rs.core.Request req, java.lang.String identifier, java.lang.String element) and Class: edu.harvard.iq.dataverse.api.Users, Method: jakarta.ws.rs.core.Response getTraces(jakarta.ws.rs.container.ContainerRequestContext crc, java.lang.String identifier)
```

In addition, using https://quobix.com/vacuum I found some more errors:

```
$ vacuum lint target/classes/META-INF/openapi.yaml -ade
Location                                    | Severity | Message                                                                                        | Rule                         | Category   | Path
target/classes/META-INF/openapi.yaml:1163:3 | error    | paths `/admin/groups/ip/{groupIdtf}` and `/admin/groups/ip/{groupName}` must not...            | path-params                  | Operations | $.paths.['/admin/groups/ip/{groupName}']
target/classes/META-INF/openapi.yaml:1746:7 | error    | the 'put' operation at path '/admin/settings/{name}' contains a duplicate operat...            | operation-operationId-unique | Operations | $.paths['/admin/settings/{name}'].put
target/classes/META-INF/openapi.yaml:1757:7 | error    | the 'delete' operation at path '/admin/settings/{name}' contains a duplicate ope...            | operation-operationId-unique | Operations | $.paths['/admin/settings/{name}'].delete
target/classes/META-INF/openapi.yaml:2142:3 | error    | paths `/admin/workflows/{identifier}` and `/admin/workflows/{id}` must not be eq...            | path-params                  | Operations | $.paths.['/admin/workflows/{id}']
target/classes/META-INF/openapi.yaml:2302:7 | error    | the 'post' operation at path '/builtin-users/{password}/{key}/{sendEmailNotifica...            | operation-operationId-unique | Operations | $.paths['/builtin-users/{password}/{key}/{sendEmailNotificat...
target/classes/META-INF/openapi.yaml:3870:7 | error    | the 'get' operation at path '/datasets/{id}/versions/{versionId}/metadata' conta...            | operation-operationId-unique | Operations | $.paths['/datasets/{id}/versions/{versionId}/metadata'].get
target/classes/META-INF/openapi.yaml:4780:7 | error    | the 'get' operation at path '/files/{id}' contains a duplicate operationId 'Files_getFileData' | operation-operationId-unique | Operations | $.paths['/files/{id}'].get
target/classes/META-INF/openapi.yaml:6527:7 | error    | the 'get' operation at path '/users/{identifier}/traces/{element}' contains a du...            | operation-operationId-unique | Operations | $.paths['/users/{identifier}/traces/{element}'].get
```

It found the same duplicates and two additional errors.

Enabling the OWASP mode we have a lot more errors... :see_no_evil: 