### PR TITLE
Documentation update to java requirements

### DIFF
--- a/doc/sphinx-guides/source/developers/classic-dev-env.rst
+++ b/doc/sphinx-guides/source/developers/classic-dev-env.rst
@@ -37,7 +37,7 @@ Windows is gaining support through Docker as described in the :doc:`windows` sec
 Install Java
 ~~~~~~~~~~~~
 
-The Dataverse Software requires Java 11.
+The Dataverse Software requires Java 17.
 
 We suggest downloading OpenJDK from https://adoptopenjdk.net
 


### PR DESCRIPTION
Documentation update to java requirements

**What this PR does / why we need it**:
Java version is 17 not 11