### PR TITLE
10441 - missed release note addition

### DIFF
--- a/doc/release-notes/10339-workflow.md
+++ b/doc/release-notes/10339-workflow.md
@@ -1,1 +1,3 @@
 The computational workflow metadata block has been updated to present a clickable link for the External Code Repository URL field.
+
+Release notes should include the usual instructions, for those who have installed this optional block, to update the computational_workflow block. (PR#10441)


### PR DESCRIPTION
**What this PR does / why we need it**: PR #10441 changed the computational_workflow metadatablock, so we'll need the usual instructions for updating it (for those who've installed it). This PR just adds this note to the existing release note in that PR so we don't forget.
