### PR TITLE
comment out /dv/lang to prevent verbose logging

### DIFF
--- a/doc/sphinx-guides/source/container/running/demo.rst
+++ b/doc/sphinx-guides/source/container/running/demo.rst
@@ -140,19 +140,25 @@ One you make this change it should be visible in the copyright in the bottom lef
 Multiple Languages
 ++++++++++++++++++
 
-Generally speaking, you'll want to follow :ref:`i18n` in the Installation Guide to set up multiple languages such as English and French.
+Generally speaking, you'll want to follow :ref:`i18n` in the Installation Guide to set up multiple languages. (You need to create your own "languages.zip" file, for example.) Here will give you guidance specific to this demo tutorial. We'll be setting up a toggle between English and French.
 
-To set up the toggle between English and French, we'll use a slight variation on the command in the instructions above, adding the unblock key we created above:
+First, edit the ``compose.yml`` file and uncomment the following line:
 
-``curl "http://localhost:8080/api/admin/settings/:Languages?unblock-key=unblockme" -X PUT -d '[{"locale":"en","title":"English"},{"locale":"fr","title":"Français"}]'``
+.. code-block:: text
 
-Similarly, when loading the "languages.zip" file, we'll add the unblock key:
+        #-Ddataverse.lang.directory=/dv/lang
+
+Next, upload "languages.zip" to the "loadpropertyfiles" API endpoint as shown below. This should place files ending in ".properties" into the ``/dv/lang`` directory configured above.
+
+Please note that we are using a slight variation on the command in the instructions above, adding the unblock key we created above:
 
 ``curl "http://localhost:8080/api/admin/datasetfield/loadpropertyfiles?unblock-key=unblockme" -X POST --upload-file /tmp/languages/languages.zip -H "Content-Type: application/zip"``
 
-Stop and start the Dataverse container in order for the language toggle to work.
+Next, set up the UI toggle between English and French, again using the unblock key:
 
-Note that ``dataverse.lang.directory=/dv/lang`` has already been configured for you in the ``compose.yml`` file. The step where you loaded "languages.zip" should have populated the ``/dv/lang`` directory with files ending in ".properties".
+``curl "http://localhost:8080/api/admin/settings/:Languages?unblock-key=unblockme" -X PUT -d '[{"locale":"en","title":"English"},{"locale":"fr","title":"Français"}]'``
+
+Stop and start the Dataverse container in order for the language toggle to work.
 
 Next Steps
 ----------

--- a/doc/sphinx-guides/source/container/running/demo.rst
+++ b/doc/sphinx-guides/source/container/running/demo.rst
@@ -148,7 +148,7 @@ First, edit the ``compose.yml`` file and uncomment the following line:
 
         #-Ddataverse.lang.directory=/dv/lang
 
-Next, upload "languages.zip" to the "loadpropertyfiles" API endpoint as shown below. This should place files ending in ".properties" into the ``/dv/lang`` directory configured above.
+Next, upload "languages.zip" to the "loadpropertyfiles" API endpoint as shown below. This will place files ending in ".properties" into the ``/dv/lang`` directory configured above.
 
 Please note that we are using a slight variation on the command in the instructions above, adding the unblock key we created above:
 

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -57,7 +57,7 @@ services:
         -Ddataverse.pid.fake.label=FakeDOIProvider
         -Ddataverse.pid.fake.authority=10.5072
         -Ddataverse.pid.fake.shoulder=FK2/
-        -Ddataverse.lang.directory=/dv/lang
+        #-Ddataverse.lang.directory=/dv/lang
     ports:
       - "8080:8080" # HTTP (Dataverse Application)
       - "4949:4848" # HTTPS (Payara Admin Console)

--- a/docker/compose/demo/compose.yml
+++ b/docker/compose/demo/compose.yml
@@ -26,7 +26,7 @@ services:
         -Ddataverse.pid.fake.label=FakeDOIProvider
         -Ddataverse.pid.fake.authority=10.5072
         -Ddataverse.pid.fake.shoulder=FK2/
-        -Ddataverse.lang.directory=/dv/lang
+        #-Ddataverse.lang.directory=/dv/lang
     ports:
       - "8080:8080" # HTTP (Dataverse Application)
       - "4848:4848" # HTTP (Payara Admin Console)


### PR DESCRIPTION
**What this PR does / why we need it**:

When I created this pull request:

- #10940

... I didn't test it in a fresh environment where I hadn't loaded languages.zip.

In this PR, I'm commenting out `/dev/lang` and updating the instructions to explain that you should uncomment the `/dev/lang` line if you want multiple languages.

**Which issue(s) this PR closes**:

- Closes #11043

**Special notes for your reviewer**:

You can preview the docs at https://dataverse-guide--11063.org.readthedocs.build/en/11063/container/running/demo.html#multiple-languages

**Suggestions on how to test this**:

Make sure the two compose files still work. We could retest the language setup but it should be unchanged.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No.

**Is there a release notes update needed for this change?**:

No, the release note in #11043 is generic enough that it's fine as-is.

**Additional documentation**:

See https://dataverse-guide--11063.org.readthedocs.build/en/11063/container/running/demo.html#multiple-languages