### PR TITLE
upgrade docker maven plugin to 0.45

### DIFF
--- a/modules/dataverse-parent/pom.xml
+++ b/modules/dataverse-parent/pom.xml
@@ -198,7 +198,7 @@
         <pomchecker-maven-plugin.version>1.7.0</pomchecker-maven-plugin.version>
         
         <!-- Container related -->
-        <fabric8-dmp.version>0.43.4</fabric8-dmp.version>
+        <fabric8-dmp.version>0.45.0</fabric8-dmp.version>
     </properties>
     
     <pluginRepositories>


### PR DESCRIPTION
**What this PR does / why we need it**:

Lower versions don't work on Mac

**Which issue(s) this PR closes**:

- Closes #9771

**Special notes for your reviewer**:

None.

**Suggestions on how to test this**:

This is how I tested it:

```
mvn -Pct -f modules/container-base clean package -Dbase.image.tag=9771
mvn -Pct clean package docker:run -Dbase.image.tag=9771
```

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No.

**Is there a release notes update needed for this change?**:

No.

**Additional documentation**:

No.