### PR TITLE
#10442 fix null from template

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/search/IndexServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/search/IndexServiceBean.java
@@ -1016,7 +1016,7 @@ public class IndexServiceBean {
                              */
                             if (dsf.getControlledVocabularyValues().isEmpty()) {
                                 for (DatasetFieldValue dfv : dsf.getDatasetFieldValues()) {
-                                    if (dfv.getValue().equals(DatasetField.NA_VALUE)) {
+                                    if (dfv.getValue() == null || dfv.getValue().equals(DatasetField.NA_VALUE)) {
                                         continue;
                                     }
                                     solrInputDocument.addField(solrFieldSearchable, dfv.getValue());


### PR DESCRIPTION
**What this PR does / why we need it**: Fixes an issue where new datasets created in UI with template are failing to index

**Which issue(s) this PR closes**:

Closes #10442 Datasets created via template are not indexed

**Special notes for your reviewer**: This is a BandAid(tm) fix. Needed for 6.2. Should probably revisit templates to see why there are nulls getting into the controlled vocab values.

**Suggestions on how to test this**: This only seems to effect templates that were created prior to the current release/dev environment, so to test you need to go to Dataverse-internal and create a dataset using the template named  "check23".  A dataset created from this template will not be indexed if you are in the current dev branch, but it will be indexed in this PR branch. Create a dataset with that template. It should be indexed properly.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
