### PR TITLE
IQSS/10656-fix permission check for request access notifications/emails 

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/FileDownloadServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/FileDownloadServiceBean.java
@@ -573,7 +573,7 @@ public class FileDownloadServiceBean implements java.io.Serializable {
     
     public void sendRequestFileAccessNotification(Dataset dataset, Long fileId, AuthenticatedUser requestor) {
         Timestamp ts = new Timestamp(new Date().getTime());
-        permissionService.getUsersWithPermissionOn(Permission.ManageDatasetPermissions, dataset).stream().forEach((au) -> {
+        permissionService.getUsersWithPermissionOn(Permission.ManageFilePermissions, dataset).stream().forEach((au) -> {
             userNotificationService.sendNotification(au, ts, UserNotification.Type.REQUESTFILEACCESS, fileId, null, requestor, true);
         });
         //send the user that requested access a notification that they requested the access


### PR DESCRIPTION
**What this PR does / why we need it**: Per the issue, emails about file access requests are being sent to people with ManageDatasetPermission rather than the new ManageFilePermission. This PR is a one line fix for that.

**Which issue(s) this PR closes**:

Closes #10656

**Special notes for your reviewer**:

**Suggestions on how to test this**: Setup a dataset with restricted files and add people with filemanager permission, verify that they receive notifications/emails when file access is requested.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
