### PR TITLE
IQSS/10840 - DatasetTypesIT test fix

### DIFF
--- a/src/test/java/edu/harvard/iq/dataverse/api/DatasetTypesIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/DatasetTypesIT.java
@@ -240,7 +240,8 @@ public class DatasetTypesIT {
         numbersOnly.prettyPrint();
         numbersOnly.then().assertThat().statusCode(BAD_REQUEST.getStatusCode());
 
-        String randomName = UUID.randomUUID().toString().substring(0, 8);
+        //Avoid all-numeric names (which are not allowed)
+        String randomName = "A" + UUID.randomUUID().toString().substring(0, 8);
         String jsonIn = Json.createObjectBuilder().add("name", randomName).build().toString();
 
         System.out.println("adding type with name " + randomName);


### PR DESCRIPTION
**What this PR does / why we need it**:
Simple fix for a random test failure - when the generated alphanumeric name is randomly all numeric, which is not allowed.
**Which issue(s) this PR closes**:

Closes #10840 

**Special notes for your reviewer**:
Simple fix - we've had this class of issue before.

**Suggestions on how to test this**: Just verify the test passes - probably not worth trying to see the problem on the current branch - https://jenkins.dataverse.org/blue/organizations/jenkins/IQSS-Dataverse-Develop-PR/detail/PR-10632/16/tests/ shows one occurence.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
