### PR TITLE
IQSS/11264 - Add pseudo-exponential backoff to dataset page refresh

### DIFF
--- a/doc/release-notes/11264-slower refresh for long running locks.md
+++ b/doc/release-notes/11264-slower refresh for long running locks.md
@@ -1,0 +1,1 @@
+When a dataset has a long running lock, including when it is 'in review', Dataverse will now slow the page refresh rate over time.

--- a/src/main/webapp/dataset.xhtml
+++ b/src/main/webapp/dataset.xhtml
@@ -858,6 +858,11 @@
                                 $(this).ready(function () {
                                     refreshIfStillLocked();
                                 });
+                            
+                                var initialInterval = 5000; // 5 seconds
+                                var maxInterval = 300000; // 5 minutes
+                                var currentInterval = initialInterval;
+                                var backoffFactor = 1.2; // Exponential factor
                                 function refreshIfStillLocked() {
                                     if ($('input[id$="datasetLockedForAnyReasonVariable"]').val() === 'true') {
                                         // if dataset is locked, instruct the page to
@@ -882,18 +887,22 @@
                                                 $('button[id$="refreshButton"]').trigger('click');
                                                 //refreshAllCommand();
                                             }, 1500);
+                                        } else {
+                                          // Reset the interval if the dataset is unlocked
+                                          currentInterval = initialInterval;
                                         }
                                     }
                                 }
+                            
                                 function waitAndCheckLockAgain() {
                                     setTimeout(function () {
                                         // refresh the lock in the
                                         // backing bean; i.e., check, if the ingest has
                                         // already completed in the background:
-                                        //$('button[id$="refreshButton"]').trigger('click');
-                                        //refreshLockCommand();
                                         refreshAllLocksCommand();
-                                    }, 10000);
+                                        // Increase the interval exponentially for the next check
+                                        currentInterval = Math.min((currentInterval * backoffFactor) + 2, maxInterval);
+                                    }, currentInterval);
                                 }
                                 //]]>
                             </script>


### PR DESCRIPTION
**What this PR does / why we need it**: The dataset page currently refreshes every 10 seconds looking for locks to be removed, which is not very useful for long-running locks, e.g. in review, or ingest, publish, etc. with large/many files. This PR adds a pseudo-exponential backoff - in the front-end JavaScript - in the rate of refresh to reduce the load. The constants chose make the updates slightly faster for the first two refreshes and then quickly backs off to 5 minute refreshes (after ~ 90 seconds, the new algorithm will have had fewer total refreshes and will only be refreshing ~once per minute)

**Which issue(s) this PR closes**:

- Closes #11264

**Special notes for your reviewer**: This is a minor improvement, but hopefully reduces server load for in review datasets in particular, as well as long running Globus transfers, pub with many files, etc.

**Suggestions on how to test this**: Put a dataset in review and check the refresh rate in the browser console - verify it is slowing down.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
