### PR TITLE
docs: "Update a Dataverse Collection" vs. "Change Collection Attributes"

### DIFF
--- a/doc/sphinx-guides/source/api/native-api.rst
+++ b/doc/sphinx-guides/source/api/native-api.rst
@@ -126,6 +126,8 @@ Same as in :ref:`create-dataverse-api`, the request JSON supports an optional ``
 
 To obtain an example of how these objects are included in the JSON file, download :download:`dataverse-complete-optional-params.json <../_static/api/dataverse-complete-optional-params.json>` file and modify it to suit your needs.
 
+See also :ref:`collection-attributes-api`.
+
 .. _view-dataverse:
 
 View a Dataverse Collection
@@ -1057,6 +1059,8 @@ The following attributes are supported:
 * ``description`` Description
 * ``affiliation`` Affiliation
 * ``filePIDsEnabled`` ("true" or "false") Restricted to use by superusers and only when the :ref:`:AllowEnablingFilePIDsPerCollection <:AllowEnablingFilePIDsPerCollection>` setting is true. Enables or disables registration of file-level PIDs in datasets within the collection (overriding the instance-wide setting).
+
+See also :ref:`update-dataverse-api`.
 
 .. _collection-storage-quotas:
 


### PR DESCRIPTION
**What this PR does / why we need it**:

A new "Update a Dataverse Collection" was added in #10925 and users of the older "Change Collection Attributes" should probably be aware of it.

This pull request cross references the two APIs.

**Which issue(s) this PR closes**:

None but relates to #10904 and the PR above.

**Special notes for your reviewer**:

I was tempted to say that the "Update a Dataverse Collection" does everything that the "Change Collection Attributes" API does and more but I'm not sure if it handles `filePIDsEnabled`. 

**Suggestions on how to test this**:

Review the docs that are automatically built.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No.

**Is there a release notes update needed for this change?**:

No. 

**Additional documentation**:

None.