### PR TITLE
makes auto-select feature for dataset thumbnail optional 

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/Dataset.java
+++ b/src/main/java/edu/harvard/iq/dataverse/Dataset.java
@@ -6,6 +6,7 @@ import edu.harvard.iq.dataverse.harvest.client.HarvestingClient;
 import edu.harvard.iq.dataverse.license.License;
 import edu.harvard.iq.dataverse.makedatacount.DatasetExternalCitations;
 import edu.harvard.iq.dataverse.makedatacount.DatasetMetrics;
+import edu.harvard.iq.dataverse.settings.FeatureFlags;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.sql.Timestamp;
@@ -205,6 +206,10 @@ public class Dataset extends DvObjectContainer {
         if (!isHarvested) {
             StorageUse storageUse = new StorageUse(this); 
             this.setStorageUse(storageUse);
+        }
+        
+        if (!FeatureFlags.ENABLE_DATASET_THUMBNAIL_AUTOSELECT.enabled()) {
+            this.setUseGenericThumbnail(true);
         }
     }
     

--- a/src/main/java/edu/harvard/iq/dataverse/DatasetVersionServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetVersionServiceBean.java
@@ -9,6 +9,7 @@ import edu.harvard.iq.dataverse.authorization.users.AuthenticatedUser;
 import static edu.harvard.iq.dataverse.batch.jobs.importer.filesystem.FileRecordJobListener.SEP;
 import edu.harvard.iq.dataverse.batch.util.LoggingUtil;
 import edu.harvard.iq.dataverse.search.SolrSearchResult;
+import edu.harvard.iq.dataverse.settings.FeatureFlags;
 import edu.harvard.iq.dataverse.settings.SettingsServiceBean;
 import edu.harvard.iq.dataverse.util.BundleUtil;
 import edu.harvard.iq.dataverse.util.MarkupChecker;
@@ -807,36 +808,11 @@ public class DatasetVersionServiceBean implements java.io.Serializable {
             return null;
         }
 
-        Long thumbnailFileId;
+        if (FeatureFlags.ENABLE_DATASET_THUMBNAIL_AUTOSELECT.enabled()) {
+            Long thumbnailFileId;
 
-        // First, let's see if there are thumbnails that have already been 
-        // generated:
-        try {
-            thumbnailFileId = (Long) em.createNativeQuery("SELECT df.id "
-                    + "FROM datafile df, filemetadata fm, datasetversion dv, dvobject o "
-                    + "WHERE dv.id = " + versionId + " "
-                    + "AND df.id = o.id "
-                    + "AND fm.datasetversion_id = dv.id "
-                    + "AND fm.datafile_id = df.id "
-                    + "AND df.restricted = false "
-                    + "AND df.embargo_id is null "
-                    + "AND df.retention_id is null "
-                    + "AND o.previewImageAvailable = true "
-                    + "ORDER BY df.id LIMIT 1;").getSingleResult();
-        } catch (Exception ex) {
-            thumbnailFileId = null;
-        }
-
-        if (thumbnailFileId != null) {
-            logger.fine("DatasetVersionService,getThumbnailByVersionid(): found already generated thumbnail for version " + versionId + ": " + thumbnailFileId);
-            assignDatasetThumbnailByNativeQuery(versionId, thumbnailFileId);
-            return thumbnailFileId;
-        }
-
-        if (!systemConfig.isThumbnailGenerationDisabledForImages()) {
-            // OK, let's try and generate an image thumbnail!
-            long imageThumbnailSizeLimit = systemConfig.getThumbnailSizeLimitImage();
-
+            // First, let's see if there are thumbnails that have already been 
+            // generated:
             try {
                 thumbnailFileId = (Long) em.createNativeQuery("SELECT df.id "
                         + "FROM datafile df, filemetadata fm, datasetversion dv, dvobject o "
@@ -844,63 +820,89 @@ public class DatasetVersionServiceBean implements java.io.Serializable {
                         + "AND df.id = o.id "
                         + "AND fm.datasetversion_id = dv.id "
                         + "AND fm.datafile_id = df.id "
-                        + "AND o.previewimagefail = false "
                         + "AND df.restricted = false "
                         + "AND df.embargo_id is null "
                         + "AND df.retention_id is null "
-                        + "AND df.contenttype LIKE 'image/%' "
-                        + "AND NOT df.contenttype = 'image/fits' "
-                        + "AND df.filesize < " + imageThumbnailSizeLimit + " "
-                        + "ORDER BY df.filesize ASC LIMIT 1;").getSingleResult();
+                        + "AND o.previewImageAvailable = true "
+                        + "ORDER BY df.id LIMIT 1;").getSingleResult();
             } catch (Exception ex) {
                 thumbnailFileId = null;
             }
 
             if (thumbnailFileId != null) {
-                logger.fine("obtained file id: " + thumbnailFileId);
-                DataFile thumbnailFile = datafileService.find(thumbnailFileId);
-                if (thumbnailFile != null) {
-                    if (datafileService.isThumbnailAvailable(thumbnailFile)) {
-                        assignDatasetThumbnailByNativeQuery(versionId, thumbnailFileId);
-                        return thumbnailFileId;
+                logger.fine("DatasetVersionService,getThumbnailByVersionid(): found already generated thumbnail for version " + versionId + ": " + thumbnailFileId);
+                assignDatasetThumbnailByNativeQuery(versionId, thumbnailFileId);
+                return thumbnailFileId;
+            }
+
+            if (!systemConfig.isThumbnailGenerationDisabledForImages()) {
+                // OK, let's try and generate an image thumbnail!
+                long imageThumbnailSizeLimit = systemConfig.getThumbnailSizeLimitImage();
+
+                try {
+                    thumbnailFileId = (Long) em.createNativeQuery("SELECT df.id "
+                            + "FROM datafile df, filemetadata fm, datasetversion dv, dvobject o "
+                            + "WHERE dv.id = " + versionId + " "
+                            + "AND df.id = o.id "
+                            + "AND fm.datasetversion_id = dv.id "
+                            + "AND fm.datafile_id = df.id "
+                            + "AND o.previewimagefail = false "
+                            + "AND df.restricted = false "
+                            + "AND df.embargo_id is null "
+                            + "AND df.retention_id is null "
+                            + "AND df.contenttype LIKE 'image/%' "
+                            + "AND NOT df.contenttype = 'image/fits' "
+                            + "AND df.filesize < " + imageThumbnailSizeLimit + " "
+                            + "ORDER BY df.filesize ASC LIMIT 1;").getSingleResult();
+                } catch (Exception ex) {
+                    thumbnailFileId = null;
+                }
+
+                if (thumbnailFileId != null) {
+                    logger.fine("obtained file id: " + thumbnailFileId);
+                    DataFile thumbnailFile = datafileService.find(thumbnailFileId);
+                    if (thumbnailFile != null) {
+                        if (datafileService.isThumbnailAvailable(thumbnailFile)) {
+                            assignDatasetThumbnailByNativeQuery(versionId, thumbnailFileId);
+                            return thumbnailFileId;
+                        }
+                    }
+                }
+            }
+
+            // And if that didn't work, try the same thing for PDFs:
+            if (!systemConfig.isThumbnailGenerationDisabledForPDF()) {
+                // OK, let's try and generate an image thumbnail!
+                long imageThumbnailSizeLimit = systemConfig.getThumbnailSizeLimitPDF();
+                try {
+                    thumbnailFileId = (Long) em.createNativeQuery("SELECT df.id "
+                            + "FROM datafile df, filemetadata fm, datasetversion dv, dvobject o "
+                            + "WHERE dv.id = " + versionId + " "
+                            + "AND df.id = o.id "
+                            + "AND fm.datasetversion_id = dv.id "
+                            + "AND fm.datafile_id = df.id "
+                            + "AND o.previewimagefail = false "
+                            + "AND df.restricted = false "
+                            + "AND df.embargo_id is null "
+                            + "AND df.retention_id is null "
+                            + "AND df.contenttype = 'application/pdf' "
+                            + "AND df.filesize < " + imageThumbnailSizeLimit + " "
+                            + "ORDER BY df.filesize ASC LIMIT 1;").getSingleResult();
+                } catch (Exception ex) {
+                    thumbnailFileId = null;
+                }
+
+                if (thumbnailFileId != null) {
+                    DataFile thumbnailFile = datafileService.find(thumbnailFileId);
+                    if (thumbnailFile != null) {
+                        if (datafileService.isThumbnailAvailable(thumbnailFile)) {
+                            assignDatasetThumbnailByNativeQuery(versionId, thumbnailFileId);
+                            return thumbnailFileId;
+                        }
                     }
                 }
             }
         }
-
-        // And if that didn't work, try the same thing for PDFs:
-        if (!systemConfig.isThumbnailGenerationDisabledForPDF()) {
-            // OK, let's try and generate an image thumbnail!
-            long imageThumbnailSizeLimit = systemConfig.getThumbnailSizeLimitPDF();
-            try {
-                thumbnailFileId = (Long) em.createNativeQuery("SELECT df.id "
-                        + "FROM datafile df, filemetadata fm, datasetversion dv, dvobject o "
-                        + "WHERE dv.id = " + versionId + " "
-                        + "AND df.id = o.id "
-                        + "AND fm.datasetversion_id = dv.id "
-                        + "AND fm.datafile_id = df.id "
-                        + "AND o.previewimagefail = false "
-                        + "AND df.restricted = false "
-                        + "AND df.embargo_id is null "
-                        + "AND df.retention_id is null "
-                        + "AND df.contenttype = 'application/pdf' "
-                        + "AND df.filesize < " + imageThumbnailSizeLimit + " "
-                        + "ORDER BY df.filesize ASC LIMIT 1;").getSingleResult();
-            } catch (Exception ex) {
-                thumbnailFileId = null;
-            }
-
-            if (thumbnailFileId != null) {
-                DataFile thumbnailFile = datafileService.find(thumbnailFileId);
-                if (thumbnailFile != null) {
-                    if (datafileService.isThumbnailAvailable(thumbnailFile)) {
-                        assignDatasetThumbnailByNativeQuery(versionId, thumbnailFileId);
-                        return thumbnailFileId;
-                    }
-                }
-            }
-        }
-
         return null;
     }
     

--- a/src/main/java/edu/harvard/iq/dataverse/settings/FeatureFlags.java
+++ b/src/main/java/edu/harvard/iq/dataverse/settings/FeatureFlags.java
@@ -91,6 +91,16 @@ public enum FeatureFlags {
      * @since Dataverse 6.3
      */
     DISABLE_RETURN_TO_AUTHOR_REASON("disable-return-to-author-reason"),
+    /**
+     * This flag enables the feature that automatically selects one of the 
+     * DataFile thumbnails in the dataset/version as the dedicated thumbnail
+     * for the dataset.
+     * 
+     * @apiNote Raise flag by setting
+     * "dataverse.feature.enable-dataset-thumbnail-autoselect"
+     * @since Dataverse 6.4
+     */
+    ENABLE_DATASET_THUMBNAIL_AUTOSELECT("enable-dataset-thumbnail-autoselect"),
     ;
     
     final String flag;


### PR DESCRIPTION
**What this PR does / why we need it**:
(copy-and-paste from linked issue:)
There is a bug in 6.3 with designated dataset thumbnails that breaks collection pages. I'm not describing it in detail here since there will be a dedicated issue for it. Turning the auto-select feature off does not fully solve this problem, but it will mitigate it significantly, because most newly published datasets will not have the designated thumbnail to cause a problem.


**Which issue(s) this PR closes**:

Closes #10815

**Special notes for your reviewer**:

**Suggestions on how to test this**:

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
