### PR TITLE
#10403 if a dataset is not published only users with ViewUnpublishedD…

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/api/Access.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Access.java
@@ -1831,10 +1831,11 @@ public class Access extends AbstractApiBean {
         }
         if (!published) { // and restricted or embargoed (implied by earlier processing)
             // If the file is not published, they can still download the file, if the user
-            // has the permission to view unpublished versions:
+            // has the permission to view unpublished versions and download files:
 
             // This line handles all three authenticated session user, token user, and guest cases.
-            if (permissionService.requestOn(dvr, df.getOwner()).has(Permission.ViewUnpublishedDataset)) {
+            if ( permissionService.requestOn(dvr, df.getOwner()).has(Permission.ViewUnpublishedDataset)
+              && permissionService.requestOn(dvr, df.getOwner()).has(Permission.DownloadFile)) {
                 // it's not unthinkable, that a GuestUser could be given
                 // the ViewUnpublished permission!
                 logger.log(Level.FINE,


### PR DESCRIPTION
…ataset AND DownloadFile rights can download

**What this PR does / why we need it**:
There are two permissions which have undocumented hierarchical relationship: ViewUnpublishedDataset and DownloadFile. The user who has no DownloadFile, but has ViewUnpublishedDataset permission can download files, which is - according to our users and I agree with them - counter intuitive. I expect that the person who does not have right to download files should not be able to download files. So this PR adds a second condition: only users can download filed from unpublished datasets who have both ViewUnpublishedDataset and DownloadFile rights.

**Which issue(s) this PR closes**:

Closes #10403 

**Special notes for your reviewer**:

**Suggestions on how to test this**:
1) Create a user with a role covering ViewUnpublishedDataset (user1), and another one who have role covering ViewUnpublishedDataset and DownloadFile (user2)
2) create a dataset (but not publish it) with a single file
3) be sure that user1 can not download the file, but user2 can

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
No

**Is there a release notes update needed for this change?**:
No

**Additional documentation**:
No