### PR TITLE
IQSS/10462 - Fix when MDC is displayed

### DIFF
--- a/src/main/webapp/dataset.xhtml
+++ b/src/main/webapp/dataset.xhtml
@@ -592,7 +592,7 @@
                                                         </span>
                                                 </div>
                                                 <!-- Make Data Count citations (DOIs only, not Handles) -->
-                                                <div class="metrics-count-block" jsf:rendered="#{settingsWrapper.makeDataCountDisplayEnabled and DatasetPage.doi}">
+                                                <div class="metrics-count-block" jsf:rendered="#{settingsWrapper.makeDataCountDisplayEnabled and DatasetPage.DOI}">
                                                     <p:commandLink oncomplete="PF('citationsDialog').show();">
                                                         <h:outputFormat value="{0} #{bundle['metrics.citations']}">
                                                             <f:param value="#{fn:length(datasetExternalCitationsServiceBean.getDatasetExternalCitationsByDataset(DatasetPage.dataset))}"/>


### PR DESCRIPTION
**What this PR does / why we need it**:
This fixes the dataset page when MDC display is enabled.
**Which issue(s) this PR closes**:

Closes #10462

**Special notes for your reviewer**: A trivial fix - DatasetPage has an isDOI() method and the xhtml checked for DatasetPage.doi (lower case).

**Suggestions on how to test this**:  Set [:MDCLogPath](https://guides.dataverse.org/en/latest/installation/config.html#mdclogpath)
and/or
[:DisplayMDCMetrics](https://guides.dataverse.org/en/latest/installation/config.html#displaymdcmetrics) to true and go to a dataset page. (With logging on, the default is for display to be true so setting either MDC related setting results in the bug being visible. See @stevenwinship who say it on his test box.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**: Probably needs to be made available ASAP for MDC sites, perhaps as a GDCC bug patch version. (FWIW: There are some Globus download fixes ready for review as well that should get out for those wanting to try Globus).

**Additional documentation**:
