### PR TITLE
PR template: add hyphen to show issue title

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@
 
 **Which issue(s) this PR closes**:
 
-Closes #
+- Closes #
 
 **Special notes for your reviewer**:
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, our PR template doesn't have a hypen for the "closes" line like this:

Closes #6226

In this PR, I'm suggesting we add a hypen so that the issue title is shown, like this:

- Closes #6226

This is what the frontend PR template does, by the way. See https://raw.githubusercontent.com/IQSS/dataverse-frontend/refs/heads/develop/.github/PULL_REQUEST_TEMPLATE.md