### PR TITLE
Add instruction to use title case in headings in documentation.md

### DIFF
--- a/doc/sphinx-guides/source/contributor/documentation.md
+++ b/doc/sphinx-guides/source/contributor/documentation.md
@@ -131,6 +131,7 @@ Please observe the following when writing documentation:
 - Use American English spelling.
 - Use examples when possible.
 - Break up longer paragraphs.
+- Use Title Case in Headings.
 - Use "double quotes" instead of 'single quotes'.
 - Favor "and" (data and code) over slashes (data/code).
 


### PR DESCRIPTION
Addition of using title case for headings. I used title case for the instruction to illustrate.

**What this PR does / why we need it**:
Need for instruction to use title case in headings

**Which issue(s) this PR closes**:

Closes #

**Special notes for your reviewer**:
Used title case in the instruction as illustration. But can be reverted if confusing.

**Suggestions on how to test this**:

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
