### PR TITLE
10977 Globus Upload optimization - batch file size lookups 

### DIFF
--- a/doc/release-notes/10977-globus-filesize-lookup.md
+++ b/doc/release-notes/10977-globus-filesize-lookup.md
@@ -1,0 +1,6 @@
+## A new Globus optimization setting 
+
+An optimization has been added for the Globus upload workflow, with a corresponding new database setting: `:GlobusBatchLookupSize`
+
+
+See the [Database Settings](https://guides.dataverse.org/en/6.5/installation/config.html#GlobusBatchLookupSize) section of the Guides for more information.

--- a/doc/sphinx-guides/source/installation/config.rst
+++ b/doc/sphinx-guides/source/installation/config.rst
@@ -4849,6 +4849,13 @@ The URL where the `dataverse-globus <https://github.com/scholarsportal/dataverse
 
 The interval in seconds between Dataverse calls to Globus to check on upload progress. Defaults to 50 seconds (or to 10 minutes, when the ``globus-use-experimental-async-framework`` feature flag is enabled). See :ref:`globus-support` for details.
 
+.. _:GlobusBatchLookupSize:
+
+:GlobusBatchLookupSize
+++++++++++++++++++++++
+
+In the initial implementation, when files were added to the dataset upon completion of a Globus upload task, Dataverse would make a separate Globus API call to look up the size of every new file. This proved to be a significant bottleneck at Harvard Dataverse with users transferring batches of many thousands of files (this in turn was made possible by the Globus improvements in v6.4). An optimized lookup mechanism was added in response, where the Globus Service makes a listing API call on the entire remote folder, then populates the file sizes for all the new file entries before passing them to the Ingest service. This approach however may in fact slow things down in a scenario where there are already thousands of files in the Globus folder for the dataset, and only a small number of new files are being added. To address this, the number of files in a batch for which this method should be used was made configurable. If not set, it will default to 50 (a completely arbitrary number). Setting it to 0 will always use this method with Globus uploads. Setting it to some very large number will disable it completely. This was made a database setting, as opposed to a JVM option, in order to make it configurable in real time. 
+
 :GlobusSingleFileTransfer
 +++++++++++++++++++++++++
 

--- a/src/main/java/edu/harvard/iq/dataverse/MailServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/MailServiceBean.java
@@ -283,7 +283,7 @@ public class MailServiceBean implements java.io.Serializable {
            if (objectOfNotification != null){
                String messageText = getMessageTextBasedOnNotification(notification, objectOfNotification, comment, requestor);
                String subjectText = MailUtil.getSubjectTextBasedOnNotification(notification, objectOfNotification);
-               if (!(messageText.isEmpty() || subjectText.isEmpty())){
+               if (!(StringUtils.isEmpty(messageText) || StringUtils.isEmpty(subjectText))){
                    retval = sendSystemEmail(emailAddress, subjectText, messageText, isHtmlContent);
                } else {
                    logger.warning("Skipping " + notification.getType() +  " notification, because couldn't get valid message");

--- a/src/main/java/edu/harvard/iq/dataverse/dataaccess/GlobusOverlayAccessIO.java
+++ b/src/main/java/edu/harvard/iq/dataverse/dataaccess/GlobusOverlayAccessIO.java
@@ -215,7 +215,7 @@ public class GlobusOverlayAccessIO<T extends DvObject> extends AbstractRemoteOve
                 JsonArray dataArray = responseJson.getJsonArray("DATA");
                 if (dataArray != null && dataArray.size() != 0) {
                     //File found
-                    return (long) responseJson.getJsonArray("DATA").getJsonObject(0).getJsonNumber("size").longValueExact();
+                    return (long) dataArray.getJsonObject(0).getJsonNumber("size").longValueExact();
                 }
             } else {
                 logger.warning("Response from " + get.getURI().toString() + " was "

--- a/src/main/java/edu/harvard/iq/dataverse/datasetutility/AddReplaceFileHelper.java
+++ b/src/main/java/edu/harvard/iq/dataverse/datasetutility/AddReplaceFileHelper.java
@@ -136,10 +136,7 @@ public class AddReplaceFileHelper{
     private String newFileName;                 // step 30
     private String newFileContentType;          // step 30
     private String newStorageIdentifier;        // step 30
-    private String newCheckSum;                 // step 30
-    private ChecksumType newCheckSumType;       //step 30
-    private Long suppliedFileSize = null; 
-
+    
     // -- Optional  
     private DataFile fileToReplace;             // step 25
     
@@ -147,6 +144,7 @@ public class AddReplaceFileHelper{
     private DatasetVersion clone;
     List<DataFile> initialFileList; 
     List<DataFile> finalFileList;
+    private boolean trustSuppliedFileSizes; 
     
     // -----------------------------------
     // Ingested files
@@ -611,18 +609,9 @@ public class AddReplaceFileHelper{
             return false;
             
         }
-        if (optionalFileParams != null) {
-            if (optionalFileParams.hasCheckSum()) {
-                newCheckSum = optionalFileParams.getCheckSum();
-                newCheckSumType = optionalFileParams.getCheckSumType();
-            }
-            if (optionalFileParams.hasFileSize()) {
-                suppliedFileSize = optionalFileParams.getFileSize();
-            }
-        }
 
         msgt("step_030_createNewFilesViaIngest");
-        if (!this.step_030_createNewFilesViaIngest()){
+        if (!this.step_030_createNewFilesViaIngest(optionalFileParams)){
             return false;
             
         }
@@ -1195,7 +1184,7 @@ public class AddReplaceFileHelper{
     }
     
     
-    private boolean step_030_createNewFilesViaIngest(){
+    private boolean step_030_createNewFilesViaIngest(OptionalFileParams optionalFileParams){
         
         if (this.hasError()){
             return false;
@@ -1207,6 +1196,22 @@ public class AddReplaceFileHelper{
             //Don't repeatedly update the clone (losing changes) in multifile case
             clone = workingVersion.cloneDatasetVersion();
         }
+        
+        Long suppliedFileSize = null;
+        String newCheckSum = null;
+        ChecksumType newCheckSumType = null;
+        
+        
+        if (optionalFileParams != null) {
+            if (optionalFileParams.hasCheckSum()) {
+                newCheckSum = optionalFileParams.getCheckSum();
+                newCheckSumType = optionalFileParams.getCheckSumType();
+            }
+            if (trustSuppliedFileSizes && optionalFileParams.hasFileSize()) {
+                suppliedFileSize = optionalFileParams.getFileSize();
+            }
+        }
+        
         try {
             UploadSessionQuotaLimit quota = null; 
             if (systemConfig.isStorageQuotasEnforced()) {
@@ -2028,9 +2033,15 @@ public class AddReplaceFileHelper{
      * @param jsonData - an array of jsonData entries (one per file) using the single add file jsonData format
      * @param dataset
      * @param authUser
+     * @param trustSuppliedSizes - whether to accept the fileSize values passed 
+     *        in jsonData (we don't want to trust the users of the S3 direct 
+     *        upload API with that information - we will verify the status of
+     *        the files in the S3 bucket and confirm the sizes in the process. 
+     *        we do want GlobusService to be able to pass the file sizes, since
+     *        they are obtained and verified via a Globus API lookup). 
      * @return
      */
-    public Response addFiles(String jsonData, Dataset dataset, User authUser) {
+    public Response addFiles(String jsonData, Dataset dataset, User authUser, boolean trustSuppliedFileSizes) {
         msgt("(addFilesToDataset) jsonData: " + jsonData.toString());
 
         JsonArrayBuilder jarr = Json.createArrayBuilder();
@@ -2039,6 +2050,7 @@ public class AddReplaceFileHelper{
 
         int totalNumberofFiles = 0;
         int successNumberofFiles = 0;
+        this.trustSuppliedFileSizes = trustSuppliedFileSizes; 
         // -----------------------------------------------------------
         // Read jsonData and Parse files information from jsondata  :
         // -----------------------------------------------------------
@@ -2169,6 +2181,10 @@ public class AddReplaceFileHelper{
         return Response.ok().entity(Json.createObjectBuilder()
                 .add("status", ApiConstants.STATUS_OK)
                 .add("data", Json.createObjectBuilder().add("Files", jarr).add("Result", result)).build() ).build();
+    }
+    
+    public Response addFiles(String jsonData, Dataset dataset, User authUser) {
+        return addFiles(jsonData, dataset, authUser, false);
     }
     
     /**

--- a/src/main/java/edu/harvard/iq/dataverse/datasetutility/AddReplaceFileHelper.java
+++ b/src/main/java/edu/harvard/iq/dataverse/datasetutility/AddReplaceFileHelper.java
@@ -138,7 +138,8 @@ public class AddReplaceFileHelper{
     private String newStorageIdentifier;        // step 30
     private String newCheckSum;                 // step 30
     private ChecksumType newCheckSumType;       //step 30
-    
+    private Long suppliedFileSize = null; 
+
     // -- Optional  
     private DataFile fileToReplace;             // step 25
     
@@ -610,11 +611,14 @@ public class AddReplaceFileHelper{
             return false;
             
         }
-        if(optionalFileParams != null) {
-        	if(optionalFileParams.hasCheckSum()) {
-        		newCheckSum = optionalFileParams.getCheckSum();
-        		newCheckSumType = optionalFileParams.getCheckSumType();
-        	}
+        if (optionalFileParams != null) {
+            if (optionalFileParams.hasCheckSum()) {
+                newCheckSum = optionalFileParams.getCheckSum();
+                newCheckSumType = optionalFileParams.getCheckSumType();
+            }
+            if (optionalFileParams.hasFileSize()) {
+                suppliedFileSize = optionalFileParams.getFileSize();
+            }
         }
 
         msgt("step_030_createNewFilesViaIngest");
@@ -1204,20 +1208,11 @@ public class AddReplaceFileHelper{
             clone = workingVersion.cloneDatasetVersion();
         }
         try {
-            /*CreateDataFileResult result = FileUtil.createDataFiles(workingVersion,
-                    this.newFileInputStream,
-                    this.newFileName,
-                    this.newFileContentType,
-                    this.newStorageIdentifier,
-                    this.newCheckSum,
-                    this.newCheckSumType,
-                    this.systemConfig);*/
-            
             UploadSessionQuotaLimit quota = null; 
             if (systemConfig.isStorageQuotasEnforced()) {
                 quota = fileService.getUploadSessionQuotaLimit(dataset);
             }
-            Command<CreateDataFileResult> cmd = new CreateNewDataFilesCommand(dvRequest, workingVersion, newFileInputStream, newFileName, newFileContentType, newStorageIdentifier, quota, newCheckSum, newCheckSumType);
+            Command<CreateDataFileResult> cmd = new CreateNewDataFilesCommand(dvRequest, workingVersion, newFileInputStream, newFileName, newFileContentType, newStorageIdentifier, quota, newCheckSum, newCheckSumType, suppliedFileSize);
             CreateDataFileResult createDataFilesResult = commandEngine.submit(cmd);
             initialFileList = createDataFilesResult.getDataFiles();
 

--- a/src/main/java/edu/harvard/iq/dataverse/datasetutility/OptionalFileParams.java
+++ b/src/main/java/edu/harvard/iq/dataverse/datasetutility/OptionalFileParams.java
@@ -39,6 +39,12 @@ import java.util.stream.Collectors;
  *  - Provenance related information
  * 
  * @author rmp553
+ * @todo (?) We may want to consider renaming this class to DataFileParams or
+ * DataFileInfo... it was originally created to encode some bits of info - 
+ * the file "tags" specifically, that didn't fit in elsewhere in the normal 
+ * workflow; but it's been expanded to cover pretty much everything else associated
+ * with DataFiles and it's not really "optional" anymore when, for example, used
+ * in the direct upload workflow. (?)
  */
 public class OptionalFileParams {
 

--- a/src/main/java/edu/harvard/iq/dataverse/datasetutility/OptionalFileParams.java
+++ b/src/main/java/edu/harvard/iq/dataverse/datasetutility/OptionalFileParams.java
@@ -76,6 +76,8 @@ public class OptionalFileParams {
     public static final String MIME_TYPE_ATTR_NAME = "mimeType";
     private String checkSumValue;
     private ChecksumType checkSumType;
+    public static final String FILE_SIZE_ATTR_NAME = "fileSize";
+    private Long fileSize;
     public static final String LEGACY_CHECKSUM_ATTR_NAME = "md5Hash";
     public static final String CHECKSUM_OBJECT_NAME = "checksum";
     public static final String CHECKSUM_OBJECT_TYPE = "@type";
@@ -268,6 +270,18 @@ public class OptionalFileParams {
     public ChecksumType getCheckSumType() {
         return checkSumType;
     }
+    
+    public boolean hasFileSize() {
+        return fileSize != null;
+    }
+    
+    public Long getFileSize() {
+        return fileSize;
+    }
+    
+    public void setFileSize(long fileSize) {
+        this.fileSize = fileSize;
+    }
 
     /**
      *  Set tags
@@ -416,7 +430,13 @@ public class OptionalFileParams {
             this.checkSumType = ChecksumType.fromString(((JsonObject) jsonObj.get(CHECKSUM_OBJECT_NAME)).get(CHECKSUM_OBJECT_TYPE).getAsString());
 
         }
-        
+        // -------------------------------
+        // get file size as a Long, if supplied
+        // -------------------------------
+        if ((jsonObj.has(FILE_SIZE_ATTR_NAME)) && (!jsonObj.get(FILE_SIZE_ATTR_NAME).isJsonNull())){
+
+            this.fileSize = jsonObj.get(FILE_SIZE_ATTR_NAME).getAsLong();
+        }
         // -------------------------------
         // get tags 
         // -------------------------------

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/CreateNewDataFilesCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/CreateNewDataFilesCommand.java
@@ -93,6 +93,10 @@ public class CreateNewDataFilesCommand extends AbstractCommand<CreateDataFileRes
         this(aRequest, version, inputStream, fileName, suppliedContentType, newStorageIdentifier, quota, newCheckSum, newCheckSumType, null, null);
     }
     
+    public CreateNewDataFilesCommand(DataverseRequest aRequest, DatasetVersion version, InputStream inputStream, String fileName, String suppliedContentType, String newStorageIdentifier, UploadSessionQuotaLimit quota, String newCheckSum, DataFile.ChecksumType newCheckSumType, Long newFileSize) {
+        this(aRequest, version, inputStream, fileName, suppliedContentType, newStorageIdentifier, quota, newCheckSum, newCheckSumType, newFileSize, null);
+    }
+    
     // This version of the command must be used when files are created in the 
     // context of creating a brand new dataset (from the Add Dataset page):
     
@@ -636,6 +640,7 @@ public class CreateNewDataFilesCommand extends AbstractCommand<CreateDataFileRes
                 createIngestFailureReport(datafile, warningMessage);
                 datafile.SetIngestProblem();
             }
+            logger.info("datafile size: " + datafile.getFilesize());
             if (datafile.getFilesize() < 0) {
                 datafile.setFilesize(fileSize);
             }
@@ -654,6 +659,7 @@ public class CreateNewDataFilesCommand extends AbstractCommand<CreateDataFileRes
                 quota.setTotalUsageInBytes(quota.getTotalUsageInBytes() + fileSize);
             }
 
+            logger.info("datafile size (again): " + datafile.getFilesize());
             return CreateDataFileResult.success(fileName, finalType, datafiles);
         }
 

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/CreateNewDataFilesCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/CreateNewDataFilesCommand.java
@@ -640,7 +640,6 @@ public class CreateNewDataFilesCommand extends AbstractCommand<CreateDataFileRes
                 createIngestFailureReport(datafile, warningMessage);
                 datafile.SetIngestProblem();
             }
-            logger.info("datafile size: " + datafile.getFilesize());
             if (datafile.getFilesize() < 0) {
                 datafile.setFilesize(fileSize);
             }
@@ -659,7 +658,6 @@ public class CreateNewDataFilesCommand extends AbstractCommand<CreateDataFileRes
                 quota.setTotalUsageInBytes(quota.getTotalUsageInBytes() + fileSize);
             }
 
-            logger.info("datafile size (again): " + datafile.getFilesize());
             return CreateDataFileResult.success(fileName, finalType, datafiles);
         }
 

--- a/src/main/java/edu/harvard/iq/dataverse/globus/GlobusServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/globus/GlobusServiceBean.java
@@ -1093,7 +1093,7 @@ public class GlobusServiceBean implements java.io.Serializable {
         // The old code had 2 sec. of sleep, so ...
         Thread.sleep(2000);
 
-        Response addFilesResponse = addFileHelper.addFiles(newjsonData, dataset, authUser);
+        Response addFilesResponse = addFileHelper.addFiles(newjsonData, dataset, authUser, true);
 
         if (addFilesResponse == null) {
             logger.info("null response from addFiles call");

--- a/src/main/java/edu/harvard/iq/dataverse/globus/GlobusServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/globus/GlobusServiceBean.java
@@ -986,11 +986,15 @@ public class GlobusServiceBean implements java.io.Serializable {
             inputList.add(fileId + "IDsplit" + fullPath + "IDsplit" + fileName);
         }
         
-        // Look up the sizes of all the files in the dataset folder, to avoid 
-        // looking them up one by one later:
-        // @todo: we should only be doing this if this is a managed store, probably? 
-        GlobusEndpoint endpoint = getGlobusEndpoint(dataset);
-        Map<String, Long> fileSizeMap = lookupFileSizes(endpoint, endpoint.getBasePath());
+        Map<String, Long> fileSizeMap = null; 
+        
+        if (filesJsonArray.size() >= systemConfig.getGlobusBatchLookupSize()) {
+            // Look up the sizes of all the files in the dataset folder, to avoid 
+            // looking them up one by one later:
+            // @todo: we should only be doing this if this is a managed store, probably (?) 
+            GlobusEndpoint endpoint = getGlobusEndpoint(dataset);
+            fileSizeMap = lookupFileSizes(endpoint, endpoint.getBasePath());
+        }
 
         // calculateMissingMetadataFields: checksum, mimetype
         JsonObject newfilesJsonObject = calculateMissingMetadataFields(inputList, myLogger);
@@ -1034,7 +1038,7 @@ public class GlobusServiceBean implements java.io.Serializable {
                             .add("/fileSize", Json.createValue(uploadedFileSize)).build();
                     fileJsonObject = patch.apply(fileJsonObject);
                 } else {
-                    logger.warning("No file size entry found for file "+fileId);
+                    logger.fine("No file size entry found for file "+fileId);
                 }
                 addFilesJsonData.add(fileJsonObject);
                 countSuccess++;

--- a/src/main/java/edu/harvard/iq/dataverse/ingest/IngestServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/ingest/IngestServiceBean.java
@@ -350,7 +350,7 @@ public class IngestServiceBean {
                         // to S3 that go through the jsf dataset page. Or the Globus
                         // uploads, where the file sizes are looked up in bulk on 
                         // the completion of the remote upload task. 
-                        if (dataFile.getFilesize() > 0) {
+                        if (dataFile.getFilesize() >= 0) {
                             confirmedFileSize = dataFile.getFilesize();
                         } else {
                             dataAccess.open(DataAccessOption.READ_ACCESS);

--- a/src/main/java/edu/harvard/iq/dataverse/ingest/IngestServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/ingest/IngestServiceBean.java
@@ -344,10 +344,20 @@ public class IngestServiceBean {
                     try {
                         StorageIO<DvObject> dataAccess = DataAccess.getStorageIO(dataFile);
                         //Populate metadata
-                        dataAccess.open(DataAccessOption.READ_ACCESS);
-                        // (the .open() above makes a remote call to check if 
-                        // the file exists and obtains its size)
-                        confirmedFileSize = dataAccess.getSize();
+                        
+                        // There are direct upload sub-cases where the file size 
+                        // is already known at this point. For example, direct uploads
+                        // to S3 that go through the jsf dataset page. Or the Globus
+                        // uploads, where the file sizes are looked up in bulk on 
+                        // the completion of the remote upload task. 
+                        if (dataFile.getFilesize() > 0) {
+                            confirmedFileSize = dataFile.getFilesize();
+                        } else {
+                            dataAccess.open(DataAccessOption.READ_ACCESS);
+                            // (the .open() above makes a remote call to check if 
+                            // the file exists and obtains its size)
+                            confirmedFileSize = dataAccess.getSize();
+                        }
                         
                         // For directly-uploaded files, we will perform the file size
                         // limit and quota checks here. Perform them *again*, in 
@@ -362,13 +372,16 @@ public class IngestServiceBean {
                         if (fileSizeLimit == null || confirmedFileSize < fileSizeLimit) {
                         
                             //set file size
-                            logger.fine("Setting file size: " + confirmedFileSize);
-                            dataFile.setFilesize(confirmedFileSize);
+                            if (dataFile.getFilesize() < 1) {
+                                logger.fine("Setting file size: " + confirmedFileSize);
+                                dataFile.setFilesize(confirmedFileSize);
+                            }
                                                 
                             if (dataAccess instanceof S3AccessIO) {
                                 ((S3AccessIO<DvObject>) dataAccess).removeTempTag();
                             }
                             savedSuccess = true;
+                            logger.info("directly uploaded file successfully saved. file size: "+dataFile.getFilesize());
                         }
                     } catch (IOException ioex) {
                         logger.warning("Failed to get file size, storage id, or failed to remove the temp tag on the saved S3 object" + dataFile.getStorageIdentifier() + " ("

--- a/src/main/java/edu/harvard/iq/dataverse/ingest/IngestServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/ingest/IngestServiceBean.java
@@ -372,7 +372,7 @@ public class IngestServiceBean {
                         if (fileSizeLimit == null || confirmedFileSize < fileSizeLimit) {
                         
                             //set file size
-                            if (dataFile.getFilesize() < 1) {
+                            if (dataFile.getFilesize() < 0) {
                                 logger.fine("Setting file size: " + confirmedFileSize);
                                 dataFile.setFilesize(confirmedFileSize);
                             }

--- a/src/main/java/edu/harvard/iq/dataverse/settings/SettingsServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/settings/SettingsServiceBean.java
@@ -539,6 +539,12 @@ public class SettingsServiceBean {
          *
          */
         GlobusSingleFileTransfer,
+        /** Lower limit of the number of files in a Globus upload task where 
+         * the batch mode should be utilized in looking up the file information 
+         * on the remote end node (file sizes, primarily), instead of individual
+         * lookups. 
+         */
+        GlobusBatchLookupSize,
         /**
          * Optional external executables to run on the metadata for dataverses 
          * and datasets being published; as an extra validation step, to 

--- a/src/main/java/edu/harvard/iq/dataverse/util/SystemConfig.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/SystemConfig.java
@@ -78,6 +78,7 @@ public class SystemConfig {
     public static final long defaultZipDownloadLimit = 104857600L; // 100MB
     private static final int defaultMultipleUploadFilesLimit = 1000;
     private static final int defaultLoginSessionTimeout = 480; // = 8 hours
+    private static final int defaultGlobusBatchLookupSize = 50; 
     
     private String buildNumber = null;
     
@@ -954,6 +955,11 @@ public class SystemConfig {
         return (isGlobusDownload() && settingsService.isTrueForKey(SettingsServiceBean.Key.GlobusSingleFileTransfer, false));
     }
 
+    public int getGlobusBatchLookupSize() {
+        String batchSizeOption = settingsService.getValueForKey(SettingsServiceBean.Key.GlobusBatchLookupSize);
+        return getIntLimitFromStringOrDefault(batchSizeOption, defaultGlobusBatchLookupSize);
+    }
+    
     private Boolean getMethodAvailable(String method, boolean upload) {
         String methods = settingsService.getValueForKey(
                 upload ? SettingsServiceBean.Key.UploadMethods : SettingsServiceBean.Key.DownloadMethods);

--- a/src/main/java/propertyFiles/Bundle.properties
+++ b/src/main/java/propertyFiles/Bundle.properties
@@ -843,7 +843,8 @@ notification.email.datasetWasMentioned=Hello {0},<br><br> The {1} has just been 
 notification.email.datasetWasMentioned.subject={0}: A Dataset Relationship has been reported!
 notification.email.globus.uploadCompleted.subject={0}: Files uploaded successfully via Globus and verified
 notification.email.globus.downloadCompleted.subject={0}: Files downloaded successfully via Globus
-notification.email.globus.uploadCompletedWithErrors.subject={0}:  Uploaded files via Globus with errors
+notification.email.globus.downloadCompletedWithErrors.subject={0}: Globus download task completed, errors encountered
+notification.email.globus.uploadCompletedWithErrors.subject={0}: Globus upload task completed with errors
 notification.email.globus.uploadFailedRemotely.subject={0}:  Failed to upload files via Globus
 notification.email.globus.uploadFailedLocally.subject={0}:  Failed to add files uploaded via Globus to dataset
 # dataverse.xhtml

--- a/src/main/java/propertyFiles/Bundle.properties
+++ b/src/main/java/propertyFiles/Bundle.properties
@@ -307,7 +307,13 @@ notification.typeDescription.WORKFLOW_FAILURE=External workflow run has failed
 notification.typeDescription.STATUSUPDATED=Status of dataset has been updated
 notification.typeDescription.DATASETCREATED=Dataset was created by user
 notification.typeDescription.DATASETMENTIONED=Dataset was referenced in remote system
-
+notification.typeDescription.GLOBUSUPLOADCOMPLETED=Globus upload is completed
+notification.typeDescription.GLOBUSUPLOADCOMPLETEDWITHERRORS=Globus upload completed with errors
+notification.typeDescription.GLOBUSDOWNLOADCOMPLETED=Globus download is completed
+notification.typeDescription.GLOBUSDOWNLOADCOMPLETEDWITHERRORS=Globus download completed with errors
+notification.typeDescription.GLOBUSUPLOADLOCALFAILURE=Globus upload failed, internal error
+notification.typeDescription.GLOBUSUPLOADREMOTEFAILURE=Globus upload failed, remote transfer error
+notification.typeDescription.REQUESTEDFILEACCESS=File access requested
 groupAndRoles.manageTips=Here is where you can access and manage all the groups you belong to, and the roles you have been assigned.
 user.message.signup.label=Create Account
 user.message.signup.tip=Why have a Dataverse account? To create your own dataverse and customize it, add datasets, or request access to restricted files.


### PR DESCRIPTION
**What this PR does / why we need it**:

See the linked issue. 

**Which issue(s) this PR closes**:

- Closes #10977
- Closes #11030

**Special notes for your reviewer**:

The guide entry explains what was done in the PR. 
My own big concern (aside from a large portion of the code in GlobusServiceBean needing an overall refactoring) is that we have very few tests for the Globus functionality, and I am at a bit of loss how to create such tests. I may go ahead and open a separate issue for that effort. 

**Suggestions on how to test this**:

Globus functionality can be tested on dataverse-internal. There is one NESE storage volume (labeled `NESEtapeDemo`) that's identical to that in prod., except it is connected to a NESE volume specifically reserved for testing. The [instructions](https://github.com/IQSS/dataverse.harvard.edu/blob/master/doc/globus/README.md) for the prod. end users should work exactly the same way on dataverse-internal. 

The actual test would involve successfully uploading a large enough number of files in a single batch to trigger the new optimization.  This would be 50+ files by default; alternatively, the `:GlobusBatchLookupSize` setting could be set to some lower number for this test. 

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
