### PR TITLE
standardize image url

### DIFF
--- a/doc/release-notes/10831-standardize-image-url-of-search-api.md
+++ b/doc/release-notes/10831-standardize-image-url-of-search-api.md
@@ -1,0 +1,28 @@
+Search API (/api/search) response will now include new image_url format for the Datafile and Dataverse logo.
+Note to release not writer: this supersedes the release note 10810-search-api-payload-extensions.md
+
+For Dataverse:
+
+- "image_url" (optional)
+
+```javascript
+"items": [
+    {
+        "name": "Darwin's Finches",
+        ...
+        "image_url":"/api/access/dvCardImage/{identifier}"
+(etc, etc)
+```
+
+For DataFile:
+
+- "image_url" (optional)
+
+```javascript
+"items": [
+    {
+        "name": "test.txt",
+        ...
+        "image_url":"/api/access/datafile/{identifier}?imageThumb=true"
+(etc, etc)
+```

--- a/doc/release-notes/10831-standardize-image-url-of-search-api.md
+++ b/doc/release-notes/10831-standardize-image-url-of-search-api.md
@@ -1,5 +1,5 @@
 Search API (/api/search) response will now include new image_url format for the Datafile and Dataverse logo.
-Note to release not writer: this supersedes the release note 10810-search-api-payload-extensions.md
+Note to release note writer: this supersedes the release note 10810-search-api-payload-extensions.md
 
 For Dataverse:
 

--- a/doc/sphinx-guides/source/api/changelog.rst
+++ b/doc/sphinx-guides/source/api/changelog.rst
@@ -7,6 +7,11 @@ This API changelog is experimental and we would love feedback on its usefulness.
     :local:
     :depth: 1
 
+v6.4
+----
+
+- ** /api/search?q=**: Json values for image_url in DataFiles and Collections have changed from Base64URL ("data:image/png;base64,...) to "/api/access/datafile/{identifier}?imageThumb=true" and "/api/access/dvCardImage/{identifier}" respectively. This was done to match the image_url of Dataset.
+
 v6.3
 ----
 

--- a/doc/sphinx-guides/source/api/changelog.rst
+++ b/doc/sphinx-guides/source/api/changelog.rst
@@ -7,11 +7,6 @@ This API changelog is experimental and we would love feedback on its usefulness.
     :local:
     :depth: 1
 
-v6.4
-----
-
-- ** /api/search?q=**: Json values for image_url in DataFiles and Collections have changed from Base64URL ("data:image/png;base64,...) to "/api/access/datafile/{identifier}?imageThumb=true" and "/api/access/dvCardImage/{identifier}" respectively. This was done to match the image_url of Dataset.
-
 v6.3
 ----
 

--- a/doc/sphinx-guides/source/api/search.rst
+++ b/doc/sphinx-guides/source/api/search.rst
@@ -61,7 +61,7 @@ https://demo.dataverse.org/api/search?q=trees
                     "name":"Trees",
                     "type":"dataverse",
                     "url":"https://demo.dataverse.org/dataverse/trees",
-                    "image_url":"data:image/png;base64,iVBORw0...",
+                    "image_url":"https://demo.dataverse.org/api/access/dvCardImage/1",
                     "identifier":"trees",
                     "description":"A tree dataverse with some birds",
                     "published_at":"2016-05-10T12:53:38Z",
@@ -76,7 +76,7 @@ https://demo.dataverse.org/api/search?q=trees
                     "name":"Chestnut Trees",
                     "type":"dataverse",
                     "url":"https://demo.dataverse.org/dataverse/chestnuttrees",
-                    "image_url":"data:image/png;base64,iVBORw0...",
+                    "image_url":"https://demo.dataverse.org/api/access/dvCardImage/2",
                     "identifier":"chestnuttrees",
                     "description":"A dataverse with chestnut trees and an oriole",
                     "published_at":"2016-05-10T12:52:38Z",
@@ -91,7 +91,7 @@ https://demo.dataverse.org/api/search?q=trees
                     "name":"trees.png",
                     "type":"file",
                     "url":"https://demo.dataverse.org/api/access/datafile/12",
-                    "image_url":"data:image/png;base64,iVBORw0...",
+                    "image_url":"https://demo.dataverse.org/api/access/datafile/12?imageThumb=true",
                     "file_id":"12",
                     "description":"",
                     "published_at":"2016-05-10T12:53:39Z",
@@ -113,7 +113,7 @@ https://demo.dataverse.org/api/search?q=trees
                     "name":"Birds",
                     "type":"dataverse",
                     "url":"https://demo.dataverse.org/dataverse/birds",
-                    "image_url":"data:image/png;base64,iVBORw0...",
+                    "image_url":"https://demo.dataverse.org/api/access/dvCardImage/3",
                     "identifier":"birds",
                     "description":"A bird Dataverse collection with some trees",
                     "published_at":"2016-05-10T12:57:27Z",
@@ -173,8 +173,6 @@ https://demo.dataverse.org/api/search?q=trees
         }
     }
 
-Note that the image_url field, if exists, will be returned as a regular URL for Datasets, while for Files and Dataverses, it will be returned as a Base64 URL. We plan to standardize this behavior so that the field always returns a regular URL. (See: https://github.com/IQSS/dataverse/issues/10831)
-
 .. _advancedsearch-example:
 
 Advanced Search Examples
@@ -202,7 +200,7 @@ In this example, ``show_relevance=true`` matches per field are shown. Available 
                     "name":"Finches",
                     "type":"dataverse",
                     "url":"https://demo.dataverse.org/dataverse/finches",
-                    "image_url":"data:image/png;base64,iVBORw0...",
+                    "image_url":"https://demo.dataverse.org/api/access/dvCardImage/2",
                     "identifier":"finches",
                     "description":"A Dataverse collection with finches",
                     "published_at":"2016-05-10T12:57:38Z",

--- a/src/main/java/edu/harvard/iq/dataverse/DataverseServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DataverseServiceBean.java
@@ -364,7 +364,7 @@ public class DataverseServiceBean implements java.io.Serializable {
 
     public String getDataverseLogoThumbnailAsUrl(Long dvId) {
         File dataverseLogoFile = getLogoById(dvId);
-        if (dataverseLogoFile != null) {
+        if (dataverseLogoFile != null && dataverseLogoFile.exists()) {
             return SystemConfig.getDataverseSiteUrlStatic() + "/api/access/dvCardImage/" + dvId;
         }
         return null;

--- a/src/main/java/edu/harvard/iq/dataverse/DataverseServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DataverseServiceBean.java
@@ -361,7 +361,15 @@ public class DataverseServiceBean implements java.io.Serializable {
         } 
         return null;
     }
-        
+
+    public String getDataverseLogoThumbnailAsUrl(Long dvId) {
+        File dataverseLogoFile = getLogoById(dvId);
+        if (dataverseLogoFile != null) {
+            return SystemConfig.getDataverseSiteUrlStatic() + "/api/access/dvCardImage/" + dvId;
+        }
+        return null;
+    }
+
     private File getLogo(Dataverse dataverse) {
         if (dataverse.getId() == null) {
             return null; 

--- a/src/main/java/edu/harvard/iq/dataverse/ThumbnailServiceWrapper.java
+++ b/src/main/java/edu/harvard/iq/dataverse/ThumbnailServiceWrapper.java
@@ -48,6 +48,18 @@ public class ThumbnailServiceWrapper implements java.io.Serializable  {
     private Map<Long, DvObject> dvobjectViewMap = new HashMap<>();
     private Map<Long, Boolean> hasThumbMap = new HashMap<>();
 
+    public String getFileCardImageAsUrl(SolrSearchResult result) {
+        if (result.isHarvested()) {
+            return null;
+        }
+
+        if (result.getEntity() == null) {
+            return null;
+        }
+
+        return SystemConfig.getDataverseSiteUrlStatic() + "/api/access/datafile/" + result.getEntity().getId() + "?imageThumb=true";
+    }
+
     // it's the responsibility of the user - to make sure the search result
     // passed to this method is of the Datafile type!
     public String getFileCardImageAsBase64Url(SolrSearchResult result) {
@@ -208,7 +220,13 @@ public class ThumbnailServiceWrapper implements java.io.Serializable  {
     public String getDataverseCardImageAsBase64Url(SolrSearchResult result) {
         return dataverseService.getDataverseLogoThumbnailAsBase64ById(result.getEntityId());
     }
-    
+
+    // it's the responsibility of the user - to make sure the search result
+    // passed to this method is of the Dataverse type!
+    public String getDataverseCardImageAsUrl(SolrSearchResult result) {
+        return dataverseService.getDataverseLogoThumbnailAsUrl(result.getEntityId());
+    }
+
     public void resetObjectMaps() {
         dvobjectThumbnailsMap = new HashMap<>();
         dvobjectViewMap = new HashMap<>();

--- a/src/main/java/edu/harvard/iq/dataverse/ThumbnailServiceWrapper.java
+++ b/src/main/java/edu/harvard/iq/dataverse/ThumbnailServiceWrapper.java
@@ -49,15 +49,14 @@ public class ThumbnailServiceWrapper implements java.io.Serializable  {
     private Map<Long, Boolean> hasThumbMap = new HashMap<>();
 
     public String getFileCardImageAsUrl(SolrSearchResult result) {
-        if (result.isHarvested()) {
-            return null;
+
+        if (!result.isHarvested() && result.getEntity() != null && (!((DataFile)result.getEntity()).isRestricted()
+                || permissionsWrapper.hasDownloadFilePermission(result.getEntity()))
+                && isThumbnailAvailable((DataFile) result.getEntity())) {
+            return SystemConfig.getDataverseSiteUrlStatic() + "/api/access/datafile/" + result.getEntity().getId() + "?imageThumb=true";
         }
 
-        if (result.getEntity() == null) {
-            return null;
-        }
-
-        return SystemConfig.getDataverseSiteUrlStatic() + "/api/access/datafile/" + result.getEntity().getId() + "?imageThumb=true";
+        return null;
     }
 
     // it's the responsibility of the user - to make sure the search result

--- a/src/main/java/edu/harvard/iq/dataverse/search/SearchServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/search/SearchServiceBean.java
@@ -593,7 +593,7 @@ public class SearchServiceBean {
                 solrSearchResult.setDataverseAffiliation(dataverseAffiliation);
                 solrSearchResult.setDataverseParentAlias(dataverseParentAlias);
                 solrSearchResult.setDataverseParentName(dataverseParentName);
-                solrSearchResult.setImageUrl(thumbnailServiceWrapper.getDataverseCardImageAsBase64Url(solrSearchResult));
+                solrSearchResult.setImageUrl(thumbnailServiceWrapper.getDataverseCardImageAsUrl(solrSearchResult));
                 /**
                  * @todo Expose this API URL after "dvs" is changed to
                  * "dataverses". Also, is an API token required for published
@@ -652,7 +652,7 @@ public class SearchServiceBean {
                 }
                 solrSearchResult.setHtmlUrl(baseUrl + "/dataset.xhtml?persistentId=" + parentGlobalId);
                 solrSearchResult.setDownloadUrl(baseUrl + "/api/access/datafile/" + entityid);
-                solrSearchResult.setImageUrl(thumbnailServiceWrapper.getFileCardImageAsBase64Url(solrSearchResult));
+                solrSearchResult.setImageUrl(thumbnailServiceWrapper.getFileCardImageAsUrl(solrSearchResult));
                 /**
                  * @todo We are not yet setting the API URL for files because
                  * not all files have metadata. Only subsettable files (those

--- a/src/test/java/edu/harvard/iq/dataverse/api/SearchIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/SearchIT.java
@@ -1284,7 +1284,7 @@ public class SearchIT {
     }
 
     @Test
-    public void testSearchFiles() {
+    public void testSearchFilesAndUrlImages() {
         Response createUser = UtilIT.createRandomUser();
         createUser.prettyPrint();
         String username = UtilIT.getUsernameFromResponse(createUser);
@@ -1303,6 +1303,11 @@ public class SearchIT {
 
         String pathToFile = "src/main/webapp/resources/images/dataverseproject.png";
         Response uploadImage = UtilIT.uploadFileViaNative(datasetId.toString(), pathToFile, apiToken);
+        uploadImage.prettyPrint();
+        uploadImage.then().assertThat()
+                .statusCode(200);
+        pathToFile = "src/main/webapp/resources/js/mydata.js";
+        Response uploadFile = UtilIT.uploadFileViaNative(datasetId.toString(), pathToFile, apiToken);
         uploadImage.prettyPrint();
         uploadImage.then().assertThat()
                 .statusCode(200);
@@ -1325,5 +1330,21 @@ public class SearchIT {
                 .body("data.items[0].url", CoreMatchers.containsString("/api/access/datafile/"))
                 .body("data.items[0].image_url", CoreMatchers.containsString("/api/access/datafile/"))
                 .body("data.items[0].image_url", CoreMatchers.containsString("imageThumb=true"));
+
+        searchResp = UtilIT.search(dataverseAlias, apiToken);
+        searchResp.prettyPrint();
+        searchResp.then().assertThat()
+                .statusCode(OK.getStatusCode())
+                .body("data.items[0].type", CoreMatchers.is("dataverse"))
+                .body("data.items[0].url", CoreMatchers.containsString("/dataverse/"))
+                .body("data.items[0]", CoreMatchers.not(CoreMatchers.hasItem("url_image")));
+
+        searchResp = UtilIT.search("mydata", apiToken);
+        searchResp.prettyPrint();
+        searchResp.then().assertThat()
+                .statusCode(OK.getStatusCode())
+                .body("data.items[0].type", CoreMatchers.is("file"))
+                .body("data.items[0].url", CoreMatchers.containsString("/datafile/"))
+                .body("data.items[0]", CoreMatchers.not(CoreMatchers.hasItem("url_image")));
     }
 }

--- a/src/test/java/edu/harvard/iq/dataverse/api/SearchIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/SearchIT.java
@@ -1283,4 +1283,47 @@ public class SearchIT {
     public static void cleanup() {
     }
 
+    @Test
+    public void testSearchFiles() {
+        Response createUser = UtilIT.createRandomUser();
+        createUser.prettyPrint();
+        String username = UtilIT.getUsernameFromResponse(createUser);
+        String apiToken = UtilIT.getApiTokenFromResponse(createUser);
+
+        Response createDataverseResponse = UtilIT.createRandomDataverse(apiToken);
+        createDataverseResponse.prettyPrint();
+        String dataverseAlias = UtilIT.getAliasFromResponse(createDataverseResponse);
+
+        Response createDatasetResponse = UtilIT.createRandomDatasetViaNativeApi(dataverseAlias, apiToken);
+        createDatasetResponse.prettyPrint();
+        Integer datasetId = UtilIT.getDatasetIdFromResponse(createDatasetResponse);
+        System.out.println("id: " + datasetId);
+        String datasetPid = JsonPath.from(createDatasetResponse.getBody().asString()).getString("data.persistentId");
+        System.out.println("datasetPid: " + datasetPid);
+
+        String pathToFile = "src/main/webapp/resources/images/dataverseproject.png";
+        Response uploadImage = UtilIT.uploadFileViaNative(datasetId.toString(), pathToFile, apiToken);
+        uploadImage.prettyPrint();
+        uploadImage.then().assertThat()
+                .statusCode(200);
+
+        Response publishDataverse = UtilIT.publishDataverseViaSword(dataverseAlias, apiToken);
+        publishDataverse.prettyPrint();
+        publishDataverse.then().assertThat()
+                .statusCode(OK.getStatusCode());
+        Response publishDataset = UtilIT.publishDatasetViaNativeApi(datasetId, "major", apiToken);
+        publishDataset.prettyPrint();
+        publishDataset.then().assertThat()
+                .statusCode(OK.getStatusCode());
+
+        Response searchResp = UtilIT.search("dataverseproject", apiToken);
+        searchResp.prettyPrint();
+        searchResp.then().assertThat()
+                .statusCode(OK.getStatusCode())
+                .body("data.items[0].type", CoreMatchers.is("file"))
+                .body("data.items[0].file_content_type", CoreMatchers.is("image/png"))
+                .body("data.items[0].url", CoreMatchers.containsString("/api/access/datafile/"))
+                .body("data.items[0].image_url", CoreMatchers.containsString("/api/access/datafile/"))
+                .body("data.items[0].image_url", CoreMatchers.containsString("imageThumb=true"));
+    }
 }


### PR DESCRIPTION
**What this PR does / why we need it**: Currently, image_url returns base64 URLs for files and dataverses, while it returns a regular URL for datasets. The goal is to standardize all URLs to use the same format. We have chosen to use regular URLs instead of base64 for all cases.

**Which issue(s) this PR closes**:https://github.com/IQSS/dataverse/issues/10831

Closes #10831 

**Special notes for your reviewer**:

**Suggestions on how to test this**: SearchIT has a test for datafiles. Collection test can be done manually by adding a logo and calling a search. verify that the image_url is there and is reachable.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: No

**Is there a release notes update needed for this change?**: Yes, since this changes the body of the search response

**Additional documentation**:
