### PR TITLE
Flaky XmlMetadataTemplateTest fix

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/pidproviders/doi/XmlMetadataTemplate.java
+++ b/src/main/java/edu/harvard/iq/dataverse/pidproviders/doi/XmlMetadataTemplate.java
@@ -69,8 +69,6 @@ public class XmlMetadataTemplate {
     public static final String XML_SCHEMA_VERSION = "4.5";
 
     private DoiMetadata doiMetadata;
-    //QDR - used to get ROR name from ExternalVocabularyValue via pidProvider.get
-    private PidProvider pidProvider = null;
 
     public XmlMetadataTemplate() {
     }
@@ -98,13 +96,6 @@ public class XmlMetadataTemplate {
         String language = null; // machine locale? e.g. for Publisher which is global
         String metadataLanguage = null; // when set, otherwise = language?
         
-        //QDR - used to get ROR name from ExternalVocabularyValue via pidProvider.get
-        GlobalId pid = null;
-        pid = dvObject.getGlobalId();
-        if ((pid == null) && (dvObject instanceof DataFile df)) {
-                pid = df.getOwner().getGlobalId();
-            }
-        pidProvider = PidUtil.getPidProvider(pid.getProviderId());
         XMLStreamWriter xmlw = XMLOutputFactory.newInstance().createXMLStreamWriter(outputStream);
         xmlw.writeStartElement("resource");
         boolean deaccessioned=false;


### PR DESCRIPTION
**What this PR does / why we need it**: Some obsolete code in the XmlMetadataTemplate class that tried to find the PidProvider for a 10.5072/FK2* identifier was causing intermittent failures - depending on whether other tests had added/remove a DOI provider for that authority/shoulder. This was seen in #10567 and #11222 recently. This PR removes the obsolete code which is doing the PidProvider lookup.

**Which issue(s) this PR closes**:

- Closes #

**Special notes for your reviewer**: FWIW: This code's from #10632 where the pidprovider was originally used as a way to call a method in the DatasetFieldServiceBean (since XMLMetadataTemplate isn't a bean). That was replaced by 
https://github.com/IQSS/dataverse/blob/3aea1482dcc2f97741ba79b2f4b93b069b425871/src/main/java/edu/harvard/iq/dataverse/pidproviders/doi/XmlMetadataTemplate.java#L651 , but it appears the initial lookup of the PID provider wasn't removed.

**Suggestions on how to test this**: Basic regression testing w.r.t. creating/publishing a DataCite DOI dataset? Nominally there should be no effect except for no future test fails.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
