### PR TITLE
prevent DOCS_AND_FREQS_AND_POSITIONS Solr error

### DIFF
--- a/doc/release-notes/10887-solr-field-types.md
+++ b/doc/release-notes/10887-solr-field-types.md
@@ -73,6 +73,26 @@ Now start Solr.
 
 8\. Reindex Solr
 
+Note: these instructions are a little different than usual because we observed a strange error about `DOCS_AND_FREQS_AND_POSITIONS` when testing upgrades (see #11139 for details). Extra steps about explicitly clearing the index and reloading the core are included. If you run into trouble, as a last resort, you could reinstall Solr completely and then reindex.
+
+Clear the Solr index:
+
+```shell
+curl http://localhost:8080/api/admin/index/clear
+```
+
+Make sure the Solr index is empty:
+
+```shell
+curl "http://localhost:8983/solr/collection1/select?rows=1000000&wt=json&indent=true&q=*%3A*"
+```
+
+Reload the Solr core:
+
+```shell
+curl "http://localhost:8983/solr/admin/cores?action=RELOAD&core=collection1"
+```
+
 Below is the simplest way to reindex Solr:
 
 ```shell


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR updates the release note added for #10887 to prevent a strange "DOCS_AND_FREQS_AND_POSITIONS" error we observed switching to the Solr schema.xml in that PR.

**Which issue(s) this PR closes**:

- Closes #11139

**Special notes for your reviewer**:

**Suggestions on how to test this**:

Two ways:

Try to reproduce #11139 on a classic installation where we've kept the Solr index (internal or beta, maybe?). [edit: not internal - I erased the old index there before reindexing - L.A.]

In a Docker environment run code prior to #10887 (consider running the search tests with `mvn test -Dtest=SearchIT`). Then pull the latest to pick up #10887, upgrade your schema with `cp conf/solr/schema.xml docker-dev-volumes/solr/data/data/collection1/conf/schema.xml`, and then try to reproduce #11139.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No.

**Is there a release notes update needed for this change?**:

Yes, this PR updates release notes.

**Additional documentation**:

None.