### PR TITLE
Updates the updateDataverse API endpoint to support cases where an "inherit from parent" configuration is desired

### DIFF
--- a/doc/release-notes/11018-update-dataverse-endpoint-update.md
+++ b/doc/release-notes/11018-update-dataverse-endpoint-update.md
@@ -1,0 +1,8 @@
+The updateDataverse API endpoint has been updated to support an "inherit from parent" configuration for metadata blocks, facets, and input levels.
+
+When it comes to omitting any of these fields in the request JSON:
+
+- Omitting ``facetIds`` or ``metadataBlockNames`` causes the Dataverse collection to inherit the corresponding configuration from its parent.
+- Omitting ``inputLevels`` removes any existing input levels in the Dataverse collection.
+
+Previously, not setting these fields meant keeping the existing ones in the Dataverse.

--- a/doc/release-notes/11018-update-dataverse-endpoint-update.md
+++ b/doc/release-notes/11018-update-dataverse-endpoint-update.md
@@ -3,6 +3,6 @@ The updateDataverse API endpoint has been updated to support an "inherit from pa
 When it comes to omitting any of these fields in the request JSON:
 
 - Omitting ``facetIds`` or ``metadataBlockNames`` causes the Dataverse collection to inherit the corresponding configuration from its parent.
-- Omitting ``inputLevels`` removes any existing input levels in the Dataverse collection.
+- Omitting ``inputLevels`` removes any existing custom input levels in the Dataverse collection.
 
 Previously, not setting these fields meant keeping the existing ones in the Dataverse.

--- a/doc/sphinx-guides/source/api/native-api.rst
+++ b/doc/sphinx-guides/source/api/native-api.rst
@@ -118,11 +118,18 @@ The fully expanded example above (without environment variables) looks like this
 
 You should expect an HTTP 200 response and JSON beginning with "status":"OK" followed by a representation of the updated Dataverse collection.
 
-Same as in :ref:`create-dataverse-api`, the request JSON supports an optional ``metadataBlocks`` object, with the following supported sub-objects:
+Same as in :ref:`create-dataverse-api`, the request JSON supports a ``metadataBlocks`` object, with the following supported sub-objects:
 
-- ``metadataBlockNames``: The names of the metadata blocks you want to add to the Dataverse collection.
-- ``inputLevels``: The names of the fields in each metadata block for which you want to add a custom configuration regarding their inclusion or requirement when creating and editing datasets in the new Dataverse collection. Note that if the corresponding metadata blocks names are not specified in the ``metadataBlockNames``` field, they will be added automatically to the Dataverse collection.
-- ``facetIds``: The names of the fields to use as facets for browsing datasets and collections in the new Dataverse collection. Note that the order of the facets is defined by their order in the provided JSON array.
+- ``metadataBlockNames``: The names of the metadata blocks to be assigned to the Dataverse collection.
+- ``inputLevels``: The names of the fields in each metadata block for which you want to add a custom configuration regarding their inclusion or requirement when creating and editing datasets in the Dataverse collection. Note that if the corresponding metadata blocks names are not specified in the ``metadataBlockNames``` field, they will be added automatically to the Dataverse collection.
+- ``facetIds``: The names of the fields to use as facets for browsing datasets and collections in the Dataverse collection. Note that the order of the facets is defined by their order in the provided JSON array.
+
+Note that setting any of these fields overwrites the previous configuration.
+
+When it comes to omitting these fields in the JSON:
+
+- Omitting ``facetIds`` or ``metadataBlockNames`` causes the Dataverse collection to inherit the corresponding configuration from its parent.
+- Omitting ``inputLevels`` removes any existing input levels in the Dataverse collection.
 
 To obtain an example of how these objects are included in the JSON file, download :download:`dataverse-complete-optional-params.json <../_static/api/dataverse-complete-optional-params.json>` file and modify it to suit your needs.
 

--- a/doc/sphinx-guides/source/api/native-api.rst
+++ b/doc/sphinx-guides/source/api/native-api.rst
@@ -129,7 +129,7 @@ Note that setting any of these fields overwrites the previous configuration.
 When it comes to omitting these fields in the JSON:
 
 - Omitting ``facetIds`` or ``metadataBlockNames`` causes the Dataverse collection to inherit the corresponding configuration from its parent.
-- Omitting ``inputLevels`` removes any existing input levels in the Dataverse collection.
+- Omitting ``inputLevels`` removes any existing custom input levels in the Dataverse collection.
 
 To obtain an example of how these objects are included in the JSON file, download :download:`dataverse-complete-optional-params.json <../_static/api/dataverse-complete-optional-params.json>` file and modify it to suit your needs.
 

--- a/doc/sphinx-guides/source/api/native-api.rst
+++ b/doc/sphinx-guides/source/api/native-api.rst
@@ -130,6 +130,7 @@ When it comes to omitting these fields in the JSON:
 
 - Omitting ``facetIds`` or ``metadataBlockNames`` causes the Dataverse collection to inherit the corresponding configuration from its parent.
 - Omitting ``inputLevels`` removes any existing custom input levels in the Dataverse collection.
+- Omitting the entire ``metadataBlocks`` object in the request JSON would exclude the three sub-objects, resulting in the application of the two changes described above.
 
 To obtain an example of how these objects are included in the JSON file, download :download:`dataverse-complete-optional-params.json <../_static/api/dataverse-complete-optional-params.json>` file and modify it to suit your needs.
 

--- a/doc/sphinx-guides/source/api/native-api.rst
+++ b/doc/sphinx-guides/source/api/native-api.rst
@@ -118,7 +118,7 @@ The fully expanded example above (without environment variables) looks like this
 
 You should expect an HTTP 200 response and JSON beginning with "status":"OK" followed by a representation of the updated Dataverse collection.
 
-Same as in :ref:`create-dataverse-api`, the request JSON supports a ``metadataBlocks`` object, with the following supported sub-objects:
+Same as in :ref:`create-dataverse-api`, the request JSON supports an optional ``metadataBlocks`` object, with the following supported sub-objects:
 
 - ``metadataBlockNames``: The names of the metadata blocks to be assigned to the Dataverse collection.
 - ``inputLevels``: The names of the fields in each metadata block for which you want to add a custom configuration regarding their inclusion or requirement when creating and editing datasets in the Dataverse collection. Note that if the corresponding metadata blocks names are not specified in the ``metadataBlockNames``` field, they will be added automatically to the Dataverse collection.

--- a/src/main/java/edu/harvard/iq/dataverse/Dataverse.java
+++ b/src/main/java/edu/harvard/iq/dataverse/Dataverse.java
@@ -595,6 +595,10 @@ public class Dataverse extends DvObjectContainer {
         this.metadataBlocks = new ArrayList<>(metadataBlocks);
     }
 
+    public void clearMetadataBlocks() {
+        this.metadataBlocks.clear();
+    }
+
     public List<DatasetFieldType> getCitationDatasetFieldTypes() {
         return citationDatasetFieldTypes;
     }

--- a/src/main/java/edu/harvard/iq/dataverse/api/Dataverses.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Dataverses.java
@@ -195,7 +195,7 @@ public class Dataverses extends AbstractApiBean {
             List<DatasetFieldType> facets = parseFacets(body);
 
             AuthenticatedUser u = getRequestAuthenticatedUserOrDie(crc);
-            dataverse = execCommand(new UpdateDataverseCommand(dataverse, facets, null, createDataverseRequest(u), inputLevels, metadataBlocks, updatedDataverseDTO));
+            dataverse = execCommand(new UpdateDataverseCommand(dataverse, facets, null, createDataverseRequest(u), inputLevels, metadataBlocks, updatedDataverseDTO, true));
             return ok(json(dataverse));
 
         } catch (WrappedResponse ww) {

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/CreateDataverseCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/CreateDataverseCommand.java
@@ -39,7 +39,7 @@ public class CreateDataverseCommand extends AbstractWriteDataverseCommand {
                                   List<DatasetFieldType> facets,
                                   List<DataverseFieldTypeInputLevel> inputLevels,
                                   List<MetadataBlock> metadataBlocks) {
-        super(created, created.getOwner(), request, facets, inputLevels, metadataBlocks);
+        super(created, created.getOwner(), request, facets, inputLevels, metadataBlocks, false);
     }
 
     @Override

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/UpdateDataverseCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/UpdateDataverseCommand.java
@@ -32,7 +32,7 @@ public class UpdateDataverseCommand extends AbstractWriteDataverseCommand {
                                   List<Dataverse> featuredDataverses,
                                   DataverseRequest request,
                                   List<DataverseFieldTypeInputLevel> inputLevels) {
-        this(dataverse, facets, featuredDataverses, request, inputLevels, null, null);
+        this(dataverse, facets, featuredDataverses, request, inputLevels, null, null, false);
     }
 
     public UpdateDataverseCommand(Dataverse dataverse,
@@ -41,8 +41,9 @@ public class UpdateDataverseCommand extends AbstractWriteDataverseCommand {
                                   DataverseRequest request,
                                   List<DataverseFieldTypeInputLevel> inputLevels,
                                   List<MetadataBlock> metadataBlocks,
-                                  DataverseDTO updatedDataverseDTO) {
-        super(dataverse, dataverse, request, facets, inputLevels, metadataBlocks);
+                                  DataverseDTO updatedDataverseDTO,
+                                  boolean resetRelationsOnNullValues) {
+        super(dataverse, dataverse, request, facets, inputLevels, metadataBlocks, resetRelationsOnNullValues);
         if (featuredDataverses != null) {
             this.featuredDataverseList = new ArrayList<>(featuredDataverses);
         } else {


### PR DESCRIPTION
**What this PR does / why we need it**:

The updateDataverse API endpoint has been updated to support an "inherit from parent" configuration for metadata blocks, facets, and input levels.

When it comes to omitting any of these fields in the request JSON:

- Omitting ``facetIds`` or ``metadataBlockNames`` causes the Dataverse collection to inherit the corresponding configuration from its parent.
- Omitting ``inputLevels`` removes any existing input levels in the Dataverse collection.

Previously, not setting these fields meant keeping the existing ones in the Dataverse.

**Which issue(s) this PR closes**:

- Closes #11018 

**Special notes for your reviewer**:

I have applied this behavior only to the updateDataverse endpoint, preserving the previous behavior of the UpdateDataverseCommand in other places for backwards compatibility.

**Suggestions on how to test this**:

1. Create a Dataverse.
2. Download https://github.com/IQSS/dataverse/blob/develop/doc/sphinx-guides/source/_static/api/dataverse-complete-optional-params.json
3. Test updating the created Dataverse by submitting different versions of the previous JSON. (Including the fields mentioned above / not including them)

`curl -H "X-Dataverse-key:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" -X PUT "http://localhost:8080/api/dataverses/dvAlias" --upload-file update-dataverse.json
`
**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No

**Is there a release notes update needed for this change?**:

Yes, attached.

**Additional documentation**:

None