### PR TITLE
how to set up languages (English, French, etc.) in Docker

### DIFF
--- a/doc/release-notes/10939-i18n-docker.md
+++ b/doc/release-notes/10939-i18n-docker.md
@@ -1,0 +1,5 @@
+## Multiple Language in Docker
+
+Configuration and documentation has been added to explain how to set up multiple languages (e.g. English and French) in the tutorial for setting up Dataverse in Docker.
+
+See also #10939

--- a/doc/sphinx-guides/source/container/running/demo.rst
+++ b/doc/sphinx-guides/source/container/running/demo.rst
@@ -137,6 +137,23 @@ In the example below of configuring :ref:`:FooterCopyright` we use the default u
 
 One you make this change it should be visible in the copyright in the bottom left of every page.
 
+Multiple Languages
+++++++++++++++++++
+
+Generally speaking, you'll want to follow :ref:`i18n` in the Installation Guide to set up multiple languages such as English and French.
+
+To set up the toggle between English and French, we'll use a slight variation on the command in the instructions above, adding the unblock key we created above:
+
+``curl "http://localhost:8080/api/admin/settings/:Languages?unblock-key=unblockme" -X PUT -d '[{"locale":"en","title":"English"},{"locale":"fr","title":"Français"}]'``
+
+Similarly, when loading the "languages.zip" file, we'll add the unblock key:
+
+``curl "http://localhost:8080/api/admin/datasetfield/loadpropertyfiles?unblock-key=unblockme" -X POST --upload-file /tmp/languages/languages.zip -H "Content-Type: application/zip"``
+
+Stop and start the Dataverse container in order for the language toggle to work.
+
+Note that ``dataverse.lang.directory=/dv/lang`` has already been configured for you in the ``compose.yml`` file. The step where you loaded "languages.zip" should have populated the ``/dv/lang`` directory with files ending in ".properties".
+
 Next Steps
 ----------
 

--- a/doc/sphinx-guides/source/installation/config.rst
+++ b/doc/sphinx-guides/source/installation/config.rst
@@ -1783,7 +1783,7 @@ Now that you have a "languages.zip" file, you can load it into your Dataverse in
 
 ``curl http://localhost:8080/api/admin/datasetfield/loadpropertyfiles -X POST --upload-file /tmp/languages/languages.zip -H "Content-Type: application/zip"``
 
-Click on the languages using the drop down in the header to try them out.
+Stop and start Payara and then click on the languages using the drop down in the header to try them out.
 
 .. _help-translate:
 

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -57,6 +57,7 @@ services:
         -Ddataverse.pid.fake.label=FakeDOIProvider
         -Ddataverse.pid.fake.authority=10.5072
         -Ddataverse.pid.fake.shoulder=FK2/
+        -Ddataverse.lang.directory=/dv/lang
     ports:
       - "8080:8080" # HTTP (Dataverse Application)
       - "4949:4848" # HTTPS (Payara Admin Console)

--- a/docker/compose/demo/compose.yml
+++ b/docker/compose/demo/compose.yml
@@ -26,6 +26,7 @@ services:
         -Ddataverse.pid.fake.label=FakeDOIProvider
         -Ddataverse.pid.fake.authority=10.5072
         -Ddataverse.pid.fake.shoulder=FK2/
+        -Ddataverse.lang.directory=/dv/lang
     ports:
       - "8080:8080" # HTTP (Dataverse Application)
       - "4848:4848" # HTTP (Payara Admin Console)


### PR DESCRIPTION
**What this PR does / why we need it**:

Setting up languages is a little different in Docker. Some extra config and docs were needed. You can preview the new docs here: https://dataverse-guide--10940.org.readthedocs.build/en/10940/container/running/demo.html#multiple-languages

This PR is partially a response to https://dataverse.zulipchat.com/#narrow/channel/378866-troubleshooting/topic/translation.20not.20working/near/477393219 where @aialves indicated trouble with the docs. Overall, they seem fine, except for the need to restart Payara, which has now been added to both classic and containerized docs.

**Which issue(s) this PR closes**:

- Closes #10939

**Special notes for your reviewer**:

None

**Suggestions on how to test this**:

Follow the tutorial this PR updates.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No but here's a fun screenshot of Dataverse in French:

![Screenshot 2024-10-18 at 2 42 16 PM](https://github.com/user-attachments/assets/87be3b69-c508-43c3-9267-30e140897d57)

**Is there a release notes update needed for this change?**:

Yes, included.

**Additional documentation**:
