### PR TITLE
Adds DataLad to the list of integrations in the dataverse admin guide…

### DIFF
--- a/doc/release-notes/10468-doc-datalad-integration.md
+++ b/doc/release-notes/10468-doc-datalad-integration.md
@@ -1,0 +1,1 @@
+DataLad has been integrated with Dataverse. For more information, see https://dataverse-guide--10470.org.readthedocs.build/en/10470/admin/integrations.html#datalad

--- a/doc/sphinx-guides/source/admin/integrations.rst
+++ b/doc/sphinx-guides/source/admin/integrations.rst
@@ -132,6 +132,32 @@ Globus transfer uses an efficient transfer mechanism and has additional features
 Users can transfer files via `Globus <https://www.globus.org>`_ into and out of datasets, or reference files on a remote Globus endpoint, when their Dataverse installation is configured to use a Globus accessible store(s) 
 and a community-developed `dataverse-globus <https://github.com/scholarsportal/dataverse-globus>`_ app has been properly installed and configured.
 
+DataLad
++++++++
+
+`DataLad`_ is a free and open source decentralized data management system that is built on `git`_
+and `git-annex`_ and provides a unified interface for version control, deposition, content retrieval,
+provenance tracking, reproducible execution, and further collaborative management of distributed and
+arbitrarily large datasets.
+
+If your dataset is structured as a `DataLad dataset`_ and you have a local DataLad installation,
+the `datalad-dataverse`_ extension package provides interoperability with Dataverse for the purpose
+of depositing DataLad datasets to and retrieving DataLad datasets from Dataverse instances, together
+with full version history.
+
+For further information, visit the ``datalad-dataverse`` extension's `documentation page`_, see the
+`quickstart`_ for installation details, or follow the step-by-step `tutorial`_ to get hands-on
+experience.
+
+.. _DataLad: https://www.datalad.org
+.. _git: https://git-scm.com
+.. _git-annex: https://git-annex.branchable.com
+.. _DataLad dataset: https://handbook.datalad.org/en/latest/basics/basics-datasets.html
+.. _datalad-dataverse: https://github.com/datalad/datalad-dataverse
+.. _documentation page: https://docs.datalad.org/projects/dataverse/en/latest/index.html
+.. _quickstart: https://docs.datalad.org/projects/dataverse/en/latest/settingup.html
+.. _tutorial: https://docs.datalad.org/projects/dataverse/en/latest/tutorial.html
+
 
 Embedding Data on Websites
 --------------------------


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds DataLad to the list of dataverse integrations, because of the functionality provided by the [datalad-dataverse](https://github.com/datalad/datalad-dataverse) extension

**Which issue(s) this PR closes**:

Closes #10468

**Special notes for your reviewer**:

This is just a documentation update

**Suggestions on how to test this**:

- Install sphinx and the relevant sphinx extensions for dataverse docs locally
- Run `make html` from `doc/sphinx-guides`

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

N/A

**Is there a release notes update needed for this change?**:

Not that I am aware of

**Additional documentation**:

N/A