### PR TITLE
in "requested access" email, add space after link to prevent it from breaking 

### DIFF
--- a/doc/release-notes/10384-link.md
+++ b/doc/release-notes/10384-link.md
@@ -1,0 +1,3 @@
+### Broken Link in Email When Users Request Access to Files
+
+When users request access to a files, the people who have permission to grant access receive an email with a link in it that didn't work due to a trailing period (full stop) right next to the link (e.g. `https://demo.dataverse.org/permissions-manage-files.xhtml?id=9.`) A space has been added to fix this. See #10384 and #11115.

--- a/src/main/java/propertyFiles/Bundle.properties
+++ b/src/main/java/propertyFiles/Bundle.properties
@@ -804,7 +804,7 @@ notification.email.greeting.html=Hello, <br>
 # Bundle file editors, please note that "notification.email.welcome" is used in a unit test
 notification.email.welcome=Welcome to {0}! Get started by adding or finding data. Have questions? Check out the User Guide at {1}/{2}/user or contact {3} at {4} for assistance.
 notification.email.welcomeConfirmEmailAddOn=\n\nPlease verify your email address at {0} . Note, the verify link will expire after {1}. Send another verification email by visiting your account page.
-notification.email.requestFileAccess=File access requested for dataset: {0} by {1} ({2}). Manage permissions at {3}.
+notification.email.requestFileAccess=File access requested for dataset: {0} by {1} ({2}). Manage permissions at {3} .
 notification.email.requestFileAccess.guestbookResponse=<br><br>Guestbook Response:<br><br>{0}
 notification.email.grantFileAccess=Access granted for files in dataset: {0} (view at {1} ).
 notification.email.rejectFileAccess=Your request for access was rejected for the requested files in the dataset: {0} (view at {1} ). If you have any questions about why your request was rejected, you may reach the dataset owner using the "Contact" link on the upper right corner of the dataset page.


### PR DESCRIPTION
**What this PR does / why we need it**:

Otherwise, the link doesn't work.

**Which issue(s) this PR closes**:

- Closes #10384

**Special notes for your reviewer**:

None.

**Suggestions on how to test this**:

Test manually or run `mvn test -Dtest=AccessIT#testRequestAccess` and then look at the emails generated.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

## Before (e.g. "id=9.")

![Screenshot 2024-12-19 at 2 30 10 PM](https://github.com/user-attachments/assets/3085cb92-5eee-45fc-9cea-6193a6cefa44)

## After (e.g. "id=19 .")

![Screenshot 2024-12-19 at 2 34 42 PM](https://github.com/user-attachments/assets/32ae313e-ba3c-4579-b086-88db6f38a825)

**Is there a release notes update needed for this change?**:

**Additional documentation**:
