### PR TITLE
Copy labels from issue to pull request

### DIFF
--- a/.github/workflows/copy_labels.yml
+++ b/.github/workflows/copy_labels.yml
@@ -1,0 +1,15 @@
+name: Copy labels from issue to pull request
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  copy-labels:
+    runs-on: ubuntu-latest
+    name: Copy labels from linked issues
+    steps:
+      - name: copy-labels
+        uses: michalvankodev/copy-issue-labels@v1.3.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**What this PR does / why we need it**:

Copies labels from an issue to the PR that closes that issue.

**Which issue(s) this PR closes**:

- Closes #11262

**Special notes for your reviewer**:

Thanks to @g-saracca for showing the way here: https://github.com/IQSS/dataverse-client-javascript/blob/f34ea3b6c9f4e612ddbf23fc9f934e76112c5402/.github/workflows/copy_labels.yml

Docs at https://github.com/marketplace/actions/copy-issue-labels

**Suggestions on how to test this**:

Were the labels copied over?