### PR TITLE
#10466: quick fix for math challenge contact form on 403 error page

### DIFF
--- a/doc/release-notes/10466-math-challenge-403-error-page.md
+++ b/doc/release-notes/10466-math-challenge-403-error-page.md
@@ -1,0 +1,1 @@
+On forbidden access error page, also know as 403 error page, the math challenge is now correctly display to submit the contact form.

--- a/src/main/java/edu/harvard/iq/dataverse/SendFeedbackDialog.java
+++ b/src/main/java/edu/harvard/iq/dataverse/SendFeedbackDialog.java
@@ -129,6 +129,10 @@ public class SendFeedbackDialog implements java.io.Serializable {
     }
 
     public String getMessageTo() {
+        if (op1 == null || op2 == null) {
+            // Fix for 403 error page: initUserInput method doesn't call before
+            initUserInput(null);
+        }
         if (feedbackTarget == null) {
             return BrandingUtil.getSupportTeamName(systemAddress);
         } else if (feedbackTarget.isInstanceofDataverse()) {


### PR DESCRIPTION
**What this PR does / why we need it**:

If a user wishes to access a page, but is prevented from doing so by a rights issue (ACL), the error message on page 403 indicates this. Actually, the form can no longer be submitted because the mathematical challenge is empty. This PR corrects this and makes it possible to submit this form again.

**Which issue(s) this PR closes**:

Closes #10466 

**Special notes for your reviewer**:

I do a simple quick fix, I don't understand why the `SendFeedbackDialog.initUserInput` method isn't called. But with the new SPA interface, this bug will disappear, as it's linked to the current JSF view (view from MVC). So it seems to me that this is acceptable.

**Suggestions on how to test this**:

I use this test case to validate this PR :
* I login into a repository with a account A
* I create a collection and publish them
* Into this dataverse, I create a dataset in draft status
* I copy the URL of the dataset
* I logout and re-sigin with a another account B
* I try to access to the dataset previously created
* On the 403 page (forbidden access), I open the contact form to verify if the math challenge is now print

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No change

**Is there a release notes update needed for this change?**:

I don't think because the contact form on forbidden access page is a small functionality. But if needed I can write them.

**Additional documentation**:

No