### PR TITLE
Fix PUBLICATION_STATUS facet order and visibility

### DIFF
--- a/doc/release-notes/10338-expose-and-sort-publish-status-facet.md
+++ b/doc/release-notes/10338-expose-and-sort-publish-status-facet.md
@@ -1,0 +1,1 @@
+In version 6.1, the publication status facet location was unintentionally moved to the bottom, and it also prevented it from being visible to guest users. In version 6.2, we have restored its visibility to all users and moved it back to the top of the list.

--- a/doc/release-notes/10338-expose-and-sort-publish-status-facet.md
+++ b/doc/release-notes/10338-expose-and-sort-publish-status-facet.md
@@ -1,1 +1,1 @@
-In version 6.1, the publication status facet location was unintentionally moved to the bottom, and it also prevented it from being visible to guest users. In version 6.2, we have restored its visibility to all users and moved it back to the top of the list.
+In version 6.1, the publication status facet location was unintentionally moved to the bottom. In this version, we have restored the original order.

--- a/src/main/java/edu/harvard/iq/dataverse/search/SearchServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/search/SearchServiceBean.java
@@ -214,16 +214,17 @@ public class SearchServiceBean {
         }
         
         List<DataverseMetadataBlockFacet> metadataBlockFacets = new LinkedList<>();
-        
-        /*
-         * We talked about this in slack on 2021-09-14, Users can see objects on draft/unpublished 
-         *  if the owner gives permissions to all users so it makes sense to expose this facet 
-         *  to all users. The request of this change started because the order of the facets were 
-         *  changed with the PR #9635 and this was unintended.
-         */
-         solrQuery.addFacetField(SearchFields.PUBLICATION_STATUS);
 
         if (addFacets) {
+
+            /*
+            * We talked about this in slack on 2021-09-14, Users can see objects on draft/unpublished 
+            *  if the owner gives permissions to all users so it makes sense to expose this facet 
+            *  to all users. The request of this change started because the order of the facets were 
+            *  changed with the PR #9635 and this was unintended.
+            */
+            solrQuery.addFacetField(SearchFields.PUBLICATION_STATUS);
+
             // -----------------------------------
             // Facets to Retrieve
             // -----------------------------------

--- a/src/main/java/edu/harvard/iq/dataverse/search/SearchServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/search/SearchServiceBean.java
@@ -187,19 +187,11 @@ public class SearchServiceBean {
         SolrQuery solrQuery = new SolrQuery();
         query = SearchUtil.sanitizeQuery(query);
         solrQuery.setQuery(query);
-//        SortClause foo = new SortClause("name", SolrQuery.ORDER.desc);
-//        if (query.equals("*") || query.equals("*:*")) {
-//            solrQuery.setSort(new SortClause(SearchFields.NAME_SORT, SolrQuery.ORDER.asc));
         if (sortField != null) {
             // is it ok not to specify any sort? - there are cases where we 
             // don't care, and it must cost some extra cycles -- L.A.
             solrQuery.setSort(new SortClause(sortField, sortOrder));
         }
-//        } else {
-//            solrQuery.setSort(sortClause);
-//        }
-//        solrQuery.setSort(sortClause);
-
         
         solrQuery.setParam("fl", "*,score");
         solrQuery.setParam("qt", "/select");
@@ -222,6 +214,14 @@ public class SearchServiceBean {
         }
         
         List<DataverseMetadataBlockFacet> metadataBlockFacets = new LinkedList<>();
+        
+        /*
+         * We talked about this in slack on 2021-09-14, Users can see objects on draft/unpublished 
+         *  if the owner gives permissions to all users so it makes sense to expose this facet 
+         *  to all users. The request of this change started because the order of the facets were 
+         *  changed with the PR #9635 and this was unintended.
+         */
+         solrQuery.addFacetField(SearchFields.PUBLICATION_STATUS);
 
         if (addFacets) {
             // -----------------------------------
@@ -251,6 +251,7 @@ public class SearchServiceBean {
                             DatasetFieldType datasetField = dataverseFacet.getDatasetFieldType();
                             solrQuery.addFacetField(datasetField.getSolrField().getNameFacetable());
                         }
+
                         // Get all metadata block facets configured to be displayed
                         metadataBlockFacets.addAll(dataverse.getMetadataBlockFacets());
                     }
@@ -1029,11 +1030,11 @@ public class SearchServiceBean {
 
         AuthenticatedUser au = (AuthenticatedUser) user;
 
-        if (addFacets) {
-            // Logged in user, has publication status facet
-            //
-            solrQuery.addFacetField(SearchFields.PUBLICATION_STATUS);
-        }
+        // if (addFacets) {
+        //     // Logged in user, has publication status facet
+        //     //
+        //     solrQuery.addFacetField(SearchFields.PUBLICATION_STATUS);
+        // }
 
         // ----------------------------------------------------
         // (3) Is this a Super User?

--- a/src/main/java/edu/harvard/iq/dataverse/search/SearchServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/search/SearchServiceBean.java
@@ -217,13 +217,7 @@ public class SearchServiceBean {
 
         if (addFacets) {
 
-            /*
-            * We talked about this in slack on 2021-09-14, Users can see objects on draft/unpublished 
-            *  if the owner gives permissions to all users so it makes sense to expose this facet 
-            *  to all users. The request of this change started because the order of the facets were 
-            *  changed with the PR #9635 and this was unintended.
-            */
-            solrQuery.addFacetField(SearchFields.PUBLICATION_STATUS);
+            
 
             // -----------------------------------
             // Facets to Retrieve
@@ -232,6 +226,13 @@ public class SearchServiceBean {
             solrQuery.addFacetField(SearchFields.DATAVERSE_CATEGORY);
             solrQuery.addFacetField(SearchFields.METADATA_SOURCE);
             solrQuery.addFacetField(SearchFields.PUBLICATION_YEAR);
+            /*
+            * We talked about this in slack on 2021-09-14, Users can see objects on draft/unpublished 
+            *  if the owner gives permissions to all users so it makes sense to expose this facet 
+            *  to all users. The request of this change started because the order of the facets were 
+            *  changed with the PR #9635 and this was unintended.
+            */
+            solrQuery.addFacetField(SearchFields.PUBLICATION_STATUS);
             solrQuery.addFacetField(SearchFields.DATASET_LICENSE);
             /**
              * @todo when a new method on datasetFieldService is available


### PR DESCRIPTION
**What this PR does / why we need it**:

It was reported that the order of the facets was unintentionally changed, this PR adds the publication status facet back to the original place, it also was discussed on Slack that users can see objects even if they are not published if the owner grants access to the group. 

**Which issue(s) this PR closes**:

Closes #10338

**Suggestions on how to test this**:

- If you are logged in and you have objects with published, draft and/or unpublished status you should see this facet on the top of the left side.
- If you create a dataset unpublished and give access to everyone you should be able to see this facet on the top while not being logged in.
- If you have a dataset on draft and give access to everyone you should be able to see this facet on the top while not being logged in.


**Is there a release notes update needed for this change?**:
Yes

