### PR TITLE
IQSS 10390: Multipid UI Fix

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DataversePage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DataversePage.java
@@ -1303,9 +1303,18 @@ public class DataversePage implements java.io.Serializable {
         Set<String> providerIds = PidUtil.getManagedProviderIds();
         Set<Entry<String, String>> options = new HashSet<Entry<String, String>>();
         if (providerIds.size() > 1) {
-            String label = defaultPidProvider.getLabel() + BundleUtil.getStringFromBundle("dataverse.default") + ": "
-                    + defaultPidProvider.getProtocol() + ":" + defaultPidProvider.getAuthority()
-                    + defaultPidProvider.getSeparator() + defaultPidProvider.getShoulder();
+
+            String label = null;
+            if (this.dataverse.getOwner() != null && this.dataverse.getOwner().getEffectivePidGenerator()!= null) {
+                PidProvider inheritedPidProvider = this.dataverse.getOwner().getEffectivePidGenerator();
+                label = inheritedPidProvider.getLabel() + BundleUtil.getStringFromBundle("dataverse.inherited") + ": "
+                        + inheritedPidProvider.getProtocol() + ":" + inheritedPidProvider.getAuthority()
+                        + inheritedPidProvider.getSeparator() + inheritedPidProvider.getShoulder();
+            } else {
+                label = defaultPidProvider.getLabel() + BundleUtil.getStringFromBundle("dataverse.default") + ": "
+                        + defaultPidProvider.getProtocol() + ":" + defaultPidProvider.getAuthority()
+                        + defaultPidProvider.getSeparator() + defaultPidProvider.getShoulder();
+            }
             Entry<String, String> option = new AbstractMap.SimpleEntry<String, String>("default", label);
             options.add(option);
         }

--- a/src/main/java/edu/harvard/iq/dataverse/DataversePage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DataversePage.java
@@ -1307,11 +1307,11 @@ public class DataversePage implements java.io.Serializable {
             String label = null;
             if (this.dataverse.getOwner() != null && this.dataverse.getOwner().getEffectivePidGenerator()!= null) {
                 PidProvider inheritedPidProvider = this.dataverse.getOwner().getEffectivePidGenerator();
-                label = inheritedPidProvider.getLabel() + BundleUtil.getStringFromBundle("dataverse.inherited") + ": "
+                label = inheritedPidProvider.getLabel() + " " + BundleUtil.getStringFromBundle("dataverse.inherited") + ": "
                         + inheritedPidProvider.getProtocol() + ":" + inheritedPidProvider.getAuthority()
                         + inheritedPidProvider.getSeparator() + inheritedPidProvider.getShoulder();
             } else {
-                label = defaultPidProvider.getLabel() + BundleUtil.getStringFromBundle("dataverse.default") + ": "
+                label = defaultPidProvider.getLabel() +  " " + BundleUtil.getStringFromBundle("dataverse.default") + ": "
                         + defaultPidProvider.getProtocol() + ":" + defaultPidProvider.getAuthority()
                         + defaultPidProvider.getSeparator() + defaultPidProvider.getShoulder();
             }

--- a/src/main/java/edu/harvard/iq/dataverse/DvObjectContainer.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DvObjectContainer.java
@@ -252,7 +252,11 @@ public abstract class DvObjectContainer extends DvObject {
                             providerSpecs.getString("authority"), providerSpecs.getString("shoulder"));
                 }
             }
-            setPidGenerator(pidGenerator);
+            if(pidGenerator!=null && pidGenerator.canManagePID()) {
+                setPidGenerator(pidGenerator);
+            } else {
+                setPidGenerator(null);
+            }
         }
         return pidGenerator;
     }

--- a/src/main/java/edu/harvard/iq/dataverse/DvObjectContainer.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DvObjectContainer.java
@@ -201,9 +201,9 @@ public abstract class DvObjectContainer extends DvObject {
     }
 
     // Used in JSF when selecting the PidGenerator
+    // It only returns an id if this dvObjectContainer has PidGenerator specs set on it, otherwise it returns "default" 
     public String getPidGeneratorId() {
-        PidProvider pidGenerator = getEffectivePidGenerator();
-        if (pidGenerator == null) {
+        if (StringUtils.isBlank(getPidGeneratorSpecs())) {
             return "default";
         } else {
             return getEffectivePidGenerator().getId();

--- a/src/main/java/edu/harvard/iq/dataverse/api/Datasets.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Datasets.java
@@ -4598,7 +4598,7 @@ public class Datasets extends AbstractApiBean {
         PidProvider pidProvider = dataset.getEffectivePidGenerator();
         if(pidProvider == null) {
             //This is basically a config error, e.g. if a valid pid provider was removed after this dataset used it
-            return error(Response.Status.NOT_FOUND, "No PID Generator found for the give id");
+            return error(Response.Status.NOT_FOUND, BundleUtil.getStringFromBundle("datasets.api.pidgenerator.notfound"));
         }
         String pidGeneratorId = pidProvider.getId();
         return ok(pidGeneratorId);

--- a/src/main/java/propertyFiles/Bundle.properties
+++ b/src/main/java/propertyFiles/Bundle.properties
@@ -2684,6 +2684,7 @@ datasets.api.deaccessionDataset.invalid.forward.url=Invalid deaccession forward 
 datasets.api.globusdownloaddisabled=File transfer from Dataverse via Globus is not available for this dataset.
 datasets.api.globusdownloadnotfound=List of files to transfer not found.
 datasets.api.globusuploaddisabled=File transfer to Dataverse via Globus is not available for this dataset.
+datasets.api.pidgenerator.notfound=No PID Generator configured for the give id.
 
 #Dataverses.java
 dataverses.api.update.default.contributor.role.failure.role.not.found=Role {0} not found.

--- a/src/test/java/edu/harvard/iq/dataverse/pidproviders/PidUtilTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/pidproviders/PidUtilTest.java
@@ -388,8 +388,16 @@ public class PidUtilTest {
         assertEquals("fake1", dataset1.getGlobalId().getProviderId());
         assertEquals("ez1", dataset1.getEffectivePidGenerator().getId());
         
-        
-        
+        //Now test failure case
+        dataverse1.setPidGenerator(null);
+        dataset1.setPidGenerator(null);
+        pidGeneratorSpecs = Json.createObjectBuilder().add("protocol", AbstractDOIProvider.DOI_PROTOCOL).add("authority","10.9999").add("shoulder", "FK2").build().toString();
+        //Set a PID generator on the parent
+        dataverse1.setPidGeneratorSpecs(pidGeneratorSpecs);
+        assertEquals(pidGeneratorSpecs, dataverse1.getPidGeneratorSpecs());
+        //Verify that the parent's PID generator is the effective one
+        assertNull(dataverse1.getEffectivePidGenerator());
+        assertNull(dataset1.getEffectivePidGenerator());
     }
     
     @Test


### PR DESCRIPTION
**What this PR does / why we need it**: Fixes the issue by adding logic to determine what option will be inherited by a collection - the global default or the value inherited from a parent collection. The PR also addresses the issue with the GET /api/datasets/id/pidGenerator call sometime returning "default" instead of the PidProvider that will be used (as documented in the Guides).

**Which issue(s) this PR closes**:

Closes #10390

**Special notes for your reviewer**: Suggesting we put this in 6.2 to avoid a bug going out.

**Suggestions on how to test this**: Have more than one pid provider configured, create a subcollection and verify that the menu of options on the Dataverse/Edit/GeneralInfo pane shows the options, including one that is either the (default) - if no parent collection has a non-default selection - or (inherited...) option - when a parent/grandparent has an explicit PIDProvider setting. 
Can also call the API call above and verify that it returns a PidProvider id in all cases.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: see screenshot in inssue.

**Is there a release notes update needed for this change?**: no - fixes a bug that hasn't yet been released.

**Additional documentation**:
