### PR TITLE
Extends users/token GET endpoint to support any auth mechanism for retrieving the token

### DIFF
--- a/doc/release-notes/10914-users-token-api-credentials.md
+++ b/doc/release-notes/10914-users-token-api-credentials.md
@@ -1,0 +1,3 @@
+Extended the users/token GET endpoint to support any auth mechanism for retrieving the token information.
+
+Previously, this endpoint only accepted an API token to retrieve its information. Now, it accepts any authentication mechanism and returns the associated API token information.

--- a/src/main/java/edu/harvard/iq/dataverse/api/Users.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Users.java
@@ -137,15 +137,20 @@ public class Users extends AbstractApiBean {
     @Path("token")
     @AuthRequired
     @GET
-    public Response getTokenExpirationDate() {
-        ApiToken token = authSvc.findApiToken(getRequestApiKey());
-        
-        if (token == null) {
-            return notFound("Token " + getRequestApiKey() + " not found.");
+    public Response getTokenExpirationDate(@Context ContainerRequestContext crc) {
+        try {
+            AuthenticatedUser user = getRequestAuthenticatedUserOrDie(crc);
+            ApiToken token = authSvc.findApiTokenByUser(user);
+
+            if (token == null) {
+                return notFound("Token not found.");
+            }
+
+            return ok(String.format("Token %s expires on %s", token.getTokenString(), token.getExpireTime()));
+
+        } catch (WrappedResponse wr) {
+            return wr.getResponse();
         }
-        
-        return ok("Token " + getRequestApiKey() + " expires on " + token.getExpireTime());
-        
     }
     
     @Path("token/recreate")

--- a/src/test/java/edu/harvard/iq/dataverse/api/UsersIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/UsersIT.java
@@ -405,7 +405,6 @@ public class UsersIT {
         */
         
         createUser = UtilIT.createRandomUser();
-        String username = UtilIT.getUsernameFromResponse(createUser);
         String apiToken = UtilIT.getApiTokenFromResponse(createUser);
         Response createDataverseResponse = UtilIT.createRandomDataverse(apiToken);
         createDataverseResponse.prettyPrint();
@@ -428,7 +427,7 @@ public class UsersIT {
         getExpiration = UtilIT.getTokenExpiration(tokenForPrivateUrlUser);
         getExpiration.prettyPrint();
         getExpiration.then().assertThat()
-                .statusCode(NOT_FOUND.getStatusCode());
+                .statusCode(UNAUTHORIZED.getStatusCode());
 
         createUser = UtilIT.createRandomUser();
         assertEquals(OK.getStatusCode(), createUser.getStatusCode());


### PR DESCRIPTION
**What this PR does / why we need it**:

Changes users/token GET endpoint to support any auth mechanism for retrieving the token.

Previously, this endpoint only accepted an API token to retrieve its information. Now, it accepts any authentication mechanism and returns the associated API token information.

**Which issue(s) this PR closes**:

- Closes #10914 

**Special notes for your reviewer**:

For private URL tokens, the endpoint returns `Unauthorized`. Before this change, it returned `Not Found`. I believe this behavior is correct since a private URL user [is not considered an authenticated user](https://github.com/IQSS/dataverse/blob/develop/src/main/java/edu/harvard/iq/dataverse/authorization/users/PrivateUrlUser.java#L52) and therefore cannot obtain an API token, but I think it's necessary to double-check this.

**Suggestions on how to test this**:

Visual inspection and call the API token endpoint with any available auth mechanism. We can test the endpoint using the session cookie authentication (we should enable the feature flag) by sending the associated cookie, and verify we obtain the API token if created.

`curl --cookie "JSESSIONID=<cookie_value>" -X GET http://localhost:8080/api/users/token
`
**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No

**Is there a release notes update needed for this change?**:

I am not sure, but I have added them

**Additional documentation**:

None