### PR TITLE
Update link to metadata text guidelines in Dataverse style guide

### DIFF
--- a/doc/sphinx-guides/source/admin/metadatacustomization.rst
+++ b/doc/sphinx-guides/source/admin/metadatacustomization.rst
@@ -644,6 +644,12 @@ Tips from the Dataverse Community
 
 When creating new metadata blocks, please review the :doc:`/style/text` section of the Style Guide, which includes guidance about naming metadata fields and writing text for metadata tooltips and watermarks.
 
+If there are tips that you feel are omitted from this document, please open an issue at https://github.com/IQSS/dataverse/issues and consider making a pull request to make improvements. You can find this document at https://github.com/IQSS/dataverse/blob/develop/doc/sphinx-guides/source/admin/metadatacustomization.rst
+
+Alternatively, you are welcome to request "edit" access to this "Tips for Dataverse Software metadata blocks from the community" Google doc: https://docs.google.com/document/d/1XpblRw0v0SvV-Bq6njlN96WyHJ7tqG0WWejqBdl7hE0/edit?usp=sharing
+
+The thinking is that the tips can become issues and the issues can eventually be worked on as features to improve the Dataverse Software metadata system.
+
 Development Tasks Specific to Changing Fields in Core Metadata Blocks
 ---------------------------------------------------------------------
 

--- a/doc/sphinx-guides/source/admin/metadatacustomization.rst
+++ b/doc/sphinx-guides/source/admin/metadatacustomization.rst
@@ -644,12 +644,6 @@ Tips from the Dataverse Community
 
 When creating new metadata blocks, please review the :doc:`/style/text` section of the Style Guide, which includes guidance about naming metadata fields and writing text for metadata tooltips and watermarks.
 
-If there are tips that you feel are omitted from this document, please open an issue at https://github.com/IQSS/dataverse/issues and consider making a pull request to make improvements. You can find this document at https://github.com/IQSS/dataverse/blob/develop/doc/sphinx-guides/source/admin/metadatacustomization.rst
-
-Alternatively, you are welcome to request "edit" access to this "Tips for Dataverse Software metadata blocks from the community" Google doc: https://docs.google.com/document/d/1XpblRw0v0SvV-Bq6njlN96WyHJ7tqG0WWejqBdl7hE0/edit?usp=sharing
-
-The thinking is that the tips can become issues and the issues can eventually be worked on as features to improve the Dataverse Software metadata system.
-
 Development Tasks Specific to Changing Fields in Core Metadata Blocks
 ---------------------------------------------------------------------
 

--- a/doc/sphinx-guides/source/style/text.rst
+++ b/doc/sphinx-guides/source/style/text.rst
@@ -9,4 +9,4 @@ Here we describe the guidelines that help us provide helpful, clear and consiste
 Metadata Text Guidelines
 ========================
 
-These guidelines are maintained in `a Google Doc <https://docs.google.com/document/d/1uRk_dAZlaCS91YFbqE6L9Jwhwum7mOadkJ59XUx40Sg>`__ as we expect to make frequent changes to them. We welcome comments in the Google Doc.
+These guidelines are maintained in `a Google Doc <https://docs.google.com/document/d/1tY5t3gjrIgAGoRxVMWQSCh46fnbSmnFDLQ7aLkNLhJ8/>`__ as we expect to make frequent changes to them. We welcome comments in the Google Doc.


### PR DESCRIPTION
Preview changes:

- https://dataverse-guide--10962.org.readthedocs.build/en/10962/admin/metadatacustomization.html#tips-from-the-dataverse-community
- https://dataverse-guide--10962.org.readthedocs.build/en/10962/style/text.html#metadata-text-guidelines

Update link to metadata text guidelines in Dataverse style guide

**What this PR does / why we need it**:
In the [documentation page on Text in the style guide](https://guides.dataverse.org/en/latest/style/text.html), the link lead to a google doc which stated that the document was now located at another location with the link. This PR changes the old link to the new location as mentioned in the google doc.
**Which issue(s) this PR closes**:

- Closes #10838

**Special notes for your reviewer**:
NA
**Suggestions on how to test this**:
Click on the new link.
**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
No
**Is there a release notes update needed for this change?**:
No
**Additional documentation**:
