### PR TITLE
Update testing-infrastructure.md - Added verbiage around Jenkins job failing after a release and how to troubleshoot it

### DIFF
--- a/doc/sphinx-guides/source/qa/testing-infrastructure.md
+++ b/doc/sphinx-guides/source/qa/testing-infrastructure.md
@@ -31,6 +31,8 @@ To build and test a PR, we use a job called `IQSS_Dataverse_Internal` on <https:
 
 1. If for some reason it didn't deploy, check the server.log file. It may just be a caching issue so try un-deploying, deleting cache, restarting, and re-deploying on the server (`su - dataverse` then `/usr/local/payara6/bin/asadmin list-applications; /usr/local/payara6/bin/asadmin undeploy dataverse-6.1; /usr/local/payara6/bin/asadmin deploy /tmp/dataverse-6.1.war`)
 
+1. When a Jenkins job fails after a release, it might be due to the version number in the `pom.xml` file not being updated in the pull request (PR). To verify this, open the relevant GitHub ticket, navigate to the PR branch, and go to `dataverse > modules > dataverse-parent > pom.xml`. Look for the version number, typically shown as `<revision>6.3</revision>`, and ensure it matches the current Dataverse build version.
+
 1. If that didn't work, you may have run into a Flyway DB script collision error but that should be indicated by the server.log. See {doc}`/developers/sql-upgrade-scripts` in the Developer Guide. In the case of a collision, ask the developer to rename the script.
 
 1.	Assuming the above steps worked, and they should 99% of the time, test away! Note: be sure to `tail -F server.log` in a terminal window while you are doing any testing. This way you can spot problems that may not appear in the UI and have easier access to any stack traces for easier reporting.

--- a/doc/sphinx-guides/source/qa/testing-infrastructure.md
+++ b/doc/sphinx-guides/source/qa/testing-infrastructure.md
@@ -31,7 +31,7 @@ To build and test a PR, we use a job called `IQSS_Dataverse_Internal` on <https:
 
 1. If for some reason it didn't deploy, check the server.log file. It may just be a caching issue so try un-deploying, deleting cache, restarting, and re-deploying on the server (`su - dataverse` then `/usr/local/payara6/bin/asadmin list-applications; /usr/local/payara6/bin/asadmin undeploy dataverse-6.1; /usr/local/payara6/bin/asadmin deploy /tmp/dataverse-6.1.war`)
 
-1. When a Jenkins job fails after a release, it might be due to the version number in the `pom.xml` file not being updated in the pull request (PR). To verify this, open the relevant GitHub ticket, navigate to the PR branch, and go to `dataverse > modules > dataverse-parent > pom.xml`. Look for the version number, typically shown as `<revision>6.3</revision>`, and ensure it matches the current Dataverse build version.
+1. When a Jenkins job fails after a release, it might be due to the version number in the `pom.xml` file not being updated in the pull request (PR). To verify this, open the relevant GitHub issue, navigate to the PR branch, and go to `dataverse > modules > dataverse-parent > pom.xml`. Look for the version number, typically shown as `<revision>6.3</revision>`, and ensure it matches the current Dataverse build version. If it doesn't match, ask the developer to update the branch with the latest from the "develop" branch.
 
 1. If that didn't work, you may have run into a Flyway DB script collision error but that should be indicated by the server.log. See {doc}`/developers/sql-upgrade-scripts` in the Developer Guide. In the case of a collision, ask the developer to rename the script.
 


### PR DESCRIPTION
**Description**: 
After a release, it's important to update the version number in the PR to match the latest release version. Failing to do so can cause the Jenkins build to fail. Ensure that the PR version number aligns with the current Dataverse version to avoid this issue. For this PR, we are adding a bullet under the Infrastructure of Testing section of the QA Guide to provide a solution. 

Added statement under QA Guide> Infrastructure of Testing> 6. When a Jenkins job fails after a release, it might be due to the version number in the 'pom.xml' file not being updated in the pull request (PR). To Verify this, open the relevant GitHub ticket, navigate to the PR branch, and go to 'dataverse>modules>dataverse-parent>pom.xml'. Look for the version number, typically shown as '<revision>6.3</revision>', and ensure it matches the current Dataverse build version.

Preview at https://dataverse-guide--10951.org.readthedocs.build/en/10951/qa/testing-infrastructure.html





