### PR TITLE
IQSS/10568-Fix File Reingest from UI

### DIFF
--- a/doc/release-notes/10568-Fix File Reingest.md
+++ b/doc/release-notes/10568-Fix File Reingest.md
@@ -1,0 +1,1 @@
+A bug that prevented the Ingest option in the File page Edit File menu from working has been fixed

--- a/src/main/java/edu/harvard/iq/dataverse/FilePage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/FilePage.java
@@ -522,10 +522,9 @@ public class FilePage implements java.io.Serializable {
             return null;
         }
 
-        DataFile dataFile = fileMetadata.getDataFile();
-        editDataset = dataFile.getOwner();
+        editDataset = file.getOwner();
         
-        if (dataFile.isTabularData()) {
+        if (file.isTabularData()) {
             JH.addMessage(FacesMessage.SEVERITY_WARN, BundleUtil.getStringFromBundle("file.ingest.alreadyIngestedWarning"));
             return null;
         }
@@ -537,25 +536,25 @@ public class FilePage implements java.io.Serializable {
             return null;
         }
         
-        if (!FileUtil.canIngestAsTabular(dataFile)) {
+        if (!FileUtil.canIngestAsTabular(file)) {
             JH.addMessage(FacesMessage.SEVERITY_WARN, BundleUtil.getStringFromBundle("file.ingest.cantIngestFileWarning"));
             return null;
             
         }
         
-        dataFile.SetIngestScheduled();
+        file.SetIngestScheduled();
                 
-        if (dataFile.getIngestRequest() == null) {
-            dataFile.setIngestRequest(new IngestRequest(dataFile));
+        if (file.getIngestRequest() == null) {
+            file.setIngestRequest(new IngestRequest(file));
         }
 
-        dataFile.getIngestRequest().setForceTypeCheck(true);
+        file.getIngestRequest().setForceTypeCheck(true);
         
         // update the datafile, to save the newIngest request in the database:
         datafileService.save(file);
         
         // queue the data ingest job for asynchronous execution: 
-        String status = ingestService.startIngestJobs(editDataset.getId(), new ArrayList<>(Arrays.asList(dataFile)), (AuthenticatedUser) session.getUser());
+        String status = ingestService.startIngestJobs(editDataset.getId(), new ArrayList<>(Arrays.asList(file)), (AuthenticatedUser) session.getUser());
         
         if (!StringUtil.isEmpty(status)) {
             // This most likely indicates some sort of a problem (for example, 
@@ -565,9 +564,9 @@ public class FilePage implements java.io.Serializable {
             // successfully gone through the process of trying to schedule the 
             // ingest job...
             
-            logger.warning("Ingest Status for file: " + dataFile.getId() + " : " + status);
+            logger.warning("Ingest Status for file: " + file.getId() + " : " + status);
         }
-        logger.fine("File: " + dataFile.getId() + " ingest queued");
+        logger.fine("File: " + file.getId() + " ingest queued");
 
         init();
         JsfHelper.addInfoMessage(BundleUtil.getStringFromBundle("file.ingest.ingestQueued"));


### PR DESCRIPTION
**What this PR does / why we need it**: Fixes file re-ingest in the UI

**Which issue(s) this PR closes**:

Closes #10568

**Special notes for your reviewer**:

**Suggestions on how to test this**: Add an ingestible file, go to the file page, click uningest. Confirm the tab and other versions are gone. Click ingest, wait for ingest to finish, check that the versions are back. (Tested at QDR, the PR passed this test.)

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**: provided - not sure if its needed

**Additional documentation**:
