### PR TITLE
fix get major version when deaccessioned

### DIFF
--- a/doc/release-notes/10947-unpublished-files-appearing-in-search-results-for-anon-user.md
+++ b/doc/release-notes/10947-unpublished-files-appearing-in-search-results-for-anon-user.md
@@ -1,4 +1,4 @@
-A bug fix was made that gets the major version of a Dataset when all major version were deaccessioned. This fixes the incorrect showing of the files as unpublished in the search list even when they are published.
+A bug fix was made that gets the major version of a Dataset when all major versions were deaccessioned. This fixes the incorrect showing of the files as "Unpublished" in the search list even when they are published.
 This fix affects the indexing meaning these datasets must be re-indexed once Dataverse is updated. This can be manually done by calling the index API for each affected Dataset.
 
 Example:

--- a/doc/release-notes/10947-unpublished-files-appearing-in-search-results-for-anon-user.md
+++ b/doc/release-notes/10947-unpublished-files-appearing-in-search-results-for-anon-user.md
@@ -1,7 +1,7 @@
 ## Unpublished file bug fix
 
 A bug fix was made that gets the major version of a Dataset when all major versions were deaccessioned. This fixes the incorrect showing of the files as "Unpublished" in the search list even when they are published.
-This fix affects the indexing meaning these datasets must be re-indexed once Dataverse is updated. This can be manually done by calling the index API for each affected Dataset.
+This fix affects the indexing, meaning these datasets must be re-indexed once Dataverse is updated. This can be manually done by calling the index API for each affected Dataset.
 
 Example:
 ```shell

--- a/doc/release-notes/10947-unpublished-files-appearing-in-search-results-for-anon-user.md
+++ b/doc/release-notes/10947-unpublished-files-appearing-in-search-results-for-anon-user.md
@@ -7,3 +7,5 @@ Example:
 ```shell
 curl http://localhost:8080/api/admin/index/dataset?persistentId=doi:10.7910/DVN/6X4ZZL
 ```
+
+See also #10947 and #10974.

--- a/doc/release-notes/10947-unpublished-files-appearing-in-search-results-for-anon-user.md
+++ b/doc/release-notes/10947-unpublished-files-appearing-in-search-results-for-anon-user.md
@@ -1,0 +1,7 @@
+A bug fix was made that gets the major version of a Dataset when all major version were deaccessioned. This fixes the incorrect showing of the files as unpublished in the search list even when they are published.
+This fix affects the indexing meaning these datasets must be re-indexed once Dataverse is updated. This can be manually done by calling the index API for each affected Dataset.
+
+Example:
+```shell
+curl http://localhost:8080/api/admin/index/dataset?persistentId=doi:10.7910/DVN/6X4ZZL
+```

--- a/doc/release-notes/10947-unpublished-files-appearing-in-search-results-for-anon-user.md
+++ b/doc/release-notes/10947-unpublished-files-appearing-in-search-results-for-anon-user.md
@@ -1,3 +1,5 @@
+## Unpublished file bug fix
+
 A bug fix was made that gets the major version of a Dataset when all major versions were deaccessioned. This fixes the incorrect showing of the files as "Unpublished" in the search list even when they are published.
 This fix affects the indexing meaning these datasets must be re-indexed once Dataverse is updated. This can be manually done by calling the index API for each affected Dataset.
 

--- a/src/main/java/edu/harvard/iq/dataverse/Dataset.java
+++ b/src/main/java/edu/harvard/iq/dataverse/Dataset.java
@@ -483,8 +483,17 @@ public class Dataset extends DvObjectContainer {
         if (this.isHarvested()) {
             return getVersions().get(0).getReleaseTime();
         } else {
+            Long majorVersion = null;
             for (DatasetVersion version : this.getVersions()) {
-                if (version.isReleased() && version.getMinorVersionNumber().equals((long) 0)) {
+                if (version.isReleased()) {
+                    if (version.getMinorVersionNumber().equals((long) 0)) {
+                        return version.getReleaseTime();
+                    } else if (majorVersion == null) {
+                        majorVersion = version.getVersionNumber();
+                    }
+                } else if (version.isDeaccessioned() && majorVersion != null
+                        && majorVersion.longValue() == version.getVersionNumber().longValue()
+                        && version.getMinorVersionNumber().equals((long) 0)) {
                     return version.getReleaseTime();
                 }
             }

--- a/src/test/java/edu/harvard/iq/dataverse/DatasetTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/DatasetTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 
 /**
@@ -240,5 +241,41 @@ public class DatasetTest {
 
         assertTrue(dataset.isDeaccessioned());
     }
- 
+
+    @Test
+    public void testGetMostRecentMajorVersionReleaseDateWithDeaccessionedVersions() {
+        List<DatasetVersion> versionList = new ArrayList<DatasetVersion>();
+
+        long ver = 5;
+        // 5.2
+        DatasetVersion relVersion = new DatasetVersion();
+        relVersion.setVersionState(VersionState.RELEASED);
+        relVersion.setMinorVersionNumber(2L);
+        relVersion.setVersionNumber(ver);
+        versionList.add(relVersion);
+
+        // 5.1
+        relVersion = new DatasetVersion();
+        relVersion.setVersionState(VersionState.DEACCESSIONED);
+        relVersion.setMinorVersionNumber(1L);
+        relVersion.setVersionNumber(ver);
+        versionList.add(relVersion);
+
+        // 5.0, 4.0, 3.0, 2.0, 1.0
+        while  (ver > 0) {
+            DatasetVersion deaccessionedVersion = new DatasetVersion();
+            deaccessionedVersion.setVersionState(VersionState.DEACCESSIONED);
+            // only add an actual date to v5.0 so the assertNotNull will only pass if this version's date is returned
+            deaccessionedVersion.setReleaseTime((ver == 5) ? new Date() : null);
+            deaccessionedVersion.setMinorVersionNumber(0L);
+            deaccessionedVersion.setVersionNumber(ver--);
+            versionList.add(deaccessionedVersion);
+        }
+
+        Dataset dataset = new Dataset();
+        dataset.setVersions(versionList);
+
+        Date releaseDate = dataset.getMostRecentMajorVersionReleaseDate();
+        assertNotNull(releaseDate);
+    }
 }


### PR DESCRIPTION
**What this PR does / why we need it**: Anonymous users are able to see files labeled as "Unpublished" in the search results on Dataverse, even though these files are actually published.

**Which issue(s) this PR closes**: https://github.com/IQSS/dataverse/issues/10947

- Closes #10947

**Special notes for your reviewer**:

**Suggestions on how to test this**:
1. Deploy in a server like perf in order to have lots of data or locally and publish a dataset with version 1.0 with a file. Deaccession the dataset. Update the file and publish as 1.1
2. Select "View All Data."
3. Check the "Files" filter under the search filters.
4. Under the "Publication Status" section, the "Unpublished" option will appear.
5. Select the "Unpublished" filter option.
This will result in the "Unpublished" label appearing, as seen in the provided screenshot, even though the files appear to be published when viewed individually.
6. Check the versions to see that the major versions are deaccessioned and the latest file has a minor version
6. Re-index the dataset curl http://localhost:8080/api/admin/index/dataset?persistentId=doi:10.7910/DVN/RCQXN1
7. Re-load the "view All Data" page and see that the number of "Unpublished" files has decreased by the number of files in the dataset that was re-indexed
Note: without this fix the number should remain the same



**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:No

**Is there a release notes update needed for this change?**: Included

**Additional documentation**:
