### PR TITLE
switch container demo tutorial from FAKE to perma

### DIFF
--- a/doc/release-notes/11107-fake-to-perma-demo.md
+++ b/doc/release-notes/11107-fake-to-perma-demo.md
@@ -1,0 +1,3 @@
+### Demo/Eval Container Tutorial
+
+The demo/eval container tutorial has been updated to use the Permalink PID provider instead of the FAKE DOI Provider. See also #11107.

--- a/doc/sphinx-guides/source/container/running/demo.rst
+++ b/doc/sphinx-guides/source/container/running/demo.rst
@@ -160,6 +160,11 @@ Next, set up the UI toggle between English and French, again using the unblock k
 
 Stop and start the Dataverse container in order for the language toggle to work.
 
+PID Providers
++++++++++++++
+
+Dataverse supports multiple Persistent ID (PID) providers. The ``compose.yml`` file uses the Permalink PID provider. Follow :ref:`pids-configuration` to reconfigure as needed.
+
 Next Steps
 ----------
 

--- a/docker/compose/demo/compose.yml
+++ b/docker/compose/demo/compose.yml
@@ -20,12 +20,12 @@ services:
         -Ddataverse.files.file1.type=file
         -Ddataverse.files.file1.label=Filesystem
         -Ddataverse.files.file1.directory=${STORAGE_DIR}/store
-        -Ddataverse.pid.providers=fake
-        -Ddataverse.pid.default-provider=fake
-        -Ddataverse.pid.fake.type=FAKE
-        -Ddataverse.pid.fake.label=FakeDOIProvider
-        -Ddataverse.pid.fake.authority=10.5072
-        -Ddataverse.pid.fake.shoulder=FK2/
+        -Ddataverse.pid.providers=perma1
+        -Ddataverse.pid.default-provider=perma1
+        -Ddataverse.pid.perma1.type=perma
+        -Ddataverse.pid.perma1.label=Perma1
+        -Ddataverse.pid.perma1.authority=DV
+        -Ddataverse.pid.perma1.permalink.separator=/
         #-Ddataverse.lang.directory=/dv/lang
     ports:
       - "8080:8080" # HTTP (Dataverse Application)


### PR DESCRIPTION
**What this PR does / why we need it**:

The Permalink PID provider is well suited to dev, devo, and evaluation environments. Partially inspired by a [question](https://dataverse.zulipchat.com/#narrow/channel/378866-troubleshooting/topic/Custom.20.E2.80.9CPerma.E2.80.9D.20PID.20Setup.20.26.20Indexing.20Problem/near/489429388) about how to set it up, we decided to go ahead and update the compose.yml file used in our demo/eval tutorial ([6.5 version](https://guides.dataverse.org/en/6.5/container/running/demo.html)) to use Permalinks instead of the FAKE DOI provider.

**Which issue(s) this PR closes**:

- Closes #11107

**Special notes for your reviewer**:

As I mentioned in Slack, I still think [the docs](https://iqss.slack.com/archives/C03R1E7T4KA/p1734539709498769) are a bit off but I didn't want to muddy the waters too much in this PR.

**Suggestions on how to test this**:

Follow the tutorial. Make sure a dataset is properly indexed.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No, but as shown in the screenshot below, PIDs look something like this: perma:DV/ADTGQL

In the citation, the URL form is shown, like this: http://localhost:8080/citation?persistentId=perma:DV/ADTGQL

![Screenshot 2024-12-18 at 3 17 35 PM](https://github.com/user-attachments/assets/467fb395-65ff-4fb5-8e1e-74e0e04d8190)

**Is there a release notes update needed for this change?**:

Yes, added.

**Additional documentation**:

Preview at https://dataverse-guide--11108.org.readthedocs.build/en/11108/container/running/demo.html
