### PR TITLE
displayOnCreate set to true for depositor and dateOfDeposit in Citation metadata block

### DIFF
--- a/doc/release-notes/10850-citation-tsv-displayoncreate-depositor-dateofdeposit.md
+++ b/doc/release-notes/10850-citation-tsv-displayoncreate-depositor-dateofdeposit.md
@@ -1,0 +1,1 @@
+The fields depositor and dateOfDeposit in the citation.tsv metadatablock have been updated to have the property displayOnCreate set to TRUE.

--- a/doc/release-notes/10850-citation-tsv-displayoncreate-depositor-dateofdeposit.md
+++ b/doc/release-notes/10850-citation-tsv-displayoncreate-depositor-dateofdeposit.md
@@ -1,1 +1,1 @@
-The fields depositor and dateOfDeposit in the citation.tsv metadatablock have been updated to have the property displayOnCreate set to TRUE.
+The fields depositor and dateOfDeposit in the citation.tsv metadata block file have been updated to have the property displayOnCreate set to TRUE.

--- a/scripts/api/data/metadatablocks/citation.tsv
+++ b/scripts/api/data/metadatablocks/citation.tsv
@@ -59,8 +59,8 @@
 	distributorURL	URL	The URL of the distributor's webpage	https://	url	55	<a href="#VALUE" target="_blank" rel="noopener">#VALUE</a>	FALSE	FALSE	FALSE	FALSE	FALSE	FALSE	distributor	citation	
 	distributorLogoURL	Logo URL	The URL of the distributor's logo image, used to show the image on the Dataset's page	https://	url	56	<img src="#VALUE" alt="#NAME" class="metadata-logo"/><br/>	FALSE	FALSE	FALSE	FALSE	FALSE	FALSE	distributor	citation	
 	distributionDate	Distribution Date	The date when the Dataset was made available for distribution/presentation	YYYY-MM-DD	date	57		TRUE	FALSE	FALSE	TRUE	FALSE	FALSE		citation	
-	depositor	Depositor	The entity, such as a person or organization, that deposited the Dataset in the repository	1) FamilyName, GivenName or 2) Organization	text	58		FALSE	FALSE	FALSE	FALSE	FALSE	FALSE		citation	
-	dateOfDeposit	Deposit Date	The date when the Dataset was deposited into the repository	YYYY-MM-DD	date	59		FALSE	FALSE	FALSE	TRUE	FALSE	FALSE		citation	http://purl.org/dc/terms/dateSubmitted
+	depositor	Depositor	The entity, such as a person or organization, that deposited the Dataset in the repository	1) FamilyName, GivenName or 2) Organization	text	58		FALSE	FALSE	FALSE	FALSE	TRUE	FALSE		citation
+	dateOfDeposit	Deposit Date	The date when the Dataset was deposited into the repository	YYYY-MM-DD	date	59		FALSE	FALSE	FALSE	TRUE	TRUE	FALSE		citation	http://purl.org/dc/terms/dateSubmitted
 	timePeriodCovered	Time Period	The time period that the data refer to. Also known as span. This is the time period covered by the data, not the dates of coding, collecting data, or making documents machine-readable		none	60	;	FALSE	FALSE	TRUE	FALSE	FALSE	FALSE		citation	https://schema.org/temporalCoverage
 	timePeriodCoveredStart	Start Date	The start date of the time period that the data refer to	YYYY-MM-DD	date	61	#NAME: #VALUE 	TRUE	FALSE	FALSE	TRUE	FALSE	FALSE	timePeriodCovered	citation	
 	timePeriodCoveredEnd	End Date	The end date of the time period that the data refer to	YYYY-MM-DD	date	62	#NAME: #VALUE 	TRUE	FALSE	FALSE	TRUE	FALSE	FALSE	timePeriodCovered	citation	

--- a/src/test/java/edu/harvard/iq/dataverse/api/MetadataBlocksIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/MetadataBlocksIT.java
@@ -51,7 +51,7 @@ public class MetadataBlocksIT {
 
         // onlyDisplayedOnCreate=true and returnDatasetFieldTypes=true
         listMetadataBlocksResponse = UtilIT.listMetadataBlocks(true, true);
-        expectedNumberOfMetadataFields = 26;
+        expectedNumberOfMetadataFields = 28;
         listMetadataBlocksResponse.then().assertThat()
                 .statusCode(OK.getStatusCode())
                 .body("data[0].fields", not(equalTo(null)))


### PR DESCRIPTION
**What this PR does / why we need it**:

The fields depositor and dateOfDeposit in the citation.tsv metadatablock have been updated to have the property `displayOnCreate` set to `TRUE`.

**Which issue(s) this PR closes**:

Closes #10850 

**Suggestions on how to test this**:

1) Test the metadatablocks API method to retrieve all metadata blocks and their fields with `onlyDisplayedOnCreate=true`:

`curl "$SERVER_URL/api/metadatablocks?returnDatasetFieldTypes=true&onlyDisplayedOnCreate=true"`

Verify that within the `citation` metadata block, depositor and dateOfDeposit are now retrieved.

2) Visual inspection of the updated MetadataBlocksIT test on: https://github.com/IQSS/dataverse/pull/10884/commits/13201dc074466a139c7797305f823f66a20783e1

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No

**Is there a release notes update needed for this change?**:

Yes, attached.

**Special notes**:

When using the generated docker image from this PR in the SPA, the fields depositor and dateOfDeposit are displayed on dataset creation, as in JSF:

<img width="1432" alt="Screenshot 2024-09-26 at 09 55 32" src="https://github.com/user-attachments/assets/018fff0d-ce0d-4f45-a264-036157dbe64a">

