### PR TITLE
fixing bug with tabs in log line for MDC

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/makedatacount/MakeDataCountLoggingServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/makedatacount/MakeDataCountLoggingServiceBean.java
@@ -46,6 +46,12 @@ public class MakeDataCountLoggingServiceBean {
     public String getLogFileName() {
         return "counter_"+new SimpleDateFormat("yyyy-MM-dd").format(new Timestamp(new Date().getTime()))+".log";
     }
+
+    // Sanitize the values to a safe string for the log file
+    static String sanitize(String in) {
+        // Log lines are tab delimited so tabs must be replaced. Replacing escape sequences with a space.
+        return in != null ? in.replaceAll("\\s+", " ") : null;
+    }
     
     public static class MakeDataCountEntry {
     
@@ -367,7 +373,7 @@ public class MakeDataCountLoggingServiceBean {
          * @param title the title to set
          */
         public final void setTitle(String title) {
-            this.title = title;
+            this.title = sanitize(title);
         }
 
         /**
@@ -384,7 +390,7 @@ public class MakeDataCountLoggingServiceBean {
          * @param publisher the publisher to set
          */
         public final void setPublisher(String publisher) {
-            this.publisher = publisher;
+            this.publisher = sanitize(publisher);
         }
 
         /**
@@ -401,7 +407,7 @@ public class MakeDataCountLoggingServiceBean {
          * @param publisherId the publisherId to set
          */
         public final void setPublisherId(String publisherId) {
-            this.publisherId = publisherId;
+            this.publisherId = sanitize(publisherId);
         }
 
         /**
@@ -418,7 +424,7 @@ public class MakeDataCountLoggingServiceBean {
          * @param authors the authors to set
          */
         public final void setAuthors(String authors) {
-            this.authors = authors;
+            this.authors = sanitize(authors);
         }
 
         /**
@@ -452,7 +458,7 @@ public class MakeDataCountLoggingServiceBean {
          * @param version the version to set
          */
         public final void setVersion(String version) {
-            this.version = version;
+            this.version = sanitize(version);
         }
 
         /**
@@ -469,7 +475,7 @@ public class MakeDataCountLoggingServiceBean {
          * @param otherId the otherId to set
          */
         public void setOtherId(String otherId) {
-            this.otherId = otherId;
+            this.otherId = sanitize(otherId);
         }
 
         /**

--- a/src/test/java/edu/harvard/iq/dataverse/makedatacount/MakeDataCountLoggingServiceBeanTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/makedatacount/MakeDataCountLoggingServiceBeanTest.java
@@ -21,7 +21,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -45,8 +44,8 @@ public class MakeDataCountLoggingServiceBeanTest {
         GlobalId id = dataset.getGlobalId();
         dataset.setGlobalId(id);
         dvVersion.setDataset(dataset);
-        dvVersion.setAuthorsStr("OneAuthor;TwoAuthor");
-        dvVersion.setTitle("Title");
+        dvVersion.setAuthorsStr("OneAuthor;\tTwoAuthor");
+        dvVersion.setTitle("Title\tWith Tab");
         dvVersion.setVersionNumber(1L);
         dvVersion.setReleaseTime(new Date());
         
@@ -64,7 +63,13 @@ public class MakeDataCountLoggingServiceBeanTest {
         
         //lastly setting attributes we don't actually use currently in our logging/constructors, just in case
         entry.setUserCookieId("UserCookId");
-        entry.setOtherId("OtherId");
+        entry.setOtherId(null); // null pointer check for sanitize method
+        assertThat(entry.getOtherId(), is("-"));
+        entry.setOtherId("OtherId\t\r\nX");
+        // escape sequences get replaced with a space in sanitize method
+        assertThat(entry.getOtherId(), is("OtherId X"));
+        // check other replacements for author list ";" becomes "|"
+        assertThat(entry.getAuthors(), is("OneAuthor| TwoAuthor"));
         
         //And test. "-" is the default
         assertThat(entry.getEventTime(), is(not("-")));


### PR DESCRIPTION
Log lines for MDC must be tab delimited but in some cases the data in the lines contain tabs which throws off the columns.
Replace the tabs with spaces in MakeDataCountLoggingServiceBean.

In this example the authors column(14) contains 2 tabs adding 2 additional columns causing an error in counter_processor
ex:
2024-03-21 15:17:49 importing log/counter_2024-02-01.log
line is wrong: 2024-02-01T00:13:30-0500 98.121.236.139 - - :guest https://dataverse.harvard.edu/api/v1/datasets/export?exporter=schema.org&persistentId=doi%3A10.7910%2FDVN%2FJ1UD6S doi:10.7910/DVN/J1UD6S - - python-requests/2.28.2 Main Cities grid tbd 00_metadata 00_metadata 100% 10 Digital Map Database of China 已启用屏幕阅读器支持。 Digital Map Database of China 2020-02-15T21:35:14Z 1 - https://dataverse.harvard.edu/api/v1/datasets/export?exporter=schema.org&persistentId=doi%3A10.7910%2FDVN%2FJ1UD6S 2020


Which issue(s) this PR closes:

Needed for https://github.com/IQSS/dataverse.harvard.edu/issues/3

Special notes for your reviewer:

Suggestions on how to test this:
Make sure the log file has no extra tabs

Does this PR introduce a user interface change? If mockups are available, please link/include them here: No

Is there a release notes update needed for this change?: No

Additional documentation: None
