### PR TITLE
Test fix for confirmEmail test failure

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/search/SearchIncludeFragment.java
+++ b/src/main/java/edu/harvard/iq/dataverse/search/SearchIncludeFragment.java
@@ -1495,15 +1495,15 @@ public class SearchIncludeFragment implements java.io.Serializable {
     }
 
     public boolean isValid(SolrSearchResult result) {
-        Long id = result.getEntityId();
-        
-        DvObject obj = dvObjectService.findDvObject(id);
-        if(obj != null && obj instanceof Dataset) {
-                
-        return result.isValid(x -> permissionsWrapper.canUpdateDataset(getDataverseRequest(), datasetService.find(x.getEntityId())));
-        }
-        logger.fine("isValid called for dvObject that is null (or not a dataset), id: " + id + "This can occur if a dataset is deleted while a search is in progress");
-        return result.isValid(x -> true);
+        return result.isValid(x -> {
+            Long id = x.getEntityId();
+            DvObject obj = dvObjectService.findDvObject(id);
+            if(obj != null && obj instanceof Dataset) {
+                return permissionsWrapper.canUpdateDataset(getDataverseRequest(), (Dataset) obj);
+            }
+            logger.fine("isValid called for dvObject that is null (or not a dataset), id: " + id + "This can occur if a dataset is deleted while a search is in progress");
+            return true;
+        });
     }
     
     public enum SortOrder {

--- a/src/main/java/edu/harvard/iq/dataverse/search/SearchIncludeFragment.java
+++ b/src/main/java/edu/harvard/iq/dataverse/search/SearchIncludeFragment.java
@@ -1501,13 +1501,8 @@ public class SearchIncludeFragment implements java.io.Serializable {
         if(obj != null && obj instanceof Dataset) {
                 
         return result.isValid(x -> permissionsWrapper.canUpdateDataset(getDataverseRequest(), datasetService.find(x.getEntityId())));
-        } else if(obj != null && obj instanceof DataFile) {
-            logger.info("Object is a DataFile");
-        } else if(obj != null && obj instanceof Dataverse) {
-            logger.info("Object is a Dataverse");
-        } else if(obj == null) {
-            logger.info("Object is null");
         }
+        logger.fine("isValid called for dvObject that is null (or not a dataset), id: " + id + "This can occur if a dataset is deleted while a search is in progress");
         return result.isValid(x -> true);
     }
     

--- a/src/main/java/edu/harvard/iq/dataverse/search/SearchIncludeFragment.java
+++ b/src/main/java/edu/harvard/iq/dataverse/search/SearchIncludeFragment.java
@@ -1495,7 +1495,20 @@ public class SearchIncludeFragment implements java.io.Serializable {
     }
 
     public boolean isValid(SolrSearchResult result) {
+        Long id = result.getEntityId();
+        
+        DvObject obj = dvObjectService.findDvObject(id);
+        if(obj != null && obj instanceof Dataset) {
+                
         return result.isValid(x -> permissionsWrapper.canUpdateDataset(getDataverseRequest(), datasetService.find(x.getEntityId())));
+        } else if(obj != null && obj instanceof DataFile) {
+            logger.info("Object is a DataFile");
+        } else if(obj != null && obj instanceof Dataverse) {
+            logger.info("Object is a Dataverse");
+        } else if(obj == null) {
+            logger.info("Object is null");
+        }
+        return result.isValid(x -> true);
     }
     
     public enum SortOrder {


### PR DESCRIPTION
**What this PR does / why we need it**: Quick draft to see if this is the problem. The server.log in Jenkins shows an error related the the dvObject being null in a permission check coming from the call modified in this PR (which was recently updated). It occurs in the log right after the noTokenCheck for confirmEmailTest. The next test appears to fail with a  500 but I see no log errors except this. I'm not sure how a searchIncludeFragment issue would get triggered from a confirmemail.xhtml call, but trying this fix to see if it helps and to log what search result might have a null entityId.

**Which issue(s) this PR closes**:

Closes #

**Special notes for your reviewer**:

**Suggestions on how to test this**:

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
