### PR TITLE
use DATAVERSE_SITEURL instead of _CT_ version

### DIFF
--- a/doc/sphinx-guides/source/container/running/demo.rst
+++ b/doc/sphinx-guides/source/container/running/demo.rst
@@ -124,8 +124,6 @@ Some JVM options can be configured as environment variables. For example, you ca
 
 We are in the process of making more JVM options configurable as environment variables. Look for the term "MicroProfile Config" in under :doc:`/installation/config` in the Installation Guide to know if you can use them this way.
 
-Please note that for a few environment variables (the ones that start with ``%ct`` in :download:`microprofile-config.properties <../../../../../src/main/resources/META-INF/microprofile-config.properties>`), you have to prepend ``_CT_`` to make, for example, ``_CT_DATAVERSE_SITEURL``. We are working on a fix for this in https://github.com/IQSS/dataverse/issues/10285.
-
 There is a final way to configure JVM options that we plan to deprecate once all JVM options have been converted to MicroProfile Config. Look for "magic trick" under "tunables" at :doc:`../app-image` for more information.
 
 Database Settings

--- a/docker/compose/demo/compose.yml
+++ b/docker/compose/demo/compose.yml
@@ -9,7 +9,7 @@ services:
     restart: on-failure
     user: payara
     environment:
-      _CT_DATAVERSE_SITEURL: "https://demo.example.org"
+      DATAVERSE_SITEURL: "https://demo.example.org"
       DATAVERSE_DB_HOST: postgres
       DATAVERSE_DB_PASSWORD: secret
       DATAVERSE_DB_USER: dataverse


### PR DESCRIPTION
The `_CT_` version is not needed now that we have upgraded to Payara 6.2024.6 in #10495 which included this fix: https://github.com/payara/Payara/pull/6550

**What this PR does / why we need it**:

**Which issue(s) this PR closes**:

- Closes #10756

**Special notes for your reviewer**:

Please see the detailed commit message.

**Suggestions on how to test this**:

- Follow the quickstart at https://guides.dataverse.org/en/6.3/container/running/demo.html using the compose file in this PR, of course.
- Create a dataset and publish it
- Click "Metadata" then "Export Metadata" and note that the value in DATAVERSE_SITEURL (https://demo.example.org) is used. You can change this value before running `docker compose up` if you like.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No.

**Is there a release notes update needed for this change?**:

No, not worth it.

**Additional documentation**:

None.