### PR TITLE
Add RO-Crate to guides

### DIFF
--- a/doc/release-notes/10744-ro-crate-docs.md
+++ b/doc/release-notes/10744-ro-crate-docs.md
@@ -1,0 +1,3 @@
+## RO-Crate Support (Metadata Export)
+
+Dataverse now supports [RO-Crate](https://www.researchobject.org/ro-crate/) in the sense that dataset metadata can be exported in that format. This functionality is not available out of the box but you can enable one or more RO-Crate exporters from the [list of external exporters](https://preview.guides.gdcc.io/en/develop/installation/advanced.html#inventory-of-external-exporters). See also #10744.

--- a/doc/sphinx-guides/source/installation/advanced.rst
+++ b/doc/sphinx-guides/source/installation/advanced.rst
@@ -136,7 +136,10 @@ Use the :ref:`dataverse.spi.exporters.directory` configuration option to specify
 Inventory of External Exporters
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-For a list of external exporters, see the README at https://github.com/gdcc/dataverse-exporters
+For a list of external exporters, see the README at https://github.com/gdcc/dataverse-exporters. To highlight a few:
+
+- Croissant
+- RO-Crate
 
 Developing New Exporters
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/sphinx-guides/source/user/dataset-management.rst
+++ b/doc/sphinx-guides/source/user/dataset-management.rst
@@ -36,7 +36,10 @@ Once a dataset has been published, its metadata can be exported in a variety of 
 - OpenAIRE
 - Schema.org JSON-LD
 
-Additional formats can be enabled. See :ref:`inventory-of-external-exporters` in the Installation Guide.
+Additional formats can be enabled. See :ref:`inventory-of-external-exporters` in the Installation Guide. To highlight a few:
+
+- Croissant
+- RO-Crate
 
 Each of these metadata exports contains the metadata of the most recently published version of the dataset.
 


### PR DESCRIPTION
**What this PR does / why we need it**:

It's not easily discoverable in the guides that Dataverse supports RO-Crate because the implementation is outside the monolith.

In this pull request, near the link to the list of external metadata exporters (which is in a README in a separate repo), we highlight RO-Crate (and Croissant) so that people searching the guides for those terms can find them.

**Which issue(s) this PR closes**:

- Closes #10744
- Relates to #8688

**Special notes for your reviewer**:

I'm definitely open to writing about RO-Crate somewhere in the User Guide (beyond a mention) but I couldn't find a good spot. Ideally, we'd have a specific place in the guides to link to from https://dataverse.org/software-features when we decide to call out RO-Crate support there (for every feature, we link to the guides). I'm open to suggestions!

**Suggestions on how to test this**:

No testing. It's just docs.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No.

**Is there a release notes update needed for this change?**:

Yes, included. In the release note I was a little non-specific about the various RO-Crate exporters but there are three of them:

- Basic RO-Crate (via Transformer) - https://github.com/gdcc/exporter-transformer/tree/1.0.9/examples/basic-ro-crate
- ARP RO-Crate (via Transformer) - https://github.com/gdcc/exporter-transformer/tree/1.0.9/examples/arp-ro-crate
- RO-Crate (from KU Leuven) - https://github.com/gdcc/exporter-ro-crate

The first two seem to work fine but I know very little about RO-Crate and can't really comment if anything isn't in line with the spec.

The last I couldn't get working, as I reported here: https://github.com/IQSS/dataverse/issues/10744#issuecomment-2273778367

**Additional documentation**:

None.