### PR TITLE
document need for vacuum full in custom format

### DIFF
--- a/doc/sphinx-guides/source/admin/troubleshooting.rst
+++ b/doc/sphinx-guides/source/admin/troubleshooting.rst
@@ -162,7 +162,9 @@ A full backup of the table can be made with pg_dump, for example:
 
 ``pg_dump <CREDENTIALS> --table=actionlogrecord --data-only <DATABASE_NAME> > /tmp/actionlogrecord_backup.sql``
 
-(In the example above, the output will be saved in raw SQL format. It is portable and human-readable, but uses a lot of space. It does, however, compress very well. Add the ``-Fc`` option to save the output in a proprietary, binary format that's already compressed). 
+In the example above, the output will be saved in raw SQL format. It is portable and human-readable, but uses a lot of space. It does, however, compress very well.
+
+Add the ``-Fc`` option to save the output in a proprietary, compressed binary format which will dump and restore much more quickly, but note that in this format dead tuples will be copied as well. To reduce the amount of storage consumed by the newly-trimmed ``actionlogrecord`` table, you must issue ``vacuum full actionlogrecord`` before dumping the database in this custom format.
 
 
 Getting Help


### PR DESCRIPTION
**What this PR does / why we need it**:

without `vacuum full` the `actionlogrecord` table will be dumped in binary format, dead tuples and all.

**Which issue(s) this PR closes**:

- Closes #11213

**Special notes for your reviewer**:

none

**Suggestions on how to test this**:

vacuum :) the resulting dump file on a test server dropped from 660+MB to 171MB just by rewriting this table.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

no

**Is there a release notes update needed for this change?**:

no

**Additional documentation**:

Preview at https://dataverse-guide--11216.org.readthedocs.build/en/11216/admin/troubleshooting.html#what-s-with-this-table-actionlogrecord-in-our-database-it-seems-to-be-growing-uncontrollably