### PR TITLE
Revert "Bump actions/download-artifact from 3 to 4.1.7 in /.github/workflows"

### DIFF
--- a/.github/workflows/deploy_beta_testing.yml
+++ b/.github/workflows/deploy_beta_testing.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Download war artifact
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@v3
         with:
           name: built-app
           path: ./

--- a/.github/workflows/maven_unit_test.yml
+++ b/.github/workflows/maven_unit_test.yml
@@ -107,7 +107,7 @@ jobs:
                   cache: maven
 
             # Get the build output from the unit test job
-            - uses: actions/download-artifact@v4.1.7
+            - uses: actions/download-artifact@v3
               with:
                   name: java-artifacts
             - run: |
@@ -140,7 +140,7 @@ jobs:
                 cache: maven
 
           # Get the build output from the integration test job
-          - uses: actions/download-artifact@v4.1.7
+          - uses: actions/download-artifact@v3
             with:
                 name: java-reportdir
           - run: tar -xvf java-reportdir.tar


### PR DESCRIPTION
I'm pretty sure we need to revert the following PR:

- IQSS/dataverse#10822

I'm seeing failures on both jobs affected.

- https://github.com/IQSS/dataverse/actions/workflows/deploy_beta_testing.yml
- https://github.com/IQSS/dataverse/actions/workflows/maven_unit_test.yml

For deploy_beta_testing at https://github.com/IQSS/dataverse/actions/runs/11600760387 for example it says "
Unable to download artifact(s): Artifact not found for name: built-app Please ensure that your artifact is not expired and the artifact was uploaded using a compatible version of toolkit/upload-artifact. For more information, visit the GitHub Artifacts FAQ: https://github.com/actions/toolkit/blob/main/packages/artifact/docs/faq.md "

![Screenshot 2024-10-30 at 5 02 31 PM](https://github.com/user-attachments/assets/68938464-a7f7-4705-b347-91ffcc37e8e7)

There's a similar error for the maven_unit_test job at https://github.com/IQSS/dataverse/actions/runs/11600879270