### PR TITLE
extended search API

### DIFF
--- a/conf/solr/schema.xml
+++ b/conf/solr/schema.xml
@@ -204,7 +204,7 @@
     <field name="fileContentType" type="string" stored="true" indexed="true" multiValued="false"/>
     <field name="deaccessionReason" type="string" stored="true" indexed="false" multiValued="false"/>
     <field name="fileRestricted" type="boolean" stored="true" indexed="false" multiValued="false"/>
-    <field name="fileDownloadable" type="boolean" stored="true" indexed="false" multiValued="false"/>
+    <field name="canDownloadFile" type="boolean" stored="true" indexed="false" multiValued="false"/>
 
     <!-- Added for Dataverse 4.0 alpha 1. This is a required field so we don't have to go to the database to get the database id of the entity. On cards we use the id in links -->
     <field name="entityId" type="plong" stored="true" indexed="true" multiValued="false"/>

--- a/conf/solr/schema.xml
+++ b/conf/solr/schema.xml
@@ -167,6 +167,8 @@
     <field name="fileNameWithoutExtension" type="text_en" stored="true" indexed="true" multiValued="true"/>
     <field name="variableName" type="text_en" stored="true" indexed="true" multiValued="true"/>
     <field name="variableLabel" type="text_en" stored="true" indexed="true" multiValued="true"/>
+    <field name="variableCount" type="plong" stored="true" indexed="false" multiValued="false"/>
+    <field name="observations" type="plong" stored="true" indexed="false" multiValued="false"/>
 
     <field name="literalQuestion" type="text_en" stored="true" indexed="true" multiValued="true"/>
     <field name="interviewInstructions" type="text_en" stored="true" indexed="true" multiValued="true"/>
@@ -201,6 +203,8 @@
     <field name="fileChecksumValue" type="string" stored="true" indexed="true" multiValued="false"/>
     <field name="fileContentType" type="string" stored="true" indexed="true" multiValued="false"/>
     <field name="deaccessionReason" type="string" stored="true" indexed="false" multiValued="false"/>
+    <field name="fileRestricted" type="boolean" stored="true" indexed="false" multiValued="false"/>
+    <field name="fileDownloadable" type="boolean" stored="true" indexed="false" multiValued="false"/>
 
     <!-- Added for Dataverse 4.0 alpha 1. This is a required field so we don't have to go to the database to get the database id of the entity. On cards we use the id in links -->
     <field name="entityId" type="plong" stored="true" indexed="true" multiValued="false"/>

--- a/doc/release-notes/11027-extend-datasets-files-from-search-api.md
+++ b/doc/release-notes/11027-extend-datasets-files-from-search-api.md
@@ -13,8 +13,10 @@ For tabular files:
 
 
 
-New fields added to solr schema.xml:
+New fields added to solr schema.xml (Note: upgrade instructions will need to include instructions for schema.xml):
 <field name="fileRestricted" type="boolean" stored="true" indexed="false" multiValued="false"/>
 <field name="canDownloadFile" type="boolean" stored="true" indexed="false" multiValued="false"/>
+<field name="variableCount" type="plong" stored="true" indexed="false" multiValued="false"/>
+<field name="observations" type="plong" stored="true" indexed="false" multiValued="false"/>
 
 See https://github.com/IQSS/dataverse/issues/11027

--- a/doc/release-notes/11027-extend-datasets-files-from-search-api.md
+++ b/doc/release-notes/11027-extend-datasets-files-from-search-api.md
@@ -7,6 +7,7 @@ For Files:
 - canDownloadFile: boolean ( from file user permission)
 - categories: array of string "categories" would be similar to what it is in metadata api.
 For tabular files:
+- tabularTags: array of string for example,{"tabularTags" : ["Event", "Genomics", "Geospatial"]}
 - variables: number/int shows how many variables we have for the tabular file
 - observations: number/int shows how many observations for the tabular file
 

--- a/doc/release-notes/11027-extend-datasets-files-from-search-api.md
+++ b/doc/release-notes/11027-extend-datasets-files-from-search-api.md
@@ -1,0 +1,19 @@
+### Feature to extend Search API for SPA
+
+Added new fields to search results type=files
+
+For Files:
+- restricted: boolean
+- canDownloadFile: boolean ( from file user permission)
+- categories: array of string "categories" would be similar to what it is in metadata api.
+For tabular files:
+- variables: number/int shows how many variables we have for the tabular file
+- observations: number/int shows how many observations for the tabular file
+
+
+
+New fields added to solr schema.xml:
+<field name="fileRestricted" type="boolean" stored="true" indexed="false" multiValued="false"/>
+<field name="fileDownloadable" type="boolean" stored="true" indexed="false" multiValued="false"/>
+
+See https://github.com/IQSS/dataverse/issues/11027

--- a/doc/release-notes/11027-extend-datasets-files-from-search-api.md
+++ b/doc/release-notes/11027-extend-datasets-files-from-search-api.md
@@ -14,6 +14,6 @@ For tabular files:
 
 New fields added to solr schema.xml:
 <field name="fileRestricted" type="boolean" stored="true" indexed="false" multiValued="false"/>
-<field name="fileDownloadable" type="boolean" stored="true" indexed="false" multiValued="false"/>
+<field name="canDownloadFile" type="boolean" stored="true" indexed="false" multiValued="false"/>
 
 See https://github.com/IQSS/dataverse/issues/11027

--- a/src/main/java/edu/harvard/iq/dataverse/search/IndexServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/search/IndexServiceBean.java
@@ -1580,6 +1580,7 @@ public class IndexServiceBean {
                     }
                     datafileSolrInputDocument.addField(SearchFields.FILE_CHECKSUM_TYPE, fileMetadata.getDataFile().getChecksumType().toString());
                     datafileSolrInputDocument.addField(SearchFields.FILE_CHECKSUM_VALUE, fileMetadata.getDataFile().getChecksumValue());
+                    datafileSolrInputDocument.addField(SearchFields.FILE_RESTRICTED, fileMetadata.getDataFile().isRestricted());
                     datafileSolrInputDocument.addField(SearchFields.DESCRIPTION, fileMetadata.getDescription());
                     datafileSolrInputDocument.addField(SearchFields.FILE_DESCRIPTION, fileMetadata.getDescription());
                     GlobalId filePid = fileMetadata.getDataFile().getGlobalId();
@@ -1602,6 +1603,9 @@ public class IndexServiceBean {
                     // names and labels:
                     if (fileMetadata.getDataFile().isTabularData()) {
                         List<DataVariable> variables = fileMetadata.getDataFile().getDataTable().getDataVariables();
+                        Long observations = fileMetadata.getDataFile().getDataTable().getCaseQuantity();
+                        datafileSolrInputDocument.addField(SearchFields.OBSERVATIONS, observations);
+                        datafileSolrInputDocument.addField(SearchFields.VARIABLE_COUNT, variables.size());
                         
                         Map<Long, VariableMetadata> variableMap = null;
                         List<VariableMetadata> variablesByMetadata = variableService.findVarMetByFileMetaId(fileMetadata.getId());

--- a/src/main/java/edu/harvard/iq/dataverse/search/SearchFields.java
+++ b/src/main/java/edu/harvard/iq/dataverse/search/SearchFields.java
@@ -171,6 +171,7 @@ public class SearchFields {
     public static final String FILE_CHECKSUM_TYPE = "fileChecksumType";
     public static final String FILE_CHECKSUM_VALUE = "fileChecksumValue";
     public static final String FILENAME_WITHOUT_EXTENSION = "fileNameWithoutExtension";
+    public static final String FILE_RESTRICTED = "fileRestricted";
     /**
      * Indexed as a string so we can facet on it.
      */
@@ -270,6 +271,8 @@ public class SearchFields {
      */
     public static final String DATASET_TYPE = "datasetType";
 
+    public static final String OBSERVATIONS = "observations";
+    public static final String VARIABLE_COUNT = "variableCount";
     public static final String VARIABLE_NAME = "variableName";
     public static final String VARIABLE_LABEL = "variableLabel";
     public static final String LITERAL_QUESTION = "literalQuestion";

--- a/src/main/java/edu/harvard/iq/dataverse/search/SearchServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/search/SearchServiceBean.java
@@ -1,6 +1,7 @@
 package edu.harvard.iq.dataverse.search;
 
 import edu.harvard.iq.dataverse.*;
+import edu.harvard.iq.dataverse.authorization.Permission;
 import edu.harvard.iq.dataverse.authorization.groups.Group;
 import edu.harvard.iq.dataverse.authorization.groups.GroupServiceBean;
 import edu.harvard.iq.dataverse.authorization.users.AuthenticatedUser;
@@ -18,6 +19,7 @@ import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -75,6 +77,8 @@ public class SearchServiceBean {
     SystemConfig systemConfig;
     @EJB
     SolrClientService solrClientService;
+    @EJB
+    PermissionServiceBean permissionService;
     @Inject
     ThumbnailServiceWrapper thumbnailServiceWrapper;
     
@@ -677,6 +681,15 @@ public class SearchServiceBean {
                     logger.info("Exception setting setFileChecksumType: " + ex);
                 }
                 solrSearchResult.setFileChecksumValue((String) solrDocument.getFieldValue(SearchFields.FILE_CHECKSUM_VALUE));
+
+                if (solrDocument.getFieldValue(SearchFields.FILE_RESTRICTED) != null) {
+                    solrSearchResult.setFileRestricted((Boolean) solrDocument.getFieldValue(SearchFields.FILE_RESTRICTED));
+                }
+
+                if (solrSearchResult.getEntity() != null) {
+                    solrSearchResult.setCanDownloadFile(permissionService.hasPermissionsFor(dataverseRequest, solrSearchResult.getEntity(), EnumSet.of(Permission.DownloadFile)));
+                }
+
                 solrSearchResult.setUnf((String) solrDocument.getFieldValue(SearchFields.UNF));
                 solrSearchResult.setDatasetVersionId(datasetVersionId);
                 List<String> fileCategories = (List) solrDocument.getFieldValues(SearchFields.FILE_TAG);
@@ -688,6 +701,10 @@ public class SearchServiceBean {
                     Collections.sort(tabularDataTags);
                     solrSearchResult.setTabularDataTags(tabularDataTags);
                 }
+                Long observations = (Long) solrDocument.getFieldValue(SearchFields.OBSERVATIONS);
+                solrSearchResult.setObservations(observations);
+                Long tabCount = (Long) solrDocument.getFieldValue(SearchFields.VARIABLE_COUNT);
+                solrSearchResult.setTabularDataCount(tabCount);
                 String filePID = (String) solrDocument.getFieldValue(SearchFields.FILE_PERSISTENT_ID);
                 if(null != filePID && !"".equals(filePID) && !"".equals("null")) {
                     solrSearchResult.setFilePersistentId(filePID);

--- a/src/main/java/edu/harvard/iq/dataverse/search/SolrSearchResult.java
+++ b/src/main/java/edu/harvard/iq/dataverse/search/SolrSearchResult.java
@@ -1102,12 +1102,16 @@ public class SolrSearchResult {
         this.fileChecksumValue = fileChecksumValue;
     }
 
-    public Boolean getFileRestricted() { return fileRestricted; }
+    public Boolean getFileRestricted() {
+        return fileRestricted;
+    }
 
     public void setFileRestricted(Boolean fileRestricted) {
         this.fileRestricted = fileRestricted;
     }
-    public Boolean getCanDownloadFile() { return canDownloadFile; }
+    public Boolean getCanDownloadFile() {
+        return canDownloadFile;
+    }
 
     public void setCanDownloadFile(Boolean canDownloadFile) {
         this.canDownloadFile = canDownloadFile;

--- a/src/main/java/edu/harvard/iq/dataverse/search/SolrSearchResult.java
+++ b/src/main/java/edu/harvard/iq/dataverse/search/SolrSearchResult.java
@@ -591,6 +591,9 @@ public class SolrSearchResult {
         if (this.fileCategories != null && !this.fileCategories.isEmpty()) {
             nullSafeJsonBuilder.add("categories", JsonPrinter.asJsonArray(this.fileCategories));
         }
+        if (this.tabularDataTags != null && !this.tabularDataTags.isEmpty()) {
+            nullSafeJsonBuilder.add("tabularTags", JsonPrinter.asJsonArray(this.tabularDataTags));
+        }
 
         if (this.entity == null) {
 

--- a/src/main/java/edu/harvard/iq/dataverse/search/SolrSearchResult.java
+++ b/src/main/java/edu/harvard/iq/dataverse/search/SolrSearchResult.java
@@ -97,6 +97,8 @@ public class SolrSearchResult {
     private String fileMd5;
     private DataFile.ChecksumType fileChecksumType;
     private String fileChecksumValue;
+    private Boolean fileRestricted;
+    private Boolean canDownloadFile;
     private String dataverseAlias;
     private String dataverseParentAlias;
     private String dataverseParentName;
@@ -122,6 +124,8 @@ public class SolrSearchResult {
     private String harvestingDescription = null;
     private List<String> fileCategories = null;
     private List<String> tabularDataTags = null;
+    private Long tabularDataCount;
+    private Long observations;
 
     private String identifierOfDataverse = null;
     private String nameOfDataverse = null;
@@ -565,7 +569,12 @@ public class SolrSearchResult {
                 .add("citationHtml", this.citationHtml)
                 .add("identifier_of_dataverse", this.identifierOfDataverse)
                 .add("name_of_dataverse", this.nameOfDataverse)
-                .add("citation", this.citation);
+                .add("citation", this.citation)
+                .add("restricted", this.fileRestricted)
+                .add("variables", this.tabularDataCount)
+                .add("observations", this.observations)
+                .add("canDownloadFile", this.canDownloadFile);
+
         // Now that nullSafeJsonBuilder has been instatiated, check for null before adding to it!
         if (showRelevance) {
             nullSafeJsonBuilder.add("matches", getRelevance());
@@ -578,6 +587,9 @@ public class SolrSearchResult {
         }
         if (!getPublicationStatuses().isEmpty()) {
             nullSafeJsonBuilder.add("publicationStatuses", getPublicationStatusesAsJSON());
+        }
+        if (this.fileCategories != null && !this.fileCategories.isEmpty()) {
+            nullSafeJsonBuilder.add("categories", JsonPrinter.asJsonArray(this.fileCategories));
         }
 
         if (this.entity == null) {
@@ -956,6 +968,18 @@ public class SolrSearchResult {
     public void setTabularDataTags(List<String> tabularDataTags) {
         this.tabularDataTags = tabularDataTags;
     }
+    public void setTabularDataCount(Long tabularDataCount) {
+        this.tabularDataCount = tabularDataCount;
+    }
+    public Long getTabularDataCount() {
+        return tabularDataCount;
+    }
+    public Long getObservations() {
+        return observations;
+    }
+    public void setObservations(Long observations) {
+        this.observations = observations;
+    }
 
     public Map<String, String> getParent() {
         return parent;
@@ -1076,6 +1100,15 @@ public class SolrSearchResult {
 
     public void setFileChecksumValue(String fileChecksumValue) {
         this.fileChecksumValue = fileChecksumValue;
+    }
+
+    public Boolean getFileRestricted() { return fileRestricted; }
+    public void setFileRestricted(Boolean fileRestricted) {
+        this.fileRestricted = fileRestricted;
+    }
+    public Boolean getCanDownloadFile() { return canDownloadFile; }
+    public void setCanDownloadFile(Boolean canDownloadFile) {
+        this.canDownloadFile = canDownloadFile;
     }
 
     public String getNameSort() {

--- a/src/main/java/edu/harvard/iq/dataverse/search/SolrSearchResult.java
+++ b/src/main/java/edu/harvard/iq/dataverse/search/SolrSearchResult.java
@@ -1103,10 +1103,12 @@ public class SolrSearchResult {
     }
 
     public Boolean getFileRestricted() { return fileRestricted; }
+
     public void setFileRestricted(Boolean fileRestricted) {
         this.fileRestricted = fileRestricted;
     }
     public Boolean getCanDownloadFile() { return canDownloadFile; }
+
     public void setCanDownloadFile(Boolean canDownloadFile) {
         this.canDownloadFile = canDownloadFile;
     }

--- a/src/main/java/edu/harvard/iq/dataverse/util/json/NullSafeJsonBuilder.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/json/NullSafeJsonBuilder.java
@@ -85,7 +85,10 @@ public class NullSafeJsonBuilder implements JsonObjectBuilder {
 		delegate.add(name, value);
 		return this;
 	}
-    
+	public NullSafeJsonBuilder add(String name, Boolean value) {
+		return (value != null) ? add(name, value.booleanValue()) : this;
+	}
+
 	@Override
 	public NullSafeJsonBuilder addNull(String name) {
 		delegate.addNull(name);


### PR DESCRIPTION
**What this PR does / why we need it**: For the SPA, in order to display the lock icon, and tags/categories information for items in the collection page, we should add some extra properties to each file item from search api once type=file.

- restricted: boolean
- canDownloadFile: boolean ( from file user permission)
- categories: array of string "categories" would be similar to what it is in metadata api, for example, {"label":"blob","description":"","restricted":true,"categories":["Data","Documentation"],"id":6}

For tabular files, there are some properties needed additionally.

- tabularTags: array of string for example,{"tabularTags" : ["Event", "Genomics", "Geospatial"]}
- variables: number/int shows how many variables we have for the tabular file
- observations: number/int shows how many observations for the tabular file

Also, for dataset search api type=dataset, because datasets' thumbnail should be displayed, an extra property is needed.

- thumbnail: string

**Which issue(s) this PR closes**: https://github.com/IQSS/dataverse/issues/11027

- Closes #11027

**Special notes for your reviewer**: Dataset field "thumbnail" is already included as "image_url" so it was not added

**Suggestions on how to test this**: See SearchIT

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**: Included

**Additional documentation**:
