### PR TITLE
fix: allow single-valued controlled vocabulary fields in Solr schema

### DIFF
--- a/conf/solr/schema.xml
+++ b/conf/solr/schema.xml
@@ -256,19 +256,19 @@
         WARNING: Do not remove the following include guards if you intend to use the neat helper scripts we provide.
     -->
     <!-- SCHEMA-FIELDS::BEGIN -->
-    <field name="3d3DTechnique" type="text_en" multiValued="true" stored="true" indexed="true"/>
+    <field name="3d3DTechnique" type="text_en" multiValued="false" stored="true" indexed="true"/>
     <field name="3dAltText" type="text_en" multiValued="false" stored="true" indexed="true"/>
     <field name="3dEquipment" type="text_en" multiValued="false" stored="true" indexed="true"/>
-    <field name="3dExportedFileFormat" type="text_en" multiValued="true" stored="true" indexed="true"/>
+    <field name="3dExportedFileFormat" type="text_en" multiValued="false" stored="true" indexed="true"/>
     <field name="3dExportedFilePolygonCount" type="text_en" multiValued="true" stored="true" indexed="true"/>
     <field name="3dHandling" type="text_en" multiValued="false" stored="true" indexed="true"/>
     <field name="3dHeight" type="text_en" multiValued="false" stored="true" indexed="true"/>
     <field name="3dLength" type="text_en" multiValued="false" stored="true" indexed="true"/>
-    <field name="3dLightingSetup" type="text_en" multiValued="true" stored="true" indexed="true"/>
+    <field name="3dLightingSetup" type="text_en" multiValued="false" stored="true" indexed="true"/>
     <field name="3dMasterFilePolygonCount" type="text_en" multiValued="false" stored="true" indexed="true"/>
     <field name="3dMaterialComposition" type="text_en" multiValued="true" stored="true" indexed="true"/>
     <field name="3dObjectDimensions" type="text_en" multiValued="false" stored="true" indexed="true"/>
-    <field name="3dUnit" type="text_en" multiValued="true" stored="true" indexed="true"/>
+    <field name="3dUnit" type="text_en" multiValued="false" stored="true" indexed="true"/>
     <field name="3dWeight" type="text_en" multiValued="false" stored="true" indexed="true"/>
     <field name="3dWidth" type="text_en" multiValued="false" stored="true" indexed="true"/>
     <field name="accessToSources" type="text_en" multiValued="false" stored="true" indexed="true"/>
@@ -343,7 +343,7 @@
     <field name="grantNumber" type="text_en" multiValued="true" stored="true" indexed="true"/>
     <field name="grantNumberAgency" type="text_en" multiValued="true" stored="true" indexed="true"/>
     <field name="grantNumberValue" type="text_en" multiValued="true" stored="true" indexed="true"/>
-    <field name="journalArticleType" type="text_en" multiValued="true" stored="true" indexed="true"/>
+    <field name="journalArticleType" type="text_en" multiValued="false" stored="true" indexed="true"/>
     <field name="journalIssue" type="text_en" multiValued="true" stored="true" indexed="true"/>
     <field name="journalPubDate" type="date_range" multiValued="true" stored="true" indexed="true"/>
     <field name="journalVolume" type="text_en" multiValued="true" stored="true" indexed="true"/>

--- a/src/main/java/edu/harvard/iq/dataverse/DatasetFieldType.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetFieldType.java
@@ -560,7 +560,7 @@ public class DatasetFieldType implements Serializable, Comparable<DatasetFieldTy
             
             boolean makeSolrFieldMultivalued;
             // http://stackoverflow.com/questions/5800762/what-is-the-use-of-multivalued-field-type-in-solr
-            if (allowMultiples || anyParentAllowsMultiplesBoolean || isControlledVocabulary()) {
+            if (allowMultiples || anyParentAllowsMultiplesBoolean) {
                 makeSolrFieldMultivalued = true;
             } else {
                 makeSolrFieldMultivalued = false;


### PR DESCRIPTION
**What this PR does / why we need it**:

A controlled vocabulary metadata field in our custom metadata blocks was incorrectly marked `multiValued` in the Solr schema. This caused errors when performing Solr queries with grouping on that field.

Example:

https://dataverse.harvard.edu/api/search?&type=dataset&q=*:*&fq={!collapse%20field=%27journalArticleType%27}

leads to

`"Search Syntax Error: Error from server at http://dvn-cloud-solr.lib.harvard.edu:8983/solr/collection1: org.apache.solr.search.SyntaxError: Collapsing not supported on multivalued fields"`.

Previously, controlled vocabulary fields were always set as `multiValued="true"` in the Solr schema, even when neither they nor their parent fields were declared to be multivalued in the TSV file. I'm not sure why. If there is a reason for this, I would be interested to know.

This affects the following fields in the standard metadata blocks, which will now be singlevalued within the Solr schema:

* [`3d3DTechnique`](https://github.com/IQSS/dataverse/blob/develop/scripts/api/data/metadatablocks/3d_objects.tsv#L4)
* [`3dExportedFileFormat`](https://github.com/IQSS/dataverse/blob/develop/scripts/api/data/metadatablocks/3d_objects.tsv#L9)
* [`3dLightingSetup`](https://github.com/IQSS/dataverse/blob/develop/scripts/api/data/metadatablocks/3d_objects.tsv#L6)
* [`3dUnit`](https://github.com/IQSS/dataverse/blob/develop/scripts/api/data/metadatablocks/3d_objects.tsv#L17)
* [`journalArticleType`](https://github.com/IQSS/dataverse/blob/develop/scripts/api/data/metadatablocks/journals.tsv?plain=1#L8)

**Which issue(s) this PR closes**:

/

**Special notes for your reviewer**:

/

**Suggestions on how to test this**:

Use the updated `schema.xml` to index datasets and verify correct behavior.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

/

**Is there a release notes update needed for this change?**:

/

**Additional documentation**:

/