### PR TITLE
chore(ct): update base image wait4x to 2.14.2 for stdlib update #10844

### DIFF
--- a/modules/container-base/src/main/docker/Dockerfile
+++ b/modules/container-base/src/main/docker/Dockerfile
@@ -106,7 +106,7 @@ EOF
 ARG JATTACH_VERSION="v2.2"
 ARG JATTACH_TGZ_CHECKSUM_AMD64="acd9e17f15749306be843df392063893e97bfecc5260eef73ee98f06e5cfe02f"
 ARG JATTACH_TGZ_CHECKSUM_ARM64="288ae5ed87ee7fe0e608c06db5a23a096a6217c9878ede53c4e33710bdcaab51"
-ARG WAIT4X_VERSION="v2.14.0"
+ARG WAIT4X_VERSION="v2.14.2"
 ARG PKGS="jq imagemagick curl unzip wget acl lsof procps netcat-openbsd dumb-init"
 
 # Installing the packages in an extra container layer for better caching


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix security issues in container base image

**Which issue(s) this PR closes**:

Closes #10844 

**Special notes for your reviewer**:
Has been tested in https://github.com/gdcc/wip-dataverse-base-image
Docker Scout before:
![grafik](https://github.com/user-attachments/assets/4bdf58bb-b4b5-4076-8eb9-2057700deb46)

Docker Scout now:
All stdlib issues vanished!

**Suggestions on how to test this**:
No testing necessary.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
Nope

**Is there a release notes update needed for this change?**:
Nope

**Additional documentation**:
None