### PR TITLE
catch exceptions from DatasetServiceBean.findDeep

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DatasetServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetServiceBean.java
@@ -19,8 +19,6 @@ import edu.harvard.iq.dataverse.engine.command.impl.GetDatasetStorageSizeCommand
 import edu.harvard.iq.dataverse.export.ExportService;
 import edu.harvard.iq.dataverse.globus.GlobusServiceBean;
 import edu.harvard.iq.dataverse.harvest.server.OAIRecordServiceBean;
-import edu.harvard.iq.dataverse.pidproviders.PidProvider;
-import edu.harvard.iq.dataverse.pidproviders.PidUtil;
 import edu.harvard.iq.dataverse.search.IndexServiceBean;
 import edu.harvard.iq.dataverse.settings.SettingsServiceBean;
 import edu.harvard.iq.dataverse.util.BundleUtil;
@@ -41,11 +39,10 @@ import jakarta.ejb.TransactionAttribute;
 import jakarta.ejb.TransactionAttributeType;
 import jakarta.inject.Named;
 import jakarta.persistence.EntityManager;
-import jakarta.persistence.LockModeType;
 import jakarta.persistence.NoResultException;
+import jakarta.persistence.NonUniqueResultException;
 import jakarta.persistence.PersistenceContext;
 import jakarta.persistence.Query;
-import jakarta.persistence.StoredProcedureQuery;
 import jakarta.persistence.TypedQuery;
 import org.apache.commons.lang3.StringUtils;
 
@@ -115,28 +112,32 @@ public class DatasetServiceBean implements java.io.Serializable {
      * @return a dataset with pre-fetched file objects
      */
     public Dataset findDeep(Object pk) {
-        return (Dataset) em.createNamedQuery("Dataset.findById")
-            .setParameter("id", pk)
-            // Optimization hints: retrieve all data in one query; this prevents point queries when iterating over the files
-            .setHint("eclipselink.left-join-fetch", "o.files.ingestRequest")
-            .setHint("eclipselink.left-join-fetch", "o.files.thumbnailForDataset")
-            .setHint("eclipselink.left-join-fetch", "o.files.dataTables")
-            .setHint("eclipselink.left-join-fetch", "o.files.auxiliaryFiles")
-            .setHint("eclipselink.left-join-fetch", "o.files.ingestReports")
-            .setHint("eclipselink.left-join-fetch", "o.files.dataFileTags")
-            .setHint("eclipselink.left-join-fetch", "o.files.fileMetadatas")
-            .setHint("eclipselink.left-join-fetch", "o.files.fileMetadatas.fileCategories")
-            .setHint("eclipselink.left-join-fetch", "o.files.fileMetadatas.varGroups")
-            //.setHint("eclipselink.left-join-fetch", "o.files.guestbookResponses
-            .setHint("eclipselink.left-join-fetch", "o.files.embargo")
-            .setHint("eclipselink.left-join-fetch", "o.files.retention")
-            .setHint("eclipselink.left-join-fetch", "o.files.fileAccessRequests")
-            .setHint("eclipselink.left-join-fetch", "o.files.owner")
-            .setHint("eclipselink.left-join-fetch", "o.files.releaseUser")
-            .setHint("eclipselink.left-join-fetch", "o.files.creator")
-            .setHint("eclipselink.left-join-fetch", "o.files.alternativePersistentIndentifiers")
-            .setHint("eclipselink.left-join-fetch", "o.files.roleAssignments")
-            .getSingleResult();
+        try {
+            return (Dataset) em.createNamedQuery("Dataset.findById")
+                    .setParameter("id", pk)
+                    // Optimization hints: retrieve all data in one query; this prevents point queries when iterating over the files
+                    .setHint("eclipselink.left-join-fetch", "o.files.ingestRequest")
+                    .setHint("eclipselink.left-join-fetch", "o.files.thumbnailForDataset")
+                    .setHint("eclipselink.left-join-fetch", "o.files.dataTables")
+                    .setHint("eclipselink.left-join-fetch", "o.files.auxiliaryFiles")
+                    .setHint("eclipselink.left-join-fetch", "o.files.ingestReports")
+                    .setHint("eclipselink.left-join-fetch", "o.files.dataFileTags")
+                    .setHint("eclipselink.left-join-fetch", "o.files.fileMetadatas")
+                    .setHint("eclipselink.left-join-fetch", "o.files.fileMetadatas.fileCategories")
+                    .setHint("eclipselink.left-join-fetch", "o.files.fileMetadatas.varGroups")
+                    //.setHint("eclipselink.left-join-fetch", "o.files.guestbookResponses
+                    .setHint("eclipselink.left-join-fetch", "o.files.embargo")
+                    .setHint("eclipselink.left-join-fetch", "o.files.retention")
+                    .setHint("eclipselink.left-join-fetch", "o.files.fileAccessRequests")
+                    .setHint("eclipselink.left-join-fetch", "o.files.owner")
+                    .setHint("eclipselink.left-join-fetch", "o.files.releaseUser")
+                    .setHint("eclipselink.left-join-fetch", "o.files.creator")
+                    .setHint("eclipselink.left-join-fetch", "o.files.alternativePersistentIndentifiers")
+                    .setHint("eclipselink.left-join-fetch", "o.files.roleAssignments")
+                    .getSingleResult();
+        } catch (NoResultException | NonUniqueResultException ex) {
+            return null;
+        }
     }
     
     public List<Dataset> findByOwnerId(Long ownerId) {


### PR DESCRIPTION
**What this PR does / why we need it**:

After this pull request was merged...

- #9684

... tests starting failing (#10599).

This pull request cherry-picks the commit https://github.com/IQSS/dataverse/pull/10371/commits/a79cdbf17ea42afd577816a01a5ac3e35d0135f6 from @luddaniel from PR #10371.

I ran just the failing test locally with `mvn test -Dtest=HarvestingServerIT#testSingleRecordOaiSet` and it passed on my machine so it seems to be a good fix.

**Which issue(s) this PR closes**:

- Closes #10599

**Special notes for your reviewer**:

**Suggestions on how to test this**:

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
