### PR TITLE
Update to #10705 fixing a blank filter query

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/search/SearchServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/search/SearchServiceBean.java
@@ -1047,7 +1047,7 @@ public class SearchServiceBean {
         // add joins on all the non-public groups that may exist for the
         // user:
 
-        // Authenticated users - and GuestUser - may be part of one or more groups; such
+        // Authenticated users, *and the GuestUser*, may be part of one or more groups; such
         // as IP Groups.
         groups = groupService.collectAncestors(groupService.groupsFor(dataverseRequest));
 

--- a/src/main/java/edu/harvard/iq/dataverse/search/SearchServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/search/SearchServiceBean.java
@@ -332,7 +332,7 @@ public class SearchServiceBean {
         // PERMISSION FILTER QUERY
         // -----------------------------------
         String permissionFilterQuery = this.getPermissionFilterQuery(dataverseRequest, solrQuery, onlyDatatRelatedToMe, addFacets);
-        if (permissionFilterQuery != null) {
+        if (!StringUtils.isBlank(permissionFilterQuery)) {
             solrQuery.addFilterQuery(permissionFilterQuery);
         }
         
@@ -1047,7 +1047,7 @@ public class SearchServiceBean {
         // add joins on all the non-public groups that may exist for the
         // user:
 
-        // Authenticated users and GuestUser may be part of one or more groups; such
+        // Authenticated users - and GuestUser - may be part of one or more groups; such
         // as IP Groups.
         groups = groupService.collectAncestors(groupService.groupsFor(dataverseRequest));
 


### PR DESCRIPTION
**What this PR does / why we need it**: Per the comment in #10705, the original PR could add a (hopefully harmless) blank filter query to the request. This PR fixes the logic - the method generating the queries returned "" when none were needed but the check to include them was for the string to != null. The PR changes to check for not null, empty, or blank.

**Which issue(s) this PR closes**:

- Closes #

**Special notes for your reviewer**:

**Suggestions on how to test this**: Verify that an empty query is not included.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
