### PR TITLE
CVOC : Adding hidden metadata fields (Ontoportal integration)

### DIFF
--- a/doc/release-notes/10503-cvoc-hidden-html-fields.md
+++ b/doc/release-notes/10503-cvoc-hidden-html-fields.md
@@ -4,5 +4,8 @@
 
 #### Hidden HTML Fields
 
-To enlarge javascript possibilities of [:CVocConf](https://guides.dataverse.org/en/6.3/installation/config.html#cvocconf) configured service, the child fields of the configured field had been added to the dataset metadata view.
-Those values are hidden and can be found with the html attribute `data-cvoc-metadata-name`. (#10503)
+External Controlled Vocabulary scripts, configured via [:CVocConf](https://guides.dataverse.org/en/6.3/installation/config.html#cvocconf), can now access the values of managed fields as well as the term-uri-field for use in constructing the metadata view for a dataset.
+
+Those values are hidden and can be found with the html attribute `data-cvoc-metadata-name`.
+
+For more information, see [#10503](https://github.com/IQSS/dataverse/pull/10503).

--- a/doc/release-notes/10503-cvoc-hidden-html-fields.md
+++ b/doc/release-notes/10503-cvoc-hidden-html-fields.md
@@ -1,0 +1,8 @@
+## Release Highlights
+
+### Updates on Support for External Vocabulary Services
+
+#### Hidden HTML Fields
+
+To enlarge javascript possibilities of [:CVocConf](https://guides.dataverse.org/en/6.3/installation/config.html#cvocconf) configured service, the child fields of the configured field had been added to the dataset metadata view.
+Those values are hidden and can be found with the html attribute `data-cvoc-metadata-name`. (#10503)

--- a/src/main/webapp/metadataFragment.xhtml
+++ b/src/main/webapp/metadataFragment.xhtml
@@ -159,6 +159,17 @@
                                                                       <f:passThroughAttribute name="data-cvoc-protocol" value="#{cvocConf.get(dsf.datasetFieldType.id).getString('protocol','')}" />
                                                                       <f:passThroughAttribute name="data-cvoc-managedfields" value="#{cvocConf.get(dsf.datasetFieldType.id).get('managedfields').toString()}" />
                                                         </h:outputText>
+                                                        <!-- Cvoc for others fields -->
+                                                        <h:outputText value="#{cvPart.key.value}"
+                                                                      escape="#{cvPart.key.datasetFieldType.isEscapeOutputText()}"
+                                                                      rendered="#{(cvocOnDsf or cvocOnCvPart) and not (
+                                                                            cvPart.key.datasetFieldType.name.equals(cvocConf.get(cvPart.key.datasetFieldType.id).getString('term-uri-field'))
+                                                                            or cvPart.key.datasetFieldType.name.equals(cvocConf.get(dsf.datasetFieldType.id).getString('term-uri-field')))}"
+                                                                      styleClass="hidden">
+                                                            <f:passThroughAttribute name="hidden" value="hidden" />
+                                                            <f:passThroughAttribute name="data-cvoc-metadata-name"
+                                                                                    value="#{cvPart.key.datasetFieldType.name}" />
+                                                        </h:outputText>
                                                     </ui:repeat>
                                                     <ui:fragment rendered="#{not compoundValuesstatus.last}">
                                                         <br/>

--- a/src/main/webapp/metadataFragment.xhtml
+++ b/src/main/webapp/metadataFragment.xhtml
@@ -89,7 +89,7 @@
                                                     <f:passThroughAttribute name="lang" value="#{DatasetPage.getFieldLanguage(cvocConf.get(dsf.datasetFieldType.id).getString('languages'))}" />
                                                     <f:passThroughAttribute name="data-cvoc-service-url" value="#{cvocConf.get(dsf.datasetFieldType.id).getString('cvoc-url','')}" />
                                                     <f:passThroughAttribute name="data-cvoc-protocol" value="#{cvocConf.get(dsf.datasetFieldType.id).getString('protocol','')}" />
-                                                    <f:passThroughAttribute name="data-cvoc-managedfields" value="#{cvocConf.get(dsf.datasetFieldType.id).get('managedfields').toString()}" />
+                                                    <f:passThroughAttribute name="data-cvoc-managedfields" value="#{cvocConf.get(dsf.datasetFieldType.id).get('managed-fields').toString()}" />
                                                 </h:outputText>
                                                 <h:outputText value="#{dsf.getDisplayValue(mdLangCode)}"
                                                     rendered="#{!dsf.datasetFieldType.allowMultiples and !cvocOnDsf}"
@@ -101,7 +101,7 @@
                                                         <f:passThroughAttribute name="lang" value="#{DatasetPage.getFieldLanguage(cvocConf.get(dsf.datasetFieldType.id).getString('languages'))}" />
                                                         <f:passThroughAttribute name="data-cvoc-service-url" value="#{cvocConf.get(dsf.datasetFieldType.id).getString('cvoc-url','')}" />
                                                         <f:passThroughAttribute name="data-cvoc-protocol" value="#{cvocConf.get(dsf.datasetFieldType.id).getString('protocol','')}" />
-                                                        <f:passThroughAttribute name="data-cvoc-managedfields" value="#{cvocConf.get(dsf.datasetFieldType.id).get('managedfields').toString()}" />
+                                                        <f:passThroughAttribute name="data-cvoc-managedfields" value="#{cvocConf.get(dsf.datasetFieldType.id).get('managed-fields').toString()}" />
                                                     </h:outputText>
                                                 </ui:repeat>
                                                 <ui:repeat value="#{dsf.getValues(mdLangCode)}" var="value" varStatus="loop" rendered="#{dsf.datasetFieldType.allowMultiples and !cvocOnDsf}">
@@ -148,7 +148,7 @@
                                                                       <f:passThroughAttribute name="data-cvoc-service-url" value="#{cvocConf.get(cvPart.key.datasetFieldType.id).getString('cvoc-url','')}" />
                                                                       <f:passThroughAttribute name="data-cvoc-protocol" value="#{cvocConf.get(cvPart.key.datasetFieldType.id).getString('protocol','')}" />
                                                                       <!-- unlikely to be used in this case -->
-                                                                      <f:passThroughAttribute name="data-cvoc-managedfields" value="#{cvocConf.get(cvPart.key.datasetFieldType.id).get('managedfields').toString()}" />
+                                                                      <f:passThroughAttribute name="data-cvoc-managedfields" value="#{cvocConf.get(cvPart.key.datasetFieldType.id).get('managed-fields').toString()}" />
                                                         </h:outputText>
                                                         <!--  Cvoc on parent field -->
                                                         <h:outputText value="#{cvPart.key.value}"
@@ -157,7 +157,7 @@
                                                                       <f:passThroughAttribute name="lang" value="#{DatasetPage.getFieldLanguage(cvocConf.get(dsf.datasetFieldType.id).getString('languages'))}" />
                                                                       <f:passThroughAttribute name="data-cvoc-service-url" value="#{cvocConf.get(dsf.datasetFieldType.id).getString('cvoc-url','')}" />
                                                                       <f:passThroughAttribute name="data-cvoc-protocol" value="#{cvocConf.get(dsf.datasetFieldType.id).getString('protocol','')}" />
-                                                                      <f:passThroughAttribute name="data-cvoc-managedfields" value="#{cvocConf.get(dsf.datasetFieldType.id).get('managedfields').toString()}" />
+                                                                      <f:passThroughAttribute name="data-cvoc-managedfields" value="#{cvocConf.get(dsf.datasetFieldType.id).get('managed-fields').toString()}" />
                                                         </h:outputText>
                                                         <!-- Cvoc for others fields -->
                                                         <h:outputText value="#{cvPart.key.value}"

--- a/src/main/webapp/metadataFragment.xhtml
+++ b/src/main/webapp/metadataFragment.xhtml
@@ -123,7 +123,7 @@
                                                   </div>
                                                 </ui:fragment>
           
-                                                <ui:repeat value="#{dsf.datasetFieldCompoundValues}" var="compoundValue" varStatus="compoundValuesstatus">
+                                                <ui:repeat value="#{dsf.datasetFieldCompoundValues}" var="compoundValue" varStatus="compoundValuesStatus">
                                                     
                                                     <ui:repeat value="#{compoundValue.displayValueMap.entrySet().toArray()}" var="cvPart" varStatus="partStatus">
                                                         <c:set var="cvocOnCvPart" value="#{cvocConf.containsKey(cvPart.key.datasetFieldType.id)}"/>
@@ -149,6 +149,7 @@
                                                                       <f:passThroughAttribute name="data-cvoc-protocol" value="#{cvocConf.get(cvPart.key.datasetFieldType.id).getString('protocol','')}" />
                                                                       <!-- unlikely to be used in this case -->
                                                                       <f:passThroughAttribute name="data-cvoc-managedfields" value="#{cvocConf.get(cvPart.key.datasetFieldType.id).get('managed-fields').toString()}" />
+                                                                      <f:passThroughAttribute name="data-cvoc-index" value="#{compoundValuesStatus.index}" />
                                                         </h:outputText>
                                                         <!--  Cvoc on parent field -->
                                                         <h:outputText value="#{cvPart.key.value}"
@@ -158,6 +159,7 @@
                                                                       <f:passThroughAttribute name="data-cvoc-service-url" value="#{cvocConf.get(dsf.datasetFieldType.id).getString('cvoc-url','')}" />
                                                                       <f:passThroughAttribute name="data-cvoc-protocol" value="#{cvocConf.get(dsf.datasetFieldType.id).getString('protocol','')}" />
                                                                       <f:passThroughAttribute name="data-cvoc-managedfields" value="#{cvocConf.get(dsf.datasetFieldType.id).get('managed-fields').toString()}" />
+                                                                      <f:passThroughAttribute name="data-cvoc-index" value="#{compoundValuesStatus.index}" />
                                                         </h:outputText>
                                                         <!-- Cvoc for others fields -->
                                                         <h:outputText value="#{cvPart.key.value}"
@@ -167,11 +169,11 @@
                                                                             or cvPart.key.datasetFieldType.name.equals(cvocConf.get(dsf.datasetFieldType.id).getString('term-uri-field')))}"
                                                                       styleClass="hidden">
                                                             <f:passThroughAttribute name="hidden" value="hidden" />
-                                                            <f:passThroughAttribute name="data-cvoc-metadata-name"
-                                                                                    value="#{cvPart.key.datasetFieldType.name}" />
+                                                            <f:passThroughAttribute name="data-cvoc-metadata-name" value="#{cvPart.key.datasetFieldType.name}" />
+                                                            <f:passThroughAttribute name="data-cvoc-index" value="#{compoundValuesStatus.index}" />
                                                         </h:outputText>
                                                     </ui:repeat>
-                                                    <ui:fragment rendered="#{not compoundValuesstatus.last}">
+                                                    <ui:fragment rendered="#{not compoundValuesStatus.last}">
                                                         <br/>
                                                     </ui:fragment>
                                                 </ui:repeat>


### PR DESCRIPTION
Following agreements on next steps of https://github.com/IQSS/dataverse/pull/10145

**What this PR does / why we need it**:

Dataset metadata view of a CVOC field is by default only `term-uri-field` value of the `CVocConf:`
Historically, this field is an idenfier (ORCID ID or skomos permalink), allowing to reconstruct data depending on user language (ex. [skosmos.js#L31](https://github.com/gdcc/dataverse-external-vocab-support/blob/main/scripts/skosmos.js#L31)) while loading the related javascript file (`js-url`) of `CVocConf:`.
Ontoportal uses 2 fields to be able to reconstruct the data. In order to minimize code modifications, we decided to add missing child fields as hidden `<span>`.

**HTML Before PR :**

```html
<span data-cvoc-headers="{&quot;Authorization&quot;:&quot;apikey token=xxx-xxx-xxx&quot;}" data-cvoc-service-url="https://data.agroportal.lirmm.fr/" data-cvoc-protocol="ontoportal" lang="fr">http://purl.obolibrary.org/obo/OBT_000193</span>
```
**HTML After PR :**

```html
<span class="hidden" data-cvoc-metadata-name="keywordValue" hidden="hidden">animal</span>
<span data-cvoc-headers="{&quot;Authorization&quot;:&quot;apikey token=xxx-xxx-xxx&quot;}" data-cvoc-service-url="https://data.agroportal.lirmm.fr/" data-cvoc-protocol="ontoportal" lang="fr">http://purl.obolibrary.org/obo/OBT_000193</span>
<span class="hidden" data-cvoc-metadata-name="keywordVocabulary" hidden="hidden">ONTOBIOTOPE</span>
<span class="hidden" data-cvoc-metadata-name="keywordVocabularyURI" hidden="hidden">https://agroportal.lirmm.fr/ontologies/ONTOBIOTOPE</span>
```

Allowing to do this in Javascript : 

```javascript
var ontology = parent.find('[data-cvoc-metadata-name="keywordVocabulary"]').text();
let termName = parent.find('[data-cvoc-metadata-name="keywordValue"]').text();
let url = cvocUrl.replace("data.", "") + "ontologies/"+ontology+"/classes/"+encodeURIComponent(id);
```

Full javascript : [ontoportal.js (POC)](https://github.com/Recherche-Data-Gouv/dataverse-external-vocab-support/blob/poc_ontoportal/scripts/ontoportal.js)

**Suggestions on how to test this**:

Check html fields on Dataset metadata view using `CVocConf:` that uses `managed-fields`.

**Does this PR introduce a user interface change?**

No