### PR TITLE
Fixes unit test assertion in JsonParserTest

### DIFF
--- a/src/test/java/edu/harvard/iq/dataverse/util/json/JsonParserTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/util/json/JsonParserTest.java
@@ -284,6 +284,7 @@ public class JsonParserTest {
             assertEquals("LABORATORY", actual.getDataverseType().toString());
             assertEquals(2, actual.getDataverseContacts().size());
             assertEquals("pi@example.edu", actual.getDataverseContacts().get(0).getContactEmail());
+            assertEquals("student@example.edu", actual.getDataverseContacts().get(1).getContactEmail());
             assertEquals(0, actual.getDataverseContacts().get(0).getDisplayOrder());
             assertEquals(1, actual.getDataverseContacts().get(1).getDisplayOrder());
         } catch (IOException ioe) {

--- a/src/test/java/edu/harvard/iq/dataverse/util/json/JsonParserTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/util/json/JsonParserTest.java
@@ -283,7 +283,7 @@ public class JsonParserTest {
             assertEquals("We do all the science.", actual.getDescription());
             assertEquals("LABORATORY", actual.getDataverseType().toString());
             assertEquals(2, actual.getDataverseContacts().size());
-            assertEquals("pi@example.edu,student@example.edu", actual.getDataverseContacts().get(0).getContactEmail());
+            assertEquals("pi@example.edu", actual.getDataverseContacts().get(0).getContactEmail());
             assertEquals(0, actual.getDataverseContacts().get(0).getDisplayOrder());
             assertEquals(1, actual.getDataverseContacts().get(1).getDisplayOrder());
         } catch (IOException ioe) {

--- a/src/test/java/edu/harvard/iq/dataverse/util/json/JsonParserTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/util/json/JsonParserTest.java
@@ -277,16 +277,17 @@ public class JsonParserTest {
         try (FileReader reader = new FileReader("doc/sphinx-guides/source/_static/api/dataverse-complete.json")) {
             dvJson = Json.createReader(reader).readObject();
             DataverseDTO actual = sut.parseDataverseDTO(dvJson);
+            List<DataverseContact> actualDataverseContacts = actual.getDataverseContacts();
             assertEquals("Scientific Research", actual.getName());
             assertEquals("science", actual.getAlias());
             assertEquals("Scientific Research University", actual.getAffiliation());
             assertEquals("We do all the science.", actual.getDescription());
             assertEquals("LABORATORY", actual.getDataverseType().toString());
-            assertEquals(2, actual.getDataverseContacts().size());
-            assertEquals("pi@example.edu", actual.getDataverseContacts().get(0).getContactEmail());
-            assertEquals("student@example.edu", actual.getDataverseContacts().get(1).getContactEmail());
-            assertEquals(0, actual.getDataverseContacts().get(0).getDisplayOrder());
-            assertEquals(1, actual.getDataverseContacts().get(1).getDisplayOrder());
+            assertEquals(2, actualDataverseContacts.size());
+            assertEquals("pi@example.edu", actualDataverseContacts.get(0).getContactEmail());
+            assertEquals("student@example.edu", actualDataverseContacts.get(1).getContactEmail());
+            assertEquals(0, actualDataverseContacts.get(0).getDisplayOrder());
+            assertEquals(1, actualDataverseContacts.get(1).getDisplayOrder());
         } catch (IOException ioe) {
             throw new JsonParseException("Couldn't read test file", ioe);
         }


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes unit test assertion in JsonParserTest

**Which issue(s) this PR closes**:

N/A

**Special notes for your reviewer**:

https://jenkins.dataverse.org/job/IQSS-dataverse-develop/1899/testReport/edu.harvard.iq.dataverse.util.json/JsonParserTest/parseDataverseDTO/ says 

`expected: <pi@example.edu,student@example.edu> but was: <pi@example.edu>
`

It's failing here: https://github.com/IQSS/dataverse/actions/runs/11662305024/job/32468392175#step:4:9654
From https://github.com/IQSS/dataverse/pull/10925

**Suggestions on how to test this**:

Visual inspection and unit test run

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No

**Is there a release notes update needed for this change?**:

No

**Additional documentation**:

None