### PR TITLE
#11208 fix update fmd api

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/api/Files.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Files.java
@@ -465,7 +465,7 @@ public class Files extends AbstractApiBean {
                 // We remove the current file from the list we'll check for duplicates.
                 // Instead, the current file is passed in as pathPlusFilename.
                 // the original test fails for published datasets/new draft because the filemetadata
-                // lacks an id for the "equals" test changing test to datafile for #11208
+                // lacks an id for the "equals" test. Changing test to datafile for #11208
                 List<FileMetadata> fmdListMinusCurrentFile = new ArrayList<>();
                 
                 for (FileMetadata fileMetadata : fmdList) {

--- a/src/main/java/edu/harvard/iq/dataverse/api/Files.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Files.java
@@ -464,12 +464,16 @@ public class Files extends AbstractApiBean {
                 String pathPlusFilename = IngestUtil.getPathAndFileNameToCheck(incomingLabel, incomingDirectoryLabel, existingLabel, existingDirectoryLabel);
                 // We remove the current file from the list we'll check for duplicates.
                 // Instead, the current file is passed in as pathPlusFilename.
+                // the original test fails for published datasets/new draft because the filemetadata
+                // lacks an id for the "equals" test changing test to datafile for #11208
                 List<FileMetadata> fmdListMinusCurrentFile = new ArrayList<>();
+                
                 for (FileMetadata fileMetadata : fmdList) {
-                    if (!fileMetadata.equals(df.getFileMetadata())) {
+                    if (!fileMetadata.getDataFile().equals(df)) {
                         fmdListMinusCurrentFile.add(fileMetadata);
                     }
                 }
+                
                 if (IngestUtil.conflictsWithExistingFilenames(pathPlusFilename, fmdListMinusCurrentFile)) {
                     return error(BAD_REQUEST, BundleUtil.getStringFromBundle("files.api.metadata.update.duplicateFile", Arrays.asList(pathPlusFilename)));
                 }

--- a/src/test/java/edu/harvard/iq/dataverse/api/FilesIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/FilesIT.java
@@ -1309,6 +1309,26 @@ public class FilesIT {
         String updateInvalidJsonString = "{\"dataFileTags\":false}";
         Response updateInvalidMetadataResponse = UtilIT.updateFileMetadata(origFileId.toString(), updateInvalidJsonString, apiToken);
         assertEquals(BAD_REQUEST.getStatusCode(), updateInvalidMetadataResponse.getStatusCode());  
+        
+        //adding a publish here to test the error seen in #11208
+        UtilIT.sleepForLock(datasetId, null, apiToken, UtilIT.MAXIMUM_INGEST_LOCK_DURATION);
+        publishDatasetResp = UtilIT.publishDatasetViaNativeApi(datasetId, "major", apiToken);
+        publishDatasetResp.prettyPrint();
+        publishDatasetResp.then().assertThat()
+                .statusCode(OK.getStatusCode());
+
+        String updateDescription2 = "update after publish";
+        String updateJsonString2 = "{\"description\":\"" + updateDescription2 + "\",\"label\":\"" + updateLabel + "\",\"categories\":[\"" + updateCategory + "\"],\"dataFileTags\":[\"" + updateDataFileTag + "\"],\"forceReplace\":false ,\"junk\":\"junk\"}";
+        Response updateMetadataResponse2 = UtilIT.updateFileMetadata(origFileId.toString(), updateJsonString2, apiToken);
+
+        updateMetadataResponse2.prettyPrint();
+
+        updateMetadataResponse2.then().assertThat()
+                .statusCode(OK.getStatusCode());
+        getUpdatedMetadataResponse = UtilIT.getDataFileMetadataDraft(origFileId, apiToken);
+        String getUpdateMetadataResponseString = getUpdatedMetadataResponse.body().asString();
+        msg(getUpdateMetadataResponseString);
+        assertEquals(updateDescription2, JsonPath.from(getUpdateMetadataResponseString).getString("description"));
 
     }
     


### PR DESCRIPTION
**What this PR does / why we need it**: Allows you to update file metadata via api when operating on a published version (that is, the api creates the draft)

**Which issue(s) this PR closes**:

- Closes #11208

**Special notes for your reviewer**:
There was some finding duplicates code private to the EditFilesPage that I considered refactoring, but the fix in the api code was fairly simple. Added a test to FilesIT - it and all the other tests therein are passing.

**Suggestions on how to test this**: Good example in the ticket. Basically invoke the update file metadata api on a published file that does not have a draft

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**: minor bug fix, probably not.

**Additional documentation**: none
