### PR TITLE
Add mimetype for 3D Data readable by the Smithsonian's Voyager app

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/api/Access.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Access.java
@@ -286,7 +286,7 @@ public class Access extends AbstractApiBean {
     @GET
     @AuthRequired
     @Path("datafile/{fileId:.+}")
-    @Produces({"application/xml"})
+    @Produces({"application/xml","*/*"})
     public Response datafile(@Context ContainerRequestContext crc, @PathParam("fileId") String fileId, @QueryParam("gbrecs") boolean gbrecs, @Context UriInfo uriInfo, @Context HttpHeaders headers, @Context HttpServletResponse response) /*throws NotFoundException, ServiceUnavailableException, PermissionDeniedException, AuthorizationRequiredException*/ {
         
         // check first if there's a trailing slash, and chop it: 

--- a/src/main/java/propertyFiles/MimeTypeDetectionByFileExtension.properties
+++ b/src/main/java/propertyFiles/MimeTypeDetectionByFileExtension.properties
@@ -38,3 +38,4 @@ nf=text/x-nextflow
 Rmd=text/x-r-notebook
 rb=text/x-ruby-script
 dag=text/x-dagman
+glb=model/gltf-binary

--- a/src/main/java/propertyFiles/MimeTypeDisplay.properties
+++ b/src/main/java/propertyFiles/MimeTypeDisplay.properties
@@ -219,6 +219,8 @@ video/quicktime=Quicktime Video
 video/webm=WebM Video
 # Network Data
 text/xml-graphml=GraphML Network Data
+# 3D Data
+model/gltf-binary=3D Model
 # Other
 application/octet-stream=Unknown
 application/x-docker-file=Docker Image File

--- a/src/main/java/propertyFiles/MimeTypeFacets.properties
+++ b/src/main/java/propertyFiles/MimeTypeFacets.properties
@@ -223,6 +223,8 @@ video/webm=Video
 # (anything else that looks like image/* will also be indexed as facet type "Video")
 # Network Data
 text/xml-graphml=Network Data
+# 3D Data
+model/gltf-binary=3D Data
 # Other
 application/octet-stream=Unknown
 application/ld+json;\u0020profile\u003d\u0022http\u003a//www.w3.org/ns/json-ld#flattened\u0020http\u003a//www.w3.org/ns/json-ld#compacted\u0020https\u003a//w3id.org/ro/crate\u0022=Metadata


### PR DESCRIPTION
**What this PR does / why we need it**: This adds support for *.glb model/gltf-binary 3D models to the mime detection and adds label/facet entries for 3D model / 3D Data

**Which issue(s) this PR closes**:  Needed to support https://github.com/gdcc/dataverse-previewers/issues/57

Closes #

**Special notes for your reviewer**: See https://github.com/gdcc/dataverse-previewers/issues/57

I've also added */* to the @Produces annotation on the file download API call. I'm not sure why it is application/xml right now (perhaps only */* is needed), but just having application/xml caused a 406 error (with type application/json :-) )when the Voyager app sent an erroneous Accept:"text/plain" header (it also failed with 406 if I made their code ask for model/gltf-binary). When the file is actually returned, it has type model/gltf-binary as it should with this PR, but without listing that explicitly or having */*, we return 406 before getting to our code due to the annotation.


**Suggestions on how to test this**: Minimally, upload a file with a glb extension and verify it gets the mimetype and label above and shows up in a 3D Data facet. To test the overall previewer that handles this mimetype, install a local copy of the new Voyager previewer in https://github.com/gdcc/dataverse-previewers/pull/77, register the new previewer using the curl command, try uploading data such as https://dataverse.harvard.edu/file.xhtml?fileId=6931827&version=1.0 (note you have to upload this file after you deploy the branch or you'll have to redetect the mimetype via API (or change in the DB)). It should show a dynamic 3D view like: 
![image](https://github.com/user-attachments/assets/478e9b3e-f61d-41da-ac1f-ff8b03a2dd2c)


**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**: Maybe? There are a few 'beta' 3D previewers that haven't been added to the guides or release notes. Not sure if we want to do that now or when there's a v1.5 release (could be around the 6.4 release if we agree these are no longer beta).

**Additional documentation**:
