### PR TITLE
content type for files with vtt extension

### DIFF
--- a/src/main/java/propertyFiles/MimeTypeDetectionByFileExtension.properties
+++ b/src/main/java/propertyFiles/MimeTypeDetectionByFileExtension.properties
@@ -16,6 +16,7 @@ mat=application/matlab-mat
 md=text/markdown
 mp3=audio/mp3
 m4a=audio/mp4
+vtt=text/vtt
 nii=image/nii
 nc=application/netcdf
 ods=application/vnd.oasis.opendocument.spreadsheet

--- a/src/main/java/propertyFiles/MimeTypeDisplay.properties
+++ b/src/main/java/propertyFiles/MimeTypeDisplay.properties
@@ -217,6 +217,7 @@ video/x-m4v=MPEG-4 Video
 video/ogg=OGG Video
 video/quicktime=Quicktime Video
 video/webm=WebM Video
+text/vtt=Web Video Text Tracks
 # Network Data
 text/xml-graphml=GraphML Network Data
 # 3D Data

--- a/src/main/java/propertyFiles/MimeTypeFacets.properties
+++ b/src/main/java/propertyFiles/MimeTypeFacets.properties
@@ -30,6 +30,7 @@ text/richtext=Text
 text/turtle=Text
 application/xml=Text
 text/xml=Text
+text/vtt=Text
 # Code
 text/x-c=Code
 text/x-c++src=Code


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently files with a `vtt` extension show in json metadata export:

          "contentType": "application/octet-stream",
          "friendlyType": "Unknown",

Desired metadata:

          "contentType": "text/vtt",
          "friendlyType": "Web Video Text Tracks", 

**Which issue(s) this PR closes**:

- Closes #

**Special notes for your reviewer**:

**Suggestions on how to test this**:

Create a dataset and upload upload https://github.com/user-attachments/files/18197712/test-files-subtitles.zip

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
