### PR TITLE
Null banner JSON message fix

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/api/Admin.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Admin.java
@@ -2337,6 +2337,13 @@ public class Admin extends AbstractApiBean {
 
         BannerMessage toAdd = new BannerMessage();
         try {
+
+            if(jsonObject == null){
+                String errorMessage = "Banner JSON object is not provided.";
+                logger.info(errorMessage);
+                return error(Status.BAD_REQUEST, errorMessage);
+            }
+
             String dismissible = jsonObject.getString("dismissibleByUser");
 
             boolean dismissibleByUser = false;

--- a/src/main/java/edu/harvard/iq/dataverse/api/Admin.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Admin.java
@@ -2338,12 +2338,6 @@ public class Admin extends AbstractApiBean {
         BannerMessage toAdd = new BannerMessage();
         try {
 
-            if(jsonObject == null){
-                String errorMessage = "Banner JSON object is not provided.";
-                logger.info(errorMessage);
-                return error(Status.BAD_REQUEST, errorMessage);
-            }
-
             String dismissible = jsonObject.getString("dismissibleByUser");
 
             boolean dismissibleByUser = false;
@@ -2374,7 +2368,7 @@ public class Admin extends AbstractApiBean {
 
         } catch (Exception e) {
             logger.warning("Unexpected Exception: " + e.getMessage());
-            return error(Status.BAD_REQUEST, "Add Banner Message unexpected exception: " + e.getMessage());
+            return error(Status.BAD_REQUEST, "Add Banner Message unexpected exception: invalid or missing JSON object.");
         }
 
     }


### PR DESCRIPTION

**Which issue(s) this PR closes**:

Closes #10638

**Suggestions on how to test this**:

- curl -H "Content-type:application/json" -X POST "http://localhost:8080/api/admin/bannerMessage" --data "{}"
- This can also be tested with postman by calling http://localhost:8080/api/admin/bannerMessage POST with no body or attached file.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:
No, it is an improvement of an error message since the current one display Java/JSON objects as part of the message