### PR TITLE
IQSS/10812 - Add details to error messages

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/api/errorhandlers/WebApplicationExceptionHandler.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/errorhandlers/WebApplicationExceptionHandler.java
@@ -18,6 +18,8 @@ import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.apache.commons.lang3.StringUtils;
+
 /**
  * Catches all types of web application exceptions like NotFoundException, etc etc and handles them properly.
  */
@@ -49,7 +51,14 @@ public class WebApplicationExceptionHandler implements ExceptionMapper<WebApplic
                 } else if ((ex.getMessage() + "").toLowerCase().startsWith("no permission to download file")) {
                     jrb.message(BundleUtil.getStringFromBundle("access.api.exception.metadata.restricted.no.permission"));
                 } else {
-                    jrb.message("Bad Request. The API request cannot be completed with the parameters supplied. Please check your code for typos, or consult our API guide at http://guides.dataverse.org.");
+                    String msg = ex.getMessage();
+                    msg = StringUtils.isEmpty(msg)
+                            ? "Bad Request. The API request cannot be completed with the parameters supplied. Please check your code for typos, or consult our API guide at http://guides.dataverse.org."
+                            : "Bad Request. The API request cannot be completed with the parameters supplied. Details: "
+                                    + msg
+                                    + " - please check your code for typos, or consult our API guide at http://guides.dataverse.org.";
+
+                    jrb.message(msg);
                     jrb.request(request);
                 }
                 break;


### PR DESCRIPTION
**What this PR does / why we need it**: This PR incorporates any messages added to a BadRequestException when it is thrown into the final message the API user sees. If there is no message, the error response is generic as before.

**Which issue(s) this PR closes**:

Closes #10812

**Special notes for your reviewer**: Feel free to improve the message

**Suggestions on how to test this**: Make a call such as
`curl -H 'X-Dataverse-key:e6affd89-03f5-4b61-8ed6-d9af41228df2' -X PUT -d '{"https://dataverse.org/schema/core#fileTermsOfAccess":{"https://dataverse.org/schema/core#dataAccessPlace":"OTR"}}' -H "Content-type:application/ld+json" -H "Accept:application/ld+json"  http://localhost:8080/api/datasets/10345/metadata` twice on a dataset (once to add the value, and the second time to trigger an error ("Can't append to a single-value field that already has a value: https://dataverse.org/schema/core#dataAccessPlace") - and verify that the test above is part of the API 400 response you get. (FWIW: If you want the call to succeed, add ?replace=true to the call).

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**: - It's a change to the "message" included in the error responses for some API calls (and we already have messages that change due to i18n), so I don't think it's needed, but I'd be happy to have a "Error messages for some API calls have more detail" as a release note and/or to have it mentioned in a change log.

**Additional documentation**:
