### PR TITLE
Extend getDataverse API json payload to include properties isMetadataBlockRoot and isFacetRoot

### DIFF
--- a/doc/release-notes/11012-get-dataverse-api-ext.md
+++ b/doc/release-notes/11012-get-dataverse-api-ext.md
@@ -1,0 +1,1 @@
+The JSON payload of the getDataverse endpoint has been extended to include properties isMetadataBlockRoot and isFacetRoot.

--- a/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
@@ -276,7 +276,9 @@ public class JsonPrinter {
         }
         bld.add("permissionRoot", dv.isPermissionRoot())
                 .add("description", dv.getDescription())
-                .add("dataverseType", dv.getDataverseType().name());
+                .add("dataverseType", dv.getDataverseType().name())
+                .add("isMetadataBlockRoot", dv.isMetadataBlockRoot())
+                .add("isFacetRoot", dv.isFacetRoot());
         if (dv.getOwner() != null) {
             bld.add("ownerId", dv.getOwner().getId());
         }

--- a/src/test/java/edu/harvard/iq/dataverse/api/DataversesIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/DataversesIT.java
@@ -135,14 +135,16 @@ public class DataversesIT {
     public void testMinimalDataverse() throws FileNotFoundException {
         Response createUser = UtilIT.createRandomUser();
         createUser.prettyPrint();
-        String username = UtilIT.getUsernameFromResponse(createUser);
         String apiToken = UtilIT.getApiTokenFromResponse(createUser);
         JsonObject dvJson;
         FileReader reader = new FileReader("doc/sphinx-guides/source/_static/api/dataverse-minimal.json");
         dvJson = Json.createReader(reader).readObject();
         Response create = UtilIT.createDataverse(dvJson, apiToken);
         create.prettyPrint();
-        create.then().assertThat().statusCode(CREATED.getStatusCode());
+        create.then().assertThat()
+                .body("data.isMetadataBlockRoot", equalTo(false))
+                .body("data.isFacetRoot", equalTo(false))
+                .statusCode(CREATED.getStatusCode());
         Response deleteDataverse = UtilIT.deleteDataverse("science", apiToken);
         deleteDataverse.prettyPrint();
         deleteDataverse.then().assertThat().statusCode(OK.getStatusCode());


### PR DESCRIPTION
**What this PR does / why we need it**:

The JSON payload of the getDataverse endpoint has been extended to include properties isMetadataBlockRoot and isFacetRoot.

**Which issue(s) this PR closes**:

- Closes #11012

**Suggestions on how to test this**:

Since it is a minor change, a visual inspection of the code and the new assertions in the IT (which should pass on jenkins) should be enough.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No

**Is there a release notes update needed for this change?**:

Yes, attached.
