### PR TITLE
Minor Bug sending software name/version to DataCite

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/pidproviders/doi/XmlMetadataTemplate.java
+++ b/src/main/java/edu/harvard/iq/dataverse/pidproviders/doi/XmlMetadataTemplate.java
@@ -1317,8 +1317,8 @@ public class XmlMetadataTemplate {
                             }
                             if (StringUtils.isNotBlank(softwareName)) {
                                 if (StringUtils.isNotBlank(softwareVersion)) {
+                                    softwareName = softwareName + ", " + softwareVersion;
                                 }
-                                softwareName = softwareName + ", " + softwareVersion;
                                 descriptionsWritten = XmlWriterUtil.writeOpenTagIfNeeded(xmlw, "descriptions", descriptionsWritten);
                                 XmlWriterUtil.writeFullElementWithAttributes(xmlw, "description", attributes, softwareName);
                             }


### PR DESCRIPTION
**What this PR does / why we need it**:
Per the plan https://docs.google.com/document/d/1JzDo9UOIy9dVvaHvtIbOI8tFU6bWdfDfuQvWWpC0tkA/edit?usp=sharing,
the DataCite XML updates done in v6.4 were supposed to send the software name when no software version was supplied and the name, version when the version is supplied. The code does not do that and would append a blank/null version in the no version case due to a misplaced parenthesis.

**Which issue(s) this PR closes**:

- Closes #

**Special notes for your reviewer**:

**Suggestions on how to test this**: Create a dataset with a software name and no version, publish it and check the DataCite export. You'll see a line like
`<description descriptionType="TechnicalInfo">DVUploader, null</description>`
before and 
`<description descriptionType="TechnicalInfo">DVUploader</description>`
after it.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
