### PR TITLE
Ordering subfields while displaying dataset version differences

### DIFF
--- a/doc/release-notes/10969-order-subfields-version-difference.md
+++ b/doc/release-notes/10969-order-subfields-version-difference.md
@@ -1,0 +1,2 @@
+Bug Fix:
+In order to facilitate the comparison between the draft version and the published version of a dataset, a sort on subfields has been added (#10969)

--- a/src/main/java/edu/harvard/iq/dataverse/DatasetVersionDifference.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetVersionDifference.java
@@ -152,8 +152,7 @@ public final class DatasetVersionDifference {
         getReplacedFiles();
         initDatasetFilesDifferencesList();
 
-        //Sort within blocks by datasetfieldtype dispaly order then....
-        //sort via metadatablock order - citation first...
+        //Sort within blocks by datasetfieldtype display order
         for (List<DatasetField[]> blockList : detailDataByBlock) {
             Collections.sort(blockList, (DatasetField[] l1, DatasetField[] l2) -> {
                     DatasetField dsfa = l1[0];  //(DatasetField[]) l1.get(0);
@@ -163,6 +162,17 @@ public final class DatasetVersionDifference {
                 return Integer.valueOf(a).compareTo(b);
             });
         }
+        //Sort existing compoundValues by datasetfieldtype display order
+        for (List<DatasetField[]> blockList : detailDataByBlock) {
+            for (DatasetField[] dfarr : blockList) {
+                for (DatasetField df : dfarr) {
+                    for (DatasetFieldCompoundValue dfcv : df.getDatasetFieldCompoundValues()) {
+                        Collections.sort(dfcv.getChildDatasetFields(), DatasetField.DisplayOrder);
+                    }
+                }
+            }
+        }
+        //Sort via metadatablock order
         Collections.sort(detailDataByBlock, (List l1, List l2) -> {
                 DatasetField dsfa[] = (DatasetField[]) l1.get(0);
                 DatasetField dsfb[] = (DatasetField[]) l2.get(0);


### PR DESCRIPTION
**What this PR does / why we need it**:

Ordering subfields while displaying dataset version differences

**Which issue(s) this PR closes**:

- Closes #10968

**Special notes for your reviewer**:

This code looks NullPointerException safe so I didn't overprotect it. 

**Suggestions on how to test this**:

Create multiple versions by modifying the subfields each time and checking the operation with the comparison pop-up.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

Before:
![Screenshot from 2024-10-25 15-42-39](https://github.com/user-attachments/assets/37d44534-2c89-42fc-9a88-a595846f68ec)

After:
![Screenshot from 2024-10-25 16-08-02](https://github.com/user-attachments/assets/db2bf5ff-6c4b-4694-8f72-3a4e0fa9163d)


**Is there a release notes update needed for this change?**:

yes