### PR TITLE
Extend the dataset version payload to include the latest published ve…

### DIFF
--- a/doc/release-notes/10761-extend-dataset-version-paylod-with-latest-published.md
+++ b/doc/release-notes/10761-extend-dataset-version-paylod-with-latest-published.md
@@ -1,0 +1,18 @@
+Get Dataset API (/api/datasets/) response will now include latestPublishedVersionId in the Json response under data.latestVersion as long as the Dataset was published at least once.
+
+Example:
+```javascript
+"latestVersion": {
+    "id": 83,
+    "datasetId": 115,
+    "datasetPersistentId": "doi:10.5072/FK2/FEEFFV",
+    "storageIdentifier": "local://10.5072/FK2/FEEFFV",
+    "versionState": "DRAFT",
+    "latestVersionPublishingState": "DRAFT",
+    "lastUpdateTime": "2024-08-16T20:04:09Z",
+    "createTime": "2024-08-16T20:04:09Z",
+    "publicationDate": "2024-08-16",
+    "citationDate": "2024-08-16",
+    "latestPublishedVersionId": 82,
+(etc, etc)
+```

--- a/doc/release-notes/10761-extend-dataset-version-paylod-with-latest-published.md
+++ b/doc/release-notes/10761-extend-dataset-version-paylod-with-latest-published.md
@@ -3,16 +3,20 @@ Get Dataset API (/api/datasets/) response will now include latestPublishedVersio
 Example:
 ```javascript
 "latestVersion": {
-    "id": 83,
-    "datasetId": 115,
-    "datasetPersistentId": "doi:10.5072/FK2/FEEFFV",
-    "storageIdentifier": "local://10.5072/FK2/FEEFFV",
-    "versionState": "DRAFT",
-    "latestVersionPublishingState": "DRAFT",
-    "lastUpdateTime": "2024-08-16T20:04:09Z",
-    "createTime": "2024-08-16T20:04:09Z",
-    "publicationDate": "2024-08-16",
-    "citationDate": "2024-08-16",
-    "latestPublishedVersionId": 82,
+    "id": 3,
+        "datasetId": 5,
+        "datasetPersistentId": "doi:10.5072/FK2/J50XYQ",
+        "storageIdentifier": "local://10.5072/FK2/J50XYQ",
+        "versionState": "DRAFT",
+        "latestVersionPublishingState": "DRAFT",
+        "lastUpdateTime": "2024-08-16T20:33:02Z",
+        "createTime": "2024-08-16T20:33:02Z",
+        "publicationDate": "2024-08-16",
+        "citationDate": "2024-08-16",
+        "latestPublishedVersion": {
+            "id": 2,
+            "versionNumber": 1,
+            "versionMinorNumber": 0
+        },
 (etc, etc)
 ```

--- a/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
@@ -446,7 +446,7 @@ public class JsonPrinter {
                 .add("citationDate", dataset.getCitationDateFormattedYYYYMMDD());
 
         DatasetVersion latestPublishedVersion = dsv.getMostRecentlyReleasedVersion();
-        if (latestPublishedVersion != null) {
+        if (latestPublishedVersion != null && dsv.getId().longValue() != latestPublishedVersion.getId().longValue()) {
             bld.add("latestPublishedVersion", jsonLatestPublishedVersion(latestPublishedVersion));
         }
         License license = DatasetUtil.getLicense(dsv);

--- a/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
@@ -447,7 +447,7 @@ public class JsonPrinter {
 
         DatasetVersion latestPublishedVersion = dsv.getMostRecentlyReleasedVersion();
         if (latestPublishedVersion != null) {
-            bld.add("latestPublishedVersionId", latestPublishedVersion.getId());
+            bld.add("latestPublishedVersion", jsonLatestPublishedVersion(latestPublishedVersion));
         }
         License license = DatasetUtil.getLicense(dsv);
         if (license != null) {
@@ -1392,6 +1392,13 @@ public class JsonPrinter {
             licenseJsonObjectBuilder.add("iconUri", licenseIconUri);
         }
         return licenseJsonObjectBuilder;
+    }
+    private static JsonObjectBuilder jsonLatestPublishedVersion(DatasetVersion dsv) {
+        JsonObjectBuilder lpvJsonObjectBuilder = jsonObjectBuilder()
+                .add("id", dsv.getId())
+                .add("versionNumber", dsv.getVersionNumber())
+                .add("versionMinorNumber", dsv.getMinorVersionNumber());
+        return lpvJsonObjectBuilder;
     }
 
     public static JsonArrayBuilder jsonDataverseFieldTypeInputLevels(List<DataverseFieldTypeInputLevel> inputLevels) {

--- a/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
@@ -445,6 +445,10 @@ public class JsonPrinter {
                 .add("publicationDate", dataset.getPublicationDateFormattedYYYYMMDD())
                 .add("citationDate", dataset.getCitationDateFormattedYYYYMMDD());
 
+        DatasetVersion latestPublishedVersion = dsv.getMostRecentlyReleasedVersion();
+        if (latestPublishedVersion != null) {
+            bld.add("latestPublishedVersionId", latestPublishedVersion.getId());
+        }
         License license = DatasetUtil.getLicense(dsv);
         if (license != null) {
             bld.add("license", jsonLicense(dsv));

--- a/src/test/java/edu/harvard/iq/dataverse/api/DatasetsIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/DatasetsIT.java
@@ -539,7 +539,7 @@ public class DatasetsIT {
         String datasetPersistentId = protocol + ":" + authority + "/" + identifier;
 
         // Should be no Latest Published Version
-        getDatasetJsonBeforePublishing.then().assertThat().body("latestPublishedVersionId", nullValue());
+        getDatasetJsonBeforePublishing.then().assertThat().body("latestPublishedVersion", nullValue());
 
         // First Publish
         Response publishDataset = UtilIT.publishDatasetViaNativeApi(datasetPersistentId, "major", apiToken);
@@ -548,10 +548,10 @@ public class DatasetsIT {
         Response getDatasetJsonAfterPublishing = UtilIT.nativeGet(datasetId, apiToken);
         getDatasetJsonAfterPublishing.prettyPrint();
         getDatasetJsonAfterPublishing.then().assertThat()
-                .body("data.latestVersion.latestPublishedVersionId", notNullValue())
+                .body("data.latestVersion.latestPublishedVersion", notNullValue())
                 .statusCode(OK.getStatusCode());
 
-        int latestPublishedVersionId = Integer.valueOf(JsonPath.from(getDatasetJsonAfterPublishing.getBody().asString()).getString("data.latestVersion.latestPublishedVersionId"));
+        int latestPublishedVersionId = Integer.valueOf(JsonPath.from(getDatasetJsonAfterPublishing.getBody().asString()).getString("data.latestVersion.latestPublishedVersion.id"));
 
         // Update, check that latest published version doesn't change
         Response updateDataset = UtilIT.updateDatasetTitleViaSword(datasetPersistentId, "New Title", apiToken);
@@ -559,7 +559,7 @@ public class DatasetsIT {
         Response getDatasetJsonAfterUpdating = UtilIT.nativeGet(datasetId, apiToken);
         getDatasetJsonAfterUpdating.prettyPrint();
         getDatasetJsonAfterUpdating.then().assertThat()
-                .body("data.latestVersion.latestPublishedVersionId", equalTo(latestPublishedVersionId))
+                .body("data.latestVersion.latestPublishedVersion.id", equalTo(latestPublishedVersionId))
                 .statusCode(OK.getStatusCode());
 
         // Now Publish the change and make sure the latest published version reflects the new published Dataset
@@ -568,9 +568,9 @@ public class DatasetsIT {
         Response getDatasetJsonAfterSecondPublishing = UtilIT.nativeGet(datasetId, apiToken);
         getDatasetJsonAfterSecondPublishing.prettyPrint();
         getDatasetJsonAfterSecondPublishing.then().assertThat()
-                .body("data.latestVersion.latestPublishedVersionId", notNullValue())
+                .body("data.latestVersion.latestPublishedVersion", notNullValue())
                 .statusCode(OK.getStatusCode());
-        int newLatestPublishedVersionId = Integer.valueOf(JsonPath.from(getDatasetJsonAfterSecondPublishing.getBody().asString()).getString("data.latestVersion.latestPublishedVersionId"));
+        int newLatestPublishedVersionId = Integer.valueOf(JsonPath.from(getDatasetJsonAfterSecondPublishing.getBody().asString()).getString("data.latestVersion.latestPublishedVersion.id"));
         assertTrue(newLatestPublishedVersionId > latestPublishedVersionId);
 
         // Clean up

--- a/src/test/java/edu/harvard/iq/dataverse/api/DatasetsIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/DatasetsIT.java
@@ -548,30 +548,28 @@ public class DatasetsIT {
         Response getDatasetJsonAfterPublishing = UtilIT.nativeGet(datasetId, apiToken);
         getDatasetJsonAfterPublishing.prettyPrint();
         getDatasetJsonAfterPublishing.then().assertThat()
-                .body("data.latestVersion.latestPublishedVersion", notNullValue())
+                .body("data.latestVersion.latestPublishedVersion", nullValue())
                 .statusCode(OK.getStatusCode());
 
-        int latestPublishedVersionId = Integer.valueOf(JsonPath.from(getDatasetJsonAfterPublishing.getBody().asString()).getString("data.latestVersion.latestPublishedVersion.id"));
+        int publishedVersionId = Integer.valueOf(JsonPath.from(getDatasetJsonAfterPublishing.getBody().asString()).getString("data.latestVersion.id"));
 
-        // Update, check that latest published version doesn't change
+        // Update, check that latest published version is in the payload and its id is correct
         Response updateDataset = UtilIT.updateDatasetTitleViaSword(datasetPersistentId, "New Title", apiToken);
         assertEquals(200, updateDataset.getStatusCode());
         Response getDatasetJsonAfterUpdating = UtilIT.nativeGet(datasetId, apiToken);
         getDatasetJsonAfterUpdating.prettyPrint();
         getDatasetJsonAfterUpdating.then().assertThat()
-                .body("data.latestVersion.latestPublishedVersion.id", equalTo(latestPublishedVersionId))
+                .body("data.latestVersion.latestPublishedVersion.id", equalTo(publishedVersionId))
                 .statusCode(OK.getStatusCode());
 
-        // Now Publish the change and make sure the latest published version reflects the new published Dataset
+        // Now Publish the change and make sure the latest published version is not in the payload since this is the latest published version
         publishDataset = UtilIT.publishDatasetViaNativeApi(datasetPersistentId, "major", apiToken);
         assertEquals(200, publishDataset.getStatusCode());
         Response getDatasetJsonAfterSecondPublishing = UtilIT.nativeGet(datasetId, apiToken);
         getDatasetJsonAfterSecondPublishing.prettyPrint();
         getDatasetJsonAfterSecondPublishing.then().assertThat()
-                .body("data.latestVersion.latestPublishedVersion", notNullValue())
+                .body("data.latestVersion.latestPublishedVersion", nullValue())
                 .statusCode(OK.getStatusCode());
-        int newLatestPublishedVersionId = Integer.valueOf(JsonPath.from(getDatasetJsonAfterSecondPublishing.getBody().asString()).getString("data.latestVersion.latestPublishedVersion.id"));
-        assertTrue(newLatestPublishedVersionId > latestPublishedVersionId);
 
         // Clean up
         Response deleteDatasetResponse = UtilIT.destroyDataset(datasetId, apiToken);


### PR DESCRIPTION

**What this PR does / why we need it**: Extend the dataset version payload to include the latest published version number.

**Which issue(s) this PR closes**: https://github.com/IQSS/dataverse/issues/10761

Closes #10761 

**Special notes for your reviewer**:

**Suggestions on how to test this**: See DatasetsIT. 

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: None

**Is there a release notes update needed for this change?**: included

**Additional documentation**:
