### PR TITLE
fix: fix bug in OAI-ORE exporter related to nested compound fields

### DIFF
--- a/doc/release-notes/10809-oai-ore-nested-compound.md
+++ b/doc/release-notes/10809-oai-ore-nested-compound.md
@@ -1,0 +1,1 @@
+The OAI-ORE exporter can now export metadata containing nested compound fields (i.e. compound fields within compound fields). See #10809 and #11190.

--- a/src/main/java/edu/harvard/iq/dataverse/util/bagit/OREMap.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/bagit/OREMap.java
@@ -444,38 +444,44 @@ public class OREMap {
 
                 for (DatasetField dsf : dscv.getChildDatasetFields()) {
                     DatasetFieldType dsft = dsf.getDatasetFieldType();
-                    if (excludeEmail && DatasetFieldType.FieldType.EMAIL.equals(dsft.getFieldType())) {
-                        continue;
-                    }
-                    // which may have multiple values
-                    if (!dsf.isEmpty()) {
-                        // Add context entry
-                        // ToDo - also needs to recurse here?
-                        JsonLDTerm subFieldName = dsft.getJsonLDTerm();
-                        if (subFieldName.inNamespace()) {
-                            localContext.putIfAbsent(subFieldName.getNamespace().getPrefix(),
-                                    subFieldName.getNamespace().getUrl());
-                        } else {
-                            localContext.putIfAbsent(subFieldName.getLabel(), subFieldName.getUrl());
+                    JsonLDTerm subFieldName = dsft.getJsonLDTerm();
+
+                    if (dsft.isCompound()) {
+                        JsonValue compoundChildVals = getJsonLDForField(dsf, excludeEmail, cvocMap, localContext);
+                        child.add(subFieldName.getLabel(), compoundChildVals);
+                    } else {
+                        if (excludeEmail && DatasetFieldType.FieldType.EMAIL.equals(dsft.getFieldType())) {
+                            continue;
                         }
-
-                        List<String> values = dsf.getValues_nondisplay();
-
-                        JsonArrayBuilder childVals = Json.createArrayBuilder();
-
-                        for (String val : dsf.getValues_nondisplay()) {
-                            logger.fine("Child name: " + dsft.getName());
-                            if (cvocMap.containsKey(dsft.getId())) {
-                                logger.fine("Calling addcvocval for: " + dsft.getName());
-                                addCvocValue(val, childVals, cvocMap.get(dsft.getId()), localContext);
+                        // which may have multiple values
+                        if (!dsf.isEmpty()) {
+                            // Add context entry
+                            // ToDo - also needs to recurse here?
+                            if (subFieldName.inNamespace()) {
+                                localContext.putIfAbsent(subFieldName.getNamespace().getPrefix(),
+                                        subFieldName.getNamespace().getUrl());
                             } else {
-                                childVals.add(val);
+                                localContext.putIfAbsent(subFieldName.getLabel(), subFieldName.getUrl());
                             }
-                        }
-                        if (values.size() > 1) {
-                            child.add(subFieldName.getLabel(), childVals);
-                        } else {
-                            child.add(subFieldName.getLabel(), childVals.build().get(0));
+
+                            List<String> values = dsf.getValues_nondisplay();
+
+                            JsonArrayBuilder childVals = Json.createArrayBuilder();
+
+                            for (String val : dsf.getValues_nondisplay()) {
+                                logger.fine("Child name: " + dsft.getName());
+                                if (cvocMap.containsKey(dsft.getId())) {
+                                    logger.fine("Calling addcvocval for: " + dsft.getName());
+                                    addCvocValue(val, childVals, cvocMap.get(dsft.getId()), localContext);
+                                } else {
+                                    childVals.add(val);
+                                }
+                            }
+                            if (values.size() > 1) {
+                                child.add(subFieldName.getLabel(), childVals);
+                            } else {
+                                child.add(subFieldName.getLabel(), childVals.build().get(0));
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR enables the OAI-ORE exporter to generate a metadata export for metadata containing nested compound fields (i.e. compound fields within compound fields).

**Which issue(s) this PR closes**:

- Closes #10809

**Special notes for your reviewer**:

/

**Suggestions on how to test this**:

1. Create a metadata block containing nested compound fields, e.g. use one in here: [nested_compound_test.tar.gz](https://github.com/IQSS/dataverse/files/10124812/nested_compound_test.tar.gz)

   `curl http://localhost:8080/api/admin/datasetfield/load -H "Content-type: text/tab-separated-values" -X POST --upload-file nested_compound_test2.tsv `

2. Enable metadata block
3. Create a dataset using the metadata block, e.g. using a JSON file in the archive linked above

   `curl -H "X-Dataverse-key: $API_TOKEN" -X POST "http://localhost:8080/api/dataverses/root/datasets" --upload-file nested_compound_test2.json -H 'Content-type:application/json'`

4. Go to `http://localhost:8080/dataset.xhtml?persistentId=...` (using PID returned by the API in 3.)
5. Publish dataset
6. Reload page
7. Open "Metadata" tab, click "Export Metadata" button and select "OAI_ORE"
8. Check that the export contains no errors: [nested_compound_test2_oai_ore_export.json](https://github.com/user-attachments/files/18560647/nested_compound_test2_oai_ore_export.json)

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

/

**Is there a release notes update needed for this change?**:

/

**Additional documentation**:

/