### PR TITLE
IQSS/11142 show replace in file differences

### DIFF
--- a/doc/release-notes/ 11142-more detailed file differences.md
+++ b/doc/release-notes/ 11142-more detailed file differences.md
@@ -1,1 +1,1 @@
-The file page version table now shows whether a file has been replaced. 
+The file page version table now shows more detail, e.g. when there are metadata changes or whether a file has been replaced. 

--- a/doc/release-notes/ 11142-more detailed file differences.md
+++ b/doc/release-notes/ 11142-more detailed file differences.md
@@ -1,0 +1,1 @@
+The file page version table now shows whether a file has been replaced. 

--- a/src/main/java/edu/harvard/iq/dataverse/DatasetVersionDifference.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetVersionDifference.java
@@ -373,9 +373,9 @@ public final class DatasetVersionDifference {
                     List.of(fmdo.getLabel(), fmdn.getLabel()));
         }
         
-        if (!StringUtils.equals(fmdo.getProvFreeForm(), fmdn.getProvFreeForm())) {
+        if (!StringUtils.equals(StringUtil.nullToEmpty(fmdo.getProvFreeForm()), StringUtil.nullToEmpty(fmdn.getProvFreeForm()))) {
             fileMetadataChanged.put("ProvFreeForm",
-                    List.of(fmdo.getProvFreeForm(), fmdn.getProvFreeForm()));
+                    List.of(StringUtil.nullToEmpty(fmdo.getProvFreeForm()), StringUtil.nullToEmpty(fmdn.getProvFreeForm())));
         }
 
         if (fmdo.isRestricted() != fmdn.isRestricted()) {

--- a/src/main/java/edu/harvard/iq/dataverse/FilePage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/FilePage.java
@@ -708,7 +708,7 @@ public class FilePage implements java.io.Serializable {
                     FileMetadata fmd = datafileService.findFileMetadataByDatasetVersionIdAndDataFileId(versionLoop.getId(), df.getId());
                     if (fmd != null) {
                         fmd.setContributorNames(datasetVersionService.getContributorsNames(versionLoop));
-                        FileVersionDifference fvd = new FileVersionDifference(fmd, getPreviousFileMetadata(fmd));
+                        FileVersionDifference fvd = new FileVersionDifference(fmd, getPreviousFileMetadata(fmd), true);
                         fmd.setFileVersionDifference(fvd);
                         retList.add(fmd);
                         foundFmd = true;
@@ -720,7 +720,7 @@ public class FilePage implements java.io.Serializable {
                     FileMetadata dummy = new FileMetadata();
                     dummy.setDatasetVersion(versionLoop);
                     dummy.setDataFile(null);
-                    FileVersionDifference fvd = new FileVersionDifference(dummy, getPreviousFileMetadata(versionLoop));
+                    FileVersionDifference fvd = new FileVersionDifference(dummy, getPreviousFileMetadata(versionLoop), true);
                     dummy.setFileVersionDifference(fvd);
                     retList.add(dummy);
                 }


### PR DESCRIPTION
**What this PR does / why we need it**: On the file page, the version table did not show when one file replaced another (it just showed No changes associated with this version. Now it shows: 
![image](https://github.com/user-attachments/assets/5d0e5d6b-08ef-4356-b188-62ecdccb670d)


**Which issue(s) this PR closes**:

- Closes #11142

**Special notes for your reviewer**: The fix for this was rather trivial, just turning on existing functionality by adding a details=true flag. However, in fixing that I discovered:
- that adding free-form provenance to a file causes the dataset version table and difference api to fail due to a null pointer - I fixed that in this PR,
- that despite being almost the same code, there is a separate FileVersionDifference class that is called from the FilePage. W.r.t. the SPA, I think the code in the FilePage that figures out which FileMetadata/DataFile to compare will need to be moved to a new API call, but it might be possible to then just use the code in DatasetVersionDifference instead to allow the other class to be deprecated. I did not dig fully into this, so it's possible that there are other differences I missed,
- The file-versions.xhtml has several cut/paste ~errors from being copied from the dataset-level code. Things like the method in https://github.com/IQSS/dataverse/blob/6d6a509c91e07f8fd375ed0c10e221d1e16ca9a0/src/main/webapp/file-versions.xhtml#L45 doesn't exist, the check at https://github.com/IQSS/dataverse/blob/6d6a509c91e07f8fd375ed0c10e221d1e16ca9a0/src/main/webapp/file-versions.xhtml#L53 references the DatasetPage, and the detailsBlocks referenced in https://github.com/IQSS/dataverse/blob/6d6a509c91e07f8fd375ed0c10e221d1e16ca9a0/src/main/webapp/file-versions.xhtml#L44C69-L44C87 only exists on the dataset page. None of these appear to be fatal - but my guess is that they probably cause there to be no checkbox column through which one could compare two versions and see the details (hence the details flag). Doesn't seem like anything worth fixing given just using details=true in the table is probably good enough, but again the SPA might want to decide whether the file version table should work more like the dataset-level one than it does/can share more code, etc.

**Suggestions on how to test this**:
Create/publish a dataset with a file, replace the file, verify that the file page version table notes the change. 
Add a free-form provenance note to the file, check that the save succeeds/the dataset page is still viewable, etc. (allowing free-form provenance is a flag that may need to be set on the test machine).

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
