### PR TITLE
Added a note to remind people to update the languages

### DIFF
--- a/doc/release-notes/6.2-release-notes.md
+++ b/doc/release-notes/6.2-release-notes.md
@@ -417,12 +417,16 @@ In the following commands we assume that Payara 6 is installed in `/usr/local/pa
 
 As noted above, deployment of the war file might take several minutes due a database migration script required for the new storage quotas feature.
 
-6\. Restart Payara
+6\. For installations with internationalization:
+
+- Please remember to update translations via [Dataverse language packs](https://github.com/GlobalDataverseCommunityConsortium/dataverse-language-packs)
+
+7\. Restart Payara
 
 - `service payara stop`
 - `service payara start`
 
-7\. Update the following Metadata Blocks to reflect the incremental improvements made to the handling of core metadata fields: 
+8\. Update the following Metadata Blocks to reflect the incremental improvements made to the handling of core metadata fields: 
 
  ```
  wget https://github.com/IQSS/dataverse/releases/download/v6.2/geospatial.tsv
@@ -442,7 +446,7 @@ wget https://github.com/IQSS/dataverse/releases/download/v6.2/biomedical.tsv
 curl http://localhost:8080/api/admin/datasetfield/load -H "Content-type: text/tab-separated-values" -X POST --upload-file scripts/api/data/metadatablocks/biomedical.tsv
 ```
 
-8\. For installations with custom or experimental metadata blocks:
+9\. For installations with custom or experimental metadata blocks:
 
 - Stop Solr instance (usually `service solr stop`, depending on Solr installation/OS, see the [Installation Guide](https://guides.dataverse.org/en/6.2/installation/prerequisites.html#solr-init-script))
 
@@ -455,7 +459,7 @@ curl http://localhost:8080/api/admin/datasetfield/load -H "Content-type: text/ta
      
 - Restart Solr instance (usually `service solr restart` depending on solr/OS)
 
-9\. Reindex Solr:
+10\. Reindex Solr:
 
    For details, see https://guides.dataverse.org/en/6.2/admin/solr-search-index.html but here is the reindex command:
 

--- a/doc/release-notes/6.2-release-notes.md
+++ b/doc/release-notes/6.2-release-notes.md
@@ -419,7 +419,7 @@ As noted above, deployment of the war file might take several minutes due a data
 
 6\. For installations with internationalization:
 
-- Please remember to update translations via [Dataverse language packs](https://github.com/GlobalDataverseCommunityConsortium/dataverse-language-packs)
+- Please remember to update translations via [Dataverse language packs](https://github.com/GlobalDataverseCommunityConsortium/dataverse-language-packs).
 
 7\. Restart Payara
 


### PR DESCRIPTION
**What this PR does / why we need it**:
It was mentioned on #10510 that people were presented with the exception ``staticSearchFields.license key is missing``  after upgrading to 6.2. This was caused by the language being outdated. 

**Which issue(s) this PR closes**:
Closes #10510

**Special notes for your reviewer**:
This is a documentation change that adds a step before restarting Payara.

**Suggestions on how to test this**:
This can be tested by checking the documentation or having a 6.1 installation updated to 6.2 with internationalization. On the issue @vbonamy and @sergejzr reported their issues were solved by upgrading their language pack and suggested this change in the documentation. 

If this is enough I will make the change on the release notes. 

