### PR TITLE
adding fix to file name for download guestbook responses

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/GuestbookResponsesPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/GuestbookResponsesPage.java
@@ -101,8 +101,9 @@ public class GuestbookResponsesPage implements java.io.Serializable {
     private String getFileName(){
        // The fix below replaces any spaces in the name of the dataverse with underscores;
        // without it, the filename was chopped off (by the browser??), and the user 
-       // was getting the file name "Foo", instead of "Foo and Bar in Social Sciences.csv". -- L.A. 
-       return  dataverse.getName().replace(' ', '_') + "_" + guestbook.getId() + "_GuestbookReponses.csv";
+       // was getting the file name "Foo", instead of "Foo and Bar in Social Sciences.csv". -- L.A.
+       // Also removing some chars that have been reported to cause issues with certain browsers
+       return  dataverse.getName().replace(' ', '_').replaceAll("[\\\\/:*?\"<>|,;]", "") + "_" + guestbook.getId() + "_GuestbookResponses.csv";
     }
 
     public void streamResponsesByDataverseAndGuestbook(){

--- a/src/main/java/edu/harvard/iq/dataverse/GuestbookResponsesPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/GuestbookResponsesPage.java
@@ -8,6 +8,7 @@ package edu.harvard.iq.dataverse;
 import edu.harvard.iq.dataverse.engine.command.impl.UpdateDataverseCommand;
 
 import edu.harvard.iq.dataverse.util.BundleUtil;
+import edu.harvard.iq.dataverse.util.FileUtil;
 import edu.harvard.iq.dataverse.util.SystemConfig;
 import java.util.List;
 import java.util.logging.Logger;
@@ -103,7 +104,7 @@ public class GuestbookResponsesPage implements java.io.Serializable {
        // without it, the filename was chopped off (by the browser??), and the user 
        // was getting the file name "Foo", instead of "Foo and Bar in Social Sciences.csv". -- L.A.
        // Also removing some chars that have been reported to cause issues with certain browsers
-       return  dataverse.getName().replace(' ', '_').replaceAll("[\\\\/:*?\"<>|,;]", "") + "_" + guestbook.getId() + "_GuestbookResponses.csv";
+       return  FileUtil.sanitizeFileName(dataverse.getName() + "_" + guestbook.getId() + "_GuestbookResponses.csv");
     }
 
     public void streamResponsesByDataverseAndGuestbook(){

--- a/src/main/java/edu/harvard/iq/dataverse/ManageGuestbooksPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/ManageGuestbooksPage.java
@@ -220,7 +220,8 @@ public class ManageGuestbooksPage implements java.io.Serializable {
        // The fix below replaces any spaces in the name of the dataverse with underscores;
        // without it, the filename was chopped off (by the browser??), and the user 
        // was getting the file name "Foo", instead of "Foo and Bar in Social Sciences.csv". -- L.A.
-       return  dataverse.getName().replace(' ', '_') + "_GuestbookReponses.csv";
+       // Also removing some chars that have been reported to cause issues with certain browsers
+       return  dataverse.getName().replace(' ', '_').replaceAll("[\\\\/:*?\"<>|,;]", "") + "_GuestbookResponses.csv";
     }
     
     public void deleteGuestbook() {

--- a/src/main/java/edu/harvard/iq/dataverse/ManageGuestbooksPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/ManageGuestbooksPage.java
@@ -5,6 +5,7 @@ import edu.harvard.iq.dataverse.engine.command.impl.DeleteGuestbookCommand;
 import edu.harvard.iq.dataverse.engine.command.impl.UpdateDataverseCommand;
 import edu.harvard.iq.dataverse.engine.command.impl.UpdateDataverseGuestbookRootCommand;
 import edu.harvard.iq.dataverse.util.BundleUtil;
+import edu.harvard.iq.dataverse.util.FileUtil;
 import edu.harvard.iq.dataverse.util.JsfHelper;
 import static edu.harvard.iq.dataverse.util.JsfHelper.JH;
 import java.util.LinkedList;
@@ -221,7 +222,7 @@ public class ManageGuestbooksPage implements java.io.Serializable {
        // without it, the filename was chopped off (by the browser??), and the user 
        // was getting the file name "Foo", instead of "Foo and Bar in Social Sciences.csv". -- L.A.
        // Also removing some chars that have been reported to cause issues with certain browsers
-       return  dataverse.getName().replace(' ', '_').replaceAll("[\\\\/:*?\"<>|,;]", "") + "_GuestbookResponses.csv";
+       return  FileUtil.sanitizeFileName(dataverse.getName() + "_GuestbookResponses.csv");
     }
     
     public void deleteGuestbook() {

--- a/src/main/java/edu/harvard/iq/dataverse/util/FileUtil.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/FileUtil.java
@@ -1816,5 +1816,13 @@ public class FileUtil implements java.io.Serializable  {
         String storageIdentifier = dataFile.getStorageIdentifier();
         return storageIdentifier.substring(0, storageIdentifier.indexOf(DataAccess.SEPARATOR));
     }
-    
+
+    /**
+     * Replace spaces with "_" and remove invalid chars
+     * @param fileNameIn - Name before sanitization NOTE: not full path since this method removes '/' and '\'
+     * @return filename without spaces or invalid chars
+     */
+    public static String sanitizeFileName(String fileNameIn) {
+        return fileNameIn == null ? null : fileNameIn.replace(' ', '_').replaceAll("[\\\\/:*?\"<>|,;]", "");
+    }
 }

--- a/src/test/java/edu/harvard/iq/dataverse/util/FileUtilTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/util/FileUtilTest.java
@@ -434,4 +434,11 @@ public class FileUtilTest {
         assertEquals("Code", FileUtil.getIndexableFacetFileType(dockerDataFile));
     }
 
+    @Test
+    public void testSanitizeFileName() {
+        assertEquals(null, FileUtil.sanitizeFileName(null));
+        assertEquals("with_space", FileUtil.sanitizeFileName("with space"));
+        assertEquals("withcomma", FileUtil.sanitizeFileName("with,comma"));
+        assertEquals("with.txt", FileUtil.sanitizeFileName("with,\\?:;,.txt"));
+    }
 }


### PR DESCRIPTION
When using the Chrome browser to download the guestbook of a Dataverse collection that has a comma in the collection's name, such as the collection named "Representation, Treatment, Outcome" the file name is truncated to Representation.

Closes https://github.com/IQSS/dataverse/issues/9401

**Special notes for your reviewer**: 

**Suggestions on how to test this**: test by creating a collection with commas in the name and setting up guestbook. Then, download using Chrome, Safari, and Firefox.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: No

**Is there a release notes update needed for this change?**: No

**Additional documentation**: Also removes other chars that could cause issues when used in a file name.
