### PR TITLE
Add Harvesting Client name to the Metadata Source facet

### DIFF
--- a/doc/release-notes/10464-add-name-harvesting-client-facet.md
+++ b/doc/release-notes/10464-add-name-harvesting-client-facet.md
@@ -1,3 +1,3 @@
-The Metadata Source facet has been updated to show the name of the import client rather than grouping all under 'harvested'
+The Metadata Source facet has been updated to show the name of the harvesting client rather than grouping all such datasets under 'harvested'
 
-TODO: Please add notes to re-index http://localhost:8080/api/admin/index guides at: https://guides.dataverse.org/en/latest/admin/solr-search-index.html
+TODO: for the v6.13 release note: Please add a full re-index using http://localhost:8080/api/admin/index to the upgrade instructions. 

--- a/doc/release-notes/10464-add-name-harvesting-client-facet.md
+++ b/doc/release-notes/10464-add-name-harvesting-client-facet.md
@@ -1,0 +1,3 @@
+The Metadata Source facet has been updated to show the name of the import client rather than grouping all under 'harvested'
+
+TODO: Please add notes to re-index http://localhost:8080/api/admin/index guides at: https://guides.dataverse.org/en/latest/admin/solr-search-index.html

--- a/src/main/java/edu/harvard/iq/dataverse/search/IndexServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/search/IndexServiceBean.java
@@ -897,7 +897,8 @@ public class IndexServiceBean {
 
         if (dataset.isHarvested()) {
             solrInputDocument.addField(SearchFields.IS_HARVESTED, true);
-            solrInputDocument.addField(SearchFields.METADATA_SOURCE, HARVESTED);
+            solrInputDocument.addField(SearchFields.METADATA_SOURCE,
+                                        dataset.getHarvestedFrom() != null ? dataset.getHarvestedFrom().getName() : HARVESTED);
         } else {
             solrInputDocument.addField(SearchFields.IS_HARVESTED, false);
             solrInputDocument.addField(SearchFields.METADATA_SOURCE, rdvName); //rootDataverseName);

--- a/src/test/java/edu/harvard/iq/dataverse/api/HarvestingClientsIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/HarvestingClientsIT.java
@@ -15,9 +15,7 @@ import static jakarta.ws.rs.core.Response.Status.UNAUTHORIZED;
 import static jakarta.ws.rs.core.Response.Status.ACCEPTED;
 import static jakarta.ws.rs.core.Response.Status.OK;
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * This class tests Harvesting Client functionality. 
@@ -272,6 +270,12 @@ public class HarvestingClientsIT {
         } while (i<maxWait); 
         
         System.out.println("Waited " + i + " seconds for the harvest to complete.");
+
+        Response searchHarvestedDatasets = UtilIT.search("metadataSource:" + nickName, normalUserAPIKey);
+        searchHarvestedDatasets.prettyPrint();
+        searchHarvestedDatasets.then().assertThat()
+                                .statusCode(OK.getStatusCode())
+                                .body("data.total_count", equalTo(expectedNumberOfSetsHarvested));
         
         // Fail if it hasn't completed in maxWait seconds
         assertTrue(i < maxWait);


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR will change the "Metadata Source" facet. It will stop showing all the Harvested datasets inside the same category and group them by the nickname of the client. ›

**Which issue(s) this PR closes**: 10298

Closes #10298

**Special notes for your reviewer**: 

We may need to update this when #10217 gets done with that value. 

**Suggestions on how to test this**:

Create multiple harvesting clients and you should be able to test the change on the facet.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

***
**Before**: 

![image](https://github.com/IQSS/dataverse/assets/142103991/4945e470-387b-463f-aa84-9fdbbcec123c)

***
**After**: 
![image](https://github.com/IQSS/dataverse/assets/142103991/48314656-ac14-4a8f-92d5-e8d41488917f)

