### PR TITLE
add aws-cli to configbaker

### DIFF
--- a/modules/container-configbaker/Dockerfile
+++ b/modules/container-configbaker/Dockerfile
@@ -21,7 +21,7 @@ ENV SCRIPT_DIR="/scripts" \
 ENV PATH="${PATH}:${SCRIPT_DIR}" \
     BOOTSTRAP_DIR="${SCRIPT_DIR}/bootstrap"
 
-ARG APK_PACKAGES="curl bind-tools netcat-openbsd jq bash dumb-init wait4x ed postgresql-client"
+ARG APK_PACKAGES="curl bind-tools netcat-openbsd jq bash dumb-init wait4x ed postgresql-client aws-cli"
 
 RUN true && \
   # Install necessary software and tools


### PR DESCRIPTION
**What this PR does / why we need it**:
So that old scripts can also be executed in the new Docker environment.

**Which issue(s) this PR closes**:

Closes #10700

**Is there a release notes update needed for this change?**:
should we put it in the release notes?
"Added aws-cli package to container-configbaker."

