### PR TITLE
limit table of contents in guides to depth of 2

### DIFF
--- a/doc/release-notes/guides-toc-depth.md
+++ b/doc/release-notes/guides-toc-depth.md
@@ -1,0 +1,3 @@
+### Guides Table of Contents Depth
+
+One the home page for each guide (User Guide, etc.) there was an overwhelming amount of information in the form of a deeply nested tabled of contents. The depth of the table of contents has been reduced to two levels, making the home pages for each guide more readable.

--- a/doc/sphinx-guides/source/admin/index.rst
+++ b/doc/sphinx-guides/source/admin/index.rst
@@ -11,6 +11,7 @@ This guide documents the functionality only available to superusers (such as "da
 **Contents:**
 
 .. toctree::
+   :maxdepth: 2
 
    dashboard
    external-tools

--- a/doc/sphinx-guides/source/api/index.rst
+++ b/doc/sphinx-guides/source/api/index.rst
@@ -9,6 +9,7 @@ API Guide
 **Contents:**
 
 .. toctree::
+   :maxdepth: 2
 
    intro
    getting-started

--- a/doc/sphinx-guides/source/container/index.rst
+++ b/doc/sphinx-guides/source/container/index.rst
@@ -4,6 +4,7 @@ Container Guide
 **Contents:**
 
 .. toctree::
+  :maxdepth: 2
 
   intro
   running/index

--- a/doc/sphinx-guides/source/contributor/index.md
+++ b/doc/sphinx-guides/source/contributor/index.md
@@ -4,7 +4,7 @@ Thank you for your interest in contributing to Dataverse!  We are open to contri
 
 ```{contents} Contents:
 :local:
-:depth: 3
+:depth: 2
 ```
 
 ## Ideas and Feature Requests

--- a/doc/sphinx-guides/source/developers/index.rst
+++ b/doc/sphinx-guides/source/developers/index.rst
@@ -9,6 +9,7 @@ Developer Guide
 **Contents:**
 
 .. toctree::
+   :maxdepth: 2
 
    intro
    dev-environment

--- a/doc/sphinx-guides/source/installation/index.rst
+++ b/doc/sphinx-guides/source/installation/index.rst
@@ -9,6 +9,7 @@ Installation Guide
 **Contents:**
 
 .. toctree::
+   :maxdepth: 2
 
    intro
    prep

--- a/doc/sphinx-guides/source/qa/index.md
+++ b/doc/sphinx-guides/source/qa/index.md
@@ -1,6 +1,8 @@
 # QA Guide
 
 ```{toctree}
+:caption: "Contents:"
+:maxdepth: 2
 overview.md
 testing-approach.md
 testing-infrastructure.md

--- a/doc/sphinx-guides/source/style/index.rst
+++ b/doc/sphinx-guides/source/style/index.rst
@@ -11,6 +11,7 @@ This style guide is meant to help developers implement clear and appropriate UI 
 **Contents:**
 
 .. toctree::
+   :maxdepth: 2
 
    foundations
    patterns

--- a/doc/sphinx-guides/source/user/index.rst
+++ b/doc/sphinx-guides/source/user/index.rst
@@ -9,6 +9,7 @@ User Guide
 **Contents:**
 
 .. toctree::
+   :maxdepth: 2
 
    account
    find-use-data


### PR DESCRIPTION
**What this PR does / why we need it**:

As discussed in a [couple](https://docs.google.com/document/d/1wUpmkOfQICuPQPbITqJ2oZSD2cSJBdHioEsaLck6_Es/edit?usp=sharing) [meetings](https://docs.google.com/document/d/1o_gjFaFpl62V8SJSbeL8V_h2-JAHrrrS48jyImU-A7c/edit?usp=sharing) with the Documentation Working Group, the amount of information you see when clicking on any given guide is overwhelming. Here's an example from the User Guide:

![Screenshot 2025-01-17 at 10 31 05 AM](https://github.com/user-attachments/assets/46053ebf-3e1c-410e-a575-dd2993492434)

This pull requests limits the depth of the table of contents to two levels. Here's the User Guide as an example:

![Screenshot 2025-01-17 at 10 58 00 AM](https://github.com/user-attachments/assets/a3df2c86-eeac-47b0-96a1-55763663b8a5)

**Which issue(s) this PR closes**:

None

**Special notes for your reviewer**:

The majority of our guides are the old school .rst variety and look the same. Two newer guides are use .md and look a bit different:

- The QA Guide shows "Contents:" in regular font instead of bold. I tried a bit to fix this but it was non-obvious so I gave up. Perhaps someday we'll move all guides from .rst to .md and they will all be consistent.
- The Contributor Guide has a box around the contents. This is because the most of the content is on a single page. This was done be design when then guide was created (see #10532). 

**Suggestions on how to test this**:

Make sure the depth is 2.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No but there are screenshots above.

**Is there a release notes update needed for this change?**:

Yes, included.

**Additional documentation**:
