### PR TITLE
IQSS/11133-search-fix

### DIFF
--- a/doc/release-notes/11133-search-fix.md
+++ b/doc/release-notes/11133-search-fix.md
@@ -1,0 +1,3 @@
+### Search fix when using AVOID_EXPENSIVE_SOLR_JOIN=true
+
+Dataverse v6.5 introduced a bug which causes search to fail for non-superusers in multiple groups when the AVOID_EXPENSIVE_SOLR_JOIN feature flag is set to true. This releases fixes the bug.

--- a/src/main/java/edu/harvard/iq/dataverse/search/SearchServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/search/SearchServiceBean.java
@@ -335,9 +335,13 @@ public class SearchServiceBean {
         // -----------------------------------
         // PERMISSION FILTER QUERY
         // -----------------------------------
-        String permissionFilterQuery = this.getPermissionFilterQuery(dataverseRequest, solrQuery, onlyDatatRelatedToMe, addFacets);
-        if (!StringUtils.isBlank(permissionFilterQuery)) {
-            solrQuery.addFilterQuery(permissionFilterQuery);
+        String permissionFilterQuery = getPermissionFilterQuery(dataverseRequest, solrQuery, onlyDatatRelatedToMe, addFacets);
+        if (!permissionFilterQuery.isEmpty()) {
+            String[] filterParts = permissionFilterQuery.split("&q1=");
+            solrQuery.addFilterQuery(filterParts[0]);
+            if(filterParts.length > 1 ) {
+                solrQuery.add("q1", filterParts[1]);
+            }
         }
         
         /**
@@ -1099,9 +1103,9 @@ public class SearchServiceBean {
         String query = (avoidJoin&& !isAllGroups(permissionFilterGroups)) ? SearchFields.PUBLIC_OBJECT + ":" + true : "";
         if (permissionFilterGroups != null && !isAllGroups(permissionFilterGroups)) {
             if (!query.isEmpty()) {
-                query = "(" + query + " OR " + "{!join from=" + SearchFields.DEFINITION_POINT + " to=id}" + SearchFields.DISCOVERABLE_BY + ":" + permissionFilterGroups + ")";
+                query = "(" + query + " OR " + "{!join from=" + SearchFields.DEFINITION_POINT + " to=id v=$q1})&q1=" + SearchFields.DISCOVERABLE_BY + ":" + permissionFilterGroups;
             } else {
-                query = "{!join from=" + SearchFields.DEFINITION_POINT + " to=id}" + SearchFields.DISCOVERABLE_BY + ":" + permissionFilterGroups;
+                query = "{!join from=" + SearchFields.DEFINITION_POINT + " to=id v=$q1}&q1=" + SearchFields.DISCOVERABLE_BY + ":" + permissionFilterGroups;
             }
         }
         return query;


### PR DESCRIPTION
**What this PR does / why we need it**: Uses the form of the join query we need that works. (There was a reversion on #10706.) As noted in the issue, this only affects the case when the AVOID_EXPENSIVE_SOLR_JOIN is true and the user is in multiple groups and is not a superuser.

**Which issue(s) this PR closes**:

- Closes #11133

**Special notes for your reviewer**:

**Suggestions on how to test this**:  Create a user in multiple groups that is not a super user, set `dataverse.feature.avoid-expensive-solr-join` to true, restart payara, and verify that this user can see public data and their own datasets. Regression test that other users aren't affected.  Note that `dataverse.feature.add-publicobject-solr-field` must also be set true (and payara restarted) and reindexing done if that wasn't true before. (This flag makes indexing add the publicObject_b=true flag for public objects which is what allows us to avoid the expensive join.)

[edit from @landreev:] Strictly speaking, this PR contains a small change in how search queries are formed when NOT in the "avoid solr join" mode as well; so, yet another regression test would be to also verify that searches are working properly **without** this optimization enabled. It is extremely unlikely that there are any such problems though. 
demo.dataverse.org now has this solr optimization mode enabled, mirroring the production. This means that, going forward, any issue like this will get detected when the release candidate is deployed on demo as part of of the release process. 


**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
