### PR TITLE
IQSS/11113 fix file perm doc creation

### DIFF
--- a/doc/release-notes/11113-avoid-orphan-perm-docs.md
+++ b/doc/release-notes/11113-avoid-orphan-perm-docs.md
@@ -1,0 +1,5 @@
+This release fixes a bug that caused Dataverse to generate unnecessary solr documents for files when a file is added/deleted from a draft dataset. These documents could accumulate and potentially impact performance.
+
+Assuming the upgrade to solr 9.7.0 also occurs in this release, there's nothing else needed for this PR. (Starting with a new solr insures the solr db is empty and that a reindex is already required.)
+
+

--- a/src/main/java/edu/harvard/iq/dataverse/DataFile.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DataFile.java
@@ -1142,4 +1142,12 @@ public class DataFile extends DvObject implements Comparable {
         }
         return inDeaccessionedVersions; // since any published version would have already returned
     }
+    public boolean isInDatasetVersion(DatasetVersion version) {
+        for (FileMetadata fmd : getFileMetadatas()) {
+            if (fmd.getDatasetVersion().equals(version)) {
+                return true;
+            }
+        }
+        return false;
+    }
 } // end of class

--- a/src/main/java/edu/harvard/iq/dataverse/search/SolrIndexServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/search/SolrIndexServiceBean.java
@@ -155,7 +155,7 @@ public class SolrIndexServiceBean {
         Map<DatasetVersion.VersionState, Boolean> desiredCards = searchPermissionsService.getDesiredCards(dataFile.getOwner());
         for (DatasetVersion datasetVersionFileIsAttachedTo : datasetVersionsToBuildCardsFor(dataFile.getOwner())) {
             boolean cardShouldExist = desiredCards.get(datasetVersionFileIsAttachedTo.getVersionState());
-            if (cardShouldExist) {
+            if (cardShouldExist && dataFile.isInDatasetVersion(datasetVersionFileIsAttachedTo)) {
                 String solrIdStart = IndexServiceBean.solrDocIdentifierFile + dataFile.getId();
                 String solrIdEnd = getDatasetOrDataFileSolrEnding(datasetVersionFileIsAttachedTo.getVersionState());
                 String solrId = solrIdStart + solrIdEnd;

--- a/src/main/java/edu/harvard/iq/dataverse/search/SolrIndexServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/search/SolrIndexServiceBean.java
@@ -155,6 +155,14 @@ public class SolrIndexServiceBean {
         Map<DatasetVersion.VersionState, Boolean> desiredCards = searchPermissionsService.getDesiredCards(dataFile.getOwner());
         for (DatasetVersion datasetVersionFileIsAttachedTo : datasetVersionsToBuildCardsFor(dataFile.getOwner())) {
             boolean cardShouldExist = desiredCards.get(datasetVersionFileIsAttachedTo.getVersionState());
+            /*
+             * Since datasetVersionFileIsAttachedTo should be a draft or the most recent
+             * released one, it could be more efficient to stop the search through
+             * FileMetadatas after those two (versus continuing through all prior versions
+             * as in isInDatasetVersion). Alternately, perhaps filesToReIndexPermissionsFor
+             * should not combine the list of files for the different datsetversions into a
+             * single list to start with.
+             */ 
             if (cardShouldExist && dataFile.isInDatasetVersion(datasetVersionFileIsAttachedTo)) {
                 String solrIdStart = IndexServiceBean.solrDocIdentifierFile + dataFile.getId();
                 String solrIdEnd = getDatasetOrDataFileSolrEnding(datasetVersionFileIsAttachedTo.getVersionState());


### PR DESCRIPTION
**What this PR does / why we need it**: This PR adds a check in the indexing code to only create a file permission doc in solr only for the datasetversions the file is in.

**Which issue(s) this PR closes**:

- Closes #11113

**Special notes for your reviewer**: As the note in the code suggests, there are cleaner ways to do this but since this is a relatively rare case (indexing when there is a currently draft version where a file has been added/dropped) I'm not sure refactoring to get more efficiency is worth the effort. (Not to say that adding/removing files is rare, but having two versions to index only occurs while there is a draft and presumably a draft like this doesn't often stay around forever, so I'm guessing this affects only a small number of files per index run. With the bug, the orphan perm docs do accumulate over time though, so fixing the bug somehow is worthwhile.)

**Suggestions on how to test this**: Create a dataset(s), where the draft version has files not in the original published version or vice versa. Then run /api/admin/index/status and you should see orphaned perm docs (docs in solr but not in the db). After the PR, this should not happen. (If you use the same solr, run /api/admin/index/clear-orphans and either edit the dataset to cause reindexing or just reindex it via the api.)

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**: included

**Additional documentation**:
