### PR TITLE
#10719 fix manage templates display

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DatasetVersionServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetVersionServiceBean.java
@@ -316,8 +316,8 @@ public class DatasetVersionServiceBean implements java.io.Serializable {
     }
     
     public boolean isVersionDefaultCustomTerms(DatasetVersion datasetVersion) {
-
-        if (datasetVersion.getId() != null) {
+        //SEK - belt and suspenders here, but this is where the bug 10719 first manifested
+        if (datasetVersion != null && datasetVersion.getId() != null) {
             try {
                 TermsOfUseAndAccess toua = (TermsOfUseAndAccess) em.createNamedQuery("TermsOfUseAndAccess.findByDatasetVersionIdAndDefaultTerms")
                         .setParameter("id", datasetVersion.getId()).setParameter("defaultTerms", TermsOfUseAndAccess.DEFAULT_NOTERMS).getSingleResult();

--- a/src/main/webapp/dataset-license-terms.xhtml
+++ b/src/main/webapp/dataset-license-terms.xhtml
@@ -44,7 +44,7 @@
                                        <h:outputText value="#{bundle['file.dataFilesTab.terms.list.license.view.description']}" escape="false"/>
                                    </p>
                                </ui:fragment>
-                               <ui:fragment rendered="#{empty editMode and empty termsOfUseAndAccess.license}">
+                               <ui:fragment rendered="#{datasetPage == true and empty editMode and empty termsOfUseAndAccess.license}">
                                    <p>
                                        <h:outputText value="#{DatasetUtil:getLicenseName(DatasetPage.workingVersion).concat(' ')}" escape="false"/>
                                        <h:outputText rendered="#{!datasetVersionServiceBean.isVersionDefaultCustomTerms(DatasetPage.workingVersion)}" value="#{bundle['file.dataFilesTab.terms.list.license.customterms.txt']}" escape="false"/>

--- a/src/main/webapp/template.xhtml
+++ b/src/main/webapp/template.xhtml
@@ -114,7 +114,7 @@
                     </ui:fragment>
                     <!-- Create/Save Dataset Button Panel -->
                     <div class="button-block" jsf:rendered="#{!empty TemplatePage.editMode}">
-                        <p:commandButton styleClass="btn btn-default" action="#{TemplatePage.save('Terms')}" update=":@form,messagePanel"
+                        <p:commandButton styleClass="btn btn-default" action="#{TemplatePage.save('Terms')}" update="@form,messagePanel"
                                          value="#{bundle['dataset.create.add.terms']}"
                                          rendered="#{TemplatePage.editMode == 'CREATE'}">  
                              <f:ajax onerror="window.scrollTo(0, 0)"/>


### PR DESCRIPTION
**What this PR does / why we need it**: Fixes display of Manage Templates page

**Which issue(s) this PR closes**:

Closes #10719 Manage Template page broken in dev

**Special notes for your reviewer**: two minor display changes - not 100% sure why they didn't error previously. 

**Suggestions on how to test this**:
Make sure that you can add, edit delete and view templates. Also set default template and use a created template to add dataset.
**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:
Bug doesn't seem to be in production, so 'no'

**Additional documentation**:
