### PR TITLE
DatasetTypesIT- Fix for timing issue in test

### DIFF
--- a/src/test/java/edu/harvard/iq/dataverse/api/DatasetTypesIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/DatasetTypesIT.java
@@ -94,7 +94,8 @@ public class DatasetTypesIT {
         String dataset2Pid = JsonPath.from(createDataset.getBody().asString()).getString("data.persistentId");
 
         UtilIT.publishDatasetViaNativeApi(dataset2Pid, "major", apiToken).then().assertThat().statusCode(OK.getStatusCode());
-
+        //An explicit sleep is needed here because the searchAndShowFacets won't sleep for the query used here
+        UtilIT.sleepForReindex(dataset2Pid, apiToken, 5);
         Response searchCollection = UtilIT.searchAndShowFacets("parentName:" + dataverseAlias, null);
         searchCollection.prettyPrint();
         searchCollection.then().assertThat()


### PR DESCRIPTION
**What this PR does / why we need it**: As reported in [the internal slack](https://iqss.slack.com/archives/C010LA04BCG/p1729706239482019) we've just seen a failure of the DatasetTypesIT.testCreateSoftwareDatasetNative test in the develop branch (with no relevant changes in the latest commits). Looking at the code, it appears that a dataset is published and a search to see if it exists in the parent is done immediately after, which may fail given that search is asynchronous.

This PR adds a sleepForReindex call after the publish.

**Which issue(s) this PR closes**:

- Closes #

**Special notes for your reviewer**:

**Suggestions on how to test this**: Just assure things work /tests pass. We don't have a good way to cause the occasional timing errors.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
