### PR TITLE
Temp file cleanup for PrimeFaces uploads 10667

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/EditDatafilesPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/EditDatafilesPage.java
@@ -2092,6 +2092,12 @@ public class EditDatafilesPage implements java.io.Serializable {
             errorMessages.add(cex.getMessage());
             uploadComponentId = event.getComponent().getClientId();
             return;
+        } finally {
+            try {
+                uFile.delete();
+            } catch (IOException ioex) {
+                logger.warning("Failed to delete temp file uploaded via PrimeFaces " + uFile.getFileName());
+            }
         }
         /*catch (FileExceedsMaxSizeException ex) {
             logger.warning("Failed to process and/or save the file " + uFile.getFileName() + "; " + ex.getMessage());


### PR DESCRIPTION
**What this PR does / why we need it**:

A one-line fix for #10667 - apparently PrimeFaces UI file upload leaves every uploaded file in the temp directory .../domain1/uploads. 
With this line, the uploaded file is properly cleaned up after it's copied to the Dataverse holding location. There are still *multiple* tiny (5-50 bytes) files left with debugging/logging messages (?) - but at least that should not be a practically important issue. 

**Which issue(s) this PR closes**:

- Closes #10667

**Special notes for your reviewer**:

**Suggestions on how to test this**:

Upload some files through the UI, check what's left in .../domain1/uploads before and after. 

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
