### PR TITLE
#10807 fix GB fragment

### DIFF
--- a/src/main/webapp/guestbook-terms-popup-fragment.xhtml
+++ b/src/main/webapp/guestbook-terms-popup-fragment.xhtml
@@ -48,7 +48,7 @@
                     </a>
                     <ui:fragment
                         rendered="#{empty workingVersion.termsOfUseAndAccess.license}">
-                        <h:outputText rendered="#{!datasetVersionServiceBean.isVersionDefaultCustomTerms(DatasetPage.workingVersion)}"
+                        <h:outputText rendered="#{!datasetVersionServiceBean.isVersionDefaultCustomTerms(workingVersion)}"
                             value="#{bundle['file.dataFilesTab.terms.list.license.customterms.txt']}"
                             escape="false" />
                     </ui:fragment>


### PR DESCRIPTION
**What this PR does / why we need it**: Fixes recently introduced error in the guestbook fragment

**Which issue(s) this PR closes**:

Closes #10807 Guestbook fragment refers to DatasetPage breaks file landing page

**Special notes for your reviewer**:

**Suggestions on how to test this**: Make sure that you can access the File page when a dataset has custom terms of use and a guestbook assigned to it

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
