### PR TITLE
#10879 remove access request from render logic

### DIFF
--- a/src/main/webapp/dataset-license-terms.xhtml
+++ b/src/main/webapp/dataset-license-terms.xhtml
@@ -12,7 +12,7 @@
                                         or !empty termsOfUseAndAccess.originalArchive or !empty termsOfUseAndAccess.availabilityStatus 
                                         or !empty termsOfUseAndAccess.contactForAccess or !empty termsOfUseAndAccess.sizeOfCollection 
                                         or !empty termsOfUseAndAccess.studyCompletion
-                                        or termsOfUseAndAccess.fileAccessRequest}"/>
+                                        }"/>
     
     <div class="text-right margin-bottom" 
          jsf:rendered="#{dataverseSession.user.authenticated and empty editMode and !widgetWrapper.widgetView


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a render issue where the "restricted files" tab is displayed but there's nothing to display on the tab

**Which issue(s) this PR closes**:

Closes #10879 Restricted files tab displayed with no data

**Special notes for your reviewer**: updated render logic to remove "allow access request" from consideration 

**Suggestions on how to test this**: The tab should be rendered if there are restricted files and/or any of the file access text fields are filled in - see ticket for details on how to recreate. 

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
no
**Is there a release notes update needed for this change?**:
no

**Additional documentation**:
none
