### PR TITLE
added isReleased to GET Dataverse reponse

### DIFF
--- a/doc/release-notes/10491-add-isreleased-to-get-dataverse-response.md
+++ b/doc/release-notes/10491-add-isreleased-to-get-dataverse-response.md
@@ -1,0 +1,22 @@
+The Dataverse object returned by /api/dataverses has been extended to include "isReleased": {boolean}.
+```javascript
+{
+    "status": "OK",
+        "data": {
+        "id": 32,
+            "alias": "dv6f645bb5",
+            "name": "dv6f645bb5",
+            "dataverseContacts": [
+            {
+                "displayOrder": 0,
+                "contactEmail": "54180268@mailinator.com"
+            }
+        ],
+            "permissionRoot": true,
+            "dataverseType": "UNCATEGORIZED",
+            "ownerId": 1,
+            "creationDate": "2024-04-12T18:05:59Z",
+            "isReleased": true
+    }
+}
+```

--- a/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
@@ -292,6 +292,7 @@ public class JsonPrinter {
         if (dv.getFilePIDsEnabled() != null) {
             bld.add("filePIDsEnabled", dv.getFilePIDsEnabled());
         }
+        bld.add("isReleased", dv.isReleased());
 
         return bld;
     }

--- a/src/test/java/edu/harvard/iq/dataverse/api/DataversesIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/DataversesIT.java
@@ -413,12 +413,13 @@ public class DataversesIT {
         Response superuserResponse = UtilIT.makeSuperUser(username);
         
         Response createDataverseResponse = UtilIT.createRandomDataverse(apiToken);
-        createDataverseResponse.prettyPrint();
+        assertTrue(createDataverseResponse.prettyPrint().contains("isReleased\": false"));
         String dataverseAlias = UtilIT.getAliasFromResponse(createDataverseResponse);
         Integer dataverseId = UtilIT.getDataverseIdFromResponse(createDataverseResponse);
         
         Response publishDataverse = UtilIT.publishDataverseViaNativeApi(dataverseAlias, apiToken);//.publishDataverseViaSword(dataverseAlias, apiToken);
         assertEquals(200, publishDataverse.getStatusCode());
+        assertTrue(publishDataverse.prettyPrint().contains("isReleased\": true"));
         
         Response createDataverseResponse2 = UtilIT.createRandomDataverse(apiToken);
         createDataverseResponse2.prettyPrint();


### PR DESCRIPTION
**What this PR does / why we need it**: For the SPA, needed to display the Unpublished label on the collections page if the Dataverse Collection hasn't been released.

**Which issue(s) this PR closes**: Add isReleased field to GET dataverse API response #10448

Closes #10448

**Special notes for your reviewer**:

**Suggestions on how to test this**:

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
