### PR TITLE
fix backwards newest oldest sort order

### DIFF
--- a/doc/release-notes/10742-newest-oldest-sort-order-backwards.md
+++ b/doc/release-notes/10742-newest-oldest-sort-order-backwards.md
@@ -1,0 +1,3 @@
+## Minor bug fix to UI to fix the order of the files on the Dataset Files page when ordering by Date
+
+A fix was made to the ui to fix the ordering 'Newest' and 'Oldest' which were reversed

--- a/src/main/webapp/filesFragment.xhtml
+++ b/src/main/webapp/filesFragment.xhtml
@@ -301,17 +301,7 @@
                                     <f:param name="folderPresort" value="#{DatasetPage.folderPresort}"/>
                                 </h:outputLink></li>
                             <li><h:outputLink rel="nofollow" value="/dataset.xhtml">
-                                    <h:outputText styleClass="#{(DatasetPage.fileSortField == 'date' and (empty DatasetPage.fileSortOrder)) ? 'highlightBold' : ''}" value="#{bundle['file.results.btn.sort.option.newest']}"/>
-                                    <f:param name="persistentId" value="#{DatasetPage.persistentId}"/>
-                                    <f:param name="version" value="#{DatasetPage.version}"/>
-                                    <f:param name="q" value="#{DatasetPage.fileLabelSearchTerm}"/>
-                                    <f:param name="fileTypeGroupFacet" value="#{DatasetPage.fileTypeFacet}"/>
-                                    <f:param name="fileAccess" value="#{DatasetPage.fileAccessFacet}"/>
-                                    <f:param name="fileSortField" value="date"/>
-                                    <f:param name="tagPresort" value="#{DatasetPage.tagPresort}"/>
-                                </h:outputLink></li>
-                            <li><h:outputLink rel="nofollow" value="/dataset.xhtml">
-                                    <h:outputText styleClass="#{(DatasetPage.fileSortField == 'date' and DatasetPage.fileSortOrder == 'desc') ? 'highlightBold' : ''}" value="#{bundle['file.results.btn.sort.option.oldest']}"/>
+                                    <h:outputText styleClass="#{(DatasetPage.fileSortField == 'date' and DatasetPage.fileSortOrder == 'desc') ? 'highlightBold' : ''}" value="#{bundle['file.results.btn.sort.option.newest']}"/>
                                     <f:param name="persistentId" value="#{DatasetPage.persistentId}"/>
                                     <f:param name="version" value="#{DatasetPage.version}"/>
                                     <f:param name="q" value="#{DatasetPage.fileLabelSearchTerm}"/>
@@ -319,6 +309,16 @@
                                     <f:param name="fileAccess" value="#{DatasetPage.fileAccessFacet}"/>
                                     <f:param name="fileSortField" value="date"/>
                                     <f:param name="fileSortOrder" value="desc"/>
+                                    <f:param name="tagPresort" value="#{DatasetPage.tagPresort}"/>
+                                </h:outputLink></li>
+                            <li><h:outputLink rel="nofollow" value="/dataset.xhtml">
+                                    <h:outputText styleClass="#{(DatasetPage.fileSortField == 'date' and (empty DatasetPage.fileSortOrder)) ? 'highlightBold' : ''}" value="#{bundle['file.results.btn.sort.option.oldest']}"/>
+                                    <f:param name="persistentId" value="#{DatasetPage.persistentId}"/>
+                                    <f:param name="version" value="#{DatasetPage.version}"/>
+                                    <f:param name="q" value="#{DatasetPage.fileLabelSearchTerm}"/>
+                                    <f:param name="fileTypeGroupFacet" value="#{DatasetPage.fileTypeFacet}"/>
+                                    <f:param name="fileAccess" value="#{DatasetPage.fileAccessFacet}"/>
+                                    <f:param name="fileSortField" value="date"/>
                                     <f:param name="tagPresort" value="#{DatasetPage.tagPresort}"/>
                                 </h:outputLink></li>
                             <li><h:outputLink rel="nofollow" value="/dataset.xhtml">


### PR DESCRIPTION
**What this PR does / why we need it**: Sort order in UI on dataset file listing is backwards for Newest and Oldest

**Which issue(s) this PR closes**:https://github.com/IQSS/dataverse/issues/10742

- Closes #10742

**Special notes for your reviewer**: fully tested the comparator and determined it was just a UI issue

**Suggestions on how to test this**: Test using UI
On a dataset file listing, click "Sort -> Newest"
The resulting order should be newest first.

On a dataset file listing, click "Sort -> Oldest"
The resulting order should be oldest first.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**: Included

**Additional documentation**:
