### PR TITLE
Revert "10476 display on create field option"

### DIFF
--- a/doc/release-notes/10476-display-on-create-field-option.md
+++ b/doc/release-notes/10476-display-on-create-field-option.md
@@ -1,6 +1,0 @@
-New feature: Collection administrators can now configure which metadata fields appear during dataset creation through the `displayOnCreate` property, even when fields are not required. This provides greater control over metadata visibility and can help improve metadata completeness.
-
-- The feature is currently available through the API endpoint `/api/dataverses/{alias}/inputLevels`
-- UI implementation will be available in a future release [#11221](https://github.com/IQSS/dataverse/issues/11221)
-
-For more information, see the [API Guide](https://guides.dataverse.org/en/latest/api/native-api.html#update-collection-input-levels) and issues [#10476](https://github.com/IQSS/dataverse/issues/10476) and [#11224](https://github.com/IQSS/dataverse/pull/11224).

--- a/doc/sphinx-guides/source/api/native-api.rst
+++ b/doc/sphinx-guides/source/api/native-api.rst
@@ -1125,6 +1125,12 @@ This endpoint expects a JSON with the following format::
     }
   ]
 
+Parameters:
+
+- ``datasetFieldTypeName``: Name of the metadata field
+- ``required``: Whether the field is required (boolean)
+- ``include``: Whether the field is included (boolean)
+
 .. code-block:: bash
 
   export API_TOKEN=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx

--- a/doc/sphinx-guides/source/api/native-api.rst
+++ b/doc/sphinx-guides/source/api/native-api.rst
@@ -1116,23 +1116,14 @@ This endpoint expects a JSON with the following format::
     {
       "datasetFieldTypeName": "datasetFieldTypeName1",
       "required": true,
-      "include": true,
-      "displayOnCreate": false
+      "include": true
     },
     {
       "datasetFieldTypeName": "datasetFieldTypeName2",
       "required": true,
-      "include": true,
-      "displayOnCreate": true
+      "include": true
     }
   ]
-
-Parameters:
-
-- ``datasetFieldTypeName``: Name of the metadata field
-- ``required``: Whether the field is required (boolean)
-- ``include``: Whether the field is included (boolean)
-- ``displayOnCreate`` (optional): Whether the field is displayed during dataset creation, even when not required (boolean)
 
 .. code-block:: bash
 

--- a/src/main/java/edu/harvard/iq/dataverse/DatasetFieldServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetFieldServiceBean.java
@@ -941,12 +941,6 @@ public class DatasetFieldServiceBean implements java.io.Serializable {
                 criteriaBuilder.isTrue(datasetFieldTypeInputLevelJoin.get("required"))
         );
 
-        // Predicate for displayOnCreate in input level
-        Predicate displayOnCreateInputLevelPredicate = criteriaBuilder.and(
-            criteriaBuilder.equal(datasetFieldTypeRoot, datasetFieldTypeInputLevelJoin.get("datasetFieldType")),
-            criteriaBuilder.isTrue(datasetFieldTypeInputLevelJoin.get("displayOnCreate"))
-        );
-
         // Create a subquery to check for the absence of a specific DataverseFieldTypeInputLevel.
         Subquery<Long> subquery = criteriaQuery.subquery(Long.class);
         Root<DataverseFieldTypeInputLevel> subqueryRoot = subquery.from(DataverseFieldTypeInputLevel.class);
@@ -969,19 +963,10 @@ public class DatasetFieldServiceBean implements java.io.Serializable {
         // Otherwise, use an always-true predicate (conjunction).
         Predicate displayedOnCreatePredicate = onlyDisplayedOnCreate
                 ? criteriaBuilder.or(
-                // 1. Field marked as displayOnCreate in input level
-                displayOnCreateInputLevelPredicate,
-                
-                // 2. Field without input level that is marked as displayOnCreate or required
-                criteriaBuilder.and(
-                    hasNoInputLevelPredicate,
-                    criteriaBuilder.or(
+                criteriaBuilder.or(
                         criteriaBuilder.isTrue(datasetFieldTypeRoot.get("displayOnCreate")),
                         fieldRequiredInTheInstallation
-                    )
                 ),
-                
-                // 3. Field required by input level
                 requiredAsInputLevelPredicate
         )
                 : criteriaBuilder.conjunction();

--- a/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
@@ -1855,7 +1855,6 @@ public class DatasetPage implements java.io.Serializable {
                 if (dsf != null){
                     // Yes, call "setInclude"
                     dsf.setInclude(oneDSFieldTypeInputLevel.isInclude());
-                    dsf.getDatasetFieldType().setDisplayOnCreate(oneDSFieldTypeInputLevel.isDisplayOnCreate());
                     // remove from hash
                     mapDatasetFields.remove(oneDSFieldTypeInputLevel.getDatasetFieldType().getId());
                 }

--- a/src/main/java/edu/harvard/iq/dataverse/Dataverse.java
+++ b/src/main/java/edu/harvard/iq/dataverse/Dataverse.java
@@ -438,12 +438,6 @@ public class Dataverse extends DvObjectContainer {
                 .anyMatch(inputLevel -> inputLevel.getDatasetFieldType().getId().equals(datasetFieldTypeId));
     }
 
-    public boolean isDatasetFieldTypeDisplayOnCreateAsInputLevel(Long datasetFieldTypeId) {
-        return dataverseFieldTypeInputLevels.stream()
-                .anyMatch(inputLevel -> inputLevel.getDatasetFieldType().getId().equals(datasetFieldTypeId) 
-                         && inputLevel.isDisplayOnCreate());
-    }
-
     public Template getDefaultTemplate() {
         return defaultTemplate;
     }

--- a/src/main/java/edu/harvard/iq/dataverse/DataverseFieldTypeInputLevel.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DataverseFieldTypeInputLevel.java
@@ -58,16 +58,14 @@ public class DataverseFieldTypeInputLevel implements Serializable {
     private DatasetFieldType datasetFieldType;
     private boolean include;
     private boolean required;
-    private boolean displayOnCreate;
     
     public DataverseFieldTypeInputLevel () {}
   
-    public DataverseFieldTypeInputLevel (DatasetFieldType fieldType, Dataverse dataverse, boolean required, boolean include, boolean displayOnCreate) {
+    public DataverseFieldTypeInputLevel (DatasetFieldType fieldType, Dataverse dataverse, boolean required, boolean include) {
         this.datasetFieldType = fieldType;
         this.dataverse = dataverse;
         this.required = required;
         this.include = include;
-        this.displayOnCreate = displayOnCreate;
     }    
 
     public Long getId() {
@@ -115,14 +113,6 @@ public class DataverseFieldTypeInputLevel implements Serializable {
 
     public void setRequired(boolean required) {
         this.required = required;
-    }
-
-    public boolean isDisplayOnCreate() {
-        return displayOnCreate;
-    }
-
-    public void setDisplayOnCreate(boolean displayOnCreate) {
-        this.displayOnCreate = displayOnCreate;
     }
 
     @Override

--- a/src/main/java/edu/harvard/iq/dataverse/DataverseFieldTypeInputLevelServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DataverseFieldTypeInputLevelServiceBean.java
@@ -117,13 +117,4 @@ public class DataverseFieldTypeInputLevelServiceBean {
         em.persist(dataverseFieldTypeInputLevel);
     }
 
-    public DataverseFieldTypeInputLevel save(DataverseFieldTypeInputLevel inputLevel) {
-        if (inputLevel.getId() == null) {
-            em.persist(inputLevel);
-            return inputLevel;
-        } else {
-            return em.merge(inputLevel);
-        }
-    }
-
 }

--- a/src/main/java/edu/harvard/iq/dataverse/DataversePage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DataversePage.java
@@ -627,16 +627,43 @@ public class DataversePage implements java.io.Serializable {
                 if (dataverse.isMetadataBlockRoot() && (mdb.isSelected() || mdb.isRequired())) {
                     selectedBlocks.add(mdb);
                     for (DatasetFieldType dsft : mdb.getDatasetFieldTypes()) {
-                        if (!dsft.isChild()) {
-                            // Save input level for parent field
-                            saveInputLevels(listDFTIL, dsft, dataverse);
+                        // currently we don't allow input levels for setting an optional field as conditionally required
+                        // so we skip looking at parents (which get set automatically with their children)
+                        if (!dsft.isHasChildren() && dsft.isRequiredDV()) {
+                            boolean addRequiredInputLevels = false;
+                            boolean parentAlreadyAdded = false;
                             
-                            // Handle child fields
-                            if (dsft.isHasChildren()) {
-                                for (DatasetFieldType child : dsft.getChildDatasetFieldTypes()) {
-                                    saveInputLevels(listDFTIL, child, dataverse);
-                                }
+                            if (!dsft.isHasParent() && dsft.isInclude()) {
+                                addRequiredInputLevels = !dsft.isRequired();
                             }
+                            if (dsft.isHasParent() && dsft.getParentDatasetFieldType().isInclude()) {
+                                addRequiredInputLevels = !dsft.isRequired() || !dsft.getParentDatasetFieldType().isRequired();
+                            }
+                            
+                            if (addRequiredInputLevels) {
+                                listDFTIL.add(new DataverseFieldTypeInputLevel(dsft, dataverse,true, true));
+                            
+                                //also add the parent as required (if it hasn't been added already)
+                                // todo: review needed .equals() methods, then change this to use a Set, in order to simplify code
+                                if (dsft.isHasParent()) {
+                                    DataverseFieldTypeInputLevel parentToAdd = new DataverseFieldTypeInputLevel(dsft.getParentDatasetFieldType(), dataverse, true, true);
+                                    for (DataverseFieldTypeInputLevel dataverseFieldTypeInputLevel : listDFTIL) {
+                                        if (dataverseFieldTypeInputLevel.getDatasetFieldType().getId() == parentToAdd.getDatasetFieldType().getId()) {
+                                            parentAlreadyAdded = true;
+                                            break;
+                                        }
+                                    }
+                                    if (!parentAlreadyAdded) {
+                                        // Only add the parent once. There's a UNIQUE (dataverse_id, datasetfieldtype_id)
+                                        // constraint on the dataversefieldtypeinputlevel table we need to avoid.
+                                        listDFTIL.add(parentToAdd);
+                                    }
+                                }      
+                            }
+                        }
+                        if ((!dsft.isHasParent() && !dsft.isInclude())
+                                || (dsft.isHasParent() && !dsft.getParentDatasetFieldType().isInclude())) {
+                            listDFTIL.add(new DataverseFieldTypeInputLevel(dsft, dataverse,false, false));                        
                         }
                     }
                 }
@@ -1003,11 +1030,27 @@ public class DataversePage implements java.io.Serializable {
 
             for (DatasetFieldType dsft : mdb.getDatasetFieldTypes()) {
                 if (!dsft.isChild()) {
-                    loadInputLevels(dsft, dataverseIdForInputLevel);
+                    DataverseFieldTypeInputLevel dsfIl = dataverseFieldTypeInputLevelService.findByDataverseIdDatasetFieldTypeId(dataverseIdForInputLevel, dsft.getId());
+                    if (dsfIl != null) {
+                        dsft.setRequiredDV(dsfIl.isRequired());
+                        dsft.setInclude(dsfIl.isInclude());
+                    } else {
+                        dsft.setRequiredDV(dsft.isRequired());
+                        dsft.setInclude(true);
+                    }
                     dsft.setOptionSelectItems(resetSelectItems(dsft));
                     if (dsft.isHasChildren()) {
                         for (DatasetFieldType child : dsft.getChildDatasetFieldTypes()) {
-                            loadInputLevels(child, dataverseIdForInputLevel);
+                            DataverseFieldTypeInputLevel dsfIlChild = dataverseFieldTypeInputLevelService.findByDataverseIdDatasetFieldTypeId(dataverseIdForInputLevel, child.getId());
+                            if (dsfIlChild != null) {
+                                child.setRequiredDV(dsfIlChild.isRequired());
+                                child.setInclude(dsfIlChild.isInclude());
+                            } else {
+                                // in the case of conditionally required (child = true, parent = false)
+                                // we set this to false; i.e this is the default "don't override" value
+                                child.setRequiredDV(child.isRequired() && dsft.isRequired());
+                                child.setInclude(true);
+                            }
                             child.setOptionSelectItems(resetSelectItems(child));
                         }
                     }
@@ -1016,22 +1059,6 @@ public class DataversePage implements java.io.Serializable {
             retList.add(mdb);
         }
         setAllMetadataBlocks(retList);
-    }
-
-    private void loadInputLevels(DatasetFieldType dsft, Long dataverseIdForInputLevel) {
-        DataverseFieldTypeInputLevel dsfIl = dataverseFieldTypeInputLevelService
-            .findByDataverseIdDatasetFieldTypeId(dataverseIdForInputLevel, dsft.getId());
-        
-        if (dsfIl != null) {
-            dsft.setRequiredDV(dsfIl.isRequired());
-            dsft.setInclude(dsfIl.isInclude());
-            dsft.setDisplayOnCreate(dsfIl.isDisplayOnCreate());
-        } else {
-            // If there is no input level, use the default values
-            dsft.setRequiredDV(dsft.isRequired());
-            dsft.setInclude(true);
-            dsft.setDisplayOnCreate(false);
-        }
     }
 
     public void validateAlias(FacesContext context, UIComponent toValidate, Object value) {
@@ -1309,58 +1336,5 @@ public class DataversePage implements java.io.Serializable {
             options.add(option);
         }
         return options;
-    }
-
-    public void updateDisplayOnCreate(Long mdbId, Long dsftId, boolean currentValue) {
-        for (MetadataBlock mdb : allMetadataBlocks) {
-            if (mdb.getId().equals(mdbId)) {
-                for (DatasetFieldType dsft : mdb.getDatasetFieldTypes()) {
-                    if (dsft.getId().equals(dsftId)) {
-                        // Update value in memory
-                        dsft.setDisplayOnCreate(!currentValue);
-                        
-                        // Update or create input level
-                        DataverseFieldTypeInputLevel existingLevel = dataverseFieldTypeInputLevelService
-                            .findByDataverseIdDatasetFieldTypeId(dataverse.getId(), dsftId);
-                        
-                        if (existingLevel != null) {
-                            existingLevel.setDisplayOnCreate(!currentValue);
-                            dataverseFieldTypeInputLevelService.save(existingLevel);
-                        } else {
-                            DataverseFieldTypeInputLevel newLevel = new DataverseFieldTypeInputLevel(
-                                dsft, 
-                                dataverse, 
-                                dsft.isRequiredDV(),
-                                true,  // default include
-                                !currentValue  // new value of displayOnCreate
-                            );
-                            dataverseFieldTypeInputLevelService.save(newLevel);
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    private void saveInputLevels(List<DataverseFieldTypeInputLevel> listDFTIL, DatasetFieldType dsft, Dataverse dataverse) {
-        // If the field already has an input level, update it
-        DataverseFieldTypeInputLevel existingLevel = dataverseFieldTypeInputLevelService
-            .findByDataverseIdDatasetFieldTypeId(dataverse.getId(), dsft.getId());
-        
-        if (existingLevel != null) {
-            existingLevel.setDisplayOnCreate(dsft.isDisplayOnCreate());
-            existingLevel.setInclude(dsft.isInclude());
-            existingLevel.setRequired(dsft.isRequiredDV());
-            listDFTIL.add(existingLevel);
-        } else if (dsft.isInclude() || dsft.isDisplayOnCreate() || dsft.isRequiredDV()) {
-            // Only create new input level if there is any specific configuration
-            listDFTIL.add(new DataverseFieldTypeInputLevel(
-                dsft, 
-                dataverse, 
-                dsft.isRequiredDV(), 
-                dsft.isInclude(), 
-                dsft.isDisplayOnCreate()
-            ));
-        }
     }
 }

--- a/src/main/java/edu/harvard/iq/dataverse/DataverseServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DataverseServiceBean.java
@@ -959,11 +959,9 @@ public class DataverseServiceBean implements java.io.Serializable {
                     if (dsfIl != null) {
                         dsft.setRequiredDV(dsfIl.isRequired());
                         dsft.setInclude(dsfIl.isInclude());
-                        dsft.setDisplayOnCreate(dsfIl.isDisplayOnCreate());
                     } else {
                         dsft.setRequiredDV(dsft.isRequired());
                         dsft.setInclude(true);
-                        dsft.setDisplayOnCreate(false);
                     }
                     List<String> childrenRequired = new ArrayList<>();
                     List<String> childrenAllowed = new ArrayList<>();
@@ -973,13 +971,11 @@ public class DataverseServiceBean implements java.io.Serializable {
                             if (dsfIlChild != null) {
                                 child.setRequiredDV(dsfIlChild.isRequired());
                                 child.setInclude(dsfIlChild.isInclude());
-                                child.setDisplayOnCreate(dsfIlChild.isDisplayOnCreate());
                             } else {
                                 // in the case of conditionally required (child = true, parent = false)
                                 // we set this to false; i.e this is the default "don't override" value
                                 child.setRequiredDV(child.isRequired() && dsft.isRequired());
                                 child.setInclude(true);
-                                child.setDisplayOnCreate(false);
                             }
                             if (child.isRequired()) {
                                 childrenRequired.add(child.getName());

--- a/src/main/java/edu/harvard/iq/dataverse/MetadataBlockServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/MetadataBlockServiceBean.java
@@ -54,52 +54,29 @@ public class MetadataBlockServiceBean {
         CriteriaQuery<MetadataBlock> criteriaQuery = criteriaBuilder.createQuery(MetadataBlock.class);
         Root<MetadataBlock> metadataBlockRoot = criteriaQuery.from(MetadataBlock.class);
         Join<MetadataBlock, DatasetFieldType> datasetFieldTypeJoin = metadataBlockRoot.join("datasetFieldTypes");
-        
+        Predicate displayOnCreatePredicate = criteriaBuilder.isTrue(datasetFieldTypeJoin.get("displayOnCreate"));
+
         if (ownerDataverse != null) {
             Root<Dataverse> dataverseRoot = criteriaQuery.from(Dataverse.class);
-            Join<Dataverse, DataverseFieldTypeInputLevel> datasetFieldTypeInputLevelJoin = 
-                dataverseRoot.join("dataverseFieldTypeInputLevels", JoinType.LEFT);
+            Join<Dataverse, DataverseFieldTypeInputLevel> datasetFieldTypeInputLevelJoin = dataverseRoot.join("dataverseFieldTypeInputLevels", JoinType.LEFT);
 
-            // Subquery to check if the input level exists
-            Subquery<Long> inputLevelSubquery = criteriaQuery.subquery(Long.class);
-            Root<DataverseFieldTypeInputLevel> subqueryRoot = inputLevelSubquery.from(DataverseFieldTypeInputLevel.class);
-            inputLevelSubquery.select(criteriaBuilder.literal(1L))
-                .where(
-                    criteriaBuilder.equal(subqueryRoot.get("dataverse"), dataverseRoot),
-                    criteriaBuilder.equal(subqueryRoot.get("datasetFieldType"), datasetFieldTypeJoin)
-                );
-
-            // Predicate for displayOnCreate in the input level
-            Predicate displayOnCreateInputLevelPredicate = criteriaBuilder.and(
-                datasetFieldTypeInputLevelJoin.get("datasetFieldType").in(metadataBlockRoot.get("datasetFieldTypes")),
-                criteriaBuilder.isTrue(datasetFieldTypeInputLevelJoin.get("displayOnCreate")));
-
-            // Predicate for required fields
             Predicate requiredPredicate = criteriaBuilder.and(
-                datasetFieldTypeInputLevelJoin.get("datasetFieldType").in(metadataBlockRoot.get("datasetFieldTypes")),
-                criteriaBuilder.isTrue(datasetFieldTypeInputLevelJoin.get("required")));
+                    datasetFieldTypeInputLevelJoin.get("datasetFieldType").in(metadataBlockRoot.get("datasetFieldTypes")),
+                    criteriaBuilder.isTrue(datasetFieldTypeInputLevelJoin.get("required")));
 
-            // Predicate for default displayOnCreate (when there is no input level)
-            Predicate defaultDisplayOnCreatePredicate = criteriaBuilder.and(
-                criteriaBuilder.not(criteriaBuilder.exists(inputLevelSubquery)),
-                criteriaBuilder.isTrue(datasetFieldTypeJoin.get("displayOnCreate")));
-
-            Predicate unionPredicate = criteriaBuilder.or(
-                displayOnCreateInputLevelPredicate,
-                requiredPredicate,
-                defaultDisplayOnCreatePredicate
-            );
+            Predicate unionPredicate = criteriaBuilder.or(displayOnCreatePredicate, requiredPredicate);
 
             criteriaQuery.where(criteriaBuilder.and(
-                criteriaBuilder.equal(dataverseRoot.get("id"), ownerDataverse.getId()),
-                metadataBlockRoot.in(dataverseRoot.get("metadataBlocks")),
-                unionPredicate
+                    criteriaBuilder.equal(dataverseRoot.get("id"), ownerDataverse.getId()),
+                    metadataBlockRoot.in(dataverseRoot.get("metadataBlocks")),
+                    unionPredicate
             ));
         } else {
-            criteriaQuery.where(criteriaBuilder.isTrue(datasetFieldTypeJoin.get("displayOnCreate")));
+            criteriaQuery.where(displayOnCreatePredicate);
         }
 
         criteriaQuery.select(metadataBlockRoot).distinct(true);
-        return em.createQuery(criteriaQuery).getResultList();
+        TypedQuery<MetadataBlock> typedQuery = em.createQuery(criteriaQuery);
+        return typedQuery.getResultList();
     }
 }

--- a/src/main/java/edu/harvard/iq/dataverse/TemplatePage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/TemplatePage.java
@@ -166,16 +166,11 @@ public class TemplatePage implements java.io.Serializable {
         }        
         
         for (DatasetField dsf: template.getFlatDatasetFields()){ 
-           DataverseFieldTypeInputLevel dsfIl = dataverseFieldTypeInputLevelService.findByDataverseIdDatasetFieldTypeId(
-               dvIdForInputLevel, 
-               dsf.getDatasetFieldType().getId()
-           );
-           if (dsfIl != null) {
+           DataverseFieldTypeInputLevel dsfIl = dataverseFieldTypeInputLevelService.findByDataverseIdDatasetFieldTypeId(dvIdForInputLevel, dsf.getDatasetFieldType().getId());
+           if (dsfIl != null){
                dsf.setInclude(dsfIl.isInclude());
-               dsf.getDatasetFieldType().setDisplayOnCreate(dsfIl.isDisplayOnCreate());
            } else {
                dsf.setInclude(true);
-               dsf.getDatasetFieldType().setDisplayOnCreate(false);
            } 
         }
     }

--- a/src/main/java/edu/harvard/iq/dataverse/api/Dataverses.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Dataverses.java
@@ -803,14 +803,13 @@ public class Dataverses extends AbstractApiBean {
 
             boolean required = inputLevel.getBoolean("required");
             boolean include = inputLevel.getBoolean("include");
-            boolean displayOnCreate = inputLevel.getBoolean("displayOnCreate", false);
 
             if (required && !include) {
                 String errorMessage = MessageFormat.format(BundleUtil.getStringFromBundle("dataverse.inputlevels.error.cannotberequiredifnotincluded"), datasetFieldTypeName);
                 throw new WrappedResponse(badRequest(errorMessage));
             }
 
-            newInputLevels.add(new DataverseFieldTypeInputLevel(datasetFieldType, dataverse, required, include, displayOnCreate));
+            newInputLevels.add(new DataverseFieldTypeInputLevel(datasetFieldType, dataverse, required, include));
         }
 
         return newInputLevels;

--- a/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
@@ -686,10 +686,8 @@ public class JsonPrinter {
             DatasetFieldType parentDatasetFieldType = datasetFieldType.getParentDatasetFieldType();
             boolean isRequired = parentDatasetFieldType == null ? datasetFieldType.isRequired() : parentDatasetFieldType.isRequired();
 
-            boolean displayOnCreateInOwnerDataverse = ownerDataverse != null && ownerDataverse.isDatasetFieldTypeDisplayOnCreateAsInputLevel(datasetFieldTypeId);
-
             boolean displayCondition = printOnlyDisplayedOnCreateDatasetFieldTypes
-                    ? (displayOnCreateInOwnerDataverse || isRequired || requiredAsInputLevelInOwnerDataverse)
+                    ? (datasetFieldType.isDisplayOnCreate() || isRequired || requiredAsInputLevelInOwnerDataverse)
                     : ownerDataverse == null || includedAsInputLevelInOwnerDataverse || isNotInputLevelInOwnerDataverse;
 
             if (displayCondition) {
@@ -1459,7 +1457,6 @@ public class JsonPrinter {
             inputLevelJsonObject.add("datasetFieldTypeName", inputLevel.getDatasetFieldType().getName());
             inputLevelJsonObject.add("required", inputLevel.isRequired());
             inputLevelJsonObject.add("include", inputLevel.isInclude());
-            inputLevelJsonObject.add("displayOnCreate", inputLevel.isDisplayOnCreate());
             jsonArrayOfInputLevels.add(inputLevelJsonObject);
         }
         return jsonArrayOfInputLevels;
@@ -1478,7 +1475,6 @@ public class JsonPrinter {
         jsonObjectBuilder.add("datasetFieldTypeName", inputLevel.getDatasetFieldType().getName());
         jsonObjectBuilder.add("required", inputLevel.isRequired());
         jsonObjectBuilder.add("include", inputLevel.isInclude());
-        jsonObjectBuilder.add("displayOnCreate", inputLevel.isDisplayOnCreate());
         return jsonObjectBuilder;
     }
 

--- a/src/test/java/edu/harvard/iq/dataverse/api/DataversesIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/DataversesIT.java
@@ -1944,37 +1944,4 @@ public class DataversesIT {
                 .body("message", equalTo("Can't find dataverse with identifier='thisDataverseDoesNotExist'"))
                 .statusCode(NOT_FOUND.getStatusCode());
     }
-
-    @Test
-    public void testUpdateInputLevelDisplayOnCreate() {
-        Response createUserResponse = UtilIT.createRandomUser();
-        String apiToken = UtilIT.getApiTokenFromResponse(createUserResponse);
-
-        Response createDataverseResponse = UtilIT.createRandomDataverse(apiToken);
-        createDataverseResponse.then().assertThat().statusCode(CREATED.getStatusCode());
-        String dataverseAlias = UtilIT.getAliasFromResponse(createDataverseResponse);
-
-        // Configure metadata blocks - disable inherit from root and set specific blocks
-        Response setMetadataBlocksResponse = UtilIT.setMetadataBlocks(
-                dataverseAlias, 
-                Json.createArrayBuilder().add("socialscience"), 
-                apiToken);
-        setMetadataBlocksResponse.then().assertThat()
-                .statusCode(OK.getStatusCode());
-
-        // Verify initial state
-        Response listMetadataBlocks = UtilIT.listMetadataBlocks(dataverseAlias, true, true, apiToken);
-        listMetadataBlocks.then().assertThat()
-                .statusCode(OK.getStatusCode())
-                .body("data.size()", equalTo(1))
-                .body("data[0].name", equalTo("socialscience"));
-
-        // Update displayOnCreate for a field
-        Response updateResponse = UtilIT.updateDataverseInputLevelDisplayOnCreate(
-            dataverseAlias, "unitOfAnalysis", true, apiToken);
-        updateResponse.then().assertThat()
-                .statusCode(OK.getStatusCode())
-                .body("data.inputLevels[0].displayOnCreate", equalTo(true))
-                .body("data.inputLevels[0].datasetFieldTypeName", equalTo("unitOfAnalysis"));
-    }
 }

--- a/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
@@ -4578,7 +4578,7 @@ public class UtilIT {
                 .header(API_TOKEN_HTTP_HEADER, apiToken)
                 .delete("/api/dataverses/" + dataverseAlias + "/featuredItems");
     }
-
+    
     public static Response deleteDatasetFiles(String datasetId, JsonArray fileIds, String apiToken) {
         String path = String.format("/api/datasets/%s/deleteFiles", datasetId);
         return given()
@@ -4587,21 +4587,4 @@ public class UtilIT {
                 .body(fileIds.toString())
                 .put(path);
     }
-  
-    public static Response updateDataverseInputLevelDisplayOnCreate(String dataverseAlias, String fieldTypeName, boolean displayOnCreate, String apiToken) {
-        JsonArrayBuilder inputLevelsArrayBuilder = Json.createArrayBuilder();
-        JsonObjectBuilder inputLevel = Json.createObjectBuilder()
-                .add("datasetFieldTypeName", fieldTypeName)
-                .add("required", false)
-                .add("include", true)
-                .add("displayOnCreate", displayOnCreate);
-        
-        inputLevelsArrayBuilder.add(inputLevel);
-        
-        return given()
-                .header(API_TOKEN_HTTP_HEADER, apiToken)
-                .body(inputLevelsArrayBuilder.build().toString())
-                .contentType(ContentType.JSON)
-                .put("/api/dataverses/" + dataverseAlias + "/inputLevels");
-     }
 }


### PR DESCRIPTION
- Reverts IQSS/dataverse#11224
- Closes #11298

See also discussion [in Slack](https://iqss.slack.com/archives/C03R1E7T4KA/p1741177168089719). We decided to leave the SQL script alone. It was added separately in #11304. The field it adds will be needed soon enough when a new PR comes in for the "display on create" feature.

Preview the guide changes here: https://dataverse-guide--11306.org.readthedocs.build/en/11306/api/native-api.html#update-collection-input-levels