### PR TITLE
Fixed typo tombstone in Bundle.properties

### DIFF
--- a/src/main/java/propertyFiles/Bundle.properties
+++ b/src/main/java/propertyFiles/Bundle.properties
@@ -2065,7 +2065,7 @@ file.deleteFileDialog.multiple.immediate=The file(s) will be deleted after you c
 file.deleteFileDialog.header=Delete Files
 file.deleteFileDialog.failed.tip=Files will not be removed from previously published versions of the dataset.
 file.deaccessionDialog.tip.permanent=Deaccession is <strong>permanent</strong>.
-file.deaccessionDialog.tip=This dataset will no longer be public and a tumbstone will display the reason for deaccessioning. <br>Please read the <a href="guides.dataverse.org/en/latest/user/dataset-management.html?highlight=deaccession#dataset-deaccession">documentation</a> if you have any questions.
+file.deaccessionDialog.tip=This dataset will no longer be public and a tombstone will display the reason for deaccessioning. <br>Please read the <a href="guides.dataverse.org/en/latest/user/dataset-management.html?highlight=deaccession#dataset-deaccession">documentation</a> if you have any questions.
 file.deaccessionDialog.version=Version
 file.deaccessionDialog.reason.question1=Which version(s) do you want to deaccession?
 file.deaccessionDialog.reason.question2=What is the reason for deaccession?


### PR DESCRIPTION
**What this PR does / why we need it**:
It fixes a typo of the word tombstone in the src/main/java/propertyFiles/Bundle.properties

**Which issue(s) this PR closes**:
It closes issue  #10918 

- Closes #10918 

**Special notes for your reviewer**:
None
**Suggestions on how to test this**:
None
**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
None
**Is there a release notes update needed for this change?**:
None
**Additional documentation**:
None