### PR TITLE
Fix metadata field type display condition in dataverses/{id}/metadatablocks API endpoint

### DIFF
--- a/doc/release-notes/10637-fix-dataverse-metadatablocks-api.md
+++ b/doc/release-notes/10637-fix-dataverse-metadatablocks-api.md
@@ -1,0 +1,2 @@
+dataverses/{id}/metadatablocks API endpoint has been fixed, since the fields returned for each metadata block when returnDatasetTypes query parameter is set to true was not correct.
+

--- a/src/main/java/edu/harvard/iq/dataverse/Dataverse.java
+++ b/src/main/java/edu/harvard/iq/dataverse/Dataverse.java
@@ -412,12 +412,18 @@ public class Dataverse extends DvObjectContainer {
     }
 
     public boolean isDatasetFieldTypeRequiredAsInputLevel(Long datasetFieldTypeId) {
-        for(DataverseFieldTypeInputLevel dataverseFieldTypeInputLevel : dataverseFieldTypeInputLevels) {
-            if (dataverseFieldTypeInputLevel.getDatasetFieldType().getId().equals(datasetFieldTypeId) && dataverseFieldTypeInputLevel.isRequired()) {
-                return true;
-            }
-        }
-        return false;
+        return dataverseFieldTypeInputLevels.stream()
+                .anyMatch(inputLevel -> inputLevel.getDatasetFieldType().getId().equals(datasetFieldTypeId) && inputLevel.isRequired());
+    }
+
+    public boolean isDatasetFieldTypeIncludedAsInputLevel(Long datasetFieldTypeId) {
+        return dataverseFieldTypeInputLevels.stream()
+                .anyMatch(inputLevel -> inputLevel.getDatasetFieldType().getId().equals(datasetFieldTypeId) && inputLevel.isInclude());
+    }
+
+    public boolean isDatasetFieldTypeInInputLevels(Long datasetFieldTypeId) {
+        return dataverseFieldTypeInputLevels.stream()
+                .anyMatch(inputLevel -> inputLevel.getDatasetFieldType().getId().equals(datasetFieldTypeId));
     }
 
     public Template getDefaultTemplate() {

--- a/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
@@ -632,7 +632,7 @@ public class JsonPrinter {
     }
 
     public static JsonObjectBuilder json(MetadataBlock metadataBlock, boolean printOnlyDisplayedOnCreateDatasetFieldTypes, Dataverse ownerDataverse) {
-        JsonObjectBuilder jsonObjectBuilder = Json.createObjectBuilder();
+        JsonObjectBuilder jsonObjectBuilder = jsonObjectBuilder();
         jsonObjectBuilder.add("id", metadataBlock.getId());
         jsonObjectBuilder.add("name", metadataBlock.getName());
         jsonObjectBuilder.add("displayName", metadataBlock.getDisplayName());

--- a/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
@@ -647,8 +647,11 @@ public class JsonPrinter {
             boolean requiredAsInputLevel = isInputLevel && ownerDataverse.isDatasetFieldTypeRequiredAsInputLevel(datasetFieldTypeId);
             boolean includedAsInputLevel = isInputLevel && ownerDataverse.isDatasetFieldTypeIncludedAsInputLevel(datasetFieldTypeId);
 
+            DatasetFieldType parentDatasetFieldType = datasetFieldType.getParentDatasetFieldType();
+            boolean isRequired = parentDatasetFieldType == null ? datasetFieldType.isRequired() : parentDatasetFieldType.isRequired();
+
             boolean displayCondition = printOnlyDisplayedOnCreateDatasetFieldTypes
-                    ? (datasetFieldType.isDisplayOnCreate() || datasetFieldType.isRequired() || requiredAsInputLevel)
+                    ? (datasetFieldType.isDisplayOnCreate() || isRequired || requiredAsInputLevel)
                     : !isInputLevel || includedAsInputLevel;
 
             if (displayCondition) {

--- a/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
@@ -643,12 +643,12 @@ public class JsonPrinter {
 
         for (DatasetFieldType datasetFieldType : datasetFieldTypes) {
             Long datasetFieldTypeId = datasetFieldType.getId();
-            boolean isInputLevel = ownerDataverse != null && ownerDataverse.isDatasetFieldTypeInInputLevels(datasetFieldTypeId);
             boolean requiredAsInputLevel = ownerDataverse != null && ownerDataverse.isDatasetFieldTypeRequiredAsInputLevel(datasetFieldTypeId);
             boolean includedAsInputLevel = ownerDataverse != null && ownerDataverse.isDatasetFieldTypeIncludedAsInputLevel(datasetFieldTypeId);
 
             DatasetFieldType parentDatasetFieldType = datasetFieldType.getParentDatasetFieldType();
             boolean isRequired = parentDatasetFieldType == null ? datasetFieldType.isRequired() : parentDatasetFieldType.isRequired();
+            boolean isInputLevel = ownerDataverse != null && ownerDataverse.isDatasetFieldTypeInInputLevels(datasetFieldTypeId);
 
             boolean displayCondition = printOnlyDisplayedOnCreateDatasetFieldTypes
                     ? (datasetFieldType.isDisplayOnCreate() || isRequired || requiredAsInputLevel)

--- a/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
@@ -643,16 +643,16 @@ public class JsonPrinter {
 
         for (DatasetFieldType datasetFieldType : datasetFieldTypes) {
             Long datasetFieldTypeId = datasetFieldType.getId();
-            boolean requiredAsInputLevel = ownerDataverse != null && ownerDataverse.isDatasetFieldTypeRequiredAsInputLevel(datasetFieldTypeId);
-            boolean includedAsInputLevel = ownerDataverse != null && ownerDataverse.isDatasetFieldTypeIncludedAsInputLevel(datasetFieldTypeId);
+            boolean requiredAsInputLevelInOwnerDataverse = ownerDataverse != null && ownerDataverse.isDatasetFieldTypeRequiredAsInputLevel(datasetFieldTypeId);
+            boolean includedAsInputLevelInOwnerDataverse = ownerDataverse != null && ownerDataverse.isDatasetFieldTypeIncludedAsInputLevel(datasetFieldTypeId);
+            boolean isNotInputLevelInOwnerDataverse = ownerDataverse != null && !ownerDataverse.isDatasetFieldTypeInInputLevels(datasetFieldTypeId);
 
             DatasetFieldType parentDatasetFieldType = datasetFieldType.getParentDatasetFieldType();
             boolean isRequired = parentDatasetFieldType == null ? datasetFieldType.isRequired() : parentDatasetFieldType.isRequired();
-            boolean isInputLevel = ownerDataverse != null && ownerDataverse.isDatasetFieldTypeInInputLevels(datasetFieldTypeId);
 
             boolean displayCondition = printOnlyDisplayedOnCreateDatasetFieldTypes
-                    ? (datasetFieldType.isDisplayOnCreate() || isRequired || requiredAsInputLevel)
-                    : !isInputLevel || includedAsInputLevel;
+                    ? (datasetFieldType.isDisplayOnCreate() || isRequired || requiredAsInputLevelInOwnerDataverse)
+                    : ownerDataverse == null || includedAsInputLevelInOwnerDataverse || isNotInputLevelInOwnerDataverse;
 
             if (displayCondition) {
                 fieldsBuilder.add(datasetFieldType.getName(), json(datasetFieldType, ownerDataverse));

--- a/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
@@ -644,8 +644,8 @@ public class JsonPrinter {
         for (DatasetFieldType datasetFieldType : datasetFieldTypes) {
             Long datasetFieldTypeId = datasetFieldType.getId();
             boolean isInputLevel = ownerDataverse != null && ownerDataverse.isDatasetFieldTypeInInputLevels(datasetFieldTypeId);
-            boolean requiredAsInputLevel = isInputLevel && ownerDataverse.isDatasetFieldTypeRequiredAsInputLevel(datasetFieldTypeId);
-            boolean includedAsInputLevel = isInputLevel && ownerDataverse.isDatasetFieldTypeIncludedAsInputLevel(datasetFieldTypeId);
+            boolean requiredAsInputLevel = ownerDataverse != null && ownerDataverse.isDatasetFieldTypeRequiredAsInputLevel(datasetFieldTypeId);
+            boolean includedAsInputLevel = ownerDataverse != null && ownerDataverse.isDatasetFieldTypeIncludedAsInputLevel(datasetFieldTypeId);
 
             DatasetFieldType parentDatasetFieldType = datasetFieldType.getParentDatasetFieldType();
             boolean isRequired = parentDatasetFieldType == null ? datasetFieldType.isRequired() : parentDatasetFieldType.isRequired();

--- a/src/test/java/edu/harvard/iq/dataverse/api/DataversesIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/DataversesIT.java
@@ -702,8 +702,10 @@ public class DataversesIT {
         Response setMetadataBlocksResponse = UtilIT.setMetadataBlocks(dataverseAlias, Json.createArrayBuilder().add("citation").add("astrophysics"), apiToken);
         setMetadataBlocksResponse.then().assertThat().statusCode(OK.getStatusCode());
 
-        String[] testInputLevelNames = {"geographicCoverage", "country"};
-        Response updateDataverseInputLevelsResponse = UtilIT.updateDataverseInputLevels(dataverseAlias, testInputLevelNames, apiToken);
+        String[] testInputLevelNames = {"geographicCoverage", "country", "city"};
+        boolean[] testRequiredInputLevels = {false, true, false};
+        boolean[] testIncludedInputLevels = {false, true, true};
+        Response updateDataverseInputLevelsResponse = UtilIT.updateDataverseInputLevels(dataverseAlias, testInputLevelNames, testRequiredInputLevels, testIncludedInputLevels, apiToken);
         updateDataverseInputLevelsResponse.then().assertThat().statusCode(OK.getStatusCode());
 
         // Dataverse not found
@@ -769,6 +771,21 @@ public class DataversesIT {
         assertThat(expectedAllMetadataBlockDisplayNames, hasItemInArray(actualMetadataBlockDisplayName2));
         assertThat(expectedAllMetadataBlockDisplayNames, hasItemInArray(actualMetadataBlockDisplayName3));
 
+        // Check dataset fields for the updated input levels are retrieved
+        int geospatialMetadataBlockIndex = actualMetadataBlockDisplayName1.equals("Geospatial Metadata") ? 0 : actualMetadataBlockDisplayName2.equals("Geospatial Metadata") ? 1 : 2;
+
+        // Since the included property of geographicCoverage is set to false, we should retrieve the total number of fields minus one
+        listMetadataBlocksResponse.then().assertThat()
+                .body(String.format("data[%d].fields.size()", geospatialMetadataBlockIndex), equalTo(10));
+
+        String actualMetadataField1 = listMetadataBlocksResponse.then().extract().path(String.format("data[%d].fields.geographicCoverage.name", geospatialMetadataBlockIndex));
+        String actualMetadataField2 = listMetadataBlocksResponse.then().extract().path(String.format("data[%d].fields.country.name", geospatialMetadataBlockIndex));
+        String actualMetadataField3 = listMetadataBlocksResponse.then().extract().path(String.format("data[%d].fields.city.name", geospatialMetadataBlockIndex));
+
+        assertNull(actualMetadataField1);
+        assertNotNull(actualMetadataField2);
+        assertNotNull(actualMetadataField3);
+
         // Existent dataverse and onlyDisplayedOnCreate=true and returnDatasetFieldTypes=true
         listMetadataBlocksResponse = UtilIT.listMetadataBlocks(dataverseAlias, true, true, apiToken);
         listMetadataBlocksResponse.then().assertThat().statusCode(OK.getStatusCode());
@@ -785,16 +802,18 @@ public class DataversesIT {
         assertThat(expectedOnlyDisplayedOnCreateMetadataBlockDisplayNames, hasItemInArray(actualMetadataBlockDisplayName2));
 
         // Check dataset fields for the updated input levels are retrieved
-        int geospatialMetadataBlockIndex = actualMetadataBlockDisplayName2.equals("Geospatial Metadata") ? 1 : 0;
+        geospatialMetadataBlockIndex = actualMetadataBlockDisplayName2.equals("Geospatial Metadata") ? 1 : 0;
 
         listMetadataBlocksResponse.then().assertThat()
-                .body(String.format("data[%d].fields.size()", geospatialMetadataBlockIndex), equalTo(2));
+                .body(String.format("data[%d].fields.size()", geospatialMetadataBlockIndex), equalTo(1));
 
-        String actualMetadataField1 = listMetadataBlocksResponse.then().extract().path(String.format("data[%d].fields.geographicCoverage.name", geospatialMetadataBlockIndex));
-        String actualMetadataField2 = listMetadataBlocksResponse.then().extract().path(String.format("data[%d].fields.country.name", geospatialMetadataBlockIndex));
+        actualMetadataField1 = listMetadataBlocksResponse.then().extract().path(String.format("data[%d].fields.geographicCoverage.name", geospatialMetadataBlockIndex));
+        actualMetadataField2 = listMetadataBlocksResponse.then().extract().path(String.format("data[%d].fields.country.name", geospatialMetadataBlockIndex));
+        actualMetadataField3 = listMetadataBlocksResponse.then().extract().path(String.format("data[%d].fields.city.name", geospatialMetadataBlockIndex));
 
-        assertNotNull(actualMetadataField1);
+        assertNull(actualMetadataField1);
         assertNotNull(actualMetadataField2);
+        assertNull(actualMetadataField3);
 
         // User has no permissions on the requested dataverse
         Response createSecondUserResponse = UtilIT.createRandomUser();
@@ -898,12 +917,16 @@ public class DataversesIT {
 
         // Update valid input levels
         String[] testInputLevelNames = {"geographicCoverage", "country"};
-        Response updateDataverseInputLevelsResponse = UtilIT.updateDataverseInputLevels(dataverseAlias, testInputLevelNames, apiToken);
+        boolean[] testRequiredInputLevels = {true, false};
+        boolean[] testIncludedInputLevels = {true, false};
+        Response updateDataverseInputLevelsResponse = UtilIT.updateDataverseInputLevels(dataverseAlias, testInputLevelNames, testRequiredInputLevels, testIncludedInputLevels, apiToken);
+        String actualInputLevelName = updateDataverseInputLevelsResponse.then().extract().path("data.inputLevels[0].datasetFieldTypeName");
+        int geographicCoverageInputLevelIndex = actualInputLevelName.equals("geographicCoverage") ? 0 : 1;
         updateDataverseInputLevelsResponse.then().assertThat()
-                .body("data.inputLevels[0].required", equalTo(true))
-                .body("data.inputLevels[0].include", equalTo(true))
-                .body("data.inputLevels[1].required", equalTo(true))
-                .body("data.inputLevels[1].include", equalTo(true))
+                .body(String.format("data.inputLevels[%d].include", geographicCoverageInputLevelIndex), equalTo(true))
+                .body(String.format("data.inputLevels[%d].required", geographicCoverageInputLevelIndex), equalTo(true))
+                .body(String.format("data.inputLevels[%d].include", 1 - geographicCoverageInputLevelIndex), equalTo(false))
+                .body(String.format("data.inputLevels[%d].required", 1 - geographicCoverageInputLevelIndex), equalTo(false))
                 .statusCode(OK.getStatusCode());
         String actualFieldTypeName1 = updateDataverseInputLevelsResponse.then().extract().path("data.inputLevels[0].datasetFieldTypeName");
         String actualFieldTypeName2 = updateDataverseInputLevelsResponse.then().extract().path("data.inputLevels[1].datasetFieldTypeName");
@@ -913,15 +936,14 @@ public class DataversesIT {
 
         // Update input levels with an invalid field type name
         String[] testInvalidInputLevelNames = {"geographicCoverage", "invalid1"};
-        updateDataverseInputLevelsResponse = UtilIT.updateDataverseInputLevels(dataverseAlias, testInvalidInputLevelNames, apiToken);
+        updateDataverseInputLevelsResponse = UtilIT.updateDataverseInputLevels(dataverseAlias, testInvalidInputLevelNames, testRequiredInputLevels, testIncludedInputLevels, apiToken);
         updateDataverseInputLevelsResponse.then().assertThat()
                 .body("message", equalTo("Invalid dataset field type name: invalid1"))
                 .statusCode(BAD_REQUEST.getStatusCode());
 
         // Update invalid empty input levels
         testInputLevelNames = new String[]{};
-        updateDataverseInputLevelsResponse = UtilIT.updateDataverseInputLevels(dataverseAlias, testInputLevelNames, apiToken);
-        updateDataverseInputLevelsResponse.prettyPrint();
+        updateDataverseInputLevelsResponse = UtilIT.updateDataverseInputLevels(dataverseAlias, testInputLevelNames, testRequiredInputLevels, testIncludedInputLevels, apiToken);
         updateDataverseInputLevelsResponse.then().assertThat()
                 .body("message", equalTo("Error while updating dataverse input levels: Input level list cannot be null or empty"))
                 .statusCode(INTERNAL_SERVER_ERROR.getStatusCode());

--- a/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
@@ -3953,20 +3953,23 @@ public class UtilIT {
                 .post("/api/datasets/" + datasetId + "/requestGlobusUploadPaths");
     }
 
-    static Response updateDataverseInputLevels(String dataverseAlias, String[] inputLevelNames, String apiToken) {
-        JsonArrayBuilder contactArrayBuilder = Json.createArrayBuilder();
-        for(String inputLevelName : inputLevelNames) {
-            contactArrayBuilder.add(Json.createObjectBuilder()
-                    .add("datasetFieldTypeName", inputLevelName)
-                    .add("required", true)
-                    .add("include", true)
-            );
+    public static Response updateDataverseInputLevels(String dataverseAlias, String[] inputLevelNames, boolean[] requiredInputLevels, boolean[] includedInputLevels, String apiToken) {
+        JsonArrayBuilder inputLevelsArrayBuilder = Json.createArrayBuilder();
+        for (int i = 0; i < inputLevelNames.length; i++) {
+            inputLevelsArrayBuilder.add(createInputLevelObject(inputLevelNames[i], requiredInputLevels[i], includedInputLevels[i]));
         }
         return given()
                 .header(API_TOKEN_HTTP_HEADER, apiToken)
-                .body(contactArrayBuilder.build().toString())
+                .body(inputLevelsArrayBuilder.build().toString())
                 .contentType(ContentType.JSON)
                 .put("/api/dataverses/" + dataverseAlias + "/inputLevels");
+    }
+
+    private static JsonObjectBuilder createInputLevelObject(String name, boolean required, boolean include) {
+        return Json.createObjectBuilder()
+                .add("datasetFieldTypeName", name)
+                .add("required", required)
+                .add("include", include);
     }
 
     public static Response getOpenAPI(String accept, String format) {


### PR DESCRIPTION
**What this PR does / why we need it**:

dataverses/{id}/metadatablocks API endpoint has been fixed, since the fields returned for each metadata block when returnDatasetTypes query parameter is set to true was not correct.

**Which issue(s) this PR closes**:

Closes #10637 

**Special notes for your reviewer**:

The goal of the changes is for the endpoint to return the correct blocks and field types for both the create dataset form (onlyDisplayedOnCreate=true) and the edit dataset form (onlyDisplayedOnCreate=false).

The conditions on the input levels, which are configured when creating or editing the collection, were not working as expected.

**Suggestions on how to test this**:

New IT tests have been added, but for manual testing, follow these steps:

Create different collections with required or included fields (input levels) using the checkboxes in the metadata fields section.

![Screenshot 2024-06-20 at 09 22 44](https://github.com/IQSS/dataverse/assets/17010447/52abbccd-3023-4d45-ae37-4fa056fe4a07)

Then, call the dataverses/{id}/metadatablocks API endpoint using returnDatasetFieldTypes=true, for each collection you created.

First, add onlyDisplayedOnCreate=true to return the fields that should be displayed in the create dataset form. This should match what you see on JSF:

`curl -H "X-Dataverse-key:XXXXX" "http://localhost:8080/api/dataverses/{ID}/metadatablocks?returnDatasetFieldTypes=true&returnDatasetFieldTypes=true"`

Then, add onlyDisplayedOnCreate=false, to return the fields you see in the edit dataset form. Again, this should match what you see on JSF:

`curl -H "X-Dataverse-key:XXXXX" "http://localhost:8080/api/dataverses/{ID}/metadatablocks?returnDatasetFieldTypes=false&returnDatasetFieldTypes=true"`

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No

**Is there a release notes update needed for this change?**:

Yes, attached.

**Additional documentation**:

None