### PR TITLE
clarify which PID settings are required

### DIFF
--- a/doc/sphinx-guides/source/installation/config.rst
+++ b/doc/sphinx-guides/source/installation/config.rst
@@ -307,7 +307,7 @@ to be compatible with the MicroProfile specification which means that
 Global Settings
 ^^^^^^^^^^^^^^^
 
-The following three global settings are required to configure PID Providers in the Dataverse software:
+The following two global settings are required to configure PID Providers in the Dataverse software:
 
 .. _dataverse.pid.providers:
 


### PR DESCRIPTION
**What this PR does / why we need it**:

People are confused. The way it's worded, it sounds like `dataverse.spi.pidproviders.directory` is required. Please see https://dataverse.zulipchat.com/#narrow/channel/378866-troubleshooting/topic/DOI.20config.20change.2C.20server.20down/near/497448462