### PR TITLE
IQSS/10814 Improve dataset version differencing

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DatasetVersionDifference.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetVersionDifference.java
@@ -8,6 +8,8 @@ import edu.harvard.iq.dataverse.util.StringUtil;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import java.util.logging.Logger;
 
@@ -15,6 +17,7 @@ import org.apache.commons.lang3.StringUtils;
 import edu.harvard.iq.dataverse.util.BundleUtil;
 import java.util.Arrays;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -106,50 +109,69 @@ public final class DatasetVersionDifference {
                 addToSummary(null, dsfn);
             }
         }
-        
-        // TODO: ? 
-        // It looks like we are going through the filemetadatas in both versions, 
-        // *sequentially* (i.e. at the cost of O(N*M)), to select the lists of 
-        // changed, deleted and added files between the 2 versions... But why 
-        // are we doing it, if we are doing virtually the same thing inside 
-        // the initDatasetFilesDifferenceList(), below - but in a more efficient 
-        // way (sorting both lists, then goint through them in parallel, at the 
-        // cost of (N+M) max.? 
-        // -- 4.6 Nov. 2016
-        
+        logger.info("Start alt loop: " + System.currentTimeMillis());
+        Map<Long, FileMetadata> originalFileMetadataMap = new HashMap<>();
+        Map<Long, FileMetadata> previousIDtoFileMetadataMap = new HashMap<>();
         for (FileMetadata fmdo : originalVersion.getFileMetadatas()) {
-            boolean deleted = true;
-            for (FileMetadata fmdn : newVersion.getFileMetadatas()) {
-                if (fmdo.getDataFile().equals(fmdn.getDataFile())) {
-                    deleted = false;
-                    if (!compareFileMetadatas(fmdo, fmdn)) {
-                        changedFileMetadata.add(fmdo);
-                        changedFileMetadata.add(fmdn);
-                    }
-                    if (!variableMetadataUtil.compareVariableMetadata(fmdo,fmdn) || !compareVarGroup(fmdo, fmdn)) {
-                        changedVariableMetadata.add(fmdo);
-                        changedVariableMetadata.add(fmdn);
-                    }
-                    break;
+            originalFileMetadataMap.put(fmdo.getDataFile().getId(), fmdo);
+        }
+        logger.info("End getorigids loop: " + System.currentTimeMillis());
+        for (FileMetadata fmdn : newVersion.getFileMetadatas()) {
+            DataFile ndf = fmdn.getDataFile();
+            Long id = ndf.getId();
+            FileMetadata fmdo = originalFileMetadataMap.get(id);
+            //If this file was in the original version
+            if(fmdo!= null) {
+                //Check for differences
+                if (!compareFileMetadatas(fmdo, fmdn)) {
+                    logger.info("Adding file metadata diff: " + fmdo.getId());
+                    logger.info("Adding file metadata diff: " + fmdn.getId());
+                    changedFileMetadata.add(fmdo);
+                    changedFileMetadata.add(fmdn);
                 }
-            }
-            if (deleted) {
-                removedFiles.add(fmdo);
+                if (!VariableMetadataUtil.compareVariableMetadata(fmdo,fmdn) || !compareVarGroup(fmdo, fmdn)) {
+                    changedVariableMetadata.add(fmdo);
+                    changedVariableMetadata.add(fmdn);
+                }
+                // And drop it from the list since it can't be a deleted file
+                originalFileMetadataMap.remove(id);
+            } else {
+                //It wasn't in the original version
+                Long prevID = ndf.getPreviousDataFileId();
+                //It might be a replacement file or an added file
+                if(prevID != null) {
+                    //Add it to a map so we can check later to see if it's a replacement
+                    previousIDtoFileMetadataMap.put(prevID, fmdn);
+                } else {
+                    //Otherwise make it an added file now
+                    addedFiles.add(fmdn);
+                }
             }
         }
-        for (FileMetadata fmdn : newVersion.getFileMetadatas()) {
-            boolean added = true;
-            for (FileMetadata fmdo : originalVersion.getFileMetadatas()) {
-                if (fmdo.getDataFile().equals(fmdn.getDataFile())) {
-                    added = false;
-                    break;
-                }
+        //Finally check any remaining files from the original version that weren't in the new version'
+        for (Long removedId : originalFileMetadataMap.keySet()) {
+            //See if it has been replaced
+            FileMetadata replacingFmd = previousIDtoFileMetadataMap.get(removedId);
+            FileMetadata fmdRemoved = originalFileMetadataMap.get(removedId);
+            if (replacingFmd != null) {
+                //This is a replacement
+                replacedFiles.add(new FileMetadata[] { fmdRemoved, replacingFmd });
+                //Drop if from the map 
+                previousIDtoFileMetadataMap.remove(removedId);
+            } else {
+                //This is a removed file
+                removedFiles.add(fmdRemoved);
             }
-            if (added) {
-                addedFiles.add(fmdn);
-            }
-        }        
-        getReplacedFiles();
+        }
+        // Any fms left are not updating existing files and aren't replacing a file, but
+        // they are claiming a previous file id. That shouldn't be possible, but this will
+        // make sure they get listed in the difference if they do
+        for (Entry<Long, FileMetadata> entry : previousIDtoFileMetadataMap.entrySet()) {
+            logger.warning("Previous file id claimed for a new file: fmd id: " + entry.getValue() + ", previous file id: " + entry.getKey());
+            addedFiles.add(entry.getValue());
+        }
+        
+        logger.info("End alt loop: " + System.currentTimeMillis());
         initDatasetFilesDifferencesList();
 
         //Sort within blocks by datasetfieldtype dispaly order then....
@@ -173,293 +195,61 @@ public final class DatasetVersionDifference {
         getTermsDifferences();
     }
     
-    private void getReplacedFiles() {
-        if (addedFiles.isEmpty() || removedFiles.isEmpty()) {
-            return;
-        }
-        List<FileMetadata> addedToReplaced = new ArrayList<>();
-        List<FileMetadata> removedToReplaced = new ArrayList<>();
-        for (FileMetadata added : addedFiles) {
-            DataFile addedDF = added.getDataFile();
-            Long replacedId = addedDF.getPreviousDataFileId();
-            if (added.getDataFile().getPreviousDataFileId() != null){
-            }
-            for (FileMetadata removed : removedFiles) {
-                DataFile test = removed.getDataFile();
-                if (test.getId().equals(replacedId)) {                  
-                    addedToReplaced.add(added);
-                    removedToReplaced.add(removed);
-                    FileMetadata[] replacedArray = new FileMetadata[2];
-                    replacedArray[0] = removed;
-                    replacedArray[1] = added;
-                    replacedFiles.add(replacedArray);
-                }
-            }
-        }
-        if(addedToReplaced.isEmpty()){
-        } else{
-            addedToReplaced.stream().forEach((delete) -> {
-                addedFiles.remove(delete);
-            });
-            removedToReplaced.stream().forEach((delete) -> {
-                removedFiles.remove(delete);
-            });
-        }
-    }
+
        
     private void getTermsDifferences() {
 
-        changedTermsAccess = new ArrayList<>();
-        if (newVersion.getTermsOfUseAndAccess() != null && originalVersion.getTermsOfUseAndAccess() != null) {
-            if (!StringUtil.nullToEmpty(newVersion.getTermsOfUseAndAccess().getTermsOfUse()).equals(StringUtil.nullToEmpty(originalVersion.getTermsOfUseAndAccess().getTermsOfUse()))) {
-                String diffLabel = BundleUtil.getStringFromBundle("file.dataFilesTab.terms.list.termsOfUse.header");
-                changedTermsAccess = addToTermsChangedList(changedTermsAccess, diffLabel, StringUtil.nullToEmpty(originalVersion.getTermsOfUseAndAccess().getTermsOfUse()), StringUtil.nullToEmpty(newVersion.getTermsOfUseAndAccess().getTermsOfUse()));
-            }
-            if (!StringUtil.nullToEmpty(newVersion.getTermsOfUseAndAccess().getConfidentialityDeclaration()).equals(StringUtil.nullToEmpty(originalVersion.getTermsOfUseAndAccess().getConfidentialityDeclaration()))) {
-                String diffLabel = BundleUtil.getStringFromBundle("file.dataFilesTab.terms.list.termsOfUse.addInfo.declaration");
-                changedTermsAccess = addToTermsChangedList(changedTermsAccess, diffLabel, StringUtil.nullToEmpty(originalVersion.getTermsOfUseAndAccess().getConfidentialityDeclaration()),
-                        StringUtil.nullToEmpty(newVersion.getTermsOfUseAndAccess().getConfidentialityDeclaration()));
-            }
-            if (!StringUtil.nullToEmpty(newVersion.getTermsOfUseAndAccess().getSpecialPermissions()).equals(StringUtil.nullToEmpty(originalVersion.getTermsOfUseAndAccess().getSpecialPermissions()))) {
-                String diffLabel = BundleUtil.getStringFromBundle("file.dataFilesTab.terms.list.termsOfUse.addInfo.permissions");
-                changedTermsAccess = addToTermsChangedList(changedTermsAccess, diffLabel, StringUtil.nullToEmpty(originalVersion.getTermsOfUseAndAccess().getSpecialPermissions()),
-                        StringUtil.nullToEmpty(newVersion.getTermsOfUseAndAccess().getSpecialPermissions()));
-            }
-            if (!StringUtil.nullToEmpty(newVersion.getTermsOfUseAndAccess().getRestrictions()).equals(StringUtil.nullToEmpty(originalVersion.getTermsOfUseAndAccess().getRestrictions()))) {
-                String diffLabel = BundleUtil.getStringFromBundle("file.dataFilesTab.terms.list.termsOfUse.addInfo.restrictions");
-                changedTermsAccess = addToTermsChangedList(changedTermsAccess, diffLabel, StringUtil.nullToEmpty(originalVersion.getTermsOfUseAndAccess().getRestrictions()),
-                        StringUtil.nullToEmpty(newVersion.getTermsOfUseAndAccess().getRestrictions()));
-
-            }
-            if (!StringUtil.nullToEmpty(newVersion.getTermsOfUseAndAccess().getCitationRequirements()).equals(StringUtil.nullToEmpty(originalVersion.getTermsOfUseAndAccess().getCitationRequirements()))) {
-                String diffLabel = BundleUtil.getStringFromBundle("file.dataFilesTab.terms.list.termsOfUse.addInfo.citationRequirements");
-                changedTermsAccess = addToTermsChangedList(changedTermsAccess, diffLabel, StringUtil.nullToEmpty(originalVersion.getTermsOfUseAndAccess().getCitationRequirements()),
-                        StringUtil.nullToEmpty(newVersion.getTermsOfUseAndAccess().getCitationRequirements()));
-            }
-            if (!StringUtil.nullToEmpty(newVersion.getTermsOfUseAndAccess().getDepositorRequirements()).equals(StringUtil.nullToEmpty(originalVersion.getTermsOfUseAndAccess().getDepositorRequirements()))) {
-                String diffLabel = BundleUtil.getStringFromBundle("file.dataFilesTab.terms.list.termsOfUse.addInfo.depositorRequirements");
-                changedTermsAccess = addToTermsChangedList(changedTermsAccess, diffLabel, StringUtil.nullToEmpty(originalVersion.getTermsOfUseAndAccess().getDepositorRequirements()),
-                        StringUtil.nullToEmpty(newVersion.getTermsOfUseAndAccess().getDepositorRequirements()));
-            }
-            if (!StringUtil.nullToEmpty(newVersion.getTermsOfUseAndAccess().getConditions()).equals(StringUtil.nullToEmpty(originalVersion.getTermsOfUseAndAccess().getConditions()))) {
-                String diffLabel = BundleUtil.getStringFromBundle("file.dataFilesTab.terms.list.termsOfUse.addInfo.conditions");
-                changedTermsAccess = addToTermsChangedList(changedTermsAccess, diffLabel, StringUtil.nullToEmpty(originalVersion.getTermsOfUseAndAccess().getConditions()),
-                        StringUtil.nullToEmpty(newVersion.getTermsOfUseAndAccess().getConditions()));
-            }
-            if (!StringUtil.nullToEmpty(newVersion.getTermsOfUseAndAccess().getDisclaimer()).equals(StringUtil.nullToEmpty(originalVersion.getTermsOfUseAndAccess().getDisclaimer()))) {
-                String diffLabel = BundleUtil.getStringFromBundle("file.dataFilesTab.terms.list.termsOfUse.addInfo.disclaimer");
-                changedTermsAccess = addToTermsChangedList(changedTermsAccess, diffLabel, StringUtil.nullToEmpty(originalVersion.getTermsOfUseAndAccess().getDisclaimer()), StringUtil.nullToEmpty(newVersion.getTermsOfUseAndAccess().getDisclaimer()));
-            }
-
-            if (!StringUtil.nullToEmpty(newVersion.getTermsOfUseAndAccess().getTermsOfAccess()).equals(StringUtil.nullToEmpty(originalVersion.getTermsOfUseAndAccess().getTermsOfAccess()))) {
-                String diffLabel = BundleUtil.getStringFromBundle("file.dataFilesTab.terms.list.termsOfAccess.termsOfsAccess");
-                changedTermsAccess = addToTermsChangedList(changedTermsAccess, diffLabel, StringUtil.nullToEmpty(originalVersion.getTermsOfUseAndAccess().getTermsOfAccess()),
-                        StringUtil.nullToEmpty(newVersion.getTermsOfUseAndAccess().getTermsOfAccess()));
-            }
-            if (!StringUtil.nullToEmpty(newVersion.getTermsOfUseAndAccess().getDataAccessPlace()).equals(StringUtil.nullToEmpty(originalVersion.getTermsOfUseAndAccess().getDataAccessPlace()))) {
-                String diffLabel = BundleUtil.getStringFromBundle("file.dataFilesTab.terms.list.termsOfAccess.addInfo.dataAccessPlace");
-                changedTermsAccess = addToTermsChangedList(changedTermsAccess, diffLabel, StringUtil.nullToEmpty(originalVersion.getTermsOfUseAndAccess().getDataAccessPlace()),
-                        StringUtil.nullToEmpty(newVersion.getTermsOfUseAndAccess().getDataAccessPlace()));
-            }
-            if (!StringUtil.nullToEmpty(newVersion.getTermsOfUseAndAccess().getOriginalArchive()).equals(StringUtil.nullToEmpty(originalVersion.getTermsOfUseAndAccess().getOriginalArchive()))) {
-                String diffLabel = BundleUtil.getStringFromBundle("file.dataFilesTab.terms.list.termsOfAccess.addInfo.originalArchive");
-                changedTermsAccess = addToTermsChangedList(changedTermsAccess, diffLabel, StringUtil.nullToEmpty(originalVersion.getTermsOfUseAndAccess().getOriginalArchive()),
-                        StringUtil.nullToEmpty(newVersion.getTermsOfUseAndAccess().getOriginalArchive()));
-            }
-            if (!StringUtil.nullToEmpty(newVersion.getTermsOfUseAndAccess().getAvailabilityStatus()).equals(StringUtil.nullToEmpty(originalVersion.getTermsOfUseAndAccess().getAvailabilityStatus()))) {
-                String diffLabel = BundleUtil.getStringFromBundle("file.dataFilesTab.terms.list.termsOfAccess.addInfo.availabilityStatus");
-                changedTermsAccess = addToTermsChangedList(changedTermsAccess, diffLabel, StringUtil.nullToEmpty(originalVersion.getTermsOfUseAndAccess().getAvailabilityStatus()),
-                        StringUtil.nullToEmpty(newVersion.getTermsOfUseAndAccess().getAvailabilityStatus()));
-            }
-            if (!StringUtil.nullToEmpty(newVersion.getTermsOfUseAndAccess().getContactForAccess()).equals(StringUtil.nullToEmpty(originalVersion.getTermsOfUseAndAccess().getContactForAccess()))) {
-                String diffLabel = BundleUtil.getStringFromBundle("file.dataFilesTab.terms.list.termsOfAccess.addInfo.contactForAccess");
-                changedTermsAccess = addToTermsChangedList(changedTermsAccess, diffLabel, StringUtil.nullToEmpty(originalVersion.getTermsOfUseAndAccess().getContactForAccess()),
-                        StringUtil.nullToEmpty(newVersion.getTermsOfUseAndAccess().getContactForAccess()));
-            }
-            if (!StringUtil.nullToEmpty(newVersion.getTermsOfUseAndAccess().getSizeOfCollection()).equals(StringUtil.nullToEmpty(originalVersion.getTermsOfUseAndAccess().getSizeOfCollection()))) {
-                String diffLabel = BundleUtil.getStringFromBundle("file.dataFilesTab.terms.list.termsOfAccess.addInfo.sizeOfCollection");
-                changedTermsAccess = addToTermsChangedList(changedTermsAccess, diffLabel, StringUtil.nullToEmpty(originalVersion.getTermsOfUseAndAccess().getSizeOfCollection()),
-                        StringUtil.nullToEmpty(newVersion.getTermsOfUseAndAccess().getSizeOfCollection()));
-            }
-            if (!StringUtil.nullToEmpty(newVersion.getTermsOfUseAndAccess().getStudyCompletion()).equals(StringUtil.nullToEmpty(originalVersion.getTermsOfUseAndAccess().getStudyCompletion()))) {
-                String diffLabel = BundleUtil.getStringFromBundle("file.dataFilesTab.terms.list.termsOfAccess.addInfo.studyCompletion");
-                changedTermsAccess = addToTermsChangedList(changedTermsAccess, diffLabel, StringUtil.nullToEmpty(originalVersion.getTermsOfUseAndAccess().getStudyCompletion()),
-                        StringUtil.nullToEmpty(newVersion.getTermsOfUseAndAccess().getStudyCompletion()));
-            }
+        TermsOfUseAndAccess originalTerms = originalVersion.getTermsOfUseAndAccess();
+        if(originalTerms == null) {
+            originalTerms = new TermsOfUseAndAccess();
         }
-
-        if (newVersion.getTermsOfUseAndAccess() != null && originalVersion.getTermsOfUseAndAccess() == null) {
-            if (!StringUtil.nullToEmpty(newVersion.getTermsOfUseAndAccess().getTermsOfUse()).isEmpty()) {
-                String diffLabel = BundleUtil.getStringFromBundle("file.dataFilesTab.terms.list.termsOfUse.header");
-                changedTermsAccess = addToTermsChangedList(changedTermsAccess, diffLabel, "", StringUtil.nullToEmpty(newVersion.getTermsOfUseAndAccess().getTermsOfUse()));
-            }
-            if (!StringUtil.nullToEmpty(newVersion.getTermsOfUseAndAccess().getConfidentialityDeclaration()).isEmpty()){
-                String diffLabel = BundleUtil.getStringFromBundle("file.dataFilesTab.terms.list.termsOfUse.addInfo.declaration");
-                changedTermsAccess = addToTermsChangedList(changedTermsAccess, diffLabel, "",
-                        StringUtil.nullToEmpty(newVersion.getTermsOfUseAndAccess().getConfidentialityDeclaration()));
-            }
-            if (!StringUtil.nullToEmpty(newVersion.getTermsOfUseAndAccess().getSpecialPermissions()).isEmpty()){
-                String diffLabel = BundleUtil.getStringFromBundle("file.dataFilesTab.terms.list.termsOfUse.addInfo.permissions");
-                changedTermsAccess = addToTermsChangedList(changedTermsAccess, diffLabel, "",
-                        StringUtil.nullToEmpty(newVersion.getTermsOfUseAndAccess().getSpecialPermissions()));
-            }
-            if (!StringUtil.nullToEmpty(newVersion.getTermsOfUseAndAccess().getRestrictions()).isEmpty()){
-                String diffLabel = BundleUtil.getStringFromBundle("file.dataFilesTab.terms.list.termsOfUse.addInfo.restrictions");
-                changedTermsAccess = addToTermsChangedList(changedTermsAccess, diffLabel, "",
-                        StringUtil.nullToEmpty(newVersion.getTermsOfUseAndAccess().getRestrictions()));
-            }
-            if (!StringUtil.nullToEmpty(newVersion.getTermsOfUseAndAccess().getCitationRequirements()).isEmpty()){
-                String diffLabel = BundleUtil.getStringFromBundle("file.dataFilesTab.terms.list.termsOfUse.addInfo.citationRequirements");
-                changedTermsAccess = addToTermsChangedList(changedTermsAccess, diffLabel, "",
-                        StringUtil.nullToEmpty(newVersion.getTermsOfUseAndAccess().getCitationRequirements()));
-            }
-            if (!StringUtil.nullToEmpty(newVersion.getTermsOfUseAndAccess().getDepositorRequirements()).isEmpty()){
-                String diffLabel = BundleUtil.getStringFromBundle("file.dataFilesTab.terms.list.termsOfUse.addInfo.depositorRequirements");
-                changedTermsAccess = addToTermsChangedList(changedTermsAccess, diffLabel, "",
-                        StringUtil.nullToEmpty(newVersion.getTermsOfUseAndAccess().getDepositorRequirements()));
-            }
-            if (!StringUtil.nullToEmpty(newVersion.getTermsOfUseAndAccess().getConditions()).isEmpty()){
-                String diffLabel = BundleUtil.getStringFromBundle("file.dataFilesTab.terms.list.termsOfUse.addInfo.conditions");
-                changedTermsAccess = addToTermsChangedList(changedTermsAccess, diffLabel, "",
-                        StringUtil.nullToEmpty(newVersion.getTermsOfUseAndAccess().getConditions()));
-            }
-            if (!StringUtil.nullToEmpty(newVersion.getTermsOfUseAndAccess().getDisclaimer()).isEmpty()){
-                String diffLabel = BundleUtil.getStringFromBundle("file.dataFilesTab.terms.list.termsOfUse.addInfo.disclaimer");
-                changedTermsAccess = addToTermsChangedList(changedTermsAccess, diffLabel, "", StringUtil.nullToEmpty(newVersion.getTermsOfUseAndAccess().getDisclaimer()));
-            }
-            if (!StringUtil.nullToEmpty(newVersion.getTermsOfUseAndAccess().getTermsOfAccess()).isEmpty()){
-                String diffLabel = BundleUtil.getStringFromBundle("file.dataFilesTab.terms.list.termsOfAccess.termsOfsAccess");
-                changedTermsAccess = addToTermsChangedList(changedTermsAccess, diffLabel, "",
-                        StringUtil.nullToEmpty(newVersion.getTermsOfUseAndAccess().getTermsOfAccess()));
-            }
-            if (!StringUtil.nullToEmpty(newVersion.getTermsOfUseAndAccess().getDataAccessPlace()).isEmpty()){
-                String diffLabel = BundleUtil.getStringFromBundle("file.dataFilesTab.terms.list.termsOfAccess.addInfo.dataAccessPlace");
-                changedTermsAccess = addToTermsChangedList(changedTermsAccess, diffLabel, "",
-                        StringUtil.nullToEmpty(newVersion.getTermsOfUseAndAccess().getDataAccessPlace()));
-            }
-            if (!StringUtil.nullToEmpty(newVersion.getTermsOfUseAndAccess().getOriginalArchive()).isEmpty()){
-                String diffLabel = BundleUtil.getStringFromBundle("file.dataFilesTab.terms.list.termsOfAccess.addInfo.originalArchive");
-                changedTermsAccess = addToTermsChangedList(changedTermsAccess, diffLabel, "",
-                        StringUtil.nullToEmpty(newVersion.getTermsOfUseAndAccess().getOriginalArchive()));
-            }
-            if (!StringUtil.nullToEmpty(newVersion.getTermsOfUseAndAccess().getAvailabilityStatus()).isEmpty()){
-                String diffLabel = BundleUtil.getStringFromBundle("file.dataFilesTab.terms.list.termsOfAccess.addInfo.availabilityStatus");
-                changedTermsAccess = addToTermsChangedList(changedTermsAccess, diffLabel, "",
-                        StringUtil.nullToEmpty(newVersion.getTermsOfUseAndAccess().getAvailabilityStatus()));
-            }
-            if (!StringUtil.nullToEmpty(newVersion.getTermsOfUseAndAccess().getContactForAccess()).isEmpty()){
-                String diffLabel = BundleUtil.getStringFromBundle("file.dataFilesTab.terms.list.termsOfAccess.addInfo.contactForAccess");
-                changedTermsAccess = addToTermsChangedList(changedTermsAccess, diffLabel, "",
-                        StringUtil.nullToEmpty(newVersion.getTermsOfUseAndAccess().getContactForAccess()));
-            }
-            if (!StringUtil.nullToEmpty(newVersion.getTermsOfUseAndAccess().getSizeOfCollection()).isEmpty()){
-                String diffLabel = BundleUtil.getStringFromBundle("file.dataFilesTab.terms.list.termsOfAccess.addInfo.sizeOfCollection");
-                changedTermsAccess = addToTermsChangedList(changedTermsAccess, diffLabel, "",
-                        StringUtil.nullToEmpty(newVersion.getTermsOfUseAndAccess().getSizeOfCollection()));
-            }
-            if (!StringUtil.nullToEmpty(newVersion.getTermsOfUseAndAccess().getStudyCompletion()).isEmpty()){
-                String diffLabel = BundleUtil.getStringFromBundle("file.dataFilesTab.terms.list.termsOfAccess.addInfo.studyCompletion");
-                changedTermsAccess = addToTermsChangedList(changedTermsAccess, diffLabel, "",
-                        StringUtil.nullToEmpty(newVersion.getTermsOfUseAndAccess().getStudyCompletion()));
-            }            
-        }        
-
-        if (newVersion.getTermsOfUseAndAccess() == null && originalVersion.getTermsOfUseAndAccess() != null) {
-            if (!StringUtil.nullToEmpty(originalVersion.getTermsOfUseAndAccess().getTermsOfUse()).isEmpty()) {
-                String diffLabel = BundleUtil.getStringFromBundle("file.dataFilesTab.terms.list.termsOfUse.header");
-                changedTermsAccess = addToTermsChangedList(changedTermsAccess, diffLabel, StringUtil.nullToEmpty(originalVersion.getTermsOfUseAndAccess().getTermsOfUse()), "");
-            }
-            if (!StringUtil.nullToEmpty(originalVersion.getTermsOfUseAndAccess().getConfidentialityDeclaration()).isEmpty()){
-                String diffLabel = BundleUtil.getStringFromBundle("file.dataFilesTab.terms.list.termsOfUse.addInfo.declaration");
-                changedTermsAccess = addToTermsChangedList(changedTermsAccess, diffLabel,
-                        StringUtil.nullToEmpty(originalVersion.getTermsOfUseAndAccess().getConfidentialityDeclaration()), "");
-            }
-            if (!StringUtil.nullToEmpty(originalVersion.getTermsOfUseAndAccess().getSpecialPermissions()).isEmpty()){
-                String diffLabel = BundleUtil.getStringFromBundle("file.dataFilesTab.terms.list.termsOfUse.addInfo.permissions");
-                changedTermsAccess = addToTermsChangedList(changedTermsAccess, diffLabel,
-                        StringUtil.nullToEmpty(originalVersion.getTermsOfUseAndAccess().getSpecialPermissions()), "");
-            }
-            if (!StringUtil.nullToEmpty(originalVersion.getTermsOfUseAndAccess().getRestrictions()).isEmpty()){
-                String diffLabel = BundleUtil.getStringFromBundle("file.dataFilesTab.terms.list.termsOfUse.addInfo.restrictions");
-                changedTermsAccess = addToTermsChangedList(changedTermsAccess, diffLabel, 
-                        StringUtil.nullToEmpty(originalVersion.getTermsOfUseAndAccess().getRestrictions()), "");
-            }
-            if (!StringUtil.nullToEmpty(originalVersion.getTermsOfUseAndAccess().getCitationRequirements()).isEmpty()){
-                String diffLabel = BundleUtil.getStringFromBundle("file.dataFilesTab.terms.list.termsOfUse.addInfo.citationRequirements");
-                changedTermsAccess = addToTermsChangedList(changedTermsAccess, diffLabel, 
-                        StringUtil.nullToEmpty(originalVersion.getTermsOfUseAndAccess().getCitationRequirements()), "");
-            }
-            if (!StringUtil.nullToEmpty(originalVersion.getTermsOfUseAndAccess().getDepositorRequirements()).isEmpty()){
-                String diffLabel = BundleUtil.getStringFromBundle("file.dataFilesTab.terms.list.termsOfUse.addInfo.depositorRequirements");
-                changedTermsAccess = addToTermsChangedList(changedTermsAccess, diffLabel, 
-                        StringUtil.nullToEmpty(originalVersion.getTermsOfUseAndAccess().getDepositorRequirements()), "");
-            }
-            if (!StringUtil.nullToEmpty(originalVersion.getTermsOfUseAndAccess().getConditions()).isEmpty()){
-                String diffLabel = BundleUtil.getStringFromBundle("file.dataFilesTab.terms.list.termsOfUse.addInfo.conditions");
-                changedTermsAccess = addToTermsChangedList(changedTermsAccess, diffLabel, 
-                        StringUtil.nullToEmpty(originalVersion.getTermsOfUseAndAccess().getConditions()), "");
-            }
-            if (!StringUtil.nullToEmpty(originalVersion.getTermsOfUseAndAccess().getDisclaimer()).isEmpty()){
-                String diffLabel = BundleUtil.getStringFromBundle("file.dataFilesTab.terms.list.termsOfUse.addInfo.disclaimer");
-                changedTermsAccess = addToTermsChangedList(changedTermsAccess, diffLabel,  StringUtil.nullToEmpty(originalVersion.getTermsOfUseAndAccess().getDisclaimer()), "");
-            }
-            if (!StringUtil.nullToEmpty(originalVersion.getTermsOfUseAndAccess().getTermsOfAccess()).isEmpty()){
-                String diffLabel = BundleUtil.getStringFromBundle("file.dataFilesTab.terms.list.termsOfAccess.termsOfsAccess");
-                changedTermsAccess = addToTermsChangedList(changedTermsAccess, diffLabel, 
-                        StringUtil.nullToEmpty(originalVersion.getTermsOfUseAndAccess().getTermsOfAccess()), "");
-            }
-            if (!StringUtil.nullToEmpty(originalVersion.getTermsOfUseAndAccess().getDataAccessPlace()).isEmpty()){
-                String diffLabel = BundleUtil.getStringFromBundle("file.dataFilesTab.terms.list.termsOfAccess.addInfo.dataAccessPlace");
-                changedTermsAccess = addToTermsChangedList(changedTermsAccess, diffLabel, 
-                        StringUtil.nullToEmpty(originalVersion.getTermsOfUseAndAccess().getDataAccessPlace()), "");
-            }
-            if (!StringUtil.nullToEmpty(originalVersion.getTermsOfUseAndAccess().getOriginalArchive()).isEmpty()){
-                String diffLabel = BundleUtil.getStringFromBundle("file.dataFilesTab.terms.list.termsOfAccess.addInfo.originalArchive");
-                changedTermsAccess = addToTermsChangedList(changedTermsAccess, diffLabel, 
-                        StringUtil.nullToEmpty(originalVersion.getTermsOfUseAndAccess().getOriginalArchive()), "");
-            }
-            if (!StringUtil.nullToEmpty(originalVersion.getTermsOfUseAndAccess().getAvailabilityStatus()).isEmpty()){
-                String diffLabel = BundleUtil.getStringFromBundle("file.dataFilesTab.terms.list.termsOfAccess.addInfo.availabilityStatus");
-                changedTermsAccess = addToTermsChangedList(changedTermsAccess, diffLabel, 
-                        StringUtil.nullToEmpty(originalVersion.getTermsOfUseAndAccess().getAvailabilityStatus()), "");
-            }
-            if (!StringUtil.nullToEmpty(originalVersion.getTermsOfUseAndAccess().getContactForAccess()).isEmpty()){
-                String diffLabel = BundleUtil.getStringFromBundle("file.dataFilesTab.terms.list.termsOfAccess.addInfo.contactForAccess");
-                changedTermsAccess = addToTermsChangedList(changedTermsAccess, diffLabel, 
-                        StringUtil.nullToEmpty(originalVersion.getTermsOfUseAndAccess().getContactForAccess()), "");
-            }
-            if (!StringUtil.nullToEmpty(originalVersion.getTermsOfUseAndAccess().getSizeOfCollection()).isEmpty()){
-                String diffLabel = BundleUtil.getStringFromBundle("file.dataFilesTab.terms.list.termsOfAccess.addInfo.sizeOfCollection");
-                changedTermsAccess = addToTermsChangedList(changedTermsAccess, diffLabel, 
-                        StringUtil.nullToEmpty(originalVersion.getTermsOfUseAndAccess().getSizeOfCollection()), "");
-            }
-            if (!StringUtil.nullToEmpty(originalVersion.getTermsOfUseAndAccess().getStudyCompletion()).isEmpty()){
-                String diffLabel = BundleUtil.getStringFromBundle("file.dataFilesTab.terms.list.termsOfAccess.addInfo.studyCompletion");
-                changedTermsAccess = addToTermsChangedList(changedTermsAccess, diffLabel, 
-                        StringUtil.nullToEmpty(originalVersion.getTermsOfUseAndAccess().getStudyCompletion()), "");
-            }            
-        }               
-    }
-    
-    private DifferenceSummaryItem createSummaryItem(){
-        return null;
-    }
-    
-    private List addToSummaryGroup(String displayName, DifferenceSummaryItem differenceSummaryItem){
+        // newTerms should never be null
+        TermsOfUseAndAccess newTerms = newVersion.getTermsOfUseAndAccess();
+        if(newTerms == null) {
+            logger.warning("New version does not have TermsOfUseAndAccess");
+            newTerms = new TermsOfUseAndAccess();
+        }
         
-        return null;
+        checkAndAddToChangeList(originalTerms.getTermsOfUse(), newTerms.getTermsOfUse(),
+                BundleUtil.getStringFromBundle("file.dataFilesTab.terms.list.termsOfUse.header"));
+        checkAndAddToChangeList(originalTerms.getConfidentialityDeclaration(), newTerms.getConfidentialityDeclaration(),
+                BundleUtil.getStringFromBundle("file.dataFilesTab.terms.list.termsOfUse.addInfo.declaration"));
+        checkAndAddToChangeList(originalTerms.getSpecialPermissions(), newTerms.getSpecialPermissions(),
+                BundleUtil.getStringFromBundle("file.dataFilesTab.terms.list.termsOfUse.addInfo.permissions"));
+        checkAndAddToChangeList(originalTerms.getRestrictions(), newTerms.getRestrictions(),
+                BundleUtil.getStringFromBundle("file.dataFilesTab.terms.list.termsOfUse.addInfo.restrictions"));
+        checkAndAddToChangeList(originalTerms.getCitationRequirements(), newTerms.getCitationRequirements(),
+                BundleUtil.getStringFromBundle("file.dataFilesTab.terms.list.termsOfUse.addInfo.citationRequirements"));
+        checkAndAddToChangeList(originalTerms.getDepositorRequirements(), newTerms.getDepositorRequirements(),
+                BundleUtil.getStringFromBundle("file.dataFilesTab.terms.list.termsOfUse.addInfo.depositorRequirements"));
+        checkAndAddToChangeList(originalTerms.getConditions(), newTerms.getConditions(),
+                BundleUtil.getStringFromBundle("file.dataFilesTab.terms.list.termsOfUse.addInfo.conditions"));
+        checkAndAddToChangeList(originalTerms.getDisclaimer(), newTerms.getDisclaimer(),
+                BundleUtil.getStringFromBundle("file.dataFilesTab.terms.list.termsOfUse.addInfo.disclaimer"));
+        checkAndAddToChangeList(originalTerms.getTermsOfAccess(), newTerms.getTermsOfAccess(),
+                BundleUtil.getStringFromBundle("file.dataFilesTab.terms.list.termsOfAccess.termsOfsAccess"));
+        checkAndAddToChangeList(originalTerms.getDataAccessPlace(), newTerms.getDataAccessPlace(),
+                BundleUtil.getStringFromBundle("file.dataFilesTab.terms.list.termsOfAccess.addInfo.dataAccessPlace"));
+        checkAndAddToChangeList(originalTerms.getOriginalArchive(), newTerms.getOriginalArchive(),
+                BundleUtil.getStringFromBundle("file.dataFilesTab.terms.list.termsOfAccess.addInfo.originalArchive"));
+        checkAndAddToChangeList(originalTerms.getAvailabilityStatus(), newTerms.getAvailabilityStatus(),
+                BundleUtil.getStringFromBundle("file.dataFilesTab.terms.list.termsOfAccess.addInfo.availabilityStatus"));
+        checkAndAddToChangeList(originalTerms.getContactForAccess(), newTerms.getContactForAccess(),
+                BundleUtil.getStringFromBundle("file.dataFilesTab.terms.list.termsOfAccess.addInfo.contactForAccess"));
+        checkAndAddToChangeList(originalTerms.getSizeOfCollection(), newTerms.getSizeOfCollection(),
+                BundleUtil.getStringFromBundle("file.dataFilesTab.terms.list.termsOfAccess.addInfo.sizeOfCollection"));
+        checkAndAddToChangeList(originalTerms.getStudyCompletion(), newTerms.getStudyCompletion(),
+                BundleUtil.getStringFromBundle("file.dataFilesTab.terms.list.termsOfAccess.addInfo.studyCompletion"));
     }
-
-    private List<String[]> addToTermsChangedList(List<String[]> listIn, String label, String origVal, String newVal) {
-        String[] diffArray;
-        diffArray = new String[3];
-        diffArray[0] = label;
-        diffArray[1] = origVal;
-        diffArray[2] = newVal;
-        listIn.add(diffArray);
-        return listIn;
+    
+    private void checkAndAddToChangeList(String originalTerm, String newTerm,
+            String termLabel) {
+        originalTerm = StringUtil.nullToEmpty(originalTerm);
+        newTerm = StringUtil.nullToEmpty(newTerm);
+        if(!originalTerm.equals(newTerm)) {
+            changedTermsAccess.add(new String[]{termLabel, originalTerm, newTerm});
+        }
     }
-
 
     private void addToList(List<DatasetField[]> listIn, DatasetField dsfo, DatasetField dsfn) {
         DatasetField[] dsfArray;
@@ -523,7 +313,7 @@ public final class DatasetVersionDifference {
         summaryDataForNote.add(noteArray);
     }
 
-    private boolean compareVarGroup(FileMetadata fmdo, FileMetadata fmdn) {
+    static boolean compareVarGroup(FileMetadata fmdo, FileMetadata fmdn) {
         List<VarGroup> vglo = fmdo.getVarGroups();
         List<VarGroup> vgln = fmdn.getVarGroups();
 
@@ -533,7 +323,7 @@ public final class DatasetVersionDifference {
         int count = 0;
         for (VarGroup vgo : vglo) {
             for (VarGroup vgn : vgln) {
-                if (!variableMetadataUtil.checkDiff(vgo.getLabel(), vgn.getLabel())) {
+                if (!VariableMetadataUtil.checkDiff(vgo.getLabel(), vgn.getLabel())) {
                     Set<DataVariable> dvo = vgo.getVarsInGroup();
                     Set<DataVariable> dvn = vgn.getVarsInGroup();
                     if (dvo.equals(dvn)) {
@@ -1818,5 +1608,13 @@ public final class DatasetVersionDifference {
             }
         }
         return false;
+    }
+
+    List<FileMetadata> getgetChangedVariableMetadata() {
+        return changedVariableMetadata;
+    }
+
+    List<FileMetadata[]> getReplacedFiles() {
+        return replacedFiles;
     }
 }

--- a/src/test/java/edu/harvard/iq/dataverse/DatasetVersionDifferenceTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/DatasetVersionDifferenceTest.java
@@ -1,0 +1,299 @@
+package edu.harvard.iq.dataverse;
+
+import edu.harvard.iq.dataverse.DatasetVersionDifference.datasetFileDifferenceItem;
+import edu.harvard.iq.dataverse.DatasetVersionDifference.datasetReplaceFileItem;
+import edu.harvard.iq.dataverse.branding.BrandingUtilTest;
+import edu.harvard.iq.dataverse.datavariable.VariableMetadata;
+import edu.harvard.iq.dataverse.datavariable.VariableMetadataUtil;
+import edu.harvard.iq.dataverse.license.License;
+import java.net.URI;
+import java.sql.Timestamp;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.logging.Logger;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+
+public class DatasetVersionDifferenceTest {
+
+    private static final Logger logger = Logger.getLogger(DatasetVersion.class.getCanonicalName());
+
+    private static List<FileMetadata> addedFiles;
+    private static List<FileMetadata> removedFiles;
+    private static List<FileMetadata> changedFileMetadata;
+    private static List<FileMetadata> changedVariableMetadata;
+    private static List<FileMetadata[]> replacedFiles;
+
+    @BeforeAll
+    public static void setUp() {
+        BrandingUtilTest.setupMocks();
+    }
+
+    @AfterAll
+    public static void tearDown() {
+        BrandingUtilTest.setupMocks();
+    }
+
+    @Test
+    public void testDifferencing() {
+        Dataset dataset = new Dataset();
+        License license = new License("CC0 1.0",
+                "You can copy, modify, distribute and perform the work, even for commercial purposes, all without asking permission.",
+                URI.create("http://creativecommons.org/publicdomain/zero/1.0"), URI.create("/resources/images/cc0.png"),
+                true, 1l);
+        license.setDefault(true);
+        dataset.setProtocol("doi");
+        dataset.setAuthority("10.5072/FK2");
+        dataset.setIdentifier("LK0D1H");
+        DatasetVersion datasetVersion = new DatasetVersion();
+        datasetVersion.setDataset(dataset);
+        datasetVersion.setVersionState(DatasetVersion.VersionState.RELEASED);
+        datasetVersion.setVersionNumber(1L);
+        DatasetVersion datasetVersion2 = new DatasetVersion();
+        datasetVersion2.setDataset(dataset);
+        datasetVersion2.setVersionState(DatasetVersion.VersionState.DRAFT);
+
+        // Published version's two files
+        DataFile dataFile = new DataFile();
+        dataFile.setId(1L);
+        DataFile dataFile2 = new DataFile();
+        dataFile2.setId(2L);
+
+        FileMetadata fileMetadata1 = createFileMetadata(10L, datasetVersion, dataFile, "file1.txt");
+        fileMetadata1.setLabel("file1.txt");
+
+        FileMetadata fileMetadata2 = createFileMetadata(20L, datasetVersion, dataFile2, "file2.txt");
+
+        // Draft version - same two files with one label change
+        FileMetadata fileMetadata3 = fileMetadata1.createCopy();
+        fileMetadata3.setId(30L);
+
+        FileMetadata fileMetadata4 = fileMetadata2.createCopy();
+        fileMetadata4.setLabel("file3.txt");
+        fileMetadata4.setId(40L);
+
+        List<FileMetadata> fileMetadatas = new ArrayList<>(Arrays.asList(fileMetadata1, fileMetadata2));
+        datasetVersion.setFileMetadatas(fileMetadatas);
+        List<FileMetadata> fileMetadatas2 = new ArrayList<>(Arrays.asList(fileMetadata3, fileMetadata4));
+        datasetVersion2.setFileMetadatas(fileMetadatas2);
+
+        SimpleDateFormat dateFmt = new SimpleDateFormat("yyyyMMdd");
+        Date publicationDate;
+        try {
+            publicationDate = dateFmt.parse("19551105");
+            datasetVersion.setReleaseTime(publicationDate);
+            dataset.setPublicationDate(new Timestamp(publicationDate.getTime()));
+        } catch (ParseException e) {
+            // TODO Auto-generated catch block
+            e.printStackTrace();
+        }
+        List<DatasetVersion> versionList = new ArrayList<>(Arrays.asList(datasetVersion, datasetVersion2));
+        dataset.setVersions(versionList);
+
+        // One file has a changed label
+        List<FileMetadata> expectedAddedFiles = new ArrayList<>();
+        List<FileMetadata> expectedRemovedFiles = new ArrayList<>();
+        ;
+        List<FileMetadata> expectedChangedFileMetadata = Arrays.asList(fileMetadata2, fileMetadata4);
+        List<FileMetadata> expectedChangedVariableMetadata = new ArrayList<>();
+        List<FileMetadata[]> expectedReplacedFiles = new ArrayList<>();
+
+        compareResults(datasetVersion, datasetVersion2, expectedAddedFiles, expectedRemovedFiles,
+                expectedChangedFileMetadata, expectedChangedVariableMetadata, expectedReplacedFiles);
+        // change label for first file as well
+        fileMetadata3.setLabel("file1_updated.txt");
+        expectedChangedFileMetadata = Arrays.asList(fileMetadata1, fileMetadata3, fileMetadata2, fileMetadata4);
+        compareResults(datasetVersion, datasetVersion2, expectedAddedFiles, expectedRemovedFiles,
+                expectedChangedFileMetadata, expectedChangedVariableMetadata, expectedReplacedFiles);
+        // Add one change to variable metadata
+        fileMetadata3.setVariableMetadatas(Arrays.asList(new VariableMetadata()));
+        expectedChangedVariableMetadata = Arrays.asList(fileMetadata1, fileMetadata3);
+        compareResults(datasetVersion, datasetVersion2, expectedAddedFiles, expectedRemovedFiles,
+                expectedChangedFileMetadata, expectedChangedVariableMetadata, expectedReplacedFiles);
+        // Replaced File
+        DataFile replacingFile = new DataFile();
+        replacingFile.setId(3L);
+        replacingFile.setPreviousDataFileId(1L);
+        fileMetadata3.setDataFile(replacingFile);
+        expectedChangedFileMetadata = Arrays.asList(fileMetadata2, fileMetadata4);
+        expectedChangedVariableMetadata = new ArrayList<>();
+
+        FileMetadata[] filePair = new FileMetadata[2];
+        filePair[0] = fileMetadata1;
+        filePair[1] = fileMetadata3;
+        expectedReplacedFiles = new ArrayList<>();
+        expectedReplacedFiles.add(filePair);
+        compareResults(datasetVersion, datasetVersion2, expectedAddedFiles, expectedRemovedFiles,
+                expectedChangedFileMetadata, expectedChangedVariableMetadata, expectedReplacedFiles);
+
+        // Add a new file
+        DataFile newFile = new DataFile();
+        newFile.setId(3L);
+        FileMetadata fileMetadata5 = createFileMetadata(50L, datasetVersion2, newFile, "newFile.txt");
+        datasetVersion2.getFileMetadatas().add(fileMetadata5);
+        expectedAddedFiles = Arrays.asList(fileMetadata5);
+        compareResults(datasetVersion, datasetVersion2, expectedAddedFiles, expectedRemovedFiles,
+                expectedChangedFileMetadata, expectedChangedVariableMetadata, expectedReplacedFiles);
+
+        // Remove a file
+        datasetVersion2.getFileMetadatas().remove(fileMetadata4);
+        expectedRemovedFiles = Arrays.asList(fileMetadata2);
+        expectedChangedFileMetadata = new ArrayList<>();
+        compareResults(datasetVersion, datasetVersion2, expectedAddedFiles, expectedRemovedFiles,
+                expectedChangedFileMetadata, expectedChangedVariableMetadata, expectedReplacedFiles);
+    }
+
+    private FileMetadata createFileMetadata(long id, DatasetVersion datasetVersion, DataFile dataFile, String label) {
+        FileMetadata fileMetadata = new FileMetadata();
+        fileMetadata.setId(id);
+        fileMetadata.setDatasetVersion(datasetVersion);
+        fileMetadata.setDataFile(dataFile);
+        fileMetadata.setLabel(label);
+        fileMetadata.setCategories(new ArrayList<>());
+        return fileMetadata;
+    }
+
+    /**
+     * CompareResults is currently testing the output of the
+     * DatasetVersionDifference class with the manually created expected results
+     * included as parameters and with the results of the less efficient algorithm
+     * it is replacing. Once we're collectively convinced that the tests here are
+     * correct (i.e. the manually created expected* parameters are set correctly for
+     * each use case), we could drop running the originalCalculateDifference method
+     * and just compare with the expected* results.
+     */
+    private void compareResults(DatasetVersion datasetVersion, DatasetVersion datasetVersion2,
+            List<FileMetadata> expectedAddedFiles, List<FileMetadata> expectedRemovedFiles,
+            List<FileMetadata> expectedChangedFileMetadata, List<FileMetadata> expectedChangedVariableMetadata,
+            List<FileMetadata[]> expectedReplacedFiles) {
+        DatasetVersionDifference diff = new DatasetVersionDifference(datasetVersion2, datasetVersion);
+        // Run the original algorithm
+        originalCalculateDifference(datasetVersion2, datasetVersion);
+        // Compare the old and new algorithms
+        assertEquals(addedFiles, diff.getAddedFiles());
+        assertEquals(removedFiles, diff.getRemovedFiles());
+        assertEquals(changedFileMetadata, diff.getChangedFileMetadata());
+        assertEquals(changedVariableMetadata, diff.getgetChangedVariableMetadata());
+        assertEquals(replacedFiles.size(), diff.getReplacedFiles().size());
+        for (int i = 0; i < replacedFiles.size(); i++) {
+            assertEquals(replacedFiles.get(i)[0], diff.getReplacedFiles().get(i)[0]);
+            assertEquals(replacedFiles.get(i)[1], diff.getReplacedFiles().get(i)[1]);
+        }
+
+        // Also compare the new algorithm with the manually created expected* values for
+        // the test cases
+        assertEquals(expectedAddedFiles, diff.getAddedFiles());
+        assertEquals(expectedRemovedFiles, diff.getRemovedFiles());
+        assertEquals(expectedChangedFileMetadata, diff.getChangedFileMetadata());
+        assertEquals(expectedChangedVariableMetadata, diff.getgetChangedVariableMetadata());
+        assertEquals(expectedReplacedFiles.size(), diff.getReplacedFiles().size());
+        for (int i = 0; i < expectedReplacedFiles.size(); i++) {
+            assertEquals(expectedReplacedFiles.get(i)[0], diff.getReplacedFiles().get(i)[0]);
+            assertEquals(expectedReplacedFiles.get(i)[1], diff.getReplacedFiles().get(i)[1]);
+        }
+
+    }
+
+    @Deprecated
+    // This is the "Original" difference calculation from DatasetVersionDifference
+    // It is included here to help verify that the new implementation is the same as
+    // the original
+    private static void originalCalculateDifference(DatasetVersion newVersion, DatasetVersion originalVersion) {
+
+        addedFiles = new ArrayList<>();
+        removedFiles = new ArrayList<>();
+        changedFileMetadata = new ArrayList<>();
+        changedVariableMetadata = new ArrayList<>();
+        replacedFiles = new ArrayList<>();
+        logger.info("Start orig loops: " + System.currentTimeMillis());
+        // TODO: ?
+        // It looks like we are going through the filemetadatas in both versions,
+        // *sequentially* (i.e. at the cost of O(N*M)), to select the lists of
+        // changed, deleted and added files between the 2 versions... But why
+        // are we doing it, if we are doing virtually the same thing inside
+        // the initDatasetFilesDifferenceList(), below - but in a more efficient
+        // way (sorting both lists, then goint through them in parallel, at the
+        // cost of (N+M) max.?
+        // -- 4.6 Nov. 2016
+
+        for (FileMetadata fmdo : originalVersion.getFileMetadatas()) {
+            boolean deleted = true;
+            for (FileMetadata fmdn : newVersion.getFileMetadatas()) {
+                if (fmdo.getDataFile().equals(fmdn.getDataFile())) {
+                    deleted = false;
+                    if (!DatasetVersionDifference.compareFileMetadatas(fmdo, fmdn)) {
+                        changedFileMetadata.add(fmdo);
+                        changedFileMetadata.add(fmdn);
+                    }
+                    if (!VariableMetadataUtil.compareVariableMetadata(fmdo, fmdn)
+                            || !DatasetVersionDifference.compareVarGroup(fmdo, fmdn)) {
+                        changedVariableMetadata.add(fmdo);
+                        changedVariableMetadata.add(fmdn);
+                    }
+                    break;
+                }
+            }
+            if (deleted) {
+                removedFiles.add(fmdo);
+            }
+        }
+        for (FileMetadata fmdn : newVersion.getFileMetadatas()) {
+            boolean added = true;
+            for (FileMetadata fmdo : originalVersion.getFileMetadatas()) {
+                if (fmdo.getDataFile().equals(fmdn.getDataFile())) {
+                    added = false;
+                    break;
+                }
+            }
+            if (added) {
+                addedFiles.add(fmdn);
+            }
+        }
+
+        getReplacedFiles();
+        logger.info("End org loops: " + System.currentTimeMillis());
+
+    }
+
+    @Deprecated
+    // This is used only in the original algorithm and was removed from DatasetVersionDifference
+    private static void getReplacedFiles() {
+        if (addedFiles.isEmpty() || removedFiles.isEmpty()) {
+            return;
+        }
+        List<FileMetadata> addedToReplaced = new ArrayList<>();
+        List<FileMetadata> removedToReplaced = new ArrayList<>();
+        for (FileMetadata added : addedFiles) {
+            DataFile addedDF = added.getDataFile();
+            Long replacedId = addedDF.getPreviousDataFileId();
+            if (added.getDataFile().getPreviousDataFileId() != null) {
+            }
+            for (FileMetadata removed : removedFiles) {
+                DataFile test = removed.getDataFile();
+                if (test.getId().equals(replacedId)) {
+                    addedToReplaced.add(added);
+                    removedToReplaced.add(removed);
+                    FileMetadata[] replacedArray = new FileMetadata[2];
+                    replacedArray[0] = removed;
+                    replacedArray[1] = added;
+                    replacedFiles.add(replacedArray);
+                }
+            }
+        }
+        if (addedToReplaced.isEmpty()) {
+        } else {
+            addedToReplaced.stream().forEach((delete) -> {
+                addedFiles.remove(delete);
+            });
+            removedToReplaced.stream().forEach((delete) -> {
+                removedFiles.remove(delete);
+            });
+        }
+    }
+}


### PR DESCRIPTION
**What this PR does / why we need it**: The change in this PR makes differencing during the UpdateDatasetVersionCommand for a dataset with 10K files go from taking ~ 8 seconds to 17 ms. Presumably it improves the Version table on the dataset as well though I haven't tested that at scale.

The PR also includes some cleanup of the terms comparison - basically folding the possible null TermsOfUseAndAccess on the original or new version cases into one case by creating an empty TermsOfUseAndAccess for whichever one is missing, and adding a method to reduce repeated code.

**Which issue(s) this PR closes**:

Closes #10814

**Special notes for your reviewer**: The test currently tests against the original algorithm and against a hardcoded expected value in the test. There's no real reason to test against the original algorithm except to validate that the hardcoded expected values in the test are correct, so I've marked the test code doing the check against the original as @Deprecated. 

The current tests don't do anything to test scaling (they basically try adding one file in each category (changed metadata, changed variable-level metadata, added file, deleted file, replaced file) and see if they differences are calculated as expected/as before. If someone wants to add a loop with ~1K files, we could probably start seeing the difference.

**Suggestions on how to test this**: QA should probably both confirm that the differencing appears to work for the Unit test cases (add a version or two and change metadata, add a file, delete a file, replace a file between versions) and make sure the difference makes sense. Checking the changed variable-level metadata probably requires testing with a tab file and perhaps editing with the DataCurator (Borealis tool for editing variable metadata) or editing in the db. 

Scalability can be estimated by finding/creating a published dataset with several K files and checking the time to load the version table. (Maybe there's an API call?) I think all we need is to verify this is _much_ faster/ worth the effort. (I added logging statements to print the start/stop times before/after the new/old algorithms and then ran the code on a dataset with 10K files. I've left the timing statements for the new algorithm in for fine logging, but the original code doesn't have any.)

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
