### PR TITLE
Fix NPE using CVOC

### DIFF
--- a/doc/release-notes/10869-fix-npe-using-cvoc.md
+++ b/doc/release-notes/10869-fix-npe-using-cvoc.md
@@ -1,0 +1,1 @@
+This release fixes a bug in the external controlled vocabulary mechanism (introduced in v6.3) that could cause indexing to fail when a script is configured for one child field and no other child fields were managed.

--- a/src/main/java/edu/harvard/iq/dataverse/search/IndexServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/search/IndexServiceBean.java
@@ -1128,7 +1128,7 @@ public class IndexServiceBean {
                                 if(dsfType.getParentDatasetFieldType()!=null) {
                                     List<DatasetField> childDatasetFields = dsf.getParentDatasetFieldCompoundValue().getChildDatasetFields();
                                     for (DatasetField df : childDatasetFields) {
-                                        if(cvocManagedFieldMap.get(dsfType.getId()).contains(df.getDatasetFieldType().getName())) {
+                                        if(cvocManagedFieldMap.containsKey(dsfType.getId()) && cvocManagedFieldMap.get(dsfType.getId()).contains(df.getDatasetFieldType().getName())) {
                                             String solrManagedFieldSearchable = df.getDatasetFieldType().getSolrField().getNameSearchable();
                                             // Try to get string values from externalvocabularyvalue but for a managed fields of the CVOCConf
                                             Set<String> stringsForManagedField = datasetFieldService.getIndexableStringsByTermUri(val, cvocMap.get(dsfType.getId()), df.getDatasetFieldType().getName());


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a possible `NullPointerException` that prevents the proper indexing of a dataset.

**Which issue(s) this PR closes**:

Closes #10869

**Suggestions on how to test this**:

Play around [:CVocConf](https://guides.dataverse.org/en/6.3/installation/config.html#cvocconf) and having multiple configuration activated like SKOMOS + ORCID

**Does this PR introduce a user interface change?**:

No

**Is there a release notes update needed for this change?**:

I don't think
