### PR TITLE
clarify how to increase timeout in docker demo

### DIFF
--- a/doc/sphinx-guides/source/container/running/demo.rst
+++ b/doc/sphinx-guides/source/container/running/demo.rst
@@ -59,6 +59,8 @@ Edit the ``compose.yml`` file and look for the following section.
     container_name: "bootstrap"
     image: gdcc/configbaker:alpha
     restart: "no"
+    environment:
+      - TIMEOUT=3m
     command:
       - bootstrap.sh
       - dev
@@ -189,12 +191,16 @@ Windows support is experimental but we are very interested in supporting Windows
 Bootstrapping Did Not Complete
 ++++++++++++++++++++++++++++++
 
-In the compose file, try increasing the timeout in the bootstrap container by adding something like this:
+In the compose file, try increasing the timeout for the bootstrap container:
 
 .. code-block:: bash
 
    environment:
      - TIMEOUT=10m
+
+As described above, you'll want to stop containers, delete data, and start over with ``docker compose up``. To make sure the increased timeout is in effect, you can run ``docker logs bootstrap`` and look for the new value in the output:
+
+``Waiting for http://dataverse:8080 to become ready in max 10m.``
 
 Wrapping Up
 -----------

--- a/docker/compose/demo/compose.yml
+++ b/docker/compose/demo/compose.yml
@@ -49,6 +49,8 @@ services:
     container_name: "bootstrap"
     image: gdcc/configbaker:alpha
     restart: "no"
+    environment:
+      - TIMEOUT=3m
     command:
       - bootstrap.sh
       - dev


### PR DESCRIPTION
**What this PR does / why we need it**:

Sometimes `docker compose up` fails and it's unclear how to increase the timeout

**Which issue(s) this PR closes**:

- Closes #10409

**Special notes for your reviewer**:

None.

**Suggestions on how to test this**:

See the doc change and try it.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No.

**Is there a release notes update needed for this change?**:

No. This is a minor tweak.

**Additional documentation**:

Preview at https://dataverse-guide--10410.org.readthedocs.build/en/10410/container/running/demo.html