### PR TITLE
add jQuery to get search working in guides

### DIFF
--- a/doc/sphinx-guides/requirements.txt
+++ b/doc/sphinx-guides/requirements.txt
@@ -8,3 +8,6 @@ myst-parser==2.0.0
 
 # tabs
 sphinx-tabs==3.4.5
+
+# jQuery
+sphinxcontrib-jquery

--- a/doc/sphinx-guides/source/conf.py
+++ b/doc/sphinx-guides/source/conf.py
@@ -42,6 +42,7 @@ extensions = [
     'sphinx.ext.viewcode',
     'sphinx.ext.graphviz',
     'sphinxcontrib.icon',
+    'sphinxcontrib.jquery',
     'myst_parser',
     'sphinx_tabs.tabs',
 ]


### PR DESCRIPTION
**What this PR does / why we need it**:

Sometime after 6.1, search stopped working in the guides.

**Which issue(s) this PR closes**:

- Closes #10455

**Special notes for your reviewer**:

I'm not sure why jQuery can't be found anymore. I found this solution here:

- https://github.com/readthedocs/sphinx_rtd_theme/issues/1452

**Suggestions on how to test this**:

Test the doc preview generated by this pull request. For example, here's a search for "data": https://dataverse-guide--10456.org.readthedocs.build/en/10456/search.html?q=data&check_keywords=yes&area=default

Here is a tarball from `build html`, built from this branch: [build.tar.gz](https://github.com/IQSS/dataverse/files/14837190/build.tar.gz)

And here is an epub, also build from this branch: [Dataverse.epub.tar.gz](https://github.com/IQSS/dataverse/files/14837219/Dataverse.epub.tar.gz)

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No.

**Is there a release notes update needed for this change?**:

No.

**Additional documentation**:

No.