### PR TITLE
IQSS/11228 Summary Fields fixes

### DIFF
--- a/doc/release-notes/11228-summaryfields.md
+++ b/doc/release-notes/11228-summaryfields.md
@@ -1,0 +1,1 @@
+The :CustomDatasetSummaryFields setting now allows spaces along with a comma separating field names. In addition, a bug that caused license information to be hidden if there are no values for any of the custom fields specified has been fixed.

--- a/doc/sphinx-guides/source/installation/config.rst
+++ b/doc/sphinx-guides/source/installation/config.rst
@@ -4481,9 +4481,10 @@ Limit on how many guestbook entries to display on the guestbook-responses page. 
 :CustomDatasetSummaryFields
 +++++++++++++++++++++++++++
 
-You can replace the default dataset metadata fields that are displayed above files table on the dataset page with a custom list separated by commas using the curl command below.
+You can replace the default dataset metadata fields that are displayed above files table on the dataset page with a custom list separated by commas (with optional spaces) using the curl command below.
+Note that the License is always displayed and that the description, subject, keywords, etc. will NOT be displayed if you do not include them in the :CustomDatasetSummaryFields.
 
-``curl http://localhost:8080/api/admin/settings/:CustomDatasetSummaryFields -X PUT -d 'producer,subtitle,alternativeTitle'``
+``curl http://localhost:8080/api/admin/settings/:CustomDatasetSummaryFields -X PUT -d 'producer,subtitle, alternativeTitle'``
 
 You have to put the datasetFieldType name attribute in the :CustomDatasetSummaryFields setting for this to work.
 

--- a/src/main/java/edu/harvard/iq/dataverse/dataset/DatasetUtil.java
+++ b/src/main/java/edu/harvard/iq/dataverse/dataset/DatasetUtil.java
@@ -530,7 +530,7 @@ public class DatasetUtil {
         } else {
             summaryFieldNames = customFieldNames;
         }
-        return summaryFieldNames.split(",");
+        return summaryFieldNames.split("\\s*,\\s*");
     }
 
     public static boolean isRsyncAppropriateStorageDriver(Dataset dataset){

--- a/src/main/webapp/dataset.xhtml
+++ b/src/main/webapp/dataset.xhtml
@@ -636,14 +636,7 @@
                                     <!-- END: DEACCESSION REASON -->
 
                                     <!-- BEGIN: DATASET SUMMARY -->
-                                    <div id="dataset-summary-metadata" class="col-xs-12 col-sm-12 col-md-8 col-lg-9 metadata-container padding-none margin-bottom"
-                                         jsf:rendered="#{!widgetWrapper.widgetView and !DatasetPage.workingVersion.deaccessioned and 
-                                                         (!empty DatasetPage.datasetVersionUI.descriptionDisplay
-                                                         or !empty DatasetPage.datasetVersionUI.keywordDisplay
-                                                         or !empty DatasetPage.datasetVersionUI.subject.value
-                                                         or !empty DatasetPage.datasetVersionUI.relPublicationCitation
-                                                         or !empty DatasetPage.datasetVersionUI.relPublicationUrl
-                                                         or !empty DatasetPage.datasetVersionUI.notes.value) and !empty DatasetPage.datasetSummaryFields}">
+                                    <div id="dataset-summary-metadata" class="col-xs-12 col-sm-12 col-md-8 col-lg-9 metadata-container padding-none margin-bottom">
                                         <table class="metadata">
                                             <tbody>
                                                 <ui:repeat value="#{DatasetPage.datasetSummaryFields}" var="dsf">


### PR DESCRIPTION
**What this PR does / why we need it**: This PR fixes the problem seen in #11228 where specify fields that don't have any values also removes the license display. It also supports having spaces in the :CustomDatasetSummaryFields setting comma-separated list of fields. It doesn't enforce any minimum set of fields, but the docs note that the default fields will disappear if you don't add them to your custom setting.

**Which issue(s) this PR closes**:

- Closes #11228 

**Special notes for your reviewer**: Looks like the License got added into a table that was only rendered if there were values to show. It also looks like there was some hardcoding to check that the default fields had some value. Since we do want the license to display and the rest of the table doesn't cause problems if empty, I've just removed the jsf:rendered attribute.

**Suggestions on how to test this**: per the issue.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**: added

**Additional documentation**:
