### PR TITLE
Extended Dataverse metadatablocks API to retrieve metadata fields configured as required in the General Information pag page

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/Dataverse.java
+++ b/src/main/java/edu/harvard/iq/dataverse/Dataverse.java
@@ -411,6 +411,14 @@ public class Dataverse extends DvObjectContainer {
         return dataverseFieldTypeInputLevels;
     }
 
+    public boolean isDatasetFieldTypeRequiredAsInputLevel(Long datasetFieldTypeId) {
+        for(DataverseFieldTypeInputLevel dataverseFieldTypeInputLevel : dataverseFieldTypeInputLevels) {
+            if (dataverseFieldTypeInputLevel.getDatasetFieldType().getId().equals(datasetFieldTypeId)) {
+                return true;
+            }
+        }
+        return false;
+    }
 
     public Template getDefaultTemplate() {
         return defaultTemplate;

--- a/src/main/java/edu/harvard/iq/dataverse/MetadataBlockServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/MetadataBlockServiceBean.java
@@ -58,10 +58,18 @@ public class MetadataBlockServiceBean {
 
         if (ownerDataverse != null) {
             Root<Dataverse> dataverseRoot = criteriaQuery.from(Dataverse.class);
+            Join<Dataverse, DataverseFieldTypeInputLevel> datasetFieldTypeInputLevelJoin = dataverseRoot.join("dataverseFieldTypeInputLevels", JoinType.LEFT);
+
+            Predicate requiredPredicate = criteriaBuilder.and(
+                    datasetFieldTypeInputLevelJoin.get("datasetFieldType").in(metadataBlockRoot.get("datasetFieldTypes")),
+                    criteriaBuilder.isTrue(datasetFieldTypeInputLevelJoin.get("required")));
+
+            Predicate unionPredicate = criteriaBuilder.or(displayOnCreatePredicate, requiredPredicate);
+
             criteriaQuery.where(criteriaBuilder.and(
                     criteriaBuilder.equal(dataverseRoot.get("id"), ownerDataverse.getId()),
                     metadataBlockRoot.in(dataverseRoot.get("metadataBlocks")),
-                    displayOnCreatePredicate
+                    unionPredicate
             ));
         } else {
             criteriaQuery.where(displayOnCreatePredicate);

--- a/src/main/java/edu/harvard/iq/dataverse/api/Dataverses.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Dataverses.java
@@ -715,14 +715,15 @@ public class Dataverses extends AbstractApiBean {
                                        @QueryParam("onlyDisplayedOnCreate") boolean onlyDisplayedOnCreate,
                                        @QueryParam("returnDatasetFieldTypes") boolean returnDatasetFieldTypes) {
         try {
+            Dataverse dataverse = findDataverseOrDie(dvIdtf);
             final List<MetadataBlock> metadataBlocks = execCommand(
                     new ListMetadataBlocksCommand(
                             createDataverseRequest(getRequestUser(crc)),
-                            findDataverseOrDie(dvIdtf),
+                            dataverse,
                             onlyDisplayedOnCreate
                     )
             );
-            return ok(json(metadataBlocks, returnDatasetFieldTypes, onlyDisplayedOnCreate));
+            return ok(json(metadataBlocks, returnDatasetFieldTypes, onlyDisplayedOnCreate, dataverse));
         } catch (WrappedResponse we) {
             return we.getResponse();
         }


### PR DESCRIPTION
…fields displayed on create in a dataverse

**What this PR does / why we need it**:

**Which issue(s) this PR closes**:

Closes #

**Special notes for your reviewer**:

**Suggestions on how to test this**:

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
