### PR TITLE
add docs for disable-dataset-thumbnail-autoselect

### DIFF
--- a/doc/sphinx-guides/source/installation/config.rst
+++ b/doc/sphinx-guides/source/installation/config.rst
@@ -3343,6 +3343,9 @@ please find all known feature flags below. Any of these flags can be activated u
     * - disable-return-to-author-reason
       - Removes the reason field in the `Publish/Return To Author` dialog that was added as a required field in v6.2 and makes the reason an optional parameter in the :ref:`return-a-dataset` API call. 
       - ``Off``
+    * - disable-dataset-thumbnail-autoselect
+      - Turns off automatic selection of a dataset thumbnail from image files in that dataset. When set to ``On``, a user can still manually pick a thumbnail image, or upload a dedicated thumbnail image.
+      - ``Off``
 
 **Note:** Feature flags can be set via any `supported MicroProfile Config API source`_, e.g. the environment variable
 ``DATAVERSE_FEATURE_XXX`` (e.g. ``DATAVERSE_FEATURE_API_SESSION_AUTH=1``). These environment variables can be set in your shell before starting Payara. If you are using :doc:`Docker for development </container/dev-usage>`, you can set them in the `docker compose <https://docs.docker.com/compose/environment-variables/set-environment-variables/>`_ file.


### PR DESCRIPTION
**What this PR does / why we need it**:

When writing release notes for 6.4 I noticed the new feature flag hadn't been added to https://preview.guides.gdcc.io/en/develop/installation/config.html#feature-flags

**Which issue(s) this PR closes**:

Closes NONE

The feature flag was added in this PR:

-  #10820

Preview at https://dataverse-guide--10864.org.readthedocs.build/en/10864/installation/config.html#feature-flags