### PR TITLE
#11076 Allow User with View Unpublished Dataset Perms to access Preview URL without becoming Preview URL User

### DIFF
--- a/src/main/webapp/dataset.xhtml
+++ b/src/main/webapp/dataset.xhtml
@@ -1193,7 +1193,7 @@
                             <p>#{bundle['dataset.privateurl.general.description']}</p>     
                             <p:commandButton styleClass="btn btn-default" 
                                              value="#{bundle['dataset.privateurl.general.button.label']}" 
-                                             action="#{DatasetPage.createPrivateUrl(false)}" update="privateUrlPanel,:messagePanel" 
+                                             action="#{DatasetPage.createPrivateUrl(false)}" update="privateUrlPanel,:messagePanel,disablePrivateUrlConfirmation" 
                                              disabled="#{(!empty(DatasetPage.privateUrl) and DatasetPage.anonymizedPrivateUrl)}"
                                              rendered="#{empty(DatasetPage.privateUrl)  or (!empty(DatasetPage.privateUrl) and DatasetPage.anonymizedPrivateUrl) }"/>    
                             <p:fragment rendered="#{!empty(DatasetPage.privateUrl) and !DatasetPage.anonymizedPrivateUrl}">
@@ -1213,7 +1213,7 @@
                                <button class="btn btn-default btn-copy" data-clipboard-text="#{DatasetPage.getPrivateUrlLink(DatasetPage.privateUrl)}" jsf:rendered="#{!empty(DatasetPage.privateUrl)}" type="button">
                                     #{bundle['copyClipboard']}
                                 </button>
-                                <p:commandButton styleClass="btn btn-default" value="#{bundle['dataset.privateurl.disableGeneralPreviewUrl']}" action="#{DatasetPage.setPrivateUrlJustCreatedToFalse()}" oncomplete="PF('privateUrlConfirmation').hide();PF('disablePrivateUrlConfirmation').show()" rendered="#{!empty(DatasetPage.privateUrl)}" update="privateUrlPanel,:messagePanel"/>
+                                <p:commandButton styleClass="btn btn-default" value="#{bundle['dataset.privateurl.disableGeneralPreviewUrl']}" action="#{DatasetPage.setPrivateUrlJustCreatedToFalse()}" oncomplete="PF('privateUrlConfirmation').hide();PF('disablePrivateUrlConfirmation').show()" rendered="#{!empty(DatasetPage.privateUrl)}" update="privateUrlPanel,:messagePanel,disablePrivateUrlConfirmation"/>
                             </div>
                             </p:fragment>    
                                 
@@ -1252,7 +1252,7 @@
                                <button class="btn btn-default btn-copy" data-clipboard-text="#{DatasetPage.getPrivateUrlLink(DatasetPage.privateUrl)}" jsf:rendered="#{!empty(DatasetPage.privateUrl)}" type="button">
                                     #{bundle['copyClipboard']}
                                 </button>
-                                <p:commandButton styleClass="btn btn-default" value="#{bundle['dataset.privateurl.disableAnonPreviewUrl']}" action="#{DatasetPage.setPrivateUrlJustCreatedToFalse()}" oncomplete="PF('privateUrlConfirmation').hide();PF('disablePrivateUrlConfirmation').show()" rendered="#{!empty(DatasetPage.privateUrl)}" update="privateUrlPanel,:messagePanel"/>
+                                <p:commandButton styleClass="btn btn-default" value="#{bundle['dataset.privateurl.disableAnonPreviewUrl']}" action="#{DatasetPage.setPrivateUrlJustCreatedToFalse()}" oncomplete="PF('privateUrlConfirmation').hide();PF('disablePrivateUrlConfirmation').show()" rendered="#{!empty(DatasetPage.privateUrl)}" update="privateUrlPanel,:messagePanel,disablePrivateUrlConfirmation"/>
                             </div>    
                             </p:fragment>
                             <ui:remove>   


### PR DESCRIPTION
**What this PR does / why we need it**:
Going back to 2020 there was a known issue that as a logged in user with permission on the draft version of a dataset, if you accessed a preview url while logged in you would be logged out.

**Which issue(s) this PR closes**:

- Closes #11076 Disable Preview URL not working
- Closes #11047 Disabling Preview URL fails if you switch types

**Special notes for your reviewer**:
Added a test to the Private URL init method

**Suggestions on how to test this**:
Access Preview URL while logged in with View Unpublished Version Permissions. You should remain logged in and see the full draft version.

If you access a Preview URL while logged in as someone without View Unpublished, you will be logged out (be changed to a Preview URL user)

If not logged in, Preview URL access should be unchanged.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
No

**Is there a release notes update needed for this change?**:
Edge case - probably not worth noting

**Additional documentation**:
