### PR TITLE
GlobalDataverseCommunityConsortium:IQSS/10369-support_legacy_PID_provider_settings

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/pidproviders/PidProviderFactoryBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/pidproviders/PidProviderFactoryBean.java
@@ -123,7 +123,6 @@ public class PidProviderFactoryBean {
         if (!providers.isPresent()) {
             logger.warning(
                     "No PidProviders configured via dataverse.pid.providers. Please consider updating as older PIDProvider configuration mechanisms will be removed in a future version of Dataverse.");
-            return;
         } else {
             for (String id : providers.get()) {
                 //Allows spaces in PID_PROVIDERS setting


### PR DESCRIPTION
**What this PR does / why we need it**: A late reshuffle of the code added a return after looking for the new PID provider settings, bypassing the check of legacy settings. This PR removes the return so that legacy settings are checked again. 

**Which issue(s) this PR closes**:

Closes #10369

**Special notes for your reviewer**:

**Suggestions on how to test this**: Deploy to an existing db with legacy settings. Prior to the PR the ConfigCheck will cause the deploy to fail. With the PR, it works. (If you don't have an existing setup, run a new setup, add the legacy settings, e.g. for a FAKE provider, and then remove the -Ddataverse.pid.providers= and -Ddataverse.pid.default-provider= jvm options. Trying to restart at that point will fail, but after the PR you can deploy.)

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
