### PR TITLE
return more perms from /api/access/datafile/{id}/userPermissions

### DIFF
--- a/doc/sphinx-guides/source/api/dataaccess.rst
+++ b/doc/sphinx-guides/source/api/dataaccess.rst
@@ -428,6 +428,10 @@ In particular, the user permissions that this method checks, returned as boolean
 * Can download the file
 * Can manage the file permissions
 * Can edit the file owner dataset
+* Can edit file metadata
+* Can restrict or unrestrict the file
+* Can replace the file
+* Can delete the file
 
 A curl example using an ``id``::
 

--- a/src/main/java/edu/harvard/iq/dataverse/api/Access.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Access.java
@@ -1711,6 +1711,10 @@ public class Access extends AbstractApiBean {
         jsonObjectBuilder.add("canDownloadFile", permissionService.userOn(requestUser, dataFile).has(Permission.DownloadFile));
         jsonObjectBuilder.add("canManageFilePermissions", permissionService.userOn(requestUser, dataFile).has(Permission.ManageFilePermissions));
         jsonObjectBuilder.add("canEditOwnerDataset", permissionService.userOn(requestUser, dataFile.getOwner()).has(Permission.EditDataset));
+        jsonObjectBuilder.add("canEditFileMetadata", permissionService.userOn(requestUser, dataFile.getOwner()).has(Permission.EditDataset));
+        jsonObjectBuilder.add("canRestrictFile", permissionService.userOn(requestUser, dataFile.getOwner()).has(Permission.EditDataset));
+        jsonObjectBuilder.add("canReplaceFile", permissionService.userOn(requestUser, dataFile.getOwner()).has(Permission.EditDataset));
+        jsonObjectBuilder.add("canDeleteFile", permissionService.userOn(requestUser, dataFile.getOwner()).has(Permission.EditDataset));
         return ok(jsonObjectBuilder);
     }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

API users (especially the frontend team, which is writing the [new UI](https://github.com/IQSS/dataverse-frontend)) need more granularity when checking file permissions.

**Which issue(s) this PR closes**:

- Closes #11226

**Special notes for your reviewer**:

Instead of adding these four new permissions, the API user could simply check the existing "canEditOwnerDataset" instead. I'm curious where these permissions come from? JSF? They aren't in our main [Permission class](https://github.com/IQSS/dataverse/blob/v6.5/src/main/java/edu/harvard/iq/dataverse/authorization/Permission.java).

I cleaned up existing assertions and added a new "no perms" user and additional assertions.

**Suggestions on how to test this**:

Create some users. Give them various permissions. Check the `/api/access/datafile/{id}/userPermissions` API. Does it return the right results?

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No.

**Is there a release notes update needed for this change?**:

**Additional documentation**:
