### PR TITLE
in demo/eval env, configure root collection alias and name

### DIFF
--- a/doc/sphinx-guides/source/container/running/demo.rst
+++ b/doc/sphinx-guides/source/container/running/demo.rst
@@ -137,6 +137,15 @@ In the example below of configuring :ref:`:FooterCopyright` we use the default u
 
 One you make this change it should be visible in the copyright in the bottom left of every page.
 
+Root Collection Alias and Name
+++++++++++++++++++++++++++++++
+
+
+Before running ``docker compose up`` for the first time, you can customize the root collection alias and name by editing the following variables in ``compose.yml``:
+
+- ROOT_COLLECTION_ALIAS=root
+- ROOT_COLLECTION_NAME=Root
+
 Multiple Languages
 ++++++++++++++++++
 

--- a/docker/compose/demo/compose.yml
+++ b/docker/compose/demo/compose.yml
@@ -54,6 +54,8 @@ services:
     restart: "no"
     environment:
       - TIMEOUT=3m
+      - ROOT_COLLECTION_ALIAS=root
+      - ROOT_COLLECTION_NAME=Root
     command:
       - bootstrap.sh
       - dev

--- a/modules/container-configbaker/scripts/bootstrap/demo/init.sh
+++ b/modules/container-configbaker/scripts/bootstrap/demo/init.sh
@@ -9,6 +9,12 @@ export DATAVERSE_URL
 BLOCKED_API_KEY=${BLOCKED_API_KEY:-"unblockme"}
 export BLOCKED_API_KEY
 
+ROOT_COLLECTION_ALIAS=${ROOT_COLLECTION_ALIAS:-"root"}
+export ROOT_COLLECTION_ALIAS
+
+ROOT_COLLECTION_NAME=${ROOT_COLLECTION_NAME:-"Root"}
+export ROOT_COLLECTION_NAME
+
 # --insecure is used so we can configure a few things but
 # later in this script we'll apply the changes as if we had
 # run the script without --insecure.
@@ -18,6 +24,17 @@ echo "Running base setup-all.sh..."
 echo ""
 echo "Setting DOI provider to \"FAKE\"..."
 curl -sS -X PUT -d FAKE "${DATAVERSE_URL}/api/admin/settings/:DoiProvider"
+
+API_TOKEN=$(grep apiToken "/tmp/setup-all.sh.out" | jq ".data.apiToken" | tr -d \")
+export API_TOKEN
+
+echo ""
+echo "Setting root collection alias to ${ROOT_COLLECTION_ALIAS}..."
+curl -sS -X PUT -H "X-Dataverse-key:$API_TOKEN" "$DATAVERSE_URL/api/dataverses/:root/attribute/alias?value=$ROOT_COLLECTION_ALIAS"
+
+echo ""
+echo "Setting root collection name to ${ROOT_COLLECTION_NAME}..."
+curl -sS -X PUT -H "X-Dataverse-key:$API_TOKEN" "$DATAVERSE_URL/api/dataverses/:root/attribute/name?value=$ROOT_COLLECTION_NAME"
 
 echo ""
 echo "Revoke the key that allows for creation of builtin users..."


### PR DESCRIPTION
**What this PR does / why we need it**:

In Milestone F of the [container proposal](https://docs.google.com/document/d/14DHDB24Cp_kzpYqhHCKCtnzOw8_WuLOOONyqJHSsaYM/edit) and in [recent discussions](https://ct.gdcc.io/), we've said we want people to be able to configure the alias and name of the root collection.

**Which issue(s) this PR closes**:

- Closes #10541

**Special notes for your reviewer**:

I could have used https://guides.dataverse.org/en/6.5/api/native-api.html#update-a-dataverse-collection to update both the alias and name in one request but I went with https://guides.dataverse.org/en/6.5/api/native-api.html#collection-attributes-api because it was easier.

I have a mental TODO to try testing a name with a space in it.

I also started a topic in Zulip for discussion: https://dataverse.zulipchat.com/#narrow/channel/375812-containers/topic/in.20demo.2Feval.20env.2C.20configure.20root.20collection.20alias.20and.20name/near/496383414

**Suggestions on how to test this**:

Follow the provided instructions.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No.

**Is there a release notes update needed for this change?**:

Yes, coming.

**Additional documentation**:
