### PR TITLE
Display overview fix (external controlled vocabulary)

### DIFF
--- a/doc/release-notes/display_overview_fix.md
+++ b/doc/release-notes/display_overview_fix.md
@@ -1,0 +1,1 @@
+This bugfix corrects an issue when there are duplicated entries on the metadata page. It is fixed by correcting an IF-clause in metadataFragment.xhtml.

--- a/doc/sphinx-guides/source/api/changelog.rst
+++ b/doc/sphinx-guides/source/api/changelog.rst
@@ -7,6 +7,10 @@ This API changelog is experimental and we would love feedback on its usefulness.
     :local:
     :depth: 1
 
+v6.5
+---
+- duplicated entries are corrected on the metadata page    
+
 v6.4
 ----
 

--- a/doc/sphinx-guides/source/api/changelog.rst
+++ b/doc/sphinx-guides/source/api/changelog.rst
@@ -7,10 +7,6 @@ This API changelog is experimental and we would love feedback on its usefulness.
     :local:
     :depth: 1
 
-v6.5
----
-- duplicated entries are corrected on the metadata page    
-
 v6.4
 ----
 

--- a/src/main/webapp/metadataFragment.xhtml
+++ b/src/main/webapp/metadataFragment.xhtml
@@ -130,7 +130,7 @@
                                                     <ui:repeat value="#{compoundValue.displayValueMap.entrySet().toArray()}" var="cvPart" varStatus="partStatus">
                                                         <c:set var="cvocOnCvPart" value="#{cvocConf.containsKey(cvPart.key.datasetFieldType.id)}"/>
                                                         <h:outputText value="#{dsf.datasetFieldType.displayFormat} " rendered="${!partStatus.first and !settingsWrapper.isCvocField(cvPart.key.datasetFieldType.id)}"/>
-                                                        <ui:fragment rendered="#{!cvocOnDsfApplies or !settingsWrapper.isCvocField(cvPart.key.datasetFieldType.id)}">
+                                                        <ui:fragment rendered="#{!(cvocOnDsfApplies or settingsWrapper.isCvocField(cvPart.key.datasetFieldType.id))}">
                                                             <ui:fragment rendered="#{compoundValue.isLink(cvPart.key)}">
                                                                 <h:outputLink value="#{compoundValue.getLink()}" target="_blank">
                                                                     <h:outputText value="#{cvPart.value}"

--- a/src/main/webapp/metadataFragment.xhtml
+++ b/src/main/webapp/metadataFragment.xhtml
@@ -130,7 +130,7 @@
                                                     <ui:repeat value="#{compoundValue.displayValueMap.entrySet().toArray()}" var="cvPart" varStatus="partStatus">
                                                         <c:set var="cvocOnCvPart" value="#{cvocConf.containsKey(cvPart.key.datasetFieldType.id)}"/>
                                                         <h:outputText value="#{dsf.datasetFieldType.displayFormat} " rendered="${!partStatus.first and !settingsWrapper.isCvocField(cvPart.key.datasetFieldType.id)}"/>
-                                                        <ui:fragment rendered="#{!(cvocOnDsfApplies or settingsWrapper.isCvocField(cvPart.key.datasetFieldType.id))}">
+                                                        <ui:fragment rendered="#{!cvocOnCvPart and !cvocOnDsfApplies or !settingsWrapper.isCvocField(cvPart.key.datasetFieldType.id)}">
                                                             <ui:fragment rendered="#{compoundValue.isLink(cvPart.key)}">
                                                                 <h:outputLink value="#{compoundValue.getLink()}" target="_blank">
                                                                     <h:outputText value="#{cvPart.value}"


### PR DESCRIPTION
**What this PR does / why we need it**:
On the metadata page there can be duplicated / redundant metadata entries. This pull-request fixes an IF-clause in metadataFragment.xhtml to eliminate the redundant display of metadata fields

**Which issue(s) this PR closes**:

- Closes #11005

**Special notes for your reviewer**:

**Suggestions on how to test this**: (from Jim) - I thought I could see the issue if I configured the ORCID script but not the ROR script via the external vocabulary mechanism but trying this on demo/v6.4 isn't showing the problem. I'd suggest testing with no scripts (can add author name/affiliation/id metadata) and with the ORCID/ROR set up on the author field (able to add a person via ORCID lookup and free text, affiliation by ROR and free text) and making sure that those work. 
 ([authorIDandAffilationUsingORCIDandROR.md](https://github.com/gdcc/dataverse-external-vocab-support/blob/main/examples/authorIDandAffilationUsingORCIDandROR.md)  describes adding both using the [authorsOrcidAndRor.json](https://github.com/gdcc/dataverse-external-vocab-support/blob/main/examples/config/authorsOrcidAndRor.json) file. ).

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**: included

**Additional documentation**:
