### PR TITLE
Fix DOI/ID message when deaccession a Dataset

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/api/Datasets.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Datasets.java
@@ -4778,7 +4778,8 @@ public class Datasets extends AbstractApiBean {
             return badRequest(BundleUtil.getStringFromBundle("datasets.api.deaccessionDataset.invalid.version.identifier.error", List.of(DS_VERSION_LATEST_PUBLISHED)));
         }
         return response(req -> {
-            DatasetVersion datasetVersion = getDatasetVersionOrDie(req, versionId, findDatasetOrDie(datasetId), uriInfo, headers);
+            Dataset dataset = findDatasetOrDie(datasetId);
+            DatasetVersion datasetVersion = getDatasetVersionOrDie(req, versionId, dataset, uriInfo, headers);
             try {
                 JsonObject jsonObject = JsonUtil.getJsonObject(jsonBody);
                 datasetVersion.setVersionNote(jsonObject.getString("deaccessionReason"));
@@ -4791,7 +4792,10 @@ public class Datasets extends AbstractApiBean {
                     }
                 }
                 execCommand(new DeaccessionDatasetVersionCommand(req, datasetVersion, false));
-                return ok("Dataset " + datasetId + " deaccessioned for version " + versionId);
+
+                return ok("Dataset " + 
+                        (":persistentId".equals(datasetId) ? dataset.getAuthority() + "/" + dataset.getIdentifier() : datasetId) + 
+                        " deaccessioned for version " + versionId);
             } catch (JsonParsingException jpe) {
                 return error(Response.Status.BAD_REQUEST, "Error parsing Json: " + jpe.getMessage());
             }

--- a/src/main/java/edu/harvard/iq/dataverse/api/Datasets.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Datasets.java
@@ -4793,7 +4793,7 @@ public class Datasets extends AbstractApiBean {
                 execCommand(new DeaccessionDatasetVersionCommand(req, datasetVersion, false));
                 
                 return ok("Dataset " + 
-                        (":persistentId".equals(datasetId) ? datasetVersion.getDataset().getAuthority() + "/" + datasetVersion.getDataset().getIdentifier() : datasetId) + 
+                        (":persistentId".equals(datasetId) ? datasetVersion.getDataset().getGlobalId().asString() : datasetId) + 
                         " deaccessioned for version " + versionId);
             } catch (JsonParsingException jpe) {
                 return error(Response.Status.BAD_REQUEST, "Error parsing Json: " + jpe.getMessage());

--- a/src/main/java/edu/harvard/iq/dataverse/api/Datasets.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Datasets.java
@@ -4778,8 +4778,7 @@ public class Datasets extends AbstractApiBean {
             return badRequest(BundleUtil.getStringFromBundle("datasets.api.deaccessionDataset.invalid.version.identifier.error", List.of(DS_VERSION_LATEST_PUBLISHED)));
         }
         return response(req -> {
-            Dataset dataset = findDatasetOrDie(datasetId);
-            DatasetVersion datasetVersion = getDatasetVersionOrDie(req, versionId, dataset, uriInfo, headers);
+            DatasetVersion datasetVersion = getDatasetVersionOrDie(req, versionId, findDatasetOrDie(datasetId), uriInfo, headers);
             try {
                 JsonObject jsonObject = JsonUtil.getJsonObject(jsonBody);
                 datasetVersion.setVersionNote(jsonObject.getString("deaccessionReason"));
@@ -4792,9 +4791,9 @@ public class Datasets extends AbstractApiBean {
                     }
                 }
                 execCommand(new DeaccessionDatasetVersionCommand(req, datasetVersion, false));
-
+                
                 return ok("Dataset " + 
-                        (":persistentId".equals(datasetId) ? dataset.getAuthority() + "/" + dataset.getIdentifier() : datasetId) + 
+                        (":persistentId".equals(datasetId) ? datasetVersion.getDataset().getAuthority() + "/" + datasetVersion.getDataset().getIdentifier() : datasetId) + 
                         " deaccessioned for version " + versionId);
             } catch (JsonParsingException jpe) {
                 return error(Response.Status.BAD_REQUEST, "Error parsing Json: " + jpe.getMessage());

--- a/src/test/java/edu/harvard/iq/dataverse/api/DatasetsIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/DatasetsIT.java
@@ -3936,12 +3936,12 @@ createDataset = UtilIT.createRandomDatasetViaNativeApi(dataverse1Alias, apiToken
         publishDatasetResponse.prettyPrint();
         publishDatasetResponse.then().assertThat().statusCode(OK.getStatusCode());
 
-        String globalId = JsonPath.from(createDatasetResponse.body().asString()).getString("data.persistentId");
+        String persistentId = JsonPath.from(createDatasetResponse.body().asString()).getString("data.persistentId");
 
-        deaccessionDatasetResponse = UtilIT.deaccessionDatasetByGlobalId(globalId, DS_VERSION_LATEST_PUBLISHED, "Test deaccession reason.", null, apiToken);
+        deaccessionDatasetResponse = UtilIT.deaccessionDatasetByPersistentId(persistentId, DS_VERSION_LATEST_PUBLISHED, "Test deaccession reason.", null, apiToken);
         deaccessionDatasetResponse.prettyPrint();
         deaccessionDatasetResponse.then().assertThat().statusCode(OK.getStatusCode())
-                .assertThat().body("data.message", containsString(String.valueOf(globalId)));
+                .assertThat().body("data.message", containsString(String.valueOf(persistentId)));
     }
 
     

--- a/src/test/java/edu/harvard/iq/dataverse/api/DatasetsIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/DatasetsIT.java
@@ -3938,7 +3938,7 @@ createDataset = UtilIT.createRandomDatasetViaNativeApi(dataverse1Alias, apiToken
 
         String persistentId = JsonPath.from(createDatasetResponse.body().asString()).getString("data.persistentId");
 
-        deaccessionDatasetResponse = UtilIT.deaccessionDatasetByPersistentId(persistentId, DS_VERSION_LATEST_PUBLISHED, "Test deaccession reason.", null, apiToken);
+        deaccessionDatasetResponse = UtilIT.deaccessionDataset(persistentId, DS_VERSION_LATEST_PUBLISHED, "Test deaccession reason.", null, apiToken);
         deaccessionDatasetResponse.prettyPrint();
         deaccessionDatasetResponse.then().assertThat().statusCode(OK.getStatusCode())
                 .assertThat().body("data.message", containsString(String.valueOf(persistentId)));

--- a/src/test/java/edu/harvard/iq/dataverse/api/FilesIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/FilesIT.java
@@ -1526,6 +1526,7 @@ public class FilesIT {
                 .body("data.label", equalTo(newFileNameSecondUpdate));
 
         // The following tests cover cases where the dataset version is deaccessioned
+        
         Response deaccessionDatasetResponse = UtilIT.deaccessionDataset(datasetId, "3.0", "Test reason", null, superUserApiToken);
         deaccessionDatasetResponse.then().assertThat().statusCode(OK.getStatusCode());
 

--- a/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
@@ -3845,30 +3845,38 @@ public class UtilIT {
                 .get("/api/files/" + dataFileId + "/hasBeenDeleted");
     }
 
-    static Response deaccessionDataset(Integer datasetId, String version, String deaccessionReason, String deaccessionForwardURL, String apiToken) {
-        JsonObjectBuilder jsonObjectBuilder = Json.createObjectBuilder();
-        jsonObjectBuilder.add("deaccessionReason", deaccessionReason);
-        if (deaccessionForwardURL != null) {
-            jsonObjectBuilder.add("deaccessionForwardURL", deaccessionForwardURL);
-        }
-        String jsonString = jsonObjectBuilder.build().toString();
-        return given()
-                .header(API_TOKEN_HTTP_HEADER, apiToken)
-                .body(jsonString)
-                .post("/api/datasets/" + datasetId + "/versions/" + version + "/deaccession");
+    static Response deaccessionDataset(int datasetId, String version, String deaccessionReason, String deaccessionForwardURL, String apiToken) {
+        return deaccessionDataset(String.valueOf(datasetId), version, deaccessionReason, deaccessionForwardURL, apiToken);
     }
 
-    static Response deaccessionDatasetByPersistentId(String persistentId, String version, String deaccessionReason, String deaccessionForwardURL, String apiToken) {
+    static Response deaccessionDataset(String datasetIdOrPersistentId, String versionId, String deaccessionReason, String deaccessionForwardURL, String apiToken) {
+        
+        String idInPath = datasetIdOrPersistentId; // Assume it's a number.
+        String optionalQueryParam = ""; // If idOrPersistentId is a number we'll just put it in the path.
+        if (!NumberUtils.isCreatable(datasetIdOrPersistentId)) {
+            idInPath = ":persistentId";
+            optionalQueryParam = "?persistentId=" + datasetIdOrPersistentId;
+        }
+    
         JsonObjectBuilder jsonObjectBuilder = Json.createObjectBuilder();
         jsonObjectBuilder.add("deaccessionReason", deaccessionReason);
         if (deaccessionForwardURL != null) {
             jsonObjectBuilder.add("deaccessionForwardURL", deaccessionForwardURL);
         }
+
         String jsonString = jsonObjectBuilder.build().toString();
+        StringBuilder query = new StringBuilder()
+            .append("/api/datasets/")
+            .append(idInPath)
+            .append("/versions/")
+            .append(versionId)
+            .append("/deaccession")
+            .append(optionalQueryParam);   
+                 
         return given()
-                .header(API_TOKEN_HTTP_HEADER, apiToken)
-                .body(jsonString)
-                .post("/api/datasets/:persistentId/versions/" + version + "/deaccession?persistentId=" + persistentId);
+            .header(API_TOKEN_HTTP_HEADER, apiToken)
+            .body(jsonString)
+            .post(query.toString());
     }
 
     static Response getDownloadSize(Integer datasetId,

--- a/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
@@ -3858,6 +3858,19 @@ public class UtilIT {
                 .post("/api/datasets/" + datasetId + "/versions/" + version + "/deaccession");
     }
 
+    static Response deaccessionDatasetByGlobalId(String globalId, String version, String deaccessionReason, String deaccessionForwardURL, String apiToken) {
+        JsonObjectBuilder jsonObjectBuilder = Json.createObjectBuilder();
+        jsonObjectBuilder.add("deaccessionReason", deaccessionReason);
+        if (deaccessionForwardURL != null) {
+            jsonObjectBuilder.add("deaccessionForwardURL", deaccessionForwardURL);
+        }
+        String jsonString = jsonObjectBuilder.build().toString();
+        return given()
+                .header(API_TOKEN_HTTP_HEADER, apiToken)
+                .body(jsonString)
+                .post("/api/datasets/:persistentId/versions/" + version + "/deaccession?persistentId=" + globalId);
+    }
+
     static Response getDownloadSize(Integer datasetId,
                                     String version,
                                     String contentType,

--- a/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
@@ -3858,7 +3858,7 @@ public class UtilIT {
                 .post("/api/datasets/" + datasetId + "/versions/" + version + "/deaccession");
     }
 
-    static Response deaccessionDatasetByGlobalId(String globalId, String version, String deaccessionReason, String deaccessionForwardURL, String apiToken) {
+    static Response deaccessionDatasetByPersistentId(String persistentId, String version, String deaccessionReason, String deaccessionForwardURL, String apiToken) {
         JsonObjectBuilder jsonObjectBuilder = Json.createObjectBuilder();
         jsonObjectBuilder.add("deaccessionReason", deaccessionReason);
         if (deaccessionForwardURL != null) {
@@ -3868,7 +3868,7 @@ public class UtilIT {
         return given()
                 .header(API_TOKEN_HTTP_HEADER, apiToken)
                 .body(jsonString)
-                .post("/api/datasets/:persistentId/versions/" + version + "/deaccession?persistentId=" + globalId);
+                .post("/api/datasets/:persistentId/versions/" + version + "/deaccession?persistentId=" + persistentId);
     }
 
     static Response getDownloadSize(Integer datasetId,


### PR DESCRIPTION
**What this PR does / why we need it**:
It was reported on #10309 that this parameter was not substituted by the value on the success message.

**Which issue(s) this PR closes**:
Closes #10309

**Suggestions on how to test this**:

1. Create a Dataset version
2. Deaccession it with `http://localhost:8080/api/datasets/:persistentId/versions/:versionID/deaccession?key=API_KEY&persistentId=doi:10.5072/FK2/RGFWNO`
3. the new message should show as `"message": "Dataset 10.5072/FK2/RGFWNO deaccessioned for version 9"`
4. Check the database id still works `http://localhost:8080/api/datasets/6/versions/10/deaccession?key=API_KEY`
5. message should show as `"message": "Dataset 6 deaccessioned for version 10"`

**Is there a release notes update needed for this change?**:
No

**Additional documentation**:
No