### PR TITLE
post 6.4 container version

### DIFF
--- a/modules/dataverse-parent/pom.xml
+++ b/modules/dataverse-parent/pom.xml
@@ -446,8 +446,8 @@
                     Once the release has been made (tag created), change this back to "${parsedVersion.majorVersion}.${parsedVersion.nextMinorVersion}"
                     (These properties are provided by the build-helper plugin below.)
                 -->
-                <!--<base.image.version>${parsedVersion.majorVersion}.${parsedVersion.nextMinorVersion}</base.image.version>-->
-                <base.image.version>${revision}</base.image.version>
+                <base.image.version>${parsedVersion.majorVersion}.${parsedVersion.nextMinorVersion}</base.image.version>
+                <!--<base.image.version>${revision}</base.image.version>-->
             </properties>
     
             <build>


### PR DESCRIPTION
**What this PR does / why we need it**:

For container versions as explained at https://guides.dataverse.org/en/6.4/developers/making-releases.html#update-the-container-base-image-version-property