### PR TITLE
Update Dataverse API removes metadatablocks if optional params are omitted

### DIFF
--- a/doc/release-notes/11130-update-dataverse-api-remove-metadatablocks.md
+++ b/doc/release-notes/11130-update-dataverse-api-remove-metadatablocks.md
@@ -1,0 +1,8 @@
+### Fixes consequences for not adding some optional fields in update dataverse API
+
+Omitting optional fields inputLevels, facetIds, or metadataBlockNames caused data to be deleted.
+This fix no longer deletes data for these fields. Two new flags have been added to the ``metadataBlocks`` Json object to signal the deletion of the data.
+- ``inheritMetadataBlocksFromParent: true`` will remove ``metadataBlockNames`` and ``inputLevels`` if the Json objects are omitted.
+- ``inheritFacetsFromParent: true`` will remove ``facetIds`` if the Json object is omitted.
+
+For more information, see issue [#11130](https://github.com/IQSS/dataverse/issues/11130)

--- a/doc/sphinx-guides/source/api/native-api.rst
+++ b/doc/sphinx-guides/source/api/native-api.rst
@@ -128,11 +128,22 @@ Note that setting any of these fields overwrites the previous configuration.
 
 When it comes to omitting these fields in the JSON:
 
-- Omitting ``facetIds`` or ``metadataBlockNames`` causes the Dataverse collection to inherit the corresponding configuration from its parent.
-- Omitting ``inputLevels`` removes any existing custom input levels in the Dataverse collection.
-- Omitting the entire ``metadataBlocks`` object in the request JSON would exclude the three sub-objects, resulting in the application of the two changes described above.
+- Omitting ``facetIds`` or ``metadataBlockNames`` causes no change to the Dataverse collection. To delete the current configuration and inherit the corresponding configuration from its parent include the flag ``inheritFacetsFromParent`` and/or ``inheritMetadataBlocksFromParent`` respectively.
+- Omitting ``inputLevels`` causes no change to the Dataverse collection. Including the flag ``inheritMetadataBlocksFromParent`` will cause the custom ``inputLevels`` to be deleted and inherited from the parent.
+- Omitting the entire ``metadataBlocks`` object in the request JSON would cause no change to the ``inputLevels``, ``facetIds`` or ``metadataBlockNames`` of the Dataverse collection.
 
 To obtain an example of how these objects are included in the JSON file, download :download:`dataverse-complete-optional-params.json <../_static/api/dataverse-complete-optional-params.json>` file and modify it to suit your needs.
+
+To force the configurations to be deleted and inherited from the parent's configuration include the following ``metadataBlocks`` object in your JSON
+
+.. code-block:: json
+
+  "metadataBlocks": {
+    "inheritMetadataBlocksFromParent": true,
+    "inheritFacetsFromParent": true
+  }
+
+.. note:: Including both the list ``metadataBlockNames`` and the flag ``"inheritMetadataBlocksFromParent": true`` will result in an error being returned {"status": "ERROR", "message": "Metadata block can not contain both metadataBlockNames and inheritMetadataBlocksFromParent: true"}. The same is true for ``facetIds`` and ``inheritFacetsFromParent``.
 
 See also :ref:`collection-attributes-api`.
 

--- a/src/main/java/edu/harvard/iq/dataverse/api/Dataverses.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Dataverses.java
@@ -1,5 +1,6 @@
 package edu.harvard.iq.dataverse.api;
 
+import com.google.common.collect.Lists;
 import edu.harvard.iq.dataverse.*;
 import edu.harvard.iq.dataverse.api.auth.AuthRequired;
 import edu.harvard.iq.dataverse.api.datadeposit.SwordServiceBean;
@@ -195,7 +196,7 @@ public class Dataverses extends AbstractApiBean {
             List<DatasetFieldType> facets = parseFacets(body);
 
             AuthenticatedUser u = getRequestAuthenticatedUserOrDie(crc);
-            dataverse = execCommand(new UpdateDataverseCommand(dataverse, facets, null, createDataverseRequest(u), inputLevels, metadataBlocks, updatedDataverseDTO, true));
+            dataverse = execCommand(new UpdateDataverseCommand(dataverse, facets, null, createDataverseRequest(u), inputLevels, metadataBlocks, updatedDataverseDTO));
             return ok(json(dataverse));
 
         } catch (WrappedResponse ww) {
@@ -221,31 +222,60 @@ public class Dataverses extends AbstractApiBean {
         }
     }
 
+    /*
+    return null - ignore
+    return empty list - delete and inherit from parent
+    return non-empty list - update
+    */
     private List<DataverseFieldTypeInputLevel> parseInputLevels(String body, Dataverse dataverse) throws WrappedResponse {
         JsonObject metadataBlocksJson = getMetadataBlocksJson(body);
-        if (metadataBlocksJson == null) {
-            return null;
+        JsonArray inputLevelsArray = metadataBlocksJson != null ? metadataBlocksJson.getJsonArray("inputLevels") : null;
+
+        if (metadataBlocksJson != null && metadataBlocksJson.containsKey("inheritMetadataBlocksFromParent") && metadataBlocksJson.getBoolean("inheritMetadataBlocksFromParent")) {
+            return Lists.newArrayList(); // delete
         }
-        JsonArray inputLevelsArray = metadataBlocksJson.getJsonArray("inputLevels");
-        return inputLevelsArray != null ? parseInputLevels(inputLevelsArray, dataverse) : null;
+        return parseInputLevels(inputLevelsArray, dataverse);
     }
 
+    /*
+    return null - ignore
+    return empty list - delete and inherit from parent
+    return non-empty list - update
+    */
     private List<MetadataBlock> parseMetadataBlocks(String body) throws WrappedResponse {
         JsonObject metadataBlocksJson = getMetadataBlocksJson(body);
-        if (metadataBlocksJson == null) {
-            return null;
+        JsonArray metadataBlocksArray = metadataBlocksJson != null ? metadataBlocksJson.getJsonArray("metadataBlockNames") : null;
+
+        if (metadataBlocksArray != null && metadataBlocksJson.containsKey("inheritMetadataBlocksFromParent") && metadataBlocksJson.getBoolean("inheritMetadataBlocksFromParent")) {
+            String errorMessage = MessageFormat.format(BundleUtil.getStringFromBundle("dataverse.metadatablocks.error.containslistandinheritflag"), "metadataBlockNames", "inheritMetadataBlocksFromParent");
+            throw new WrappedResponse(badRequest(errorMessage));
         }
-        JsonArray metadataBlocksArray = metadataBlocksJson.getJsonArray("metadataBlockNames");
-        return metadataBlocksArray != null ? parseNewDataverseMetadataBlocks(metadataBlocksArray) : null;
+        if (metadataBlocksJson != null && metadataBlocksJson.containsKey("inheritMetadataBlocksFromParent") && metadataBlocksJson.getBoolean("inheritMetadataBlocksFromParent")) {
+            return Lists.newArrayList(); // delete and inherit from parent
+        }
+
+        return parseNewDataverseMetadataBlocks(metadataBlocksArray);
     }
 
+    /*
+    return null - ignore
+    return empty list - delete and inherit from parent
+    return non-empty list - update
+    */
     private List<DatasetFieldType> parseFacets(String body) throws WrappedResponse {
         JsonObject metadataBlocksJson = getMetadataBlocksJson(body);
-        if (metadataBlocksJson == null) {
-            return null;
+        JsonArray facetsArray = metadataBlocksJson != null ? metadataBlocksJson.getJsonArray("facetIds") : null;
+
+        if (facetsArray != null && metadataBlocksJson.containsKey("inheritFacetsFromParent") && metadataBlocksJson.getBoolean("inheritFacetsFromParent")) {
+            String errorMessage = MessageFormat.format(BundleUtil.getStringFromBundle("dataverse.metadatablocks.error.containslistandinheritflag"), "facetIds", "inheritFacetsFromParent");
+            throw new WrappedResponse(badRequest(errorMessage));
         }
-        JsonArray facetsArray = metadataBlocksJson.getJsonArray("facetIds");
-        return facetsArray != null ? parseFacets(facetsArray) : null;
+
+        if (metadataBlocksJson != null && metadataBlocksJson.containsKey("inheritFacetsFromParent") && metadataBlocksJson.getBoolean("inheritFacetsFromParent")) {
+            return Lists.newArrayList(); // delete and inherit from parent
+        }
+
+        return parseFacets(facetsArray);
     }
 
     private JsonObject getMetadataBlocksJson(String body) {
@@ -277,6 +307,9 @@ public class Dataverses extends AbstractApiBean {
     }
 
     private List<MetadataBlock> parseNewDataverseMetadataBlocks(JsonArray metadataBlockNamesArray) throws WrappedResponse {
+        if (metadataBlockNamesArray == null) {
+            return null;
+        }
         List<MetadataBlock> selectedMetadataBlocks = new ArrayList<>();
         for (JsonString metadataBlockName : metadataBlockNamesArray.getValuesAs(JsonString.class)) {
             MetadataBlock metadataBlock = metadataBlockSvc.findByName(metadataBlockName.getString());
@@ -745,6 +778,9 @@ public class Dataverses extends AbstractApiBean {
     }
 
     private List<DataverseFieldTypeInputLevel> parseInputLevels(JsonArray inputLevelsArray, Dataverse dataverse) throws WrappedResponse {
+        if (inputLevelsArray == null) {
+            return null;
+        }
         List<DataverseFieldTypeInputLevel> newInputLevels = new ArrayList<>();
         for (JsonValue value : inputLevelsArray) {
             JsonObject inputLevel = (JsonObject) value;
@@ -771,6 +807,9 @@ public class Dataverses extends AbstractApiBean {
     }
 
     private List<DatasetFieldType> parseFacets(JsonArray facetsArray) throws WrappedResponse {
+        if (facetsArray == null) {
+            return null;
+        }
         List<DatasetFieldType> facets = new LinkedList<>();
         for (JsonString facetId : facetsArray.getValuesAs(JsonString.class)) {
             DatasetFieldType dsfType = findDatasetFieldType(facetId.getString());

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/AbstractWriteDataverseCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/AbstractWriteDataverseCommand.java
@@ -19,15 +19,13 @@ abstract class AbstractWriteDataverseCommand extends AbstractCommand<Dataverse> 
     private final List<DataverseFieldTypeInputLevel> inputLevels;
     private final List<DatasetFieldType> facets;
     protected final List<MetadataBlock> metadataBlocks;
-    private final boolean resetRelationsOnNullValues;
 
     public AbstractWriteDataverseCommand(Dataverse dataverse,
                                          Dataverse affectedDataverse,
                                          DataverseRequest request,
                                          List<DatasetFieldType> facets,
                                          List<DataverseFieldTypeInputLevel> inputLevels,
-                                         List<MetadataBlock> metadataBlocks,
-                                         boolean resetRelationsOnNullValues) {
+                                         List<MetadataBlock> metadataBlocks) {
         super(request, affectedDataverse);
         this.dataverse = dataverse;
         if (facets != null) {
@@ -45,7 +43,6 @@ abstract class AbstractWriteDataverseCommand extends AbstractCommand<Dataverse> 
         } else {
             this.metadataBlocks = null;
         }
-        this.resetRelationsOnNullValues = resetRelationsOnNullValues;
     }
 
     @Override
@@ -59,46 +56,61 @@ abstract class AbstractWriteDataverseCommand extends AbstractCommand<Dataverse> 
         return ctxt.dataverses().save(dataverse);
     }
 
+    /*
+      metadataBlocks = null - ignore
+      metadataBlocks is empty - delete and inherit from parent
+      metadataBlocks is not empty - set with new updated values
+    */
     private void processMetadataBlocks() {
-        if (metadataBlocks != null && !metadataBlocks.isEmpty()) {
-            dataverse.setMetadataBlockRoot(true);
-            dataverse.setMetadataBlocks(metadataBlocks);
-        } else if (resetRelationsOnNullValues) {
-            dataverse.setMetadataBlockRoot(false);
-            dataverse.clearMetadataBlocks();
+        if (metadataBlocks != null) {
+            if (metadataBlocks.isEmpty()) {
+                dataverse.setMetadataBlockRoot(false);
+                dataverse.clearMetadataBlocks();
+            } else {
+                dataverse.setMetadataBlockRoot(true);
+                dataverse.setMetadataBlocks(metadataBlocks);
+            }
         }
     }
 
+    /*
+      facets = null - ignore
+      facets is empty - delete and inherit from parent
+      facets is not empty - set with new updated values
+    */
     private void processFacets(CommandContext ctxt) {
         if (facets != null) {
-            ctxt.facets().deleteFacetsFor(dataverse);
-            dataverse.setDataverseFacets(new ArrayList<>());
-           
-            if (!facets.isEmpty()) {
+            if (facets.isEmpty()) {
+                ctxt.facets().deleteFacetsFor(dataverse);
+                dataverse.setFacetRoot(false);
+            } else {
+                ctxt.facets().deleteFacetsFor(dataverse);
+                dataverse.setDataverseFacets(new ArrayList<>());
                 dataverse.setFacetRoot(true);
+                for (int i = 0; i < facets.size(); i++) {
+                    ctxt.facets().create(i, facets.get(i), dataverse);
+                }
             }
-
-            for (int i = 0; i < facets.size(); i++) {
-                ctxt.facets().create(i, facets.get(i), dataverse);
-            }
-        } else if (resetRelationsOnNullValues) {
-            ctxt.facets().deleteFacetsFor(dataverse);
-            dataverse.setFacetRoot(false);
         }
     }
 
+    /*
+      inputLevels = null - ignore
+      inputLevels is empty - delete
+      inputLevels is not empty - set with new updated values
+    */
     private void processInputLevels(CommandContext ctxt) {
         if (inputLevels != null) {
-            if (!inputLevels.isEmpty()) {
+            if (inputLevels.isEmpty()) {
+                ctxt.fieldTypeInputLevels().deleteFacetsFor(dataverse);
+            } else {
                 dataverse.addInputLevelsMetadataBlocksIfNotPresent(inputLevels);
+                ctxt.fieldTypeInputLevels().deleteFacetsFor(dataverse);
+                inputLevels.forEach(inputLevel -> {
+                    inputLevel.setDataverse(dataverse);
+                    ctxt.fieldTypeInputLevels().create(inputLevel);
+                });
             }
-            ctxt.fieldTypeInputLevels().deleteFacetsFor(dataverse);
-            inputLevels.forEach(inputLevel -> {
-                inputLevel.setDataverse(dataverse);
-                ctxt.fieldTypeInputLevels().create(inputLevel);
-            });
-        } else if (resetRelationsOnNullValues) {
-            ctxt.fieldTypeInputLevels().deleteFacetsFor(dataverse);
         }
     }
 

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/CreateDataverseCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/CreateDataverseCommand.java
@@ -39,7 +39,7 @@ public class CreateDataverseCommand extends AbstractWriteDataverseCommand {
                                   List<DatasetFieldType> facets,
                                   List<DataverseFieldTypeInputLevel> inputLevels,
                                   List<MetadataBlock> metadataBlocks) {
-        super(created, created.getOwner(), request, facets, inputLevels, metadataBlocks, false);
+        super(created, created.getOwner(), request, facets, inputLevels, metadataBlocks);
     }
 
     @Override

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/UpdateDataverseCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/UpdateDataverseCommand.java
@@ -32,7 +32,7 @@ public class UpdateDataverseCommand extends AbstractWriteDataverseCommand {
                                   List<Dataverse> featuredDataverses,
                                   DataverseRequest request,
                                   List<DataverseFieldTypeInputLevel> inputLevels) {
-        this(dataverse, facets, featuredDataverses, request, inputLevels, null, null, false);
+        this(dataverse, facets, featuredDataverses, request, inputLevels, null, null);
     }
 
     public UpdateDataverseCommand(Dataverse dataverse,
@@ -41,9 +41,8 @@ public class UpdateDataverseCommand extends AbstractWriteDataverseCommand {
                                   DataverseRequest request,
                                   List<DataverseFieldTypeInputLevel> inputLevels,
                                   List<MetadataBlock> metadataBlocks,
-                                  DataverseDTO updatedDataverseDTO,
-                                  boolean resetRelationsOnNullValues) {
-        super(dataverse, dataverse, request, facets, inputLevels, metadataBlocks, resetRelationsOnNullValues);
+                                  DataverseDTO updatedDataverseDTO) {
+        super(dataverse, dataverse, request, facets, inputLevels, metadataBlocks);
         if (featuredDataverses != null) {
             this.featuredDataverseList = new ArrayList<>(featuredDataverses);
         } else {

--- a/src/main/java/propertyFiles/Bundle.properties
+++ b/src/main/java/propertyFiles/Bundle.properties
@@ -984,6 +984,7 @@ dataverse.inputlevels.error.cannotberequiredifnotincluded=The input level for th
 dataverse.facets.error.fieldtypenotfound=Can't find dataset field type '{0}'
 dataverse.facets.error.fieldtypenotfacetable=Dataset field type '{0}' is not facetable
 dataverse.metadatablocks.error.invalidmetadatablockname=Invalid metadata block name: {0}
+dataverse.metadatablocks.error.containslistandinheritflag=Metadata block can not contain both {0} and {1}: true
 dataverse.create.error.jsonparse=Error parsing Json: {0}
 dataverse.create.error.jsonparsetodataverse=Error parsing the POSTed json into a dataverse: {0}
 # rolesAndPermissionsFragment.xhtml

--- a/src/test/java/edu/harvard/iq/dataverse/api/DataversesIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/DataversesIT.java
@@ -14,6 +14,7 @@ import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
 import java.nio.file.Paths;
+import java.text.MessageFormat;
 import java.util.Arrays;
 import java.util.List;
 import java.util.logging.Logger;
@@ -931,12 +932,14 @@ public class DataversesIT {
                 .body("data[0].fields.author.childFields.size()", is(4));
 
         Response setMetadataBlocksResponse = UtilIT.setMetadataBlocks(dataverseAlias, Json.createArrayBuilder().add("citation").add("astrophysics"), apiToken);
+        setMetadataBlocksResponse.prettyPrint();
         setMetadataBlocksResponse.then().assertThat().statusCode(OK.getStatusCode());
 
         String[] testInputLevelNames = {"geographicCoverage", "country", "city", "notesText"};
         boolean[] testRequiredInputLevels = {false, true, false, false};
         boolean[] testIncludedInputLevels = {false, true, true, false};
         Response updateDataverseInputLevelsResponse = UtilIT.updateDataverseInputLevels(dataverseAlias, testInputLevelNames, testRequiredInputLevels, testIncludedInputLevels, apiToken);
+        updateDataverseInputLevelsResponse.prettyPrint();
         updateDataverseInputLevelsResponse.then().assertThat().statusCode(OK.getStatusCode());
 
         // Dataverse not found
@@ -947,6 +950,7 @@ public class DataversesIT {
         String[] expectedAllMetadataBlockDisplayNames = {"Astronomy and Astrophysics Metadata", "Citation Metadata", "Geospatial Metadata"};
 
         listMetadataBlocksResponse = UtilIT.listMetadataBlocks(dataverseAlias, false, false, apiToken);
+        listMetadataBlocksResponse.prettyPrint();
         listMetadataBlocksResponse.then().assertThat().statusCode(OK.getStatusCode());
         listMetadataBlocksResponse.then().assertThat()
                 .statusCode(OK.getStatusCode())
@@ -1346,20 +1350,31 @@ public class DataversesIT {
         String[] newFacetIds = new String[]{"contributorName"};
         String[] newMetadataBlockNames = new String[]{"citation", "geospatial", "biomedical"};
 
+        // Assert that the error is returned for having both MetadataBlockNames and inheritMetadataBlocksFromParent
         Response updateDataverseResponse = UtilIT.updateDataverse(
-                testDataverseAlias,
-                newAlias,
-                newName,
-                newAffiliation,
-                newDataverseType,
-                newContactEmails,
-                newInputLevelNames,
-                newFacetIds,
-                newMetadataBlockNames,
-                apiToken
+                testDataverseAlias, newAlias, newName, newAffiliation, newDataverseType, newContactEmails, newInputLevelNames,
+                null, newMetadataBlockNames, apiToken,
+                Boolean.TRUE, Boolean.TRUE
         );
+        updateDataverseResponse.then().assertThat()
+                .statusCode(BAD_REQUEST.getStatusCode())
+                .body("message", equalTo(MessageFormat.format(BundleUtil.getStringFromBundle("dataverse.metadatablocks.error.containslistandinheritflag"), "metadataBlockNames", "inheritMetadataBlocksFromParent")));
+
+        // Assert that the error is returned for having both facetIds and inheritFacetsFromParent
+        updateDataverseResponse = UtilIT.updateDataverse(
+                testDataverseAlias, newAlias, newName, newAffiliation, newDataverseType, newContactEmails, newInputLevelNames,
+                newFacetIds, null, apiToken,
+                Boolean.TRUE, Boolean.TRUE
+        );
+        updateDataverseResponse.then().assertThat()
+                .statusCode(BAD_REQUEST.getStatusCode())
+                .body("message", equalTo(MessageFormat.format(BundleUtil.getStringFromBundle("dataverse.metadatablocks.error.containslistandinheritflag"), "facetIds", "inheritFacetsFromParent")));
 
         // Assert dataverse properties are updated
+        updateDataverseResponse = UtilIT.updateDataverse(
+                testDataverseAlias, newAlias, newName, newAffiliation, newDataverseType, newContactEmails, newInputLevelNames,
+                newFacetIds, newMetadataBlockNames, apiToken
+        );
         updateDataverseResponse.then().assertThat().statusCode(OK.getStatusCode());
         String actualDataverseAlias = updateDataverseResponse.then().extract().path("data.alias");
         assertEquals(newAlias, actualDataverseAlias);
@@ -1396,7 +1411,60 @@ public class DataversesIT {
         Response getDataverseResponse = UtilIT.listDataverseFacets(oldDataverseAlias, apiToken);
         getDataverseResponse.then().assertThat().statusCode(NOT_FOUND.getStatusCode());
 
+        listMetadataBlocksResponse = UtilIT.listMetadataBlocks(newAlias, false, false, apiToken);
+        listMetadataBlocksResponse.prettyPrint();
+        updateDataverseResponse = UtilIT.updateDataverse(
+                newAlias, newAlias, newName, newAffiliation, newDataverseType, newContactEmails,
+                null,
+                null,
+                null,
+                apiToken
+        );
+        updateDataverseResponse.prettyPrint();
+        listMetadataBlocksResponse = UtilIT.listMetadataBlocks(newAlias, false, false, apiToken);
+        listMetadataBlocksResponse.prettyPrint();
+
+
+        // Update the dataverse without including metadata blocks, facets, or input levels
+        // ignore the missing data so the metadata blocks, facets, and input levels are NOT deleted and inherited from the parent
+        updateDataverseResponse = UtilIT.updateDataverse(
+                newAlias, newAlias, newName, newAffiliation, newDataverseType, newContactEmails,
+                null,
+                null,
+                null,
+                apiToken
+        );
+        updateDataverseResponse.then().assertThat().statusCode(OK.getStatusCode());
+
+        // Assert that the metadata blocks are untouched and NOT inherited from the parent
+        listMetadataBlocksResponse = UtilIT.listMetadataBlocks(newAlias, false, false, apiToken);
+        listMetadataBlocksResponse.prettyPrint();
+        listMetadataBlocksResponse
+                .then().assertThat()
+                .statusCode(OK.getStatusCode())
+                .body("data.size()", equalTo(3))
+                .body("data[0].name", equalTo(actualDataverseMetadataBlock1))
+                .body("data[1].name", equalTo(actualDataverseMetadataBlock2))
+                .body("data[2].name", equalTo(actualDataverseMetadataBlock3));
+        // Assert that the dataverse should still have its input level(s)
+        listDataverseInputLevelsResponse = UtilIT.listDataverseInputLevels(newAlias, apiToken);
+        listDataverseInputLevelsResponse.prettyPrint();
+        listDataverseInputLevelsResponse
+                .then().assertThat()
+                .statusCode(OK.getStatusCode())
+                .body("data.size()", equalTo(1))
+                .body("data[0].datasetFieldTypeName", equalTo("geographicCoverage"));
+        // Assert that the dataverse should still have its Facets
+        listDataverseFacetsResponse = UtilIT.listDataverseFacets(newAlias, apiToken);
+        listDataverseFacetsResponse.prettyPrint();
+        listDataverseFacetsResponse
+                .then().assertThat()
+                .statusCode(OK.getStatusCode())
+                .body("data.size()", equalTo(1))
+                .body("data", hasItem("contributorName"));
+
         // Update the dataverse without setting metadata blocks, facets, or input levels
+        // Do NOT ignore the missing data so the metadata blocks, facets, and input levels are deleted and inherited from the parent
         updateDataverseResponse = UtilIT.updateDataverse(
                 newAlias,
                 newAlias,
@@ -1407,12 +1475,14 @@ public class DataversesIT {
                 null,
                 null,
                 null,
-                apiToken
+                apiToken,
+                Boolean.TRUE, Boolean.TRUE
         );
         updateDataverseResponse.then().assertThat().statusCode(OK.getStatusCode());
 
         // Assert that the metadata blocks are inherited from the parent
         listMetadataBlocksResponse = UtilIT.listMetadataBlocks(newAlias, false, false, apiToken);
+        listMetadataBlocksResponse.prettyPrint();
         listMetadataBlocksResponse
                 .then().assertThat()
                 .statusCode(OK.getStatusCode())

--- a/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
@@ -415,12 +415,26 @@ public class UtilIT {
             objectBuilder.add("affiliation", affiliation);
         }
 
-        updateDataverseRequestJsonWithMetadataBlocksConfiguration(inputLevelNames, facetIds, metadataBlockNames, objectBuilder);
+        updateDataverseRequestJsonWithMetadataBlocksConfiguration(inputLevelNames, facetIds, metadataBlockNames, null, null, objectBuilder);
 
         JsonObject dvData = objectBuilder.build();
         return given()
                 .body(dvData.toString()).contentType(ContentType.JSON)
                 .when().post("/api/dataverses/" + parentDV + "?key=" + apiToken);
+    }
+    static Response updateDataverse(String alias,
+                                    String newAlias,
+                                    String newName,
+                                    String newAffiliation,
+                                    String newDataverseType,
+                                    String[] newContactEmails,
+                                    String[] newInputLevelNames,
+                                    String[] newFacetIds,
+                                    String[] newMetadataBlockNames,
+                                    String apiToken) {
+
+        return updateDataverse(alias, newAlias, newName, newAffiliation, newDataverseType, newContactEmails,
+                newInputLevelNames, newFacetIds, newMetadataBlockNames, apiToken, null, null);
     }
 
     static Response updateDataverse(String alias,
@@ -432,7 +446,9 @@ public class UtilIT {
                                     String[] newInputLevelNames,
                                     String[] newFacetIds,
                                     String[] newMetadataBlockNames,
-                                    String apiToken) {
+                                    String apiToken,
+                                    Boolean inheritMetadataBlocksFromParent,
+                                    Boolean inheritFacetsFromParent) {
         JsonArrayBuilder contactArrayBuilder = Json.createArrayBuilder();
         for(String contactEmail : newContactEmails) {
             contactArrayBuilder.add(Json.createObjectBuilder().add("contactEmail", contactEmail));
@@ -445,7 +461,8 @@ public class UtilIT {
                 .add("dataverseType", newDataverseType)
                 .add("affiliation", newAffiliation);
 
-        updateDataverseRequestJsonWithMetadataBlocksConfiguration(newInputLevelNames, newFacetIds, newMetadataBlockNames, jsonBuilder);
+        updateDataverseRequestJsonWithMetadataBlocksConfiguration(newInputLevelNames, newFacetIds, newMetadataBlockNames,
+                inheritMetadataBlocksFromParent, inheritFacetsFromParent, jsonBuilder);
 
         JsonObject dvData = jsonBuilder.build();
         return given()
@@ -456,6 +473,8 @@ public class UtilIT {
     private static void updateDataverseRequestJsonWithMetadataBlocksConfiguration(String[] inputLevelNames,
                                                                                   String[] facetIds,
                                                                                   String[] metadataBlockNames,
+                                                                                  Boolean inheritFacetsFromParent,
+                                                                                  Boolean inheritMetadataBlocksFromParent,
                                                                                   JsonObjectBuilder objectBuilder) {
         JsonObjectBuilder metadataBlocksObjectBuilder = Json.createObjectBuilder();
 
@@ -478,6 +497,9 @@ public class UtilIT {
             }
             metadataBlocksObjectBuilder.add("metadataBlockNames", metadataBlockNamesArrayBuilder);
         }
+        if (inheritMetadataBlocksFromParent != null) {
+            metadataBlocksObjectBuilder.add("inheritMetadataBlocksFromParent", inheritMetadataBlocksFromParent);
+        }
 
         if (facetIds != null) {
             JsonArrayBuilder facetIdsArrayBuilder = Json.createArrayBuilder();
@@ -485,6 +507,9 @@ public class UtilIT {
                 facetIdsArrayBuilder.add(facetId);
             }
             metadataBlocksObjectBuilder.add("facetIds", facetIdsArrayBuilder);
+        }
+        if (inheritFacetsFromParent != null) {
+            metadataBlocksObjectBuilder.add("inheritFacetsFromParent", inheritFacetsFromParent);
         }
 
         objectBuilder.add("metadataBlocks", metadataBlocksObjectBuilder);


### PR DESCRIPTION
**What this PR does / why we need it**: Better control over updating dataverse metadatablocks - update/delete-inherit

**Which issue(s) this PR closes**:https://github.com/IQSS/dataverse/issues/11130

- Closes #11130

**Special notes for your reviewer**: See discussion in parent issue

**Suggestions on how to test this**: See DataversesIT. Test different combinations of Json with the three blocks and two flags.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**: Included

**Additional documentation**: native-api
