### PR TITLE
docs: file detection using first few bytes disabled on S3 direct upload

### DIFF
--- a/doc/sphinx-guides/source/api/native-api.rst
+++ b/doc/sphinx-guides/source/api/native-api.rst
@@ -3618,7 +3618,7 @@ Currently the following methods are used to detect file types:
 
 - The file type detected by the browser (or sent via API).
 - Custom code that reads the first few bytes. As explained at :ref:`s3-direct-upload-features-disabled`, this method of file type detection is not utilized during direct upload to S3, since by nature of direct upload Dataverse never sees the contents of the file. However, this code is utilized when the "redetect" API is used.
-- JHOVE: https://jhove.openpreservation.org
+- JHOVE: https://jhove.openpreservation.org . Note that the same applies about direct upload to S3 and the "redirect" API.
 - The file extension (e.g. ".ipybn") is used, defined in a file called ``MimeTypeDetectionByFileExtension.properties``.
 - The file name (e.g. "Dockerfile") is used, defined in a file called ``MimeTypeDetectionByFileName.properties``.
 

--- a/doc/sphinx-guides/source/api/native-api.rst
+++ b/doc/sphinx-guides/source/api/native-api.rst
@@ -3617,6 +3617,7 @@ The fully expanded example above (without environment variables) looks like this
 Currently the following methods are used to detect file types:
 
 - The file type detected by the browser (or sent via API).
+- Custom code that reads the first few bytes. As explained at :ref:`s3-direct-upload-features-disabled`, this code is disabled during direct upload to S3. However, this code is active when the "redetect" API is used.
 - JHOVE: https://jhove.openpreservation.org
 - The file extension (e.g. ".ipybn") is used, defined in a file called ``MimeTypeDetectionByFileExtension.properties``.
 - The file name (e.g. "Dockerfile") is used, defined in a file called ``MimeTypeDetectionByFileName.properties``.

--- a/doc/sphinx-guides/source/api/native-api.rst
+++ b/doc/sphinx-guides/source/api/native-api.rst
@@ -3617,7 +3617,7 @@ The fully expanded example above (without environment variables) looks like this
 Currently the following methods are used to detect file types:
 
 - The file type detected by the browser (or sent via API).
-- Custom code that reads the first few bytes. As explained at :ref:`s3-direct-upload-features-disabled`, this code is disabled during direct upload to S3. However, this code is active when the "redetect" API is used.
+- Custom code that reads the first few bytes. As explained at :ref:`s3-direct-upload-features-disabled`, this method of file type detection is not utilized during direct upload to S3, since by nature of direct upload Dataverse never sees the contents of the file. However, this code is utilized when the "redetect" API is used.
 - JHOVE: https://jhove.openpreservation.org
 - The file extension (e.g. ".ipybn") is used, defined in a file called ``MimeTypeDetectionByFileExtension.properties``.
 - The file name (e.g. "Dockerfile") is used, defined in a file called ``MimeTypeDetectionByFileName.properties``.

--- a/doc/sphinx-guides/source/api/native-api.rst
+++ b/doc/sphinx-guides/source/api/native-api.rst
@@ -3618,7 +3618,7 @@ Currently the following methods are used to detect file types:
 
 - The file type detected by the browser (or sent via API).
 - Custom code that reads the first few bytes. As explained at :ref:`s3-direct-upload-features-disabled`, this method of file type detection is not utilized during direct upload to S3, since by nature of direct upload Dataverse never sees the contents of the file. However, this code is utilized when the "redetect" API is used.
-- JHOVE: https://jhove.openpreservation.org . Note that the same applies about direct upload to S3 and the "redirect" API.
+- JHOVE: https://jhove.openpreservation.org . Note that the same applies about direct upload to S3 and the "redetect" API.
 - The file extension (e.g. ".ipybn") is used, defined in a file called ``MimeTypeDetectionByFileExtension.properties``.
 - The file name (e.g. "Dockerfile") is used, defined in a file called ``MimeTypeDetectionByFileName.properties``.
 

--- a/doc/sphinx-guides/source/developers/big-data-support.rst
+++ b/doc/sphinx-guides/source/developers/big-data-support.rst
@@ -44,6 +44,7 @@ Features that are Disabled if S3 Direct Upload is Enabled
 The following features are disabled when S3 direct upload is enabled.
 
 - Unzipping of zip files. (See :ref:`compressed-files`.)
+- Detection of file type based on custom code that reads the first few bytes. (See :ref:`redetect-file-type`.)
 - Extraction of metadata from FITS files. (See :ref:`fits`.)
 - Creation of NcML auxiliary files (See :ref:`netcdf-and-hdf5`.)
 - Extraction of a geospatial bounding box from NetCDF and HDF5 files (see :ref:`netcdf-and-hdf5`) unless :ref:`dataverse.netcdf.geo-extract-s3-direct-upload` is set to true.

--- a/doc/sphinx-guides/source/developers/big-data-support.rst
+++ b/doc/sphinx-guides/source/developers/big-data-support.rst
@@ -44,7 +44,7 @@ Features that are Disabled if S3 Direct Upload is Enabled
 The following features are disabled when S3 direct upload is enabled.
 
 - Unzipping of zip files. (See :ref:`compressed-files`.)
-- Detection of file type based on custom code that reads the first few bytes. (See :ref:`redetect-file-type`.)
+- Detection of file type based on JHOVE and custom code that reads the first few bytes. (See :ref:`redetect-file-type`.)
 - Extraction of metadata from FITS files. (See :ref:`fits`.)
 - Creation of NcML auxiliary files (See :ref:`netcdf-and-hdf5`.)
 - Extraction of a geospatial bounding box from NetCDF and HDF5 files (see :ref:`netcdf-and-hdf5`) unless :ref:`dataverse.netcdf.geo-extract-s3-direct-upload` is set to true.


### PR DESCRIPTION
Preview doc changes here:

- https://dataverse-guide--11035.org.readthedocs.build/en/11035/developers/big-data-support.html#features-that-are-disabled-if-s3-direct-upload-is-enabled
- https://dataverse-guide--11035.org.readthedocs.build/en/11035/api/native-api.html#redetect-file-type

**What this PR does / why we need it**:

There is confusion about file detection when using S3. See recent discussion between @bseeger and @shlake :

- https://groups.google.com/g/dataverse-community/c/TBx0TTins2k/m/ubHT7B33CAAJ
- https://groups.google.com/g/dataverse-community/c/EYPH_yPpDkI/m/WPjHSDLYBQAJ
