### PR TITLE
Fix testDeleteFile

### DIFF
--- a/src/test/java/edu/harvard/iq/dataverse/api/FilesIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/FilesIT.java
@@ -2274,9 +2274,6 @@ public class FilesIT {
         // Check file 2 still in v1.0
         Response v1 = UtilIT.getDatasetVersion(datasetPid, "1.0", apiToken);
         v1.prettyPrint();
-        v1.then().assertThat()
-                .body("data.files[0].dataFile.filename", equalTo("cc0.png"))
-                .statusCode(OK.getStatusCode());
         
         Map<String, Object> v1files1 = with(v1.body().asString()).param("fileToFind", "cc0.png")
                 .getJsonObject("data.files.find { files -> files.label == fileToFind }");
@@ -2289,9 +2286,6 @@ public class FilesIT {
         // Check file 3 still in post v1.0 draft
         Response postv1draft2 = UtilIT.getDatasetVersion(datasetPid, DS_VERSION_DRAFT, apiToken);
         postv1draft2.prettyPrint();
-        postv1draft2.then().assertThat()
-                .body("data.files[0].dataFile.filename", equalTo("orcid_16x16.png"))
-                .statusCode(OK.getStatusCode());
         
         Map<String, Object> v1files2 = with(postv1draft2.body().asString()).param("fileToFind", "orcid_16x16.png")
                 .getJsonObject("data.files.find { files -> files.label == fileToFind }");

--- a/src/test/java/edu/harvard/iq/dataverse/api/FilesIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/FilesIT.java
@@ -2274,6 +2274,8 @@ public class FilesIT {
         // Check file 2 still in v1.0
         Response v1 = UtilIT.getDatasetVersion(datasetPid, "1.0", apiToken);
         v1.prettyPrint();
+        v1.then().assertThat()
+                .statusCode(OK.getStatusCode());
         
         Map<String, Object> v1files1 = with(v1.body().asString()).param("fileToFind", "cc0.png")
                 .getJsonObject("data.files.find { files -> files.label == fileToFind }");
@@ -2286,6 +2288,8 @@ public class FilesIT {
         // Check file 3 still in post v1.0 draft
         Response postv1draft2 = UtilIT.getDatasetVersion(datasetPid, DS_VERSION_DRAFT, apiToken);
         postv1draft2.prettyPrint();
+        postv1draft2.then().assertThat()
+                .statusCode(OK.getStatusCode());
         
         Map<String, Object> v1files2 = with(postv1draft2.body().asString()).param("fileToFind", "orcid_16x16.png")
                 .getJsonObject("data.files.find { files -> files.label == fileToFind }");


### PR DESCRIPTION
**What this PR does / why we need it**: We've recently seen testDeleteFile fail to find a file (cc0.png) because the test looks for the data.files[0] element when the file is actually in data.files[1]. I've verified that between Jenkins runs where the test fails and then succeeds, that the order of files in the array is simply reversed. The code already had secondary checks for the files based on a path-based check for a file with the correct name, so I've simply deleted the checks that are hardcoded to the array position.

**Which issue(s) this PR closes**:

- Closes #

**Special notes for your reviewer**: We have MANY checks for files at data.files[0] in the test code. I don't know how many of them are checks when there are multiple files, and we (AFAIK) haven't seen other test failures due to this. That said, we may want to enforce a consistent order in the returned files to avoid more tests breaking which might make the API easier to use as well (if files are always in id order for example). With some checking in recent code, I didn't see where a change to order (making it random) might have occurred.

**Suggestions on how to test this**: Verify the tests pass. Watch over time to see that there are no testDeleteFile failures in other PRs after this is merged.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
