### PR TITLE
10242 set featured dv via api

### DIFF
--- a/doc/release-notes/10242-add-feature-dv-api
+++ b/doc/release-notes/10242-add-feature-dv-api
@@ -1,0 +1,1 @@
+New api endpoints have been added to allow you to add or remove featured collections from a dataverse collection.

--- a/doc/sphinx-guides/source/api/native-api.rst
+++ b/doc/sphinx-guides/source/api/native-api.rst
@@ -564,6 +564,50 @@ The fully expanded example above (without environment variables) looks like this
 
 Note: you must have "Add Dataset" permission in the given collection to invoke this endpoint.
 
+
+
+Set Featured Collections for a Dataverse Collection
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Assign featured collections for a given Dataverse collection identified by ``id``:
+
+.. code-block:: bash
+
+  export API_TOKEN=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+  export SERVER_URL=https://demo.dataverse.org
+  export ID=root
+
+  curl -H "X-Dataverse-key:$API_TOKEN" -X POST "$SERVER_URL/api/dataverses/$ID/featured" --upload-file collection-alias.json
+
+The fully expanded example above (without environment variables) looks like this:
+
+.. code-block:: bash
+
+  curl -H "X-Dataverse-key:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" -X POST "https://demo.dataverse.org/api/dataverses/root/featured" --upload-file collection-alias.json
+
+Where collection-alias.json contains a JSON encoded list of collections aliases to be featured (e.g. ``["collection1-alias","collection2-alias"]``).
+
+Note: You may only feature collections that are published and owned by or linked to the featuring collection.
+
+Remove Featured Collections from a Dataverse Collection
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Remove featured collections from a given Dataverse collection identified by ``id``:
+
+.. code-block:: bash
+
+  export API_TOKEN=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+  export SERVER_URL=https://demo.dataverse.org
+  export ID=root
+
+  curl -H "X-Dataverse-key:$API_TOKEN" -X DELETE "$SERVER_URL/api/dataverses/$ID/featured" 
+
+The fully expanded example above (without environment variables) looks like this:
+
+.. code-block:: bash
+
+  curl -H "X-Dataverse-key:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" -X DELETE "https://demo.dataverse.org/api/dataverses/root/featured" 
+
 .. _create-dataset-command: 
 
 Create a Dataset in a Dataverse Collection

--- a/doc/sphinx-guides/source/api/native-api.rst
+++ b/doc/sphinx-guides/source/api/native-api.rst
@@ -569,7 +569,7 @@ Note: you must have "Add Dataset" permission in the given collection to invoke t
 Set Featured Collections for a Dataverse Collection
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Assign featured collections for a given Dataverse collection identified by ``id``:
+Add featured collections to a given Dataverse collection identified by ``id``:
 
 .. code-block:: bash
 
@@ -587,7 +587,7 @@ The fully expanded example above (without environment variables) looks like this
 
 Where collection-alias.json contains a JSON encoded list of collections aliases to be featured (e.g. ``["collection1-alias","collection2-alias"]``).
 
-Note: You may only feature collections that are published and owned by or linked to the featuring collection.
+Note: You may only feature collections that are published and owned by or linked to the featuring collection. Also, using this endpoint will only add new featured collections it will not remove collections that have already been featured.
 
 Remove Featured Collections from a Dataverse Collection
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/main/java/edu/harvard/iq/dataverse/api/Dataverses.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Dataverses.java
@@ -840,6 +840,7 @@ public class Dataverses extends AbstractApiBean {
      */
     public Response setFeaturedDataverses(@Context ContainerRequestContext crc, @PathParam("identifier") String dvIdtf,  String dvAliases) {
         List<Dataverse> dvsFromInput = new LinkedList<>();
+
         for (JsonString dvAlias : Util.asJsonArray(dvAliases).getValuesAs(JsonString.class)) {
             
             Dataverse dvToBeFeatured = dataverseService.findByAlias(dvAlias.getString());

--- a/src/main/java/propertyFiles/Bundle.properties
+++ b/src/main/java/propertyFiles/Bundle.properties
@@ -2698,6 +2698,7 @@ dataverses.api.move.dataverse.failure.not.published=Published dataverse may not 
 dataverses.api.move.dataverse.error.guestbook=Dataset guestbook is not in target dataverse. 
 dataverses.api.move.dataverse.error.template=Dataverse template is not in target dataverse.
 dataverses.api.move.dataverse.error.featured=Dataverse is featured in current dataverse.
+dataverses.api.delete.featured.collections.successful=Featured dataverses have been removed
 dataverses.api.move.dataverse.error.metadataBlock=Dataverse metadata block is not in target dataverse. 
 dataverses.api.move.dataverse.error.dataverseLink=Dataverse is linked to target dataverse or one of its parents. 
 dataverses.api.move.dataverse.error.datasetLink=Dataset is linked to target dataverse or one of its parents.   

--- a/src/test/java/edu/harvard/iq/dataverse/api/DataversesIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/DataversesIT.java
@@ -692,4 +692,29 @@ public class DataversesIT {
         assertEquals(OK.getStatusCode(), deleteCollectionResponse.getStatusCode());
     }
     
+    @Test
+    public void testLinkDataverse() throws Exception {
+
+        Response createUser = UtilIT.createRandomUser();
+        String apiToken = UtilIT.getApiTokenFromResponse(createUser);
+
+        Response createDataverseResponse = UtilIT.createRandomDataverse(apiToken);
+        String dataverseAlias = UtilIT.getAliasFromResponse(createDataverseResponse);
+        
+        Response createSubDVToBeFeatured = UtilIT.createSubDataverse(UtilIT.getRandomDvAlias() + "-feature", null, apiToken, dataverseAlias);    
+        String subDataverseAlias = UtilIT.getAliasFromResponse(createSubDVToBeFeatured);
+        
+        Response featureSubDVResponse = UtilIT.addFeaturedDataverse(dataverseAlias, subDataverseAlias, apiToken);
+        
+        assertEquals(OK.getStatusCode(), featureSubDVResponse.getStatusCode());
+        
+        Response deleteSubCollectionResponse = UtilIT.deleteDataverse(subDataverseAlias, apiToken);
+        deleteSubCollectionResponse.prettyPrint();
+        assertEquals(OK.getStatusCode(), deleteSubCollectionResponse.getStatusCode());
+        
+        Response deleteCollectionResponse = UtilIT.deleteDataverse(dataverseAlias, apiToken);
+        deleteCollectionResponse.prettyPrint();
+        assertEquals(OK.getStatusCode(), deleteCollectionResponse.getStatusCode());
+    }
+    
 }

--- a/src/test/java/edu/harvard/iq/dataverse/api/DataversesIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/DataversesIT.java
@@ -35,7 +35,9 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.nio.file.Files;
 import io.restassured.path.json.JsonPath;
+import static jakarta.ws.rs.core.Response.Status.OK;
 import org.hamcrest.CoreMatchers;
+import static org.hamcrest.CoreMatchers.containsString;
 import org.hamcrest.Matchers;
 
 public class DataversesIT {
@@ -719,16 +721,27 @@ public class DataversesIT {
         Response featureSubDVResponseUnpublished = UtilIT.addFeaturedDataverse(dataverseAlias, subDataverseAlias, apiToken);
         featureSubDVResponseUnpublished.prettyPrint();
         assertEquals(400, featureSubDVResponseUnpublished.getStatusCode());
+        featureSubDVResponseUnpublished.then().assertThat()
+                .body(containsString("may not be featured"));
         
         //can't feature a dataverse you don't own
         Response featureSubDVResponseNotOwned = UtilIT.addFeaturedDataverse(dataverseAlias, "root", apiToken);
         featureSubDVResponseNotOwned.prettyPrint();
         assertEquals(400, featureSubDVResponseNotOwned.getStatusCode());
+        featureSubDVResponseNotOwned.then().assertThat()
+                .body(containsString("may not be featured"));
+        
+        //can't feature a dataverse that doesn't exist
+        Response featureSubDVResponseNotExist = UtilIT.addFeaturedDataverse(dataverseAlias, "dummy-alias-sek-foobar-333", apiToken);
+        featureSubDVResponseNotExist.prettyPrint();
+        assertEquals(400, featureSubDVResponseNotExist.getStatusCode());
+        featureSubDVResponseNotExist.then().assertThat()
+                .body(containsString("Can't find dataverse collection"));
         
         publishDataverse = UtilIT.publishDataverseViaNativeApi(subDataverseAlias, apiToken);
         assertEquals(200, publishDataverse.getStatusCode());
 
-        
+        //once published it should work
         Response featureSubDVResponse = UtilIT.addFeaturedDataverse(dataverseAlias, subDataverseAlias, apiToken);
         featureSubDVResponse.prettyPrint();
         assertEquals(OK.getStatusCode(), featureSubDVResponse.getStatusCode());

--- a/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
@@ -3265,10 +3265,13 @@ public class UtilIT {
     }
     
     static Response addFeaturedDataverse (String dvAlias, String featuredDvAlias, String apiToken) {
+        
+        String jsonString = "[\"" + featuredDvAlias + "\"]";
 
         Response addBannerMessageResponse = given()
                 .header(API_TOKEN_HTTP_HEADER, apiToken)
-                .post("/api/dataverses/"+dvAlias+"/featured/"+featuredDvAlias);
+                .body(jsonString)
+                .post("/api/dataverses/"+dvAlias+"/featured/");
         return addBannerMessageResponse;
     }
 

--- a/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
@@ -3263,6 +3263,14 @@ public class UtilIT {
                 .post("/api/roles?dvo="+dvAlias);
         return addBannerMessageResponse;
     }
+    
+    static Response addFeaturedDataverse (String dvAlias, String featuredDvAlias, String apiToken) {
+
+        Response addBannerMessageResponse = given()
+                .header(API_TOKEN_HTTP_HEADER, apiToken)
+                .post("/api/dataverses/"+dvAlias+"/featured/"+featuredDvAlias);
+        return addBannerMessageResponse;
+    }
 
     static Response deleteDataverseRole( String roleAlias, String apiToken) {
 


### PR DESCRIPTION
**What this PR does / why we need it**: Allows user to add featured collections to a given collection via the api. an additional endpoint was added to allow the user to remove featured collections from a given collection.

**Which issue(s) this PR closes**:

Closes #10242 Set featured collections through native api

**Special notes for your reviewer**:

**Suggestions on how to test this**: Note that if there are multiple aliases provided in the json file, all collections must be "featurable" for the call to work. If there are errors, only the first error will be included in response

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: none

**Is there a release notes update needed for this change?**: included in PR.

**Additional documentation**:
