### PR TITLE
IQSS/11174-ROR url not added in author affiliation

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/pidproviders/doi/XmlMetadataTemplate.java
+++ b/src/main/java/edu/harvard/iq/dataverse/pidproviders/doi/XmlMetadataTemplate.java
@@ -639,7 +639,7 @@ public class XmlMetadataTemplate {
 
                 attributeMap.put("schemeURI", "https://ror.org");
                 attributeMap.put("affiliationIdentifierScheme", "ROR");
-                attributeMap.put("affiliationIdentifier", orgName);
+                attributeMap.put("affiliationIdentifier", affiliation);
             }
 
             XmlWriterUtil.writeFullElementWithAttributes(xmlw, "affiliation", attributeMap, StringEscapeUtils.escapeXml10(orgName));


### PR DESCRIPTION
**What this PR does / why we need it**: Fixes a bug in the DataCite metadata/export.

**Which issue(s) this PR closes**:

- Closes #11174

**Special notes for your reviewer**:

**Suggestions on how to test this**:
Use a ROR URL for the author affiliation, publish, and verify that the DataCite xml exported has the ROR URL in the affiliationID attribute as in the example in the issue. (To test a dataset published with the prior code, you can just run the [reexportDataset API call ](https://guides.dataverse.org/en/latest/admin/metadataexport.html#batch-exports-through-the-api)to see the DataCite xml get updated.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
