### PR TITLE
fix search files to return latest published citation

### DIFF
--- a/doc/release-notes/10735-search-dataset-name-and-dataset-citation-different.md
+++ b/doc/release-notes/10735-search-dataset-name-and-dataset-citation-different.md
@@ -1,0 +1,4 @@
+
+### Search files Bug fix
+
+dataset-citation was displaying DRAFT version instead of latest released version

--- a/src/main/java/edu/harvard/iq/dataverse/search/IndexServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/search/IndexServiceBean.java
@@ -1328,7 +1328,8 @@ public class IndexServiceBean {
             }
             LocalDate embargoEndDate=null;
             LocalDate retentionEndDate=null;
-            final String datasetCitation = dataset.getCitation();
+            final String datasetCitation = (dataset.isReleased() && dataset.getReleasedVersion() != null) ?
+                    dataset.getCitation(dataset.getReleasedVersion()) : dataset.getCitation();
             final Long datasetId = dataset.getId();
             final String datasetGlobalId = dataset.getGlobalId().toString();
             for (FileMetadata fileMetadata : fileMetadatas) {


### PR DESCRIPTION
**What this PR does / why we need it**: Search should not return DRAFT information when a dataset is updated after publishing

**Which issue(s) this PR closes**:https://github.com/IQSS/dataverse/issues/10735

- Closes #10735

**Special notes for your reviewer**:

**Suggestions on how to test this**: Follow the steps listed in the issue.
open in browser: http://localhost:8080/api/v1/search?q=*&type=file&sort=date&order=desc&per_page=10&start=0&subtree=root

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: No

**Is there a release notes update needed for this change?**: Included

**Additional documentation**:
