### PR TITLE
explain how to customize root collection in "running in Docker" tutorial

### DIFF
--- a/doc/release-notes/10541-root-alias-name2.md
+++ b/doc/release-notes/10541-root-alias-name2.md
@@ -1,0 +1,1 @@
+The [tutorial](https://dataverse-guide--11201.org.readthedocs.build/en/11201/container/running/demo.html#root-collection-customization-alias-name-etc) on running Dataverse in Docker has been updated to explain how to configure the root collection using a JSON file. See also #10541 and #11201.

--- a/doc/sphinx-guides/source/container/running/demo.rst
+++ b/doc/sphinx-guides/source/container/running/demo.rst
@@ -29,6 +29,8 @@ To stop the containers hit ``Ctrl-c`` (hold down the ``Ctrl`` key and then hit t
 
 To start the containers, run ``docker compose up``.
 
+.. _starting-over:
+
 Deleting Data and Starting Over
 -------------------------------
 
@@ -142,15 +144,25 @@ One you make this change it should be visible in the copyright in the bottom lef
 Root Collection Customization (Alias, Name, etc.)
 +++++++++++++++++++++++++++++++++++++++++++++++++
 
-Before running ``docker compose up`` for the first time, you can customize the root collection by editing the ``init.sh`` script above.
+Before running ``docker compose up`` for the first time, you can customize the root collection by placing a JSON file in the right place.
 
-First, uncomment the section that say "Updating root collection". Note that it references the file ``/scripts/bootstrap/demo/dataverse-complete.json``.
+First, in the "demo" directory you created (see :ref:`demo-persona`), create a subdirectory called "config":
 
-Next, download :download:`dataverse-complete.json <../../_static/api/dataverse-complete.json>` and put it in the "demo" directory you created (see :ref:`demo-persona`). That directory should how have two files: ``init.sh`` and ``dataverse-complete.json``.
+``mkdir demo/config``
+
+Next, download :download:`dataverse-complete.json <../../_static/api/dataverse-complete.json>` and put it in the "config" directory you just created. The contents of your "demo" directory should look something like this:
+
+.. code-block:: bash
+
+        % find demo
+        demo
+        demo/config
+        demo/config/dataverse-complete.json
+        demo/init.sh
 
 Edit ``dataverse-complete.json`` to have the values you want. You'll want to refer to :ref:`update-dataverse-api` in the API Guide to understand the format. In that documentation you can find optional parameters as well.
 
-To test your JSON file, run ``docker compose up``. Again, this only works when you are running ``docker compose up`` for the first time.
+To test your JSON file, run ``docker compose up``. Again, this only works when you are running ``docker compose up`` for the first time. (You can always start over. See :ref:`starting-over`.)
 
 Multiple Languages
 ++++++++++++++++++

--- a/doc/sphinx-guides/source/container/running/demo.rst
+++ b/doc/sphinx-guides/source/container/running/demo.rst
@@ -46,6 +46,8 @@ Starting Fresh
 
 For this exercise, please start fresh by stopping all containers and removing the ``data`` directory.
 
+.. _demo-persona:
+
 Creating and Running a Demo Persona
 +++++++++++++++++++++++++++++++++++
 
@@ -136,6 +138,19 @@ In the example below of configuring :ref:`:FooterCopyright` we use the default u
 ``curl -X PUT -d ", My Org" "http://localhost:8080/api/admin/settings/:FooterCopyright?unblock-key=unblockme"``
 
 One you make this change it should be visible in the copyright in the bottom left of every page.
+
+Root Collection Customization (Alias, Name, etc.)
++++++++++++++++++++++++++++++++++++++++++++++++++
+
+Before running ``docker compose up`` for the first time, you can customize the root collection by editing the ``init.sh`` script above.
+
+First, uncomment the section that say "Updating root collection". Note that it references the file ``/scripts/bootstrap/demo/dataverse-complete.json``.
+
+Next, download :download:`dataverse-complete.json <../../_static/api/dataverse-complete.json>` and put it in the "demo" directory you created (see :ref:`demo-persona`). That directory should how have two files: ``init.sh`` and ``dataverse-complete.json``.
+
+Edit ``dataverse-complete.json`` to have the values you want. You'll want to refer to :ref:`update-dataverse-api` in the API Guide to understand the format. In that documentation you can find optional parameters as well.
+
+To test your JSON file, run ``docker compose up``. Again, this only works when you are running ``docker compose up`` for the first time.
 
 Multiple Languages
 ++++++++++++++++++

--- a/modules/container-configbaker/scripts/bootstrap/demo/init.sh
+++ b/modules/container-configbaker/scripts/bootstrap/demo/init.sh
@@ -19,6 +19,13 @@ echo ""
 echo "Setting DOI provider to \"FAKE\"..."
 curl -sS -X PUT -d FAKE "${DATAVERSE_URL}/api/admin/settings/:DoiProvider"
 
+API_TOKEN=$(grep apiToken "/tmp/setup-all.sh.out" | jq ".data.apiToken" | tr -d \")
+export API_TOKEN
+
+#echo ""
+#echo "Updating root collection..."
+#curl -sS -X PUT -H "X-Dataverse-key:$API_TOKEN" "$DATAVERSE_URL/api/dataverses/:root" --upload-file /scripts/bootstrap/demo/dataverse-complete.json
+
 echo ""
 echo "Revoke the key that allows for creation of builtin users..."
 curl -sS -X DELETE "${DATAVERSE_URL}/api/admin/settings/BuiltinUsers.KEY"

--- a/modules/container-configbaker/scripts/bootstrap/demo/init.sh
+++ b/modules/container-configbaker/scripts/bootstrap/demo/init.sh
@@ -22,9 +22,12 @@ curl -sS -X PUT -d FAKE "${DATAVERSE_URL}/api/admin/settings/:DoiProvider"
 API_TOKEN=$(grep apiToken "/tmp/setup-all.sh.out" | jq ".data.apiToken" | tr -d \")
 export API_TOKEN
 
-#echo ""
-#echo "Updating root collection..."
-#curl -sS -X PUT -H "X-Dataverse-key:$API_TOKEN" "$DATAVERSE_URL/api/dataverses/:root" --upload-file /scripts/bootstrap/demo/dataverse-complete.json
+ROOT_COLLECTION_JSON=/scripts/bootstrap/demo/config/dataverse-complete.json
+if [ -f $ROOT_COLLECTION_JSON ]; then
+  echo ""
+  echo "Updating root collection based on $ROOT_COLLECTION_JSON..."
+  curl -sS -X PUT -H "X-Dataverse-key:$API_TOKEN" "$DATAVERSE_URL/api/dataverses/:root" --upload-file $ROOT_COLLECTION_JSON
+fi
 
 echo ""
 echo "Revoke the key that allows for creation of builtin users..."


### PR DESCRIPTION
**What this PR does / why we need it**:

In Milestone F of the [container proposal](https://docs.google.com/document/d/14DHDB24Cp_kzpYqhHCKCtnzOw8_WuLOOONyqJHSsaYM/edit) and in [recent discussions](https://ct.gdcc.io/), we've said we want people to be able to configure the alias and name of the root collection.

**Which issue(s) this PR closes**:

- Closes #10541

**Special notes for your reviewer**:

This PR is an alternative to #11196. It allows more customization.

Please feel free to discuss here or at https://dataverse.zulipchat.com/#narrow/channel/375812-containers/topic/in.20demo.2Feval.20env.2C.20configure.20root.20collection.20alias.20and.20name/near/496383414

**Suggestions on how to test this**:

Follow the provided instructions. Your root collection should look like this:

![Screenshot 2025-01-30 at 3 57 53 PM](https://github.com/user-attachments/assets/3846b6f6-e38b-4023-93df-8885062fef9b)

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No.

**Is there a release notes update needed for this change?**:

Yes, included.

**Additional documentation**:

https://dataverse-guide--11201.org.readthedocs.build/en/11201/container/running/demo.html#root-collection-customization-alias-name-etc