### PR TITLE
Add Dependabot config for updating GH Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# Allow Dependabot to check for outdated GitHub Actions in workflows
+# This code was copied from the example at
+# https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"


### PR DESCRIPTION
**What this PR does / why we need it**:
Configure @dependabot to check for outdated GitHub Actions in workflows

**Which issue(s) this PR closes**:

- Closes #10916 – eventually, when the PRs start coming in.

**Special notes for your reviewer**:
I followed <https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot> to create the file.
Nothing will probably happen before this is merged.

I only included the `github-actions` ecosystem. Dependabot should not start creating PRs for Maven updates.

**Suggestions on how to test this**:
Watch out for pull requests created by Dependabot.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
No.

**Is there a release notes update needed for this change?**:
No.

**Additional documentation**:
https://docs.github.com/en/code-security/dependabot/ecosystems-supported-by-dependabot/supported-ecosystems-and-repositories#github-actions lists some caveats. Importantly, locally referenced and Docker-style actions are not checked for available updates.