### PR TITLE
Delete Files From Dataset

### DIFF
--- a/doc/release-notes/11230-deleteFiles api call.md
+++ b/doc/release-notes/11230-deleteFiles api call.md
@@ -1,0 +1,1 @@
+A new /api/datasets/{id}/deleteFiles call has beed added to the API, allowing delete of multiple file from the latest version of a dataset in one operation.

--- a/doc/sphinx-guides/source/api/native-api.rst
+++ b/doc/sphinx-guides/source/api/native-api.rst
@@ -3547,9 +3547,6 @@ To remove all links to blocks, send an empty array.
 Delete Files from a Dataset
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Delete Files from a Dataset
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
 Delete files from a dataset. This API call allows you to delete multiple files from a dataset in a single operation.
 
 .. code-block:: bash

--- a/doc/sphinx-guides/source/api/native-api.rst
+++ b/doc/sphinx-guides/source/api/native-api.rst
@@ -3544,6 +3544,42 @@ To update the blocks that are linked, send an array with those blocks.
 
 To remove all links to blocks, send an empty array.
 
+Delete Files from a Dataset
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Delete Files from a Dataset
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Delete files from a dataset. This API call allows you to delete multiple files from a dataset in a single operation.
+
+.. code-block:: bash
+
+  export API_TOKEN=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+  export SERVER_URL=https://demo.dataverse.org
+  export PERSISTENT_IDENTIFIER=doi:10.5072/FK2ABCDEF
+
+  curl -H "X-Dataverse-key:$API_TOKEN" -X PUT "$SERVER_URL/api/datasets/:persistentId/deleteFiles?persistentId=$PERSISTENT_IDENTIFIER" \
+  -H "Content-Type: application/json" \
+  -d '{"fileIds": [1, 2, 3]}'
+
+The fully expanded example above (without environment variables) looks like this:
+
+.. code-block:: bash
+
+  curl -H "X-Dataverse-key:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" -X PUT "https://demo.dataverse.org/api/datasets/:persistentId/deleteFiles?persistentId=doi:10.5072/FK2ABCDEF" \
+  -H "Content-Type: application/json" \
+  -d '{"fileIds": [1, 2, 3]}'
+
+The ``fileIds`` in the JSON payload should be an array of file IDs that you want to delete from the dataset.
+
+You must have the appropriate permissions to delete files from the dataset.
+
+Upon success, the API will return a JSON response with a success message and the number of files deleted.
+
+The API call will report a 400 (BAD REQUEST) error if any of the files specified do not exist or are not in the latest version of the specified dataset.
+The ``fileIds`` in the JSON payload should be an array of file IDs that you want to delete from the dataset.
+
+
 Files
 -----
 

--- a/src/main/java/edu/harvard/iq/dataverse/pidproviders/doi/XmlMetadataTemplate.java
+++ b/src/main/java/edu/harvard/iq/dataverse/pidproviders/doi/XmlMetadataTemplate.java
@@ -69,8 +69,6 @@ public class XmlMetadataTemplate {
     public static final String XML_SCHEMA_VERSION = "4.5";
 
     private DoiMetadata doiMetadata;
-    //QDR - used to get ROR name from ExternalVocabularyValue via pidProvider.get
-    private PidProvider pidProvider = null;
 
     public XmlMetadataTemplate() {
     }
@@ -98,13 +96,6 @@ public class XmlMetadataTemplate {
         String language = null; // machine locale? e.g. for Publisher which is global
         String metadataLanguage = null; // when set, otherwise = language?
         
-        //QDR - used to get ROR name from ExternalVocabularyValue via pidProvider.get
-        GlobalId pid = null;
-        pid = dvObject.getGlobalId();
-        if ((pid == null) && (dvObject instanceof DataFile df)) {
-                pid = df.getOwner().getGlobalId();
-            }
-        pidProvider = PidUtil.getPidProvider(pid.getProviderId());
         XMLStreamWriter xmlw = XMLOutputFactory.newInstance().createXMLStreamWriter(outputStream);
         xmlw.writeStartElement("resource");
         boolean deaccessioned=false;

--- a/src/test/java/edu/harvard/iq/dataverse/api/DatasetsIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/DatasetsIT.java
@@ -5645,12 +5645,12 @@ createDataset = UtilIT.createRandomDatasetViaNativeApi(dataverse1Alias, apiToken
         Response getDatasetResponse = UtilIT.nativeGet(datasetId, apiToken);
         getDatasetResponse.then().assertThat()
                 .statusCode(OK.getStatusCode())
-                .body("data.latestVersion.files", not(hasItems(hasEntry("id", file1Id))))
-                .body("data.latestVersion.files", not(hasItems(hasEntry("id", file2Id))))
-                .body("data.latestVersion.files", hasItems(hasEntry("id", file3Id)))
-                .body("data.latestVersion.files", hasItems(hasEntry("id", file4Id)))
-                .body("data.latestVersion.files", hasItems(hasEntry("id", file5Id)));
-
+                .body("data.latestVersion.files", not(hasItem(hasEntry("dataFile.id", file1Id.intValue()))))
+                .body("data.latestVersion.files", not(hasItem(hasEntry("dataFile.id", file2Id.intValue()))))
+                .body("data.latestVersion.files", hasItem(hasEntry("dataFile.id", file3Id.intValue())))
+                .body("data.latestVersion.files", hasItem(hasEntry("dataFile.id", file4Id.intValue())))
+                .body("data.latestVersion.files", hasItem(hasEntry("dataFile.id", file5Id.intValue())));
+        
         // Publish the dataset
         Response publishDatasetResponse = UtilIT.publishDatasetViaNativeApi(datasetId, "major", apiToken);
         publishDatasetResponse.then().assertThat()
@@ -5670,9 +5670,9 @@ createDataset = UtilIT.createRandomDatasetViaNativeApi(dataverse1Alias, apiToken
         getDatasetResponse = UtilIT.nativeGet(datasetId, apiToken);
         getDatasetResponse.then().assertThat()
                 .statusCode(OK.getStatusCode())
-                .body("data.latestVersion.files", not(hasItems(hasEntry("id", file3Id))))
-                .body("data.latestVersion.files", not(hasItems(hasEntry("id", file4Id))))
-                .body("data.latestVersion.files", hasItems(hasEntry("id", file5Id)));
+                .body("data.latestVersion.files", not(hasItems(hasEntry("dataFile.id", file3Id))))
+                .body("data.latestVersion.files", not(hasItems(hasEntry("dataFile.id", file4Id))))
+                .body("data.latestVersion.files", hasItems(hasEntry("dataFile.id", file5Id)));
 
         // Test error conditions
 

--- a/src/test/java/edu/harvard/iq/dataverse/api/DatasetsIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/DatasetsIT.java
@@ -5677,7 +5677,7 @@ createDataset = UtilIT.createRandomDatasetViaNativeApi(dataverse1Alias, apiToken
                 .statusCode(OK.getStatusCode())
                 .body("data.latestVersion.files.findAll { it.dataFile.id == " + file3Id + " }.size()", equalTo(0))
                 .body("data.latestVersion.files.findAll { it.dataFile.id == " + file4Id + " }.size()", equalTo(0))
-                .body("data.latestVersion.files.findAll { it.dataFile.id == " + file5Id + " }.size()", equalTo(0));
+                .body("data.latestVersion.files.findAll { it.dataFile.id == " + file5Id + " }.size()", equalTo(1));
 
         // Test error conditions
 

--- a/src/test/java/edu/harvard/iq/dataverse/api/DatasetsIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/DatasetsIT.java
@@ -5645,11 +5645,12 @@ createDataset = UtilIT.createRandomDatasetViaNativeApi(dataverse1Alias, apiToken
         Response getDatasetResponse = UtilIT.nativeGet(datasetId, apiToken);
         getDatasetResponse.then().assertThat()
                 .statusCode(OK.getStatusCode())
-                .body("data.latestVersion.files", not(hasItem(hasEntry("dataFile.id", file1Id.intValue()))))
-                .body("data.latestVersion.files", not(hasItem(hasEntry("dataFile.id", file2Id.intValue()))))
-                .body("data.latestVersion.files", hasItem(hasEntry("dataFile.id", file3Id.intValue())))
-                .body("data.latestVersion.files", hasItem(hasEntry("dataFile.id", file4Id.intValue())))
-                .body("data.latestVersion.files", hasItem(hasEntry("dataFile.id", file5Id.intValue())));
+                .body("data.latestVersion.files.findAll { it.dataFile.id == " + file1Id + " }.size()", equalTo(0))
+                .body("data.latestVersion.files.findAll { it.dataFile.id == " + file2Id + " }.size()", equalTo(0))
+                .body("data.latestVersion.files.findAll { it.dataFile.id == " + file3Id + " }.size()", equalTo(1))
+                .body("data.latestVersion.files.findAll { it.dataFile.id == " + file4Id + " }.size()", equalTo(1))
+                .body("data.latestVersion.files.findAll { it.dataFile.id == " + file5Id + " }.size()", equalTo(1));
+
         
         // Publish the dataset
         Response publishDatasetResponse = UtilIT.publishDatasetViaNativeApi(datasetId, "major", apiToken);
@@ -5670,9 +5671,9 @@ createDataset = UtilIT.createRandomDatasetViaNativeApi(dataverse1Alias, apiToken
         getDatasetResponse = UtilIT.nativeGet(datasetId, apiToken);
         getDatasetResponse.then().assertThat()
                 .statusCode(OK.getStatusCode())
-                .body("data.latestVersion.files", not(hasItems(hasEntry("dataFile.id", file3Id))))
-                .body("data.latestVersion.files", not(hasItems(hasEntry("dataFile.id", file4Id))))
-                .body("data.latestVersion.files", hasItems(hasEntry("dataFile.id", file5Id)));
+                .body("data.latestVersion.files.findAll { it.dataFile.id == " + file3Id + " }.size()", equalTo(0))
+                .body("data.latestVersion.files.findAll { it.dataFile.id == " + file4Id + " }.size()", equalTo(0))
+                .body("data.latestVersion.files.findAll { it.dataFile.id == " + file5Id + " }.size()", equalTo(0));
 
         // Test error conditions
 

--- a/src/test/java/edu/harvard/iq/dataverse/api/DatasetsIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/DatasetsIT.java
@@ -5652,6 +5652,10 @@ createDataset = UtilIT.createRandomDatasetViaNativeApi(dataverse1Alias, apiToken
                 .body("data.latestVersion.files.findAll { it.dataFile.id == " + file5Id + " }.size()", equalTo(1));
 
         
+        // Test deleting after dataset publication
+        Response publishDataverseResponse = UtilIT.publishDataverseViaNativeApi(dataverseAlias, apiToken);
+        publishDataverseResponse.then().assertThat().statusCode(OK.getStatusCode());
+
         // Publish the dataset
         Response publishDatasetResponse = UtilIT.publishDatasetViaNativeApi(datasetId, "major", apiToken);
         publishDatasetResponse.then().assertThat()

--- a/src/test/java/edu/harvard/iq/dataverse/api/DatasetsIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/DatasetsIT.java
@@ -5604,11 +5604,11 @@ createDataset = UtilIT.createRandomDatasetViaNativeApi(dataverse1Alias, apiToken
         Integer datasetId = UtilIT.getDatasetIdFromResponse(createDatasetResponse);
 
         // Add files to the dataset
-        String pathToFile1 = "src/test/resources/file1.txt";
-        String pathToFile2 = "src/test/resources/file2.txt";
-        String pathToFile3 = "src/test/resources/file3.txt";
-        String pathToFile4 = "src/test/resources/file4.txt";
-        String pathToFile5 = "src/test/resources/file5.txt";
+        String pathToFile1 = "scripts/api/data/licenses/licenseCC0-1.0.json";
+        String pathToFile2 = "scripts/api/data/licenses/licenseCC-BY-4.0.json";
+        String pathToFile3 = "scripts/api/data/licenses/licenseCC-BY-NC-4.0.json";
+        String pathToFile4 = "scripts/api/data/licenses/licenseCC-BY-NC-ND-4.0.json";
+        String pathToFile5 = "scripts/api/data/licenses/licenseCC-BY-ND-4.0.json";
 
         JsonObjectBuilder json = Json.createObjectBuilder();
         json.add("description", "File 1");

--- a/src/test/java/edu/harvard/iq/dataverse/api/DatasetsIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/DatasetsIT.java
@@ -5639,7 +5639,7 @@ createDataset = UtilIT.createRandomDatasetViaNativeApi(dataverse1Alias, apiToken
         Response deleteFilesResponse = UtilIT.deleteDatasetFiles(datasetId.toString(), fileIdsToDelete.build(), apiToken);
         deleteFilesResponse.then().assertThat()
                 .statusCode(OK.getStatusCode())
-                .body("data.message", equalTo("2 Files deleted successfully."));
+                .body("data.message", startsWith("2"));
 
         // Verify files were deleted
         Response getDatasetResponse = UtilIT.nativeGet(datasetId, apiToken);
@@ -5664,8 +5664,7 @@ createDataset = UtilIT.createRandomDatasetViaNativeApi(dataverse1Alias, apiToken
         deleteFilesResponse = UtilIT.deleteDatasetFiles(datasetId.toString(), fileIdsToDelete.build(), apiToken);
         deleteFilesResponse.then().assertThat()
                 .statusCode(OK.getStatusCode())
-                .body("data.message", equalTo("Files deleted successfully."))
-                .body("data.deletedFileCount", equalTo(2));
+                .body("data.message", startsWith("2"));
 
         // Verify files were deleted
         getDatasetResponse = UtilIT.nativeGet(datasetId, apiToken);
@@ -5684,13 +5683,12 @@ createDataset = UtilIT.createRandomDatasetViaNativeApi(dataverse1Alias, apiToken
         deleteFilesResponse = UtilIT.deleteDatasetFiles(datasetId.toString(), fileIdsToDelete.build(), apiToken);
         deleteFilesResponse.then().assertThat()
                 .statusCode(BAD_REQUEST.getStatusCode())
-                .body("message", containsString("File not found"));
+                .body("message", containsString("No files"));
 
         // Try to delete files from a non-existent dataset
         deleteFilesResponse = UtilIT.deleteDatasetFiles("999999", fileIdsToDelete.build(), apiToken);
         deleteFilesResponse.then().assertThat()
-                .statusCode(NOT_FOUND.getStatusCode())
-                .body("message", containsString("Dataset not found"));
+                .statusCode(NOT_FOUND.getStatusCode());
 
         // Try to delete files without proper permissions
         String unauthorizedUserApiToken = UtilIT.createRandomUser().then().statusCode(OK.getStatusCode())

--- a/src/test/java/edu/harvard/iq/dataverse/api/DatasetsIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/DatasetsIT.java
@@ -5703,7 +5703,7 @@ createDataset = UtilIT.createRandomDatasetViaNativeApi(dataverse1Alias, apiToken
         fileIdsToDelete.add(file5Id);
         deleteFilesResponse = UtilIT.deleteDatasetFiles(datasetId.toString(), fileIdsToDelete.build(), unauthorizedUserApiToken);
         deleteFilesResponse.then().assertThat()
-                .statusCode(UNAUTHORIZED.getStatusCode());
+                .statusCode(FORBIDDEN.getStatusCode());
 
         // Clean up
         Response deleteDatasetResponse = UtilIT.deleteDatasetViaNativeApi(datasetId, apiToken);

--- a/src/test/java/edu/harvard/iq/dataverse/api/DatasetsIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/DatasetsIT.java
@@ -5698,6 +5698,9 @@ createDataset = UtilIT.createRandomDatasetViaNativeApi(dataverse1Alias, apiToken
         // Try to delete files without proper permissions
         String unauthorizedUserApiToken = UtilIT.createRandomUser().then().statusCode(OK.getStatusCode())
                 .extract().path("data.apiToken");
+        //Reset to a valid file id
+        fileIdsToDelete = Json.createArrayBuilder();
+        fileIdsToDelete.add(file5Id);
         deleteFilesResponse = UtilIT.deleteDatasetFiles(datasetId.toString(), fileIdsToDelete.build(), unauthorizedUserApiToken);
         deleteFilesResponse.then().assertThat()
                 .statusCode(UNAUTHORIZED.getStatusCode());

--- a/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
@@ -4569,7 +4569,7 @@ public class UtilIT {
         return given()
                 .header(API_TOKEN_HTTP_HEADER, apiToken)
                 .contentType(ContentType.JSON)
-                .body(Json.createObjectBuilder().add("fileIds", fileIds).build().toString())
+                .body(fileIds.toString())
                 .put(path);
     }
 }

--- a/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
@@ -11,6 +11,7 @@ import java.io.*;
 import java.util.*;
 import java.util.logging.Logger;
 import jakarta.json.Json;
+import jakarta.json.JsonArray;
 import jakarta.json.JsonObjectBuilder;
 import jakarta.json.JsonArrayBuilder;
 import jakarta.json.JsonObject;
@@ -4552,5 +4553,14 @@ public class UtilIT {
         return given()
                 .header(API_TOKEN_HTTP_HEADER, apiToken)
                 .delete("/api/dataverses/" + dataverseAlias + "/featuredItems");
+    }
+    
+    public static Response deleteDatasetFiles(String datasetId, JsonArray fileIds, String apiToken) {
+        String path = String.format("/api/datasets/%s/deleteFiles", datasetId);
+        return given()
+                .header(API_TOKEN_HTTP_HEADER, apiToken)
+                .contentType(ContentType.JSON)
+                .body(Json.createObjectBuilder().add("fileIds", fileIds).build().toString())
+                .post(path);
     }
 }

--- a/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
@@ -4570,6 +4570,6 @@ public class UtilIT {
                 .header(API_TOKEN_HTTP_HEADER, apiToken)
                 .contentType(ContentType.JSON)
                 .body(Json.createObjectBuilder().add("fileIds", fileIds).build().toString())
-                .post(path);
+                .put(path);
     }
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a deleteFiles method to the native API for datasets, using PUT as the HTTP verb to match the existing delete metadata calls. 

**Which issue(s) this PR closes**:

- Closes #

**Special notes for your reviewer**: 
Note for posterity: To be able to use DELETE with a payload, Payara has to have an option set:
```
asadmin set
configs.config.default-config.network-config.protocols.protocol.http-listener-1.http.allow-payload-for-undefined-http-methods=true

```
The consensus in slack was to not use this approach, but if we decide to in the future, we'd need to include instructions to make this change in Payara.

**Suggestions on how to test this**:
There's an IT test that creates a dataset with files, try to delete some, publishes the dataset and then tries to delete others. It also tests using a bad fileId or datasetId or using a user w/o permissions. Those or other cases could be manually tested as well. The documentation (in the native api section) gives a curl example.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**: included.

**Additional documentation**:
