### PR TITLE
Solr: don't delete docs that will just change

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/search/IndexServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/search/IndexServiceBean.java
@@ -1935,9 +1935,9 @@ public class IndexServiceBean {
         StringBuilder result = new StringBuilder();
         String deleteDeaccessionedResult = removeSolrDocFromIndex(determineDeaccessionedDatasetId(dataset));
         result.append(deleteDeaccessionedResult);
-        List<String> docIds = findSolrDocIdsForFilesToDelete(dataset, IndexableDataset.DatasetState.DEACCESSIONED);
-        String deleteFilesResult = removeMultipleSolrDocs(docIds);
-        result.append(deleteFilesResult);
+//        List<String> docIds = findSolrDocIdsForFilesToDelete(dataset, IndexableDataset.DatasetState.DEACCESSIONED);
+//        String deleteFilesResult = removeMultipleSolrDocs(docIds);
+//        result.append(deleteFilesResult);
         return result.toString();
     }
 
@@ -1945,9 +1945,9 @@ public class IndexServiceBean {
         StringBuilder result = new StringBuilder();
         String deletePublishedResult = removeSolrDocFromIndex(determinePublishedDatasetSolrDocId(dataset));
         result.append(deletePublishedResult);
-        List<String> docIds = findSolrDocIdsForFilesToDelete(dataset, IndexableDataset.DatasetState.PUBLISHED);
-        String deleteFilesResult = removeMultipleSolrDocs(docIds);
-        result.append(deleteFilesResult);
+//        List<String> docIds = findSolrDocIdsForFilesToDelete(dataset, IndexableDataset.DatasetState.PUBLISHED);
+//        String deleteFilesResult = removeMultipleSolrDocs(docIds);
+//        result.append(deleteFilesResult);
         return result.toString();
     }
 


### PR DESCRIPTION
**What this PR does / why we need it**: The existing code made a list of all files in all versions of a dataset (using a list so with repeats) and then added all of the file docs actually in solr, and tried to delete them all. And then tried to delete them again per card. The PR changes that to find which docs exist in solr (same query as before) and then looks to find any that are not in the one/two versions of the dataset that will be indexed and sends a delete request only for the orphaned docs.

It also adds one minor improvement - skipping the file indexing doc creation loop when indexableDataset.isFilesShouldBeIndexed() is false (deaccessioned datasets) instead of going through doc creation and then not submitting it.

**Which issue(s) this PR closes**:

Closes #

**Special notes for your reviewer**:

**Suggestions on how to test this**: FWIW: I've been testing with FINE logging to see what docs exist and which ones are deleted for various cases (creating, editing, publishing, deaccessioning while adding/deleting files). Nominally, just checking api/admin/index/status and verifying that there are no orphans at the end should be sufficient (at least content docs at present - haven't changed perm doc mgmt so far).

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
