### PR TITLE
Assert true or false, not equal to true or false

### DIFF
--- a/src/test/java/edu/harvard/iq/dataverse/DatasetFieldTypeTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/DatasetFieldTypeTest.java
@@ -63,17 +63,17 @@ public class DatasetFieldTypeTest {
         //if textbox then sanitize - allow tags
         instance.setFieldType(DatasetFieldType.FieldType.TEXTBOX);
         result = instance.isSanitizeHtml();
-        assertEquals(true, result);
+        assertTrue(result);
         
         //if textbox then don't sanitize - allow tags
         instance.setFieldType(DatasetFieldType.FieldType.EMAIL);
         result = instance.isSanitizeHtml();
-        assertEquals(false, result);
+        assertFalse(result);
         
         //URL, too
         instance.setFieldType(DatasetFieldType.FieldType.URL);
         result = instance.isSanitizeHtml();
-        assertEquals(true, result);
+        assertTrue(result);
     }
     
     @Test
@@ -102,7 +102,7 @@ public class DatasetFieldTypeTest {
         //URL, too
         instance.setFieldType(DatasetFieldType.FieldType.URL);
         result = instance.isEscapeOutputText();
-        assertEquals(false, result);
+        assertFalse(result);
         
     }
     
@@ -121,7 +121,7 @@ public class DatasetFieldTypeTest {
         parent.setAllowMultiples(true);
         instance.setParentDatasetFieldType(parent);
         solrField = instance.getSolrField();
-        assertEquals(true, solrField.isAllowedToBeMultivalued());
+        assertTrue(solrField.isAllowedToBeMultivalued());
         
     }
 

--- a/src/test/java/edu/harvard/iq/dataverse/DatasetFieldValueValidatorTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/DatasetFieldValueValidatorTest.java
@@ -52,63 +52,63 @@ public class DatasetFieldValueValidatorTest {
         //Make string too long - should fail.
         value.setValue("asdfgX");
         result = instance.isValid(value, ctx);
-        assertEquals(false, result);
+        assertFalse(result);
         
         //Make string too long - should fail.
         value.setValue("asdf");
         result = instance.isValid(value, ctx);
-        assertEquals(false, result);
+        assertFalse(result);
         
         //Now lets try Dates
         dft.setFieldType(DatasetFieldType.FieldType.DATE);   
         dft.setValidationFormat(null);
         value.setValue("1999AD");
         result = instance.isValid(value, ctx);
-        assertEquals(true, result); 
+        assertTrue(result); 
         
         value.setValue("44BCE");
         result = instance.isValid(value, ctx);
-        assertEquals(true, result); 
+        assertTrue(result); 
         
         value.setValue("2004-10-27");
         result = instance.isValid(value, ctx);
-        assertEquals(true, result); 
+        assertTrue(result); 
         
         value.setValue("2002-08");
         result = instance.isValid(value, ctx);
-        assertEquals(true, result);  
+        assertTrue(result);  
         
         value.setValue("[1999?]");
         result = instance.isValid(value, ctx);
-        assertEquals(true, result); 
+        assertTrue(result); 
         
         value.setValue("Blergh");
         result = instance.isValid(value, ctx);
-        assertEquals(false, result);  
+        assertFalse(result);  
         
         //Float
         dft.setFieldType(DatasetFieldType.FieldType.FLOAT); 
         value.setValue("44");
         result = instance.isValid(value, ctx);
-        assertEquals(true, result);
+        assertTrue(result);
         
         value.setValue("44 1/2");
         result = instance.isValid(value, ctx);
-        assertEquals(false, result);
+        assertFalse(result);
         
         //Integer
         dft.setFieldType(DatasetFieldType.FieldType.INT); 
         value.setValue("44");
         result = instance.isValid(value, ctx);
-        assertEquals(true, result);
+        assertTrue(result);
         
         value.setValue("-44");
         result = instance.isValid(value, ctx);
-        assertEquals(true, result);
+        assertTrue(result);
         
         value.setValue("12.14");
         result = instance.isValid(value, ctx);
-        assertEquals(false, result);
+        assertFalse(result);
     }
 
     @Test

--- a/src/test/java/edu/harvard/iq/dataverse/DatasetVersionTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/DatasetVersionTest.java
@@ -80,7 +80,7 @@ public class DatasetVersionTest {
 
         DatasetVersion nonDraft = new DatasetVersion();
         nonDraft.setVersionState(DatasetVersion.VersionState.RELEASED);
-        assertEquals(false, nonDraft.isInReview());
+        assertFalse(nonDraft.isInReview());
         
         ds.addLock(null);
         assertFalse(nonDraft.isInReview());

--- a/src/test/java/edu/harvard/iq/dataverse/api/DatasetsIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/DatasetsIT.java
@@ -1621,7 +1621,7 @@ public class DatasetsIT {
 
         Response privateUrlRoleAssignmentShouldBeGoneAfterDraftDeleted = UtilIT.getRoleAssignmentsOnDataset(datasetId.toString(), null, apiToken);
         privateUrlRoleAssignmentShouldBeGoneAfterDraftDeleted.prettyPrint();
-        assertEquals(false, privateUrlRoleAssignmentShouldBeGoneAfterDraftDeleted.body().asString().contains(privateUrlUser.getIdentifier()));
+        assertFalse(privateUrlRoleAssignmentShouldBeGoneAfterDraftDeleted.body().asString().contains(privateUrlUser.getIdentifier()));
 
         String newTitleAgain = "I am changing the title again";
         Response draftCreatedAgainPostPub = UtilIT.updateDatasetTitleViaSword(dataset1PersistentId, newTitleAgain, apiToken);

--- a/src/test/java/edu/harvard/iq/dataverse/api/SwordIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/SwordIT.java
@@ -850,7 +850,7 @@ public class SwordIT {
         String citation = atomEntryDraftV2.body().xmlPath().getString("entry.bibliographicCitation");
         logger.info("citation (should contain 'DRAFT'): " + citation);
         boolean draftStringFoundInCitation = citation.matches(".*DRAFT.*");
-        assertEquals(true, draftStringFoundInCitation);
+        assertTrue(draftStringFoundInCitation);
 
         List<String> oneFileLeftInV2Draft = statement3.getBody().xmlPath().getList("feed.entry.id");
         logger.info("Number of files remaining in this post version 1 draft:" + oneFileLeftInV2Draft.size());

--- a/src/test/java/edu/harvard/iq/dataverse/authorization/users/AuthenticatedUserTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/authorization/users/AuthenticatedUserTest.java
@@ -378,20 +378,20 @@ public class AuthenticatedUserTest {
     public void testHasEmailMuted() {
         testUser.setMutedEmails(mutedTypes);
         System.out.println("hasEmailMuted");
-        assertEquals(true, testUser.hasEmailMuted(Type.ASSIGNROLE));
-        assertEquals(true, testUser.hasEmailMuted(Type.REVOKEROLE));
-        assertEquals(false, testUser.hasEmailMuted(Type.CREATEDV));
-        assertEquals(false, testUser.hasEmailMuted(null));
+        assertTrue(testUser.hasEmailMuted(Type.ASSIGNROLE));
+        assertTrue(testUser.hasEmailMuted(Type.REVOKEROLE));
+        assertFalse(testUser.hasEmailMuted(Type.CREATEDV));
+        assertFalse(testUser.hasEmailMuted(null));
     }
 
     @Test
     public void testHasNotificationsMutedMuted() {
         testUser.setMutedNotifications(mutedTypes);
         System.out.println("hasNotificationMuted");
-        assertEquals(true, testUser.hasNotificationMuted(Type.ASSIGNROLE));
-        assertEquals(true, testUser.hasNotificationMuted(Type.REVOKEROLE));
-        assertEquals(false, testUser.hasNotificationMuted(Type.CREATEDV));
-        assertEquals(false, testUser.hasNotificationMuted(null));
+        assertTrue(testUser.hasNotificationMuted(Type.ASSIGNROLE));
+        assertTrue(testUser.hasNotificationMuted(Type.REVOKEROLE));
+        assertFalse(testUser.hasNotificationMuted(Type.CREATEDV));
+        assertFalse(testUser.hasNotificationMuted(null));
     }
 
     @Test

--- a/src/test/java/edu/harvard/iq/dataverse/dataaccess/FileAccessIOTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/dataaccess/FileAccessIOTest.java
@@ -89,20 +89,20 @@ public class FileAccessIOTest {
      */
     @Test
     public void testOpen() throws IOException {
-        assertEquals(false, datasetAccess.canRead());
-        assertEquals(false, datasetAccess.canWrite());
+        assertFalse(datasetAccess.canRead());
+        assertFalse(datasetAccess.canWrite());
 
         datasetAccess.open(DataAccessOption.READ_ACCESS);
-        assertEquals(true, datasetAccess.canRead());
-        assertEquals(false, datasetAccess.canWrite());
+        assertTrue(datasetAccess.canRead());
+        assertFalse(datasetAccess.canWrite());
 
         datasetAccess.open(DataAccessOption.WRITE_ACCESS);
-        assertEquals(false, datasetAccess.canRead());
-        assertEquals(true, datasetAccess.canWrite());
+        assertFalse(datasetAccess.canRead());
+        assertTrue(datasetAccess.canWrite());
 
         dataFileAccess.open(DataAccessOption.READ_ACCESS);
-        assertEquals(true, dataFileAccess.canRead());
-        assertEquals(false, dataFileAccess.canWrite());
+        assertTrue(dataFileAccess.canRead());
+        assertFalse(dataFileAccess.canWrite());
     }
 
     /**
@@ -133,7 +133,7 @@ public class FileAccessIOTest {
      */
     @Test
     public void testIsAuxObjectCached() throws IOException {
-        assertEquals(true, datasetAccess.isAuxObjectCached("Dataset"));
+        assertTrue(datasetAccess.isAuxObjectCached("Dataset"));
     }
 
     /**

--- a/src/test/java/edu/harvard/iq/dataverse/dataaccess/StorageIOTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/dataaccess/StorageIOTest.java
@@ -189,48 +189,48 @@ public class StorageIOTest {
 
     @Test
     public void testFileLocation() {
-        assertEquals(true, instance.isLocalFile());
+        assertTrue(instance.isLocalFile());
         instance.setIsLocalFile(false);
-        assertEquals(false, instance.isLocalFile());
+        assertFalse(instance.isLocalFile());
 
-        assertEquals(false, instance.isRemoteAccess());
+        assertFalse(instance.isRemoteAccess());
         instance.setIsRemoteAccess(true);
-        assertEquals(true, instance.isRemoteAccess());
+        assertTrue(instance.isRemoteAccess());
     }
 
     @Test
     public void testHttpAccess() {
-        assertEquals(false, instance.isHttpAccess());
+        assertFalse(instance.isHttpAccess());
         instance.setIsHttpAccess(true);
-        assertEquals(true, instance.isHttpAccess());
+        assertTrue(instance.isHttpAccess());
     }*/
 
     @Test
     public void testDownloadSupported() {
-        assertEquals(true, instance.isDownloadSupported());
+        assertTrue(instance.isDownloadSupported());
         instance.setIsDownloadSupported(false);
-        assertEquals(false, instance.isDownloadSupported());
+        assertFalse(instance.isDownloadSupported());
     }
 
     @Test
     public void testSubsetSupported() {
-        assertEquals(false, instance.isSubsetSupported());
+        assertFalse(instance.isSubsetSupported());
         instance.setIsSubsetSupported(true);
-        assertEquals(true, instance.isSubsetSupported());
+        assertTrue(instance.isSubsetSupported());
     }
 
     @Test
     public void testZippedStream() {
-        assertEquals(false, instance.isZippedStream());
+        assertFalse(instance.isZippedStream());
         instance.setIsZippedStream(true);
-        assertEquals(true, instance.isZippedStream());
+        assertTrue(instance.isZippedStream());
     }
 
     @Test
     public void testNoVarHeader() {
-        assertEquals(false, instance.noVarHeader());
+        assertFalse(instance.noVarHeader());
         instance.setNoVarHeader(true);
-        assertEquals(true, instance.noVarHeader());
+        assertTrue(instance.noVarHeader());
     }
 
     @Test

--- a/src/test/java/edu/harvard/iq/dataverse/dataaccess/SwiftAccessIOTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/dataaccess/SwiftAccessIOTest.java
@@ -51,14 +51,14 @@ public class SwiftAccessIOTest {
      */
     @Test
     public void testPerms() throws IOException {
-        assertEquals(false, datasetAccess.canRead());
-        assertEquals(false, datasetAccess.canWrite());
+        assertFalse(datasetAccess.canRead());
+        assertFalse(datasetAccess.canWrite());
     }
     
     @Test
     public void testIsExpiryExpired() {
         long currentTime = 1502221467;
-        assertEquals(false, swiftAccess.isExpiryExpired(60, 1502281, currentTime));
+        assertFalse(swiftAccess.isExpiryExpired(60, 1502281, currentTime));
     }
     
     @Test

--- a/src/test/java/edu/harvard/iq/dataverse/datacapturemodule/DataCaptureModuleUtilTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/datacapturemodule/DataCaptureModuleUtilTest.java
@@ -18,6 +18,7 @@ import org.apache.http.impl.DefaultHttpResponseFactory;
 import org.apache.http.message.BasicStatusLine;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import org.junit.jupiter.api.Test;
 
 public class DataCaptureModuleUtilTest {
@@ -25,13 +26,13 @@ public class DataCaptureModuleUtilTest {
     @Test
     public void testRsyncSupportEnabled() {
         System.out.println("rsyncSupportEnabled");
-        assertEquals(false, DataCaptureModuleUtil.rsyncSupportEnabled(null));
-        assertEquals(true, DataCaptureModuleUtil.rsyncSupportEnabled("dcm/rsync+ssh"));
+        assertFalse(DataCaptureModuleUtil.rsyncSupportEnabled(null));
+        assertTrue(DataCaptureModuleUtil.rsyncSupportEnabled("dcm/rsync+ssh"));
         // Comma sepratated lists of upload methods are supported.
-        assertEquals(false, DataCaptureModuleUtil.rsyncSupportEnabled("native/http:dcm/rsync+ssh"));
-        assertEquals(true, DataCaptureModuleUtil.rsyncSupportEnabled("native/http,dcm/rsync+ssh"));
-        assertEquals(false, DataCaptureModuleUtil.rsyncSupportEnabled("native/http"));
-        assertEquals(false, DataCaptureModuleUtil.rsyncSupportEnabled("junk"));
+        assertFalse(DataCaptureModuleUtil.rsyncSupportEnabled("native/http:dcm/rsync+ssh"));
+        assertTrue(DataCaptureModuleUtil.rsyncSupportEnabled("native/http,dcm/rsync+ssh"));
+        assertFalse(DataCaptureModuleUtil.rsyncSupportEnabled("native/http"));
+        assertFalse(DataCaptureModuleUtil.rsyncSupportEnabled("junk"));
     }
 
     @Test

--- a/src/test/java/edu/harvard/iq/dataverse/dataset/DatasetUtilTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/dataset/DatasetUtilTest.java
@@ -70,8 +70,8 @@ public class DatasetUtilTest {
      */
     @Test
     public void testDeleteDatasetLogo() {
-        assertEquals(false, DatasetUtil.deleteDatasetLogo(null));
-        assertEquals(false, DatasetUtil.deleteDatasetLogo(new Dataset()));
+        assertFalse(DatasetUtil.deleteDatasetLogo(null));
+        assertFalse(DatasetUtil.deleteDatasetLogo(new Dataset()));
     }
 
     /**
@@ -106,7 +106,7 @@ public class DatasetUtilTest {
     @Test
     public void testIsDatasetLogoPresent() {
         Dataset dataset = MocksFactory.makeDataset();
-        assertEquals(false, DatasetUtil.isDatasetLogoPresent(dataset, ImageThumbConverter.DEFAULT_CARDIMAGE_SIZE));
+        assertFalse(DatasetUtil.isDatasetLogoPresent(dataset, ImageThumbConverter.DEFAULT_CARDIMAGE_SIZE));
     }
 
     @Test

--- a/src/test/java/edu/harvard/iq/dataverse/datavariable/VariableMetadataDDIParserTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/datavariable/VariableMetadataDDIParserTest.java
@@ -66,16 +66,16 @@ public class VariableMetadataDDIParserTest {
         assertEquals(vm.getLiteralquestion(), "This is a literal question.");
         assertEquals(vm.getNotes(), "These are notes.\nA lot of them.");
         assertEquals(vm.getUniverse(),"Our universe");
-        assertEquals(false, vm.isIsweightvar());
-        assertEquals(false, vm.isWeighted());
+        assertFalse(vm.isIsweightvar());
+        assertFalse(vm.isWeighted());
 
         testCategoriesVar1(vm);
 
 
         vm =  vmMap.get(1169L);
         assertNotNull(vm);
-        assertEquals(false, vm.isIsweightvar());
-        assertEquals(true, vm.isWeighted());
+        assertFalse(vm.isIsweightvar());
+        assertTrue(vm.isWeighted());
         assertEquals(vm.getLabel(), "age_rollup"  );
 
         assertEquals(vm.getInterviewinstruction(), null);
@@ -90,8 +90,8 @@ public class VariableMetadataDDIParserTest {
 
         vm =  vmMap.get(1168L);
         assertNotNull(vm);
-        assertEquals(true, vm.isIsweightvar());
-        assertEquals(false, vm.isWeighted());
+        assertTrue(vm.isIsweightvar());
+        assertFalse(vm.isWeighted());
         assertEquals(vm.getLabel(), "weight"  );
         assertEquals(vm.getInterviewinstruction(), null);
         assertEquals(vm.getLiteralquestion(), "Literal question for weight");

--- a/src/test/java/edu/harvard/iq/dataverse/export/SchemaDotOrgExporterTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/export/SchemaDotOrgExporterTest.java
@@ -251,7 +251,7 @@ public class SchemaDotOrgExporterTest {
      */
     @Test
     public void testIsXMLFormat() {
-        assertEquals(false, schemaDotOrgExporter instanceof XMLExporter);
+        assertFalse(schemaDotOrgExporter instanceof XMLExporter);
     }
 
     /**
@@ -259,7 +259,7 @@ public class SchemaDotOrgExporterTest {
      */
     @Test
     public void testIsHarvestable() {
-        assertEquals(false, schemaDotOrgExporter.isHarvestable());
+        assertFalse(schemaDotOrgExporter.isHarvestable());
     }
 
     /**
@@ -267,7 +267,7 @@ public class SchemaDotOrgExporterTest {
      */
     @Test
     public void testIsAvailableToUsers() {
-        assertEquals(true, schemaDotOrgExporter.isAvailableToUsers());
+        assertTrue(schemaDotOrgExporter.isAvailableToUsers());
     }
 
     /**

--- a/src/test/java/edu/harvard/iq/dataverse/ingest/IngestUtilTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/ingest/IngestUtilTest.java
@@ -112,8 +112,8 @@ public class IngestUtilTest {
         }
 
         // check filenames are unique and altered
-        assertEquals(true, file1NameAltered);
-        assertEquals(true, file2NameAltered);
+        assertTrue(file1NameAltered);
+        assertTrue(file2NameAltered);
 
         // try to add data files with "-1" duplicates and see if it gets incremented to "-2"
         IngestUtil.checkForDuplicateFileNamesFinal(datasetVersion, dataFileList, null);
@@ -128,8 +128,8 @@ public class IngestUtilTest {
         }
 
         // check filenames are unique and altered
-        assertEquals(true, file1NameAltered);
-        assertEquals(true, file2NameAltered);
+        assertTrue(file1NameAltered);
+        assertTrue(file2NameAltered);
     }
 
     @Test
@@ -218,8 +218,8 @@ public class IngestUtilTest {
         }
 
         // check filenames are unique and altered
-        assertEquals(true, file1NameAltered);
-        assertEquals(true, file2NameAltered);
+        assertTrue(file1NameAltered);
+        assertTrue(file2NameAltered);
 
         // try to add data files with "-1" duplicates and see if it gets incremented to "-2"
         IngestUtil.checkForDuplicateFileNamesFinal(datasetVersion, dataFileList, null);
@@ -234,8 +234,8 @@ public class IngestUtilTest {
         }
 
         // check filenames are unique and altered
-        assertEquals(true, file1NameAltered);
-        assertEquals(true, file2NameAltered);
+        assertTrue(file1NameAltered);
+        assertTrue(file2NameAltered);
     }
 
     @Test
@@ -347,9 +347,9 @@ public class IngestUtilTest {
         }
 
         // check filenames are unique
-        assertEquals(true, file1NameAltered);
-        assertEquals(true, file2NameAltered);
-        assertEquals(false, file3NameAltered);
+        assertTrue(file1NameAltered);
+        assertTrue(file2NameAltered);
+        assertFalse(file3NameAltered);
 
         // add duplicate file in root
         datasetVersion.getFileMetadatas().add(fmd3);
@@ -371,9 +371,9 @@ public class IngestUtilTest {
         }
 
         // check filenames are unique
-        assertEquals(true, file1NameAltered);
-        assertEquals(true, file2NameAltered);
-        assertEquals(true, file3NameAltered);
+        assertTrue(file1NameAltered);
+        assertTrue(file2NameAltered);
+        assertTrue(file3NameAltered);
     }
 
     @Test
@@ -457,7 +457,7 @@ public class IngestUtilTest {
         }
 
         // check filename is altered since tabular and will change to .tab after ingest
-        assertEquals(true, file2NameAltered);
+        assertTrue(file2NameAltered);
     }
 
     
@@ -553,8 +553,8 @@ public class IngestUtilTest {
         }
 
         // check filenames are unique and unaltered
-        assertEquals(true, file1NameAltered);
-        assertEquals(false, file2NameAltered);
+        assertTrue(file1NameAltered);
+        assertFalse(file2NameAltered);
     }
     
     @Test
@@ -657,7 +657,7 @@ public class IngestUtilTest {
         DataTable dataTable = new DataTable();
         dataTable.setUnf("unfOnDataTable");
         datafile1.setDataTable(dataTable);
-        assertEquals(true, datafile1.isTabularData());
+        assertTrue(datafile1.isTabularData());
 
         FileMetadata fmd1 = new FileMetadata();
         fmd1.setId(1L);
@@ -692,7 +692,7 @@ public class IngestUtilTest {
 
     @Test
     public void testshouldHaveUnf() {
-        assertEquals(false, IngestUtil.shouldHaveUnf(null));
+        assertFalse(IngestUtil.shouldHaveUnf(null));
     }
 
     @Test

--- a/src/test/java/edu/harvard/iq/dataverse/mydata/PagerTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/mydata/PagerTest.java
@@ -2,6 +2,8 @@ package edu.harvard.iq.dataverse.mydata;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Arrays;
@@ -171,13 +173,13 @@ public class PagerTest {
         pager1 = new Pager(102, 10, 1);
 
         msgt("Test: 102 results, 10 per page, page 1");
-        assertEquals(true, pager1.isPagerNecessary());
+        assertTrue(pager1.isPagerNecessary());
 
         assertEquals(102, pager1.getNumResults());
         assertEquals(1, pager1.getPreviousPageNumber());
         assertEquals(2, pager1.getNextPageNumber());
-        assertEquals(false, pager1.hasPreviousPageNumber());
-        assertEquals(true, pager1.hasNextPageNumber());
+        assertFalse(pager1.hasPreviousPageNumber());
+        assertTrue(pager1.hasNextPageNumber());
         
         msg("page list: " + Arrays.toString(pager1.getPageNumberList()));
         //assertEquals(new int[]{1, 2, 3, 4, 5}, pager1.getPageNumberList());
@@ -232,13 +234,13 @@ public class PagerTest {
         System.out.println("getNumResults");
         Pager pager1 = new Pager(0, 10, 1);
 
-        assertEquals(false, pager1.isPagerNecessary());
+        assertFalse(pager1.isPagerNecessary());
         
         assertEquals(0, pager1.getNumResults());
         assertEquals(0, pager1.getPreviousPageNumber());
         assertEquals(0, pager1.getNextPageNumber());
-        assertEquals(false, pager1.hasPreviousPageNumber());
-        assertEquals(false, pager1.hasNextPageNumber());
+        assertFalse(pager1.hasPreviousPageNumber());
+        assertFalse(pager1.hasNextPageNumber());
         
         msgt("page list: " + Arrays.toString(pager1.getPageNumberList()));
         //assertEquals(null, pager1.getPageNumberList());

--- a/src/test/java/edu/harvard/iq/dataverse/util/json/JsonPrinterTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/util/json/JsonPrinterTest.java
@@ -290,7 +290,7 @@ public class JsonPrinterTest {
         assertEquals("42 Inc.", jsonObject.getString("affiliation"));
         assertEquals(0, jsonObject.getJsonArray("dataverseContacts").getJsonObject(0).getInt("displayOrder"));
         assertEquals("dv42@mailinator.com", jsonObject.getJsonArray("dataverseContacts").getJsonObject(0).getString("contactEmail"));
-        assertEquals(false, jsonObject.getBoolean("permissionRoot"));
+        assertFalse(jsonObject.getBoolean("permissionRoot"));
         assertEquals("Description for Dataverse 42.", jsonObject.getString("description"));
         assertEquals("UNCATEGORIZED", jsonObject.getString("dataverseType"));
     }


### PR DESCRIPTION
**What this PR does / why we need it**: In order to make tests slightly more readable, this PR replaces calls to `assertEquals` with `true` or `false` as the first argument with calls to `assertTrue` and `assertFalse`, respectively. This PR replaces #9914.

**Which issue(s) this PR closes**:

Closes no issues.

**Special notes for your reviewer**: I recreated this encouraged by @stevenwinship. It was previously just a draft PR, probably with the idea that other assertions could also be simplified in a similar way. 

**Suggestions on how to test this**: compile and run the tests.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: no

**Is there a release notes update needed for this change?**: no

**Additional documentation**: I noticed other constructs that are used in a similar way, e.g. `MatcherAssert.assertThat(target1.equals(target2), Matchers.is(true));` in `DataverseMetadataBlockFacetTest`
