### PR TITLE
adding publication statuses to search api response

### DIFF
--- a/doc/release-notes/10733-add-publication-status-to-search-api-results.md
+++ b/doc/release-notes/10733-add-publication-status-to-search-api-results.md
@@ -1,0 +1,14 @@
+Search API (/api/search) response will now include publicationStatuses in the Json response as long as the list is not empty
+
+Example:
+```javascript
+"items": [
+    {
+        "name": "Darwin's Finches",
+        ...
+        "publicationStatuses": [
+            "Unpublished",
+            "Draft"
+        ],
+(etc, etc)
+```

--- a/doc/sphinx-guides/source/api/search.rst
+++ b/doc/sphinx-guides/source/api/search.rst
@@ -114,6 +114,9 @@ https://demo.dataverse.org/api/search?q=trees
                     "identifier_of_dataverse":"dvbe69f5e1",
                     "name_of_dataverse":"dvbe69f5e1",
                     "citation":"Finch, Fiona; Spruce, Sabrina; Poe, Edgar Allen; Mulligan, Hercules, 2019, \"Darwin's Finches\", https://doi.org/10.70122/FK2/MB5VGR, Root, V3",
+                    "publicationStatuses": [
+                        "Published"
+                    ],
                     "storageIdentifier":"file://10.70122/FK2/MB5VGR",
                     "subjects":[  
                        "Astronomy and Astrophysics",
@@ -207,6 +210,9 @@ In this example, ``show_relevance=true`` matches per field are shown. Available 
                     "published_at":"2016-05-10T12:57:45Z",
                     "citationHtml":"Finch, Fiona, 2016, \"Darwin's Finches\", <a href=\"http://dx.doi.org/10.5072/FK2/G2VPE7\" target=\"_blank\">http://dx.doi.org/10.5072/FK2/G2VPE7</a>, Root Dataverse, V1",
                     "citation":"Finch, Fiona, 2016, \"Darwin's Finches\", http://dx.doi.org/10.5072/FK2/G2VPE7, Root Dataverse, V1",
+                    "publicationStatuses": [
+                        "Published"
+                    ],
                     "matches":[
                         {
                             "authorName":{
@@ -297,6 +303,9 @@ The above example ``fq=publicationStatus:Published`` retrieves only "RELEASED" v
                     "identifier_of_dataverse": "rahman",
                     "name_of_dataverse": "mdmizanur rahman Dataverse collection",
                     "citation": "Finch, Fiona, 2019, \"Darwin's Finches\", https://doi.org/10.70122/FK2/GUAS41, Demo Dataverse, V1",
+                    "publicationStatuses": [
+                        "Published"
+                    ],
                     "storageIdentifier": "file://10.70122/FK2/GUAS41",
                     "subjects": [
                         "Medicine, Health and Life Sciences"
@@ -330,6 +339,9 @@ The above example ``fq=publicationStatus:Published`` retrieves only "RELEASED" v
                     "identifier_of_dataverse": "demo",
                     "name_of_dataverse": "Demo Dataverse",
                     "citation": "Finch, Fiona, 2020, \"Darwin's Finches\", https://doi.org/10.70122/FK2/7ZXYRH, Demo Dataverse, V1",
+                    "publicationStatuses": [
+                        "Published"
+                    ],
                     "storageIdentifier": "file://10.70122/FK2/7ZXYRH",
                     "subjects": [
                         "Medicine, Health and Life Sciences"
@@ -386,6 +398,10 @@ The above example ``metadata_fields=citation:*`` returns under "metadataBlocks" 
                     "identifier_of_dataverse": "Sample_data",
                     "name_of_dataverse": "Sample Data",
                     "citation": "Métropole, 2021, \"JDD avec GeoJson 2021-07-13T10:23:46.409Z\", https://doi.org/10.5072/FK2/GIWCKB, Root, DRAFT VERSION",
+                    "publicationStatuses": [
+                        "Unpublished",
+                        "Draft"
+                    ],
                     "storageIdentifier": "file://10.5072/FK2/GIWCKB",
                     "subjects": [
                         "Other"

--- a/src/main/java/edu/harvard/iq/dataverse/search/SolrSearchResult.java
+++ b/src/main/java/edu/harvard/iq/dataverse/search/SolrSearchResult.java
@@ -534,6 +534,9 @@ public class SolrSearchResult {
 				nullSafeJsonBuilder.add("entity_id", this.entityId);
 			}
 		}
+		if (!getPublicationStatuses().isEmpty()) {
+			nullSafeJsonBuilder.add("publicationStatuses", getPublicationStatusesAsJSON());
+		}
 
 		if (this.entity == null) {
 

--- a/src/test/java/edu/harvard/iq/dataverse/api/SearchIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/SearchIT.java
@@ -113,6 +113,7 @@ public class SearchIT {
                 .body("data.total_count", CoreMatchers.is(1))
                 .body("data.count_in_response", CoreMatchers.is(1))
                 .body("data.items[0].name", CoreMatchers.is("Darwin's Finches"))
+                .body("data.items[0].publicationStatuses", CoreMatchers.hasItems("Unpublished", "Draft"))
                 .statusCode(OK.getStatusCode());
 
         Response publishDataverse = UtilIT.publishDataverseViaSword(dataverseAlias, apiToken1);

--- a/src/test/java/edu/harvard/iq/dataverse/search/SolrSearchResultTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/search/SolrSearchResultTest.java
@@ -226,6 +226,29 @@ public class SolrSearchResultTest {
     }
 
     @Test
+    public void testSetPublicationStatusesJson() {
+
+        boolean showRelevance = false;
+        boolean showEntityIds = false;
+        boolean showApiUrls = false;
+
+        SolrSearchResult result01 = new SolrSearchResult("myQuery", "myName");
+        result01.setType(SearchConstants.DATAVERSES);
+        result01.setPublicationStatuses(List.of("Unpublished", "Draft"));
+        JsonObjectBuilder actual01 = result01.json(showRelevance, showEntityIds, showApiUrls);
+        JsonObject actual = actual01.build();
+        System.out.println("actual: " + actual);
+
+        JsonObjectBuilder expResult = Json.createObjectBuilder();
+        expResult.add("type", SearchConstants.DATAVERSE);
+        expResult.add("publicationStatuses", Json.createArrayBuilder().add("Unpublished").add("Draft").build());
+        JsonObject expected = expResult.build();
+        System.out.println("expect: " + expected);
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
     public void testJson() {
 
         boolean showRelevance = false;


### PR DESCRIPTION
**What this PR does / why we need it**: The results shown on the collection page include two labels for the publication status of the object (Dataset, File or Card). "Draft" if the current version is a draft, and "Unpublished" if no previous version of the object has been published. to implement this in the SPA, we need to add publicationStatus to the search results.

**Which issue(s) this PR closes**: [10733](https://github.com/IQSS/dataverse/issues/10733)

Closes #10733

**Special notes for your reviewer**:

**Suggestions on how to test this**: Make API calls to /api/search
curl -H "Authorization: Bearer $TOKEN" "http://localhost:8080/api/search?q=finch&fq=publicationStatus:Published&type=dataset"
Response should have:
"publicationStatuses":[...]


**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**: Yes, included in PR

**Additional documentation**:
