### PR TITLE
index after file ingest

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/ingest/IngestMessageBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/ingest/IngestMessageBean.java
@@ -23,6 +23,7 @@ package edu.harvard.iq.dataverse.ingest;
 import edu.harvard.iq.dataverse.*;
 import edu.harvard.iq.dataverse.authorization.AuthenticationServiceBean;
 import edu.harvard.iq.dataverse.authorization.users.AuthenticatedUser;
+import edu.harvard.iq.dataverse.search.IndexServiceBean;
 import edu.harvard.iq.dataverse.util.BundleUtil;
 
 import java.sql.Timestamp;
@@ -60,6 +61,7 @@ public class IngestMessageBean implements MessageListener {
     @EJB IngestServiceBean ingestService;
     @EJB UserNotificationServiceBean userNotificationService;
     @EJB AuthenticationServiceBean authenticationServiceBean;
+    @EJB IndexServiceBean indexService;
 
    
     public IngestMessageBean() {
@@ -111,6 +113,7 @@ public class IngestMessageBean implements MessageListener {
                         // and "mixed success and failure" emails. Now we never list successfully
                         // ingested files so this line is commented out.
                         // sbIngestedFiles.append(String.format("<li>%s</li>", datafile.getCurrentName()));
+                        indexService.indexDataset(datafile.getOwner(), true);
                     } else {
                         logger.warning("Error occurred during ingest job for file id " + datafile_id + "!");
                         sbIngestedFiles.append(String.format("<li>%s</li>", datafile.getCurrentName()));

--- a/src/main/java/edu/harvard/iq/dataverse/ingest/IngestMessageBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/ingest/IngestMessageBean.java
@@ -113,7 +113,7 @@ public class IngestMessageBean implements MessageListener {
                         // and "mixed success and failure" emails. Now we never list successfully
                         // ingested files so this line is commented out.
                         // sbIngestedFiles.append(String.format("<li>%s</li>", datafile.getCurrentName()));
-                        indexService.indexDataset(datafile.getOwner(), true);
+                        indexService.asyncIndexDataset(datafile.getOwner(), true);
                     } else {
                         logger.warning("Error occurred during ingest job for file id " + datafile_id + "!");
                         sbIngestedFiles.append(String.format("<li>%s</li>", datafile.getCurrentName()));


### PR DESCRIPTION
**What this PR does / why we need it**:

Files that are successfully ingested are not reindexed at tabular files. This means they don't have fields such as "variables", "observations", etc.

**Which issue(s) this PR closes**:

- Closes #11182

**Special notes for your reviewer**:

I made the simplest possible fix for this first attempt. Probably we should reduce the amount of indexing if we can. For example, if several newly ingested files come from the same dataset, we should probably only reindex the dataset at the end? I'm not sure how long ingesting will take, though. 🤔 

**Suggestions on how to test this**:

- Upload a file that will successfully ingest
- Check it with the Search API? Do you see fields like "variables" and "observations"?

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No.

**Is there a release notes update needed for this change?**:

I didn't bother.

**Additional documentation**:

None.