### PR TITLE
Fix files not uploading when there is a required selectone component

### DIFF
--- a/src/main/webapp/metadataFragment.xhtml
+++ b/src/main/webapp/metadataFragment.xhtml
@@ -285,7 +285,7 @@
                                                     <div class="form-group dataset-field-values">
                                                         <div class="form-col-container col-sm-9 edit-field">
                                                             <p:selectOneMenu value="#{dsf.singleControlledVocabularyValue}" converter="controlledVocabularyValueConverter" style="width: auto !important; max-width:100%; min-width:200px;" styleClass="form-control primitive"
-                                                                             id="unique1" required="#{dsf.required and datasetPage}" rendered="#{!dsf.datasetFieldType.allowMultiples}" filter="#{(dsf.datasetFieldType.controlledVocabularyValues.size() lt 10) ? 'false':'true'}" filterMatchMode="contains">
+                                                                             id="unique1" rendered="#{!dsf.datasetFieldType.allowMultiples}" filter="#{(dsf.datasetFieldType.controlledVocabularyValues.size() lt 10) ? 'false':'true'}" filterMatchMode="contains">
                                                                 <f:selectItem itemLabel="#{bundle.select}" itemValue="" noSelectionOption="true"/>
                                                                 <f:selectItems value="#{dsf.datasetFieldType.controlledVocabularyValues}" var="cvv" itemLabel="#{cvv.getLocaleStrValue(mdLangCode)}" itemValue="#{cvv}"/>
                                                             </p:selectOneMenu>


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes an issue with dataset field types that use controlled vocab, are only single select, and are required

**Which issue(s) this PR closes**:

Closes #10385

**Special notes for your reviewer**:
So it investigating this, I found that the selectOne simple fields had a required attribute, whereas no other fields did. Removing it fixed the issue AND validation still works correctly. 

Looked in history, found it was added 5 years ago, but not to other fields - not sure why. Likely it was not actually needed (as validation is handled differently).

Here is what the attribute looked like before removing:
```required="#{dsf.required and datasetPage}"```

**Suggestions on how to test this**:
Use the CAFE metadatablock that has dataset field types that use controlled vocab, are only single select, and are required (or create a new one for testing). Add a new dataset and try to upload a file before filling out the metadata. Make sure it gets added to the list, and then also fill out metadata, and make sure everything gets saved correctly.

Also confirm that the field still acts as required (won't save without value, gets validation message)


**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
No

**Is there a release notes update needed for this change?**:
No, simple bug fix

**Additional documentation**:
