### PR TITLE
fix: correctly set "multiValued" property in Solr schema for deeply nested fields

### DIFF
--- a/doc/release-notes/11136-solr-nested.md
+++ b/doc/release-notes/11136-solr-nested.md
@@ -1,0 +1,1 @@
+Deeply nested metadata fields are not supported but the code used to generate the Solr schema has been adjusted to support them. See #11136.

--- a/src/main/java/edu/harvard/iq/dataverse/DatasetFieldType.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetFieldType.java
@@ -541,17 +541,26 @@ public class DatasetFieldType implements Serializable, Comparable<DatasetFieldTy
                 solrType = SolrField.SolrType.FLOAT;
             }
 
-            Boolean parentAllowsMultiplesBoolean = false;
-            if (isHasParent()) {
-                if (getParentDatasetFieldType() != null) {
-                    DatasetFieldType parent = getParentDatasetFieldType();
-                    parentAllowsMultiplesBoolean = parent.isAllowMultiples();
+            Boolean anyParentAllowsMultiplesBoolean = false;
+            DatasetFieldType currentDatasetFieldType = this;
+            // Traverse up through all parents of dataset field type
+            // If any one of them allows multiples, this child's Solr field must be multi-valued
+            while (currentDatasetFieldType.isHasParent()) {
+                if (currentDatasetFieldType.getParentDatasetFieldType() != null) {
+                    DatasetFieldType parent = currentDatasetFieldType.getParentDatasetFieldType();
+                    if (parent.isAllowMultiples()) {
+                        anyParentAllowsMultiplesBoolean = true;
+                        break; // no need to keep traversing
+                    }
+                    currentDatasetFieldType = parent;
+                } else {
+                    break;
                 }
             }
             
             boolean makeSolrFieldMultivalued;
             // http://stackoverflow.com/questions/5800762/what-is-the-use-of-multivalued-field-type-in-solr
-            if (allowMultiples || parentAllowsMultiplesBoolean || isControlledVocabulary()) {
+            if (allowMultiples || anyParentAllowsMultiplesBoolean || isControlledVocabulary()) {
                 makeSolrFieldMultivalued = true;
             } else {
                 makeSolrFieldMultivalued = false;


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes a bug in the `/api/admin/index/solr/schema` endpoint reported in #9200. The `multiValued` property was not set correctly for some deeply nested metadata fields, causing indexing errors:

`org.apache.solr.common.SolrException: ERROR: [doc=dataset_1479] multiple values encountered for non multiValued field`

This is because the code only checked for whether the direct parent of a metadata field is multi-valued to see whether a child metadata field must be declared as multi-valued in the Solr schema. However, all ancestor fields (parents, grandparents, etc.) need to be checked. This PR updates the code to handle deeper metadata nesting properly.

**Which issue(s) this PR closes**:

This is related to #9200, but doesn't close the issue, because it also describes UI issues related to deeply nested fields, but it's a fix of the Solr schema bug described there.

**Special notes for your reviewer**:

/

**Suggestions on how to test this**:

1. Upload TSV metadata block file e.g. [nested_compound_test2.csv](https://github.com/user-attachments/files/18348950/nested_compound_test2.csv) (had to rename to CSV to upload here)
2. Activate metadata block
3. Use `/api/admin/index/solr/schema` to update Solr's `schema.xml`
4. Reload Solr

(see https://guides.dataverse.org/en/latest/admin/metadatacustomization.html#updating-the-solr-schema)

5. Upload dataset as JSON e.g. [nested_compound_test2.json](https://github.com/user-attachments/files/18348987/nested_compound_test2.json)
6. Confirm the dataset indexes without errors

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

/

**Is there a release notes update needed for this change?**:

/

**Additional documentation**:

/
