### PR TITLE
Fix the order of fields on the AdvancedSearch Page 

### DIFF
--- a/doc/release-notes/11272-fix-order-on-advancedsearchpage.md
+++ b/doc/release-notes/11272-fix-order-on-advancedsearchpage.md
@@ -1,0 +1,5 @@
+### Fix order of metadata fields on the advanced search page
+
+The metadata fields are now displayed in the correct order as defined in the TSV file via the displayOrder value.
+The order of the fields on the AdvancedSearch page will then be more similar to that on the metadata forms. 
+Note that fields that are not defined in the TSV file, like the 'Persistent ID' and 'Publication Date', will be displayed at the end. 

--- a/src/main/java/edu/harvard/iq/dataverse/DatasetFieldServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetFieldServiceBean.java
@@ -93,7 +93,7 @@ public class DatasetFieldServiceBean implements java.io.Serializable {
     String oldHash = null;
 
     public List<DatasetFieldType> findAllAdvancedSearchFieldTypes() {
-        return em.createQuery("select object(o) from DatasetFieldType as o where o.advancedSearchFieldType = true and o.title != '' order by o.id", DatasetFieldType.class).getResultList();
+        return em.createQuery("select object(o) from DatasetFieldType as o where o.advancedSearchFieldType = true and o.title != '' order by o.displayOrder,o.id", DatasetFieldType.class).getResultList();
     }
 
     public List<DatasetFieldType> findAllFacetableFieldTypes() {


### PR DESCRIPTION
**What this PR does / why we need it**:
Have advanced search page use a query that orders by displayOrder before id, so that it will use the displayOrder if available instead of ignoring it. 

**Which issue(s) this PR closes**:

- Closes #11272

**Special notes for your reviewer**:

**Suggestions on how to test this**:
Use a custom metadata block (tsv file) and change the order in a way that it is different from the rows order in the file, like change the last one to have order `0`. 
Then load that tsv and check the advanced search page, before the fix it would not be at the top, but after the fix it will be. 


**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:



