### PR TITLE
Added dataverse.db.parameters from long list of JVM options

### DIFF
--- a/doc/sphinx-guides/source/installation/config.rst
+++ b/doc/sphinx-guides/source/installation/config.rst
@@ -781,7 +781,7 @@ Basic Database Settings
      - | ``dataverse``
        | (installer sets to ``dvndb``)
    * - dataverse.db.parameters
-     - Connection parameters, such as ``sslmode=require``. See `Postgres JDBC docs <https://jdbc.postgresql.org/documentation/head/connect.html>`_
+     - Connection parameters, such as ``sslmode=require``. See `Postgres JDBC docs <https://jdbc.postgresql.org/documentation/head/connect.html>`
        Note: you don't need to provide the initial "?".
      - *Empty string*
 
@@ -2441,6 +2441,15 @@ The PostgreSQL server port to connect to.
 Defaults to ``5432``, the default PostgreSQL port.
 
 Can also be set via *MicroProfile Config API* sources, e.g. the environment variable ``DATAVERSE_DB_PORT``.
+
+dataverse.db.parameters
++++++++++++++++++++++++
+
+The PostgreSQL server connection parameters.
+
+Defaults to *Empty string*
+
+Can also be set via *MicroProfile Config API* sources, e.g. the environment variable ``DATAVERSE_DB_PARAMETERS``.
 
 .. _dataverse.solr.host:
 

--- a/doc/sphinx-guides/source/installation/config.rst
+++ b/doc/sphinx-guides/source/installation/config.rst
@@ -781,7 +781,7 @@ Basic Database Settings
      - | ``dataverse``
        | (installer sets to ``dvndb``)
    * - dataverse.db.parameters
-     - Connection parameters, such as ``sslmode=require``. See `Postgres JDBC docs <https://jdbc.postgresql.org/documentation/head/connect.html>`
+     - Connection parameters, such as ``sslmode=require``. See `Postgres JDBC docs <https://jdbc.postgresql.org/documentation/head/connect.html>`_
        Note: you don't need to provide the initial "?".
      - *Empty string*
 

--- a/doc/sphinx-guides/source/installation/config.rst
+++ b/doc/sphinx-guides/source/installation/config.rst
@@ -2447,7 +2447,7 @@ dataverse.db.parameters
 
 The PostgreSQL server connection parameters.
 
-Defaults to *Empty string*
+Defaults to *empty string*
 
 Can also be set via *MicroProfile Config API* sources, e.g. the environment variable ``DATAVERSE_DB_PARAMETERS``.
 


### PR DESCRIPTION
Addressing documentation issue #10669. Updated the config.rst file under doc/sphinx-guides/source/installation to add missing documentation about dataverse.db.parameters under JVM Options section

**What this PR does / why we need it**: Improve documentation

**Which issue(s) this PR closes**:

- Closes #10669

**Special notes for your reviewer**: None

**Suggestions on how to test this**: No code change. Review of the documentation change is required only.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: No

**Is there a release notes update needed for this change?**: No

**Additional documentation**: None
