### PR TITLE
Update Metadata Customization page to suggest how to implement booleans

### DIFF
--- a/doc/release-notes/11064-update-metadata-customization.md
+++ b/doc/release-notes/11064-update-metadata-customization.md
@@ -1,0 +1,1 @@
+Metadata Customization guide has been updated to explain how to implement a kind of boolean fieldtype (see [Metadata Customization Guide](https://guides.dataverse.org/en/latest/admin/metadatacustomization.html#controlledvocabulary-enumerated-properties))

--- a/doc/sphinx-guides/source/admin/metadatacustomization.rst
+++ b/doc/sphinx-guides/source/admin/metadatacustomization.rst
@@ -259,9 +259,9 @@ Each of the three main sections own sets of properties:
 |              |                                            | an existing #datasetField from          |
 |              |                                            | another metadata block.)                |
 +--------------+--------------------------------------------+-----------------------------------------+
-| Value        | A short display string, representing       | Free text                               |
-|              | an enumerated value for this field. If     |                                         |
-|              | the identifier property is empty,          |                                         |
+| Value        | A short display string, representing       | Free text. As boolean, values "True"    |
+|              | an enumerated value for this field. If     | and "False" are recommended, "Unknown"  |
+|              | the identifier property is empty,          | value is an option.                     |
 |              | this value is used as the identifier.      |                                         |
 +--------------+--------------------------------------------+-----------------------------------------+
 | identifier   | A string used to encode the selected       | Free text                               |
@@ -293,6 +293,9 @@ FieldType definitions
 +---------------+------------------------------------+
 | text          | Any text other than newlines may   |
 |               | be entered into this field.        |
+|               | The text fieldtype can be used     |
+|               | combined with                      |
+|               | #controlledVocabulary as boolean.  |
 +---------------+------------------------------------+
 | textbox       | Any text may be entered. For       |
 |               | input, the Dataverse Software      |

--- a/doc/sphinx-guides/source/admin/metadatacustomization.rst
+++ b/doc/sphinx-guides/source/admin/metadatacustomization.rst
@@ -295,7 +295,7 @@ FieldType definitions
 +---------------+------------------------------------+
 | text          | Any text other than newlines may   |
 |               | be entered into this field.        |
-|               | The text fieldtype may used to     |
+|               | The text fieldtype may be used to  |
 |               | define a boolean (see "Value"      |
 |               | under :ref:`cvoc-props`).          |
 +---------------+------------------------------------+


### PR DESCRIPTION
**What this PR does / why we need it**:

Explains how to implement a kind of boolean fieldtype in metadata customization
Related to https://github.com/IQSS/dataverse/issues/7961#issuecomment-2520594083

**Which issue(s) this PR closes**:

- Closes #7961

**Is there a release notes update needed for this change?**:

Included.

Preview doc changes at https://dataverse-guide--11064.org.readthedocs.build/en/11064/admin/metadatacustomization.html (search for "boolean").