### PR TITLE
DOI Publishing Bug Fix

### DIFF
--- a/doc/release-notes/11234-DOI Publishing Bug.md
+++ b/doc/release-notes/11234-DOI Publishing Bug.md
@@ -1,0 +1,1 @@
+This release fixes a bug which could cause publication of datasets to fail in cases where they were not assigned a DOI at creation.

--- a/src/main/java/edu/harvard/iq/dataverse/pidproviders/doi/XmlMetadataTemplate.java
+++ b/src/main/java/edu/harvard/iq/dataverse/pidproviders/doi/XmlMetadataTemplate.java
@@ -695,7 +695,7 @@ public class XmlMetadataTemplate {
         } else if (dvObject instanceof Dataset d) {
             DatasetVersion dv = d.getLatestVersionForCopy();
             Long versionNumber = dv.getVersionNumber();
-            if (versionNumber != null && !(versionNumber.equals(1) && dv.getMinorVersionNumber().equals(0))) {
+            if (versionNumber != null && !(versionNumber.equals(1L) && dv.getMinorVersionNumber().equals(0L))) {
                 isAnUpdate = true;
             }
             releaseDate = dv.getReleaseTime();

--- a/src/test/java/edu/harvard/iq/dataverse/pidproviders/doi/datacite/XmlMetadataTemplateTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/pidproviders/doi/datacite/XmlMetadataTemplateTest.java
@@ -201,6 +201,18 @@ public class XmlMetadataTemplateTest {
         assertEquals(null, XmlPath.from(xml).getString("resource.creators.creator[3].nameIdentifier.@schemeURI"));
         assertEquals("Dataverse", XmlPath.from(xml).getString("resource.publisher"));
 
+        dv.setVersionNumber(1L);
+        dv.setMinorVersionNumber(0l);
+        String xml2 = template.generateXML(d);
+        System.out.println("Output from example with v1.0 is " + xml2);
+        try {
+            StreamSource source = new StreamSource(new StringReader(xml2));
+            source.setSystemId("DataCite XML for test dataset");
+            assertTrue(XmlValidator.validateXmlSchema(source,
+                    new URL("https://schema.datacite.org/meta/kernel-4/metadata.xsd")));
+        } catch (SAXException e) {
+            System.out.println("Invalid schema: " + e.getMessage());
+        }
     }
 
     /**

--- a/src/test/java/edu/harvard/iq/dataverse/pidproviders/doi/datacite/XmlMetadataTemplateTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/pidproviders/doi/datacite/XmlMetadataTemplateTest.java
@@ -212,6 +212,7 @@ public class XmlMetadataTemplateTest {
                     new URL("https://schema.datacite.org/meta/kernel-4/metadata.xsd")));
         } catch (SAXException e) {
             System.out.println("Invalid schema: " + e.getMessage());
+            fail("Schema validation failed: " + e.getMessage());
         }
     }
 


### PR DESCRIPTION
**What this PR does / why we need it**: The code for publishing with a DOI has a bug for the case when a DOI has not been reserved prior to the publication attempt (e.g. to a prior misconfiguration/outage of DataCite, etc.). I this case, the code was finding the v1.0 added to the draft version and, due to the bug, assuming that the release was not 1.0/was an update, causing it to look for a non-existent release date and fail. The PR corrects the comparison.

**Which issue(s) this PR closes**:

- Closes #11234

**Special notes for your reviewer**:

**Suggestions on how to test this**: The automated test should do it, but you could misconfigure DataCite, create a dataset, and try to publish it. Before the PR it should fail, after it should succeed.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:

