### PR TITLE
clarify direct children only when using returnChildCount=true

### DIFF
--- a/doc/release-notes/11255-get-dataverse-api-return-child-count.md
+++ b/doc/release-notes/11255-get-dataverse-api-return-child-count.md
@@ -1,1 +1,1 @@
-Added a new query param, ``returnChildCount``, to getDataverse endpoint(``/api/dataverses/<ID>``) for optionally retrieving the child count, which represents the number of dataverses, datasets, or files within the dataverse.
+Added a new query param, ``returnChildCount``, to getDataverse endpoint(``/api/dataverses/<ID>``) for optionally retrieving the child count, which represents the number of dataverses, datasets, or files within the dataverse (direct children only). See also #11255 and #11259.

--- a/doc/sphinx-guides/source/api/native-api.rst
+++ b/doc/sphinx-guides/source/api/native-api.rst
@@ -177,7 +177,7 @@ Usage example:
 
   curl "https://demo.dataverse.org/api/dataverses/root?returnOwners=true"
 
-If you want to include the child count of the Dataverse, which represents the number of dataverses, datasets, or files within the dataverse, you must set ``returnChildCount`` query parameter to ``true``.
+If you want to include the child count of the Dataverse, which represents the number of dataverses, datasets, or files within the dataverse, you must set ``returnChildCount`` query parameter to ``true``. Please note that this count is for direct children only. It doesn't count children of subdataverses.
 
 Usage example:
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Just a doc update to clarify that the following PR is for direct children only:

- #11259