### PR TITLE
Fix bug related to returnDatasetFieldTypes in Dataverses.listMetadataBlocks endpoint

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DatasetFieldServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetFieldServiceBean.java
@@ -947,7 +947,7 @@ public class DatasetFieldServiceBean implements java.io.Serializable {
         criteriaQuery.where(
                 criteriaBuilder.equal(dataverseRoot.get("id"), dataverse.getId()), // Match the Dataverse ID.
                 criteriaBuilder.equal(metadataBlockRoot.get("id"), metadataBlock.getId()), // Match the MetadataBlock ID.
-                metadataBlockRoot.in(dataverseRoot.get("metadataBlocks")), // Ensure the MetadataBlock is part of the Dataverse.
+                metadataBlockRoot.in(dataverseRoot.get("metadataBlocks")), // Ensure the MetadataBlock is part of the Dataverse. FIXME: inherit blocks from parent
                 datasetFieldTypeRoot.in(metadataBlockRoot.get("datasetFieldTypes")), // Ensure the DatasetFieldType is part of the MetadataBlock.
                 criteriaBuilder.or(includedAsInputLevelPredicate, hasNoInputLevelPredicate), // Include DatasetFieldTypes based on the input level predicates.
                 displayedOnCreatePredicate // Apply the display-on-create filter if necessary.

--- a/src/main/java/edu/harvard/iq/dataverse/DatasetFieldServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetFieldServiceBean.java
@@ -951,7 +951,7 @@ public class DatasetFieldServiceBean implements java.io.Serializable {
         criteriaQuery.where(
                 criteriaBuilder.equal(dataverseRoot.get("id"), dataverse.getId()), // Match the Dataverse ID.
                 criteriaBuilder.equal(metadataBlockRoot.get("id"), metadataBlock.getId()), // Match the MetadataBlock ID.
-                metadataBlockRoot.in(dataverseRoot.get("metadataBlocks")), // Ensure the MetadataBlock is part of the Dataverse. FIXME: inherit blocks from parent
+                metadataBlockRoot.in(dataverseRoot.get("metadataBlocks")), // Ensure the MetadataBlock is part of the Dataverse.
                 datasetFieldTypeRoot.in(metadataBlockRoot.get("datasetFieldTypes")), // Ensure the DatasetFieldType is part of the MetadataBlock.
                 criteriaBuilder.or(includedAsInputLevelPredicate, hasNoInputLevelPredicate), // Include DatasetFieldTypes based on the input level predicates.
                 displayedOnCreatePredicate // Apply the display-on-create filter if necessary.

--- a/src/main/java/edu/harvard/iq/dataverse/DatasetFieldServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetFieldServiceBean.java
@@ -891,6 +891,10 @@ public class DatasetFieldServiceBean implements java.io.Serializable {
     }
 
     public List<DatasetFieldType> findAllInMetadataBlockAndDataverse(MetadataBlock metadataBlock, Dataverse dataverse, boolean onlyDisplayedOnCreate) {
+        if (!dataverse.isMetadataBlockRoot() && dataverse.getOwner() != null) {
+            return findAllInMetadataBlockAndDataverse(metadataBlock, dataverse.getOwner(), onlyDisplayedOnCreate);
+        }
+
         CriteriaBuilder criteriaBuilder = em.getCriteriaBuilder();
         CriteriaQuery<DatasetFieldType> criteriaQuery = criteriaBuilder.createQuery(DatasetFieldType.class);
 

--- a/src/test/java/edu/harvard/iq/dataverse/api/DataversesIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/DataversesIT.java
@@ -911,11 +911,13 @@ public class DataversesIT {
         createDataverseResponse.then().assertThat().statusCode(CREATED.getStatusCode());
         String dataverseAlias = UtilIT.getAliasFromResponse(createDataverseResponse);
 
+        // New Dataverse should return just the citation block and its displayOnCreate fields when onlyDisplayedOnCreate=true and returnDatasetFieldTypes=true
         Response listMetadataBlocks = UtilIT.listMetadataBlocks(dataverseAlias, true, true, apiToken);
         listMetadataBlocks.prettyPrint();
         listMetadataBlocks.then().assertThat().statusCode(OK.getStatusCode());
         listMetadataBlocks.then().assertThat()
                 .statusCode(OK.getStatusCode())
+                .body("data.size()", equalTo(1))
                 .body("data[0].name", is("citation"))
                 .body("data[0].fields.title.displayOnCreate", equalTo(true))
                 .body("data[0].fields.size()", is(28));

--- a/src/test/java/edu/harvard/iq/dataverse/api/DataversesIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/DataversesIT.java
@@ -911,14 +911,27 @@ public class DataversesIT {
         createDataverseResponse.then().assertThat().statusCode(CREATED.getStatusCode());
         String dataverseAlias = UtilIT.getAliasFromResponse(createDataverseResponse);
 
-        Response listMetadataBlocks = UtilIT.listMetadataBlocks(dataverseAlias, true, true, apiToken);
-        listMetadataBlocks.prettyPrint();
-        listMetadataBlocks.then().assertThat().statusCode(OK.getStatusCode());
-        listMetadataBlocks.then().assertThat()
-                .statusCode(OK.getStatusCode())
-                .body("data[0].name", is("citation"))
-                // failing? "fields" is empty, showing {}
-                .body("data[0].fields.title.displayOnCreate", equalTo(true));
+        boolean issue10984fixed = false;
+        // See https://github.com/IQSS/dataverse/issues/10984
+        if (issue10984fixed) {
+            Response listMetadataBlocks = UtilIT.listMetadataBlocks(dataverseAlias, true, true, apiToken);
+            listMetadataBlocks.prettyPrint();
+            listMetadataBlocks.then().assertThat().statusCode(OK.getStatusCode());
+            listMetadataBlocks.then().assertThat()
+                    .statusCode(OK.getStatusCode())
+                    .body("data[0].name", is("citation"))
+                    .body("data[0].fields.title.displayOnCreate", equalTo(true));
+
+        } else {
+            Response listMetadataBlocks = UtilIT.listMetadataBlocks(dataverseAlias, true, true, apiToken);
+            listMetadataBlocks.prettyPrint();
+            listMetadataBlocks.then().assertThat().statusCode(OK.getStatusCode());
+            listMetadataBlocks.then().assertThat()
+                    .statusCode(OK.getStatusCode())
+                    .body("data[0].name", is("citation"))
+                    // "fields" should be more like 28, not 0
+                    .body("data[0].fields.size()", is(0));
+        }
 
         Response setMetadataBlocksResponse = UtilIT.setMetadataBlocks(dataverseAlias, Json.createArrayBuilder().add("citation").add("astrophysics"), apiToken);
         setMetadataBlocksResponse.then().assertThat().statusCode(OK.getStatusCode());

--- a/src/test/java/edu/harvard/iq/dataverse/api/DataversesIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/DataversesIT.java
@@ -911,27 +911,14 @@ public class DataversesIT {
         createDataverseResponse.then().assertThat().statusCode(CREATED.getStatusCode());
         String dataverseAlias = UtilIT.getAliasFromResponse(createDataverseResponse);
 
-        boolean issue10984fixed = false;
-        // See https://github.com/IQSS/dataverse/issues/10984
-        if (issue10984fixed) {
-            Response listMetadataBlocks = UtilIT.listMetadataBlocks(dataverseAlias, true, true, apiToken);
-            listMetadataBlocks.prettyPrint();
-            listMetadataBlocks.then().assertThat().statusCode(OK.getStatusCode());
-            listMetadataBlocks.then().assertThat()
-                    .statusCode(OK.getStatusCode())
-                    .body("data[0].name", is("citation"))
-                    .body("data[0].fields.title.displayOnCreate", equalTo(true));
-
-        } else {
-            Response listMetadataBlocks = UtilIT.listMetadataBlocks(dataverseAlias, true, true, apiToken);
-            listMetadataBlocks.prettyPrint();
-            listMetadataBlocks.then().assertThat().statusCode(OK.getStatusCode());
-            listMetadataBlocks.then().assertThat()
-                    .statusCode(OK.getStatusCode())
-                    .body("data[0].name", is("citation"))
-                    // "fields" should be more like 28, not 0
-                    .body("data[0].fields.size()", is(0));
-        }
+        Response listMetadataBlocks = UtilIT.listMetadataBlocks(dataverseAlias, true, true, apiToken);
+        listMetadataBlocks.prettyPrint();
+        listMetadataBlocks.then().assertThat().statusCode(OK.getStatusCode());
+        listMetadataBlocks.then().assertThat()
+                .statusCode(OK.getStatusCode())
+                .body("data[0].name", is("citation"))
+                .body("data[0].fields.title.displayOnCreate", equalTo(true))
+                .body("data[0].fields.size()", is(28));
 
         Response setMetadataBlocksResponse = UtilIT.setMetadataBlocks(dataverseAlias, Json.createArrayBuilder().add("citation").add("astrophysics"), apiToken);
         setMetadataBlocksResponse.then().assertThat().statusCode(OK.getStatusCode());

--- a/src/test/java/edu/harvard/iq/dataverse/api/DataversesIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/DataversesIT.java
@@ -911,6 +911,15 @@ public class DataversesIT {
         createDataverseResponse.then().assertThat().statusCode(CREATED.getStatusCode());
         String dataverseAlias = UtilIT.getAliasFromResponse(createDataverseResponse);
 
+        Response listMetadataBlocks = UtilIT.listMetadataBlocks(dataverseAlias, true, true, apiToken);
+        listMetadataBlocks.prettyPrint();
+        listMetadataBlocks.then().assertThat().statusCode(OK.getStatusCode());
+        listMetadataBlocks.then().assertThat()
+                .statusCode(OK.getStatusCode())
+                .body("data[0].name", is("citation"))
+                // failing? "fields" is empty, showing {}
+                .body("data[0].fields.title.displayOnCreate", equalTo(true));
+
         Response setMetadataBlocksResponse = UtilIT.setMetadataBlocks(dataverseAlias, Json.createArrayBuilder().add("citation").add("astrophysics"), apiToken);
         setMetadataBlocksResponse.then().assertThat().statusCode(OK.getStatusCode());
 


### PR DESCRIPTION
**What this PR does / why we need it**:

We should be checking for inheritance of metadata blocks from parent collection to child collection.

**Which issue(s) this PR closes**:

- Closes #10984

**Special notes for your reviewer**:

@pdurbin started this pull request but @GPortas added the actual fix.

We were attempting to retrieve the metadata block fields for the requested dataverse without verifying whether isMetadataBlockRoot was set to true. See https://github.com/IQSS/dataverse/pull/10985/files#diff-171c256be8744ca0742a9570ed33a3e335eae0544d08be04545ef31fdd5328d1. Consequently, when accessing a dataverse that inherits from the root, we couldn't find a relationship with the desired metadata block, as that relationship with the block exists in the parent, not the child dataverse.

We have fixed this to always get the fields from the parent collection when isMetadataBlockRoot is false.

**Suggestions on how to test this**:

Make sure Jenkins reports all test passing.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No.

**Is there a release notes update needed for this change?**:

No. In practice, this only affects the SPA, which is still in development.

**Additional documentation**:

None.