### PR TITLE
IQSS/11069 fix index status query

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DataFileServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DataFileServiceBean.java
@@ -1407,8 +1407,7 @@ public class DataFileServiceBean implements java.io.Serializable {
     }
 
     public boolean isInReleasedVersion(Long id) {
-        Query query = em.createQuery("SELECT fm.id FROM FileMetadata fm, DvObject dvo WHERE fm.datasetVersion.id=(SELECT dv.id FROM DatasetVersion dv WHERE dv.dataset.id=dvo.owner.id and dv.versionState=edu.harvard.iq.dataverse.DatasetVersion.VersionState.RELEASED ORDER BY dv.versionNumber DESC, dv.minorVersionNumber DESC LIMIT 1) AND dvo.id=fm.dataFile.id AND fm.dataFile.id=:fid");
-        query.setParameter("fid", id);
+        Query query = em.createNativeQuery("SELECT fm.id FROM filemetadata fm WHERE fm.datasetversion_id=(SELECT dv.id FROM datasetversion dv, dvobject dvo WHERE dv.dataset_id=dvo.owner_id AND dv.versionState='RELEASED' and dvo.id=" + id + " ORDER BY dv.versionNumber DESC, dv.minorVersionNumber DESC LIMIT 1) AND fm.datafile_id=" + id);
         
         try {
             query.getSingleResult();

--- a/src/main/java/edu/harvard/iq/dataverse/search/IndexServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/search/IndexServiceBean.java
@@ -1151,9 +1151,7 @@ public class IndexServiceBean {
                                 logger.fine(solrFieldFacetable + " gets " + vals);
                                 solrInputDocument.addField(solrFieldFacetable, vals);
                             }
-                        }
-
-                        if (dsfType.isControlledVocabulary()) {
+                        } else if (dsfType.isControlledVocabulary()) {
                             /** If the cvv list is empty but the dfv list is not then it is assumed this was harvested
                              *  from an installation that had controlled vocabulary entries that don't exist in our this db
                              * @see <a href="https://github.com/IQSS/dataverse/issues/9992">Feature Request/Idea: Harvest metadata values that aren't from a list of controlled values #9992</a>
@@ -1301,7 +1299,6 @@ public class IndexServiceBean {
                 solrInputDocument.addField(SearchFields.DATASET_DEACCESSION_REASON, deaccessionNote);
             }
         }
-
         docs.add(solrInputDocument);
 
         /**
@@ -2235,8 +2232,7 @@ public class IndexServiceBean {
                     String dtype = dvObjectService.getDtype(id);
                     if (dtype == null) {
                         permissionInSolrOnly.add(docId);
-                    }
-                    if (dtype.equals(DType.Dataset.getDType())) {
+                    }else if (dtype.equals(DType.Dataset.getDType())) {
                         List<String> states = datasetService.getVersionStates(id);
                         if (states != null) {
                             String latestState = states.get(states.size() - 1);
@@ -2257,7 +2253,7 @@ public class IndexServiceBean {
                     } else if (dtype.equals(DType.DataFile.getDType())) {
                         List<VersionState> states = dataFileService.findVersionStates(id);
                         Set<String> strings = states.stream().map(VersionState::toString).collect(Collectors.toSet());
-                        logger.fine("States for " + docId + ": " + String.join(", ", strings));
+                        logger.finest("States for " + docId + ": " + String.join(", ", strings));
                         if (docId.endsWith("draft_permission")) {
                             if (!states.contains(VersionState.DRAFT)) {
                                 permissionInSolrOnly.add(docId);
@@ -2271,7 +2267,7 @@ public class IndexServiceBean {
                                 permissionInSolrOnly.add(docId);
                             } else {
                                 if (!dataFileService.isInReleasedVersion(id)) {
-                                    logger.fine("Adding doc " + docId + " to list of permissions in Solr only");
+                                    logger.finest("Adding doc " + docId + " to list of permissions in Solr only");
                                     permissionInSolrOnly.add(docId);
                                 }
                             }


### PR DESCRIPTION
**What this PR does / why we need it**: This PR fixes the query used in the admin/index/status API call. A last minute change to the query in #10710 added during review used a feature only allowed in native queries. The change in this PR adapts the query to use native syntax to fix the /index/status call.

It also fixes two other issues that can break the status call and indexing in general for single value fields used with a cvoc script. In both cases, an 'else if' is needed rather than a 'if' in the code. In the status case this resulted in a null pointer exception when orphan permission docs exist. In the latter, two code sections were adding the same field to the solr document. With a single/non-multi field (e.g. depositor) this resulted in multiple values in a single-value solr field.

**Which issue(s) this PR closes**:

- Closes #11069

**Special notes for your reviewer**: The PR also drops some per-file logging to finest to simplify debugging.

**Suggestions on how to test this**: Try the api/admin/index/status call, verify that it completes and provides a report in the server.log. For the orphan permission error - there shouldn't be a null pointer reported in server.log when there are orphan permission docs. If your repository doesn't have any, I'm not sure it's worth trying to generate them. For the cvoc error, I think the external cvoc config in use on demo, which should have the depositor field associated with the ORCID script, should show the problem. (The problem doesn't appear in v6.4 for some reason afaik, but some change in 6.5 has surfaced the issue.)  In addition to seeing the dataset indexed when a depositor entry exists, you can also look for any logs in the logs/process-failures subdirectory. There should not be any related to the dataset being tested.)

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
