### PR TITLE
Add two additional containers to provide Previewers locally

### DIFF
--- a/docker/compose/demo/compose.yml
+++ b/docker/compose/demo/compose.yml
@@ -80,6 +80,8 @@ services:
     hostname: dataverse-previewers-provider
     ports:
       - 9000:80
+    networks:
+      - dataverse      
     environment:
       - NGINX_HTTP_PORT=80
       - PREVIEWERS_PROVIDER_URL=http://${IP:-localhost}:9000
@@ -90,8 +92,9 @@ services:
     container_name: dataverse-register-previewers
     hostname: dataverse-register-previewers
     image: trivadis/dataverse-deploy-previewers:latest
+    networks:
+      - dataverse    
     environment:
-      - API_TOKEN=${API_TOKEN}
       - DATAVERSE_URL=http://dataverse:8080
       - TIMEOUT=10m
       - PREVIEWERS_PROVIDER_URL=http://${IP:-localhost}:9000

--- a/docker/compose/demo/compose.yml
+++ b/docker/compose/demo/compose.yml
@@ -74,30 +74,29 @@ services:
     volumes:
       - ./data/app/data:/dv
 
-  dataverse-previewers-provider:
+  previewers-provider:
     image: trivadis/dataverse-previewers-provider:latest
-    container_name: dataverse-previewers-provider
-    hostname: dataverse-previewers-provider
+    container_name: previewers-provider
+    hostname: previewers-provider
     ports:
       - 9000:80
     networks:
       - dataverse      
     environment:
       - NGINX_HTTP_PORT=80
-      - PREVIEWERS_PROVIDER_URL=http://${IP:-localhost}:9000
+      - PREVIEWERS_PROVIDER_URL=http://${MACHINE_IP:-localhost}:9000
       - VERSIONS="v1.4,betatest"
-    restart: unless-stopped
 
-  dataverse-register-previewers:
-    container_name: dataverse-register-previewers
-    hostname: dataverse-register-previewers
+  register-previewers:
+    container_name: register-previewers
+    hostname: register-previewers
     image: trivadis/dataverse-deploy-previewers:latest
     networks:
       - dataverse    
     environment:
       - DATAVERSE_URL=http://dataverse:8080
       - TIMEOUT=10m
-      - PREVIEWERS_PROVIDER_URL=http://${IP:-localhost}:9000
+      - PREVIEWERS_PROVIDER_URL=http://${MACHINE_IP:-localhost}:9000
       - INCLUDE_PREVIEWERS=text,html,pdf,csv,comma-separated-values,tsv,tab-separated-values,jpeg,png,gif,markdown,x-markdown
       - EXCLUDE_PREVIEWERS=
       - REMOVE_EXISTING=True

--- a/docker/compose/demo/compose.yml
+++ b/docker/compose/demo/compose.yml
@@ -82,7 +82,7 @@ services:
       - 9000:80
     environment:
       - NGINX_HTTP_PORT=80
-      - PREVIEWERS_PROVIDER_URL=http://${PUBLIC_IP:-localhost}:9000
+      - PREVIEWERS_PROVIDER_URL=http://${IP:-localhost}:9000
       - VERSIONS="v1.4,betatest"
     restart: unless-stopped
 
@@ -92,9 +92,9 @@ services:
     image: trivadis/dataverse-deploy-previewers:latest
     environment:
       - API_TOKEN=${API_TOKEN}
-      - DATAVERSE_URL=http://${PUBLIC_IP:-localhost}:8080
+      - DATAVERSE_URL=http://dataverse:8080
       - TIMEOUT=10m
-      - PREVIEWERS_PROVIDER_URL=http://${PUBLIC_IP:-localhost}:9000
+      - PREVIEWERS_PROVIDER_URL=http://${IP:-localhost}:9000
       - INCLUDE_PREVIEWERS=text,html,pdf,csv,comma-separated-values,tsv,tab-separated-values,jpeg,png,gif,markdown,x-markdown
       - EXCLUDE_PREVIEWERS=
       - REMOVE_EXISTING=True

--- a/docker/compose/demo/compose.yml
+++ b/docker/compose/demo/compose.yml
@@ -9,7 +9,7 @@ services:
     restart: on-failure
     user: payara
     environment:
-      DATAVERSE_SITEURL: "https://demo.example.org"
+      DATAVERSE_SITEURL: "http://${MACHINE_IP:-localhost}:8080"
       DATAVERSE_DB_HOST: postgres
       DATAVERSE_DB_PASSWORD: secret
       DATAVERSE_DB_USER: dataverse

--- a/docker/compose/demo/compose.yml
+++ b/docker/compose/demo/compose.yml
@@ -94,7 +94,7 @@ services:
       - API_TOKEN=${API_TOKEN}
       - DATAVERSE_URL=http://${PUBLIC_IP:-localhost}:8080
       - TIMEOUT=10m
-      - PREVIEWER_PROVIDER_URL=http://${PUBLIC_IP:-localhost}:9000
+      - PREVIEWERS_PROVIDER_URL=http://${PUBLIC_IP:-localhost}:9000
       - INCLUDE_PREVIEWERS=text,html,pdf,csv,comma-separated-values,tsv,tab-separated-values,jpeg,png,gif,markdown,x-markdown
       - EXCLUDE_PREVIEWERS=
       - REMOVE_EXISTING=True

--- a/docker/compose/demo/compose.yml
+++ b/docker/compose/demo/compose.yml
@@ -82,7 +82,7 @@ services:
       - 9000:80
     environment:
       - NGINX_HTTP_PORT=80
-      - PREVIEWERS_PROVIDER_URL=http://${IP:-localhost}:9000
+      - PREVIEWERS_PROVIDER_URL=http://${PUBLIC_IP:-localhost}:9000
       - VERSIONS="v1.4,betatest"
     restart: unless-stopped
 
@@ -92,9 +92,9 @@ services:
     image: trivadis/dataverse-deploy-previewers:latest
     environment:
       - API_TOKEN=${API_TOKEN}
-      - DATAVERSE_URL=http://${IP:-localhost}:8080
+      - DATAVERSE_URL=http://${PUBLIC_IP:-localhost}:8080
       - TIMEOUT=10m
-      - PREVIEWERS_PROVIDER_URL=http://${IP:-localhost}:9000
+      - PREVIEWERS_PROVIDER_URL=http://${PUBLIC_IP:-localhost}:9000
       - INCLUDE_PREVIEWERS=text,html,pdf,csv,comma-separated-values,tsv,tab-separated-values,jpeg,png,gif,markdown,x-markdown
       - EXCLUDE_PREVIEWERS=
       - REMOVE_EXISTING=True

--- a/docker/compose/demo/compose.yml
+++ b/docker/compose/demo/compose.yml
@@ -82,7 +82,7 @@ services:
       - 9000:80
     environment:
       - NGINX_HTTP_PORT=80
-      - PREVIEWERS_PROVIDER_URL=http://${PUBLIC_IP:-localhost}:9000
+      - PREVIEWERS_PROVIDER_URL=http://${IP:-localhost}:9000
       - VERSIONS="v1.4,betatest"
     restart: unless-stopped
 
@@ -92,9 +92,9 @@ services:
     image: trivadis/dataverse-deploy-previewers:latest
     environment:
       - API_TOKEN=${API_TOKEN}
-      - DATAVERSE_URL=http://${PUBLIC_IP:-localhost}:8080
+      - DATAVERSE_URL=http://${IP:-localhost}:8080
       - TIMEOUT=10m
-      - PREVIEWERS_PROVIDER_URL=http://${PUBLIC_IP:-localhost}:9000
+      - PREVIEWERS_PROVIDER_URL=http://${IP:-localhost}:9000
       - INCLUDE_PREVIEWERS=text,html,pdf,csv,comma-separated-values,tsv,tab-separated-values,jpeg,png,gif,markdown,x-markdown
       - EXCLUDE_PREVIEWERS=
       - REMOVE_EXISTING=True

--- a/docker/compose/demo/compose.yml
+++ b/docker/compose/demo/compose.yml
@@ -74,6 +74,34 @@ services:
     volumes:
       - ./data/app/data:/dv
 
+  dataverse-previewers-provider:
+    image: trivadis/dataverse-previewers-provider:latest
+    container_name: dataverse-previewers-provider
+    hostname: dataverse-previewers-provider
+    ports:
+      - 9000:80
+    environment:
+      - NGINX_HTTP_PORT=80
+      - PREVIEWERS_PROVIDER_URL=http://${PUBLIC_IP:-localhost}:9000
+      - VERSIONS="v1.4,betatest"
+    restart: unless-stopped
+
+  dataverse-register-previewers:
+    container_name: dataverse-register-previewers
+    hostname: dataverse-register-previewers
+    image: trivadis/dataverse-deploy-previewers:latest
+    environment:
+      - API_TOKEN=${API_TOKEN}
+      - DATAVERSE_URL=http://${PUBLIC_IP:-localhost}:8080
+      - TIMEOUT=10m
+      - PREVIEWER_PROVIDER_URL=http://${PUBLIC_IP:-localhost}:9000
+      - INCLUDE_PREVIEWERS=text,html,pdf,csv,comma-separated-values,tsv,tab-separated-values,jpeg,png,gif,markdown,x-markdown
+      - EXCLUDE_PREVIEWERS=
+      - REMOVE_EXISTING=True
+    command:
+      - deploy
+    restart: no
+
   postgres:
     container_name: "postgres"
     hostname: postgres

--- a/docker/compose/demo/compose.yml
+++ b/docker/compose/demo/compose.yml
@@ -79,11 +79,11 @@ services:
     container_name: previewers-provider
     hostname: previewers-provider
     ports:
-      - 9000:80
+      - 9000:9000
     networks:
       - dataverse      
     environment:
-      - NGINX_HTTP_PORT=80
+      - NGINX_HTTP_PORT=9000
       - PREVIEWERS_PROVIDER_URL=http://${MACHINE_IP:-localhost}:9000
       - VERSIONS="v1.4,betatest"
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds two additional docker containers:
 * register-previewers - registers previewers in Dataverse 
 * previewers-provider - provides all previewers locally

Previewers to register can be included/excluded by using `INCLUDE_PREVIEWERS` or `EXCLUDE_PREVIEWERS` environment variable. If both are empty, then all previewers are installed. 

You can list the available previewers by running `docker run trivadis/dataverse-deploy-previewers:latest previewers`. 

If you don't run docker on the same machine, then set the MACHINE_IP environment variable to the IP-Address of the Docker host. 


