### PR TITLE
IQSS/11248-Update oauth lib to fix json-smart error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -494,7 +494,7 @@
         <dependency>
             <groupId>com.nimbusds</groupId>
             <artifactId>oauth2-oidc-sdk</artifactId>
-            <version>10.13.2</version>
+            <version>11.22.1</version>
         </dependency>
         <!-- Caching library, current main use case is for OIDC authentication -->
         <dependency>


### PR DESCRIPTION
**What this PR does / why we need it**: Fixes a build error by updating the oauth library that uses the one that is now not available.

**Which issue(s) this PR closes**:

- Closes #11248

**Special notes for your reviewer**: 

**Suggestions on how to test this**: Assure it builds, regression test Oauth functionality, e.g. login via ORCID, Keycloak - whatever is convenient to configure.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
