### PR TITLE
Fixing the null-unsafe bug in JsonPrinter #10365

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
@@ -657,7 +657,7 @@ public class JsonPrinter {
     }
 
     public static JsonObjectBuilder json(FileMetadata fmd, boolean returnOwners, boolean printDatasetVersion) {
-        JsonObjectBuilder builder = jsonObjectBuilder();
+        NullSafeJsonBuilder builder = jsonObjectBuilder();
 
                 // deprecated: .add("category", fmd.getCategory())
                 // TODO: uh, figure out what to do here... it's deprecated


### PR DESCRIPTION
**What this PR does / why we need it**:

This was a simple bug in jsonprinter, recently merged (#10322). This is killing the `/addFiles` api that the Direct Upload and Globus apis rely on. 

**Which issue(s) this PR closes**:

Closes #10365

**Special notes for your reviewer**:

trivial? 

**Suggestions on how to test this**:

As of now, an attempt to use DvUploader in direct upload mode is failing when used w/ the develop branch build, with the following error message: 

```
Error response when processing files in Individual files on command line : Bad Request
{"status":"ERROR","message":"Cannot invoke \"java.lang.Long.longValue()\" because the return value of \"edu.harvard.iq.dataverse.FileMetadata.getVersion()\" is null"}
```

Should be working again with this fix applied. 

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
