### PR TITLE
Downgrade configbaker to Alpine 3.18

### DIFF
--- a/modules/container-configbaker/Dockerfile
+++ b/modules/container-configbaker/Dockerfile
@@ -10,7 +10,10 @@ ARG SOLR_VERSION
 FROM solr:${SOLR_VERSION} AS solr
 
 # Let's build us a baker
-FROM alpine:3
+# WARNING:
+# Do not upgrade the tag to :3 or :3.19 until https://pkgs.alpinelinux.org/package/v3.19/main/x86_64/c-ares is at v1.26.0+!
+# See https://github.com/IQSS/dataverse/issues/10413 for more information.
+FROM alpine:3.18
 
 ENV SCRIPT_DIR="/scripts" \
     SECRETS_DIR="/secrets" \


### PR DESCRIPTION
**What this PR does / why we need it**:
Must downgrade to Alpine 3.18 to fix curl DNS issues.

**Which issue(s) this PR closes**:

- Closes #10413 

**Special notes for your reviewer**:
Hold the review until we had an affected user test it.

**Suggestions on how to test this**:
Use the GHCR image of configbaker.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
No

**Is there a release notes update needed for this change?**:
No

**Additional documentation**:
None.