### PR TITLE
Update info in Dataverse Developers Guide about what happens when not specifying a branch when running script that deploys Dataverse on AWS

### DIFF
--- a/doc/sphinx-guides/source/developers/deployment.rst
+++ b/doc/sphinx-guides/source/developers/deployment.rst
@@ -96,7 +96,7 @@ To run it with default values you just need the script, but you may also want a 
 ec2-create-instance accepts a number of command-line switches, including:
 
 * -r: GitHub Repository URL (defaults to https://github.com/IQSS/dataverse.git)
-* -b: branch to build (defaults to develop)
+* -b: branch to build (defaults to the latest release of Dataverse)
 * -p: pemfile directory (defaults to $HOME)
 * -g: Ansible GroupVars file (if you wish to override role defaults)
 * -h: help (displays usage for each available option)

--- a/doc/sphinx-guides/source/developers/deployment.rst
+++ b/doc/sphinx-guides/source/developers/deployment.rst
@@ -91,17 +91,11 @@ Download `ec2-create-instance.sh`_ and put it somewhere reasonable. For the purp
 
 .. _ec2-create-instance.sh: https://raw.githubusercontent.com/GlobalDataverseCommunityConsortium/dataverse-ansible/master/ec2/ec2-create-instance.sh
 
-To run it with default values you just need the script, but you may also want a current copy of the ansible `group vars <https://raw.githubusercontent.com/GlobalDataverseCommunityConsortium/dataverse-ansible/master/defaults/main.yml>`_ file.
+To run the script, you can make it executable (``chmod 755 ec2-create-instance.sh``) or run it with bash, like this with ``-h`` as an argument to print the help:
 
-ec2-create-instance accepts a number of command-line switches, including:
+``bash ~/Downloads/ec2-create-instance.sh -h``
 
-* -r: GitHub Repository URL (defaults to https://github.com/IQSS/dataverse.git)
-* -b: branch to build (defaults to the latest release of Dataverse)
-* -p: pemfile directory (defaults to $HOME)
-* -g: Ansible GroupVars file (if you wish to override role defaults)
-* -h: help (displays usage for each available option)
-
-``bash ~/Downloads/ec2-create-instance.sh -b develop -r https://github.com/scholarsportal/dataverse.git -g main.yml``
+If you run the script without any arguments, it should spin up the latest version of Dataverse.
 
 You will need to wait for 15 minutes or so until the deployment is finished, longer if you've enabled sample data and/or the API test suite. Eventually, the output should tell you how to access the Dataverse installation in a web browser or via SSH. It will also provide instructions on how to delete the instance when you are finished with it. Please be aware that AWS charges per minute for a running instance. You may also delete your instance from https://console.aws.amazon.com/console/home?region=us-east-1 .
 


### PR DESCRIPTION
Correct info about what happens when -b is not used in command to create a Dataverse instance on AWS

**What this PR does / why we need it**:
Addresses the problem described in https://github.com/IQSS/dataverse/issues/10572 by editing the section of the Dataverse Developer guide about spinning up Dataverse instances on AWS.

**Which issue(s) this PR closes**:
Closes #10572 

**Suggestions on how to test this**:
Review the revised section of the Dataverse Developer guide about spinning up Dataverse instances on AWS. It should let the user know that when she runs the script to spin up a Dataverse instance without the -b option, the latest version of Dataverse is used.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
No, this PR doesn't introduce a user interface change.

**Is there a release notes update needed for this change?**:
I don't think a release note is needed for this change.