### PR TITLE
feat: add "string" type for metadata fields

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DatasetFieldType.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetFieldType.java
@@ -36,8 +36,8 @@ public class DatasetFieldType implements Serializable, Comparable<DatasetFieldTy
      * The set of possible metatypes of the field. Used for validation and layout.
      */
     public enum FieldType {
-        TEXT, TEXTBOX, DATE, EMAIL, URL, FLOAT, INT, NONE
-    };    
+        TEXT, TEXTBOX, STRING, DATE, EMAIL, URL, FLOAT, INT, NONE
+    };
     
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -539,6 +539,8 @@ public class DatasetFieldType implements Serializable, Comparable<DatasetFieldTy
                 solrType = SolrField.SolrType.INTEGER;
             } else if (fieldType.equals(FieldType.FLOAT)) {
                 solrType = SolrField.SolrType.FLOAT;
+            } else if (fieldType.equals(FieldType.STRING)) {
+                solrType = SolrField.SolrType.STRING;
             }
 
             Boolean anyParentAllowsMultiplesBoolean = false;


### PR DESCRIPTION
**What this PR does / why we need it**:

See #11147 

**Which issue(s) this PR closes**:

- Closes #11147 

**Special notes for your reviewer**:

/

**Suggestions on how to test this**:

1. Load a metadata block TSV that defines a field with type "string"

   example: https://gist.github.com/vera/fc39e7b0bb0e9da7dc24a41c680f6d59

   `curl http://localhost:8080/api/admin/datasetfield/load -H "Content-type: text/tab-separated-values" -X POST --upload-file stringtest.tsv`

2. Activate metadata block

   `curl curl -H "X-Dataverse-key:$API_TOKEN" -X POST -H "Content-type:application/json" -d "[\"stringTest\"]" http://localhost:8080/api/dataverses/:root/metadatablocks`

3. Update Solr schema

   `curl "http://localhost:8080/api/admin/index/solr/schema" | ./update-fields.sh schema.xml`

   `docker cp schema.xml solr-1:/var/solr/data/collection1/conf/schema.xml`

   `curl "http://localhost:8983/solr/admin/cores?action=RELOAD&core=collection1"`

4. Confirm that the updated Solr schema contains a new field with type "string"

   ```
    <field name="testStringField" type="string" multiValued="false" stored="true" indexed="true"/>
   ...
    <copyField source="testStringField" dest="_text_" maxChars="3000"/>
   ```

5. Create a new dataset via the UI (or API)

   ![image](https://github.com/user-attachments/assets/38f1d72d-97eb-4923-b305-3641db108bb8)

6. Verify the string value correctly ends up in Solr and can be seen on the dataset page  

   ![image](https://github.com/user-attachments/assets/5d7aed1f-5cd4-41e6-8dd6-dc9a243d7714)

   ![image](https://github.com/user-attachments/assets/0d85fa88-bd1b-4317-9c68-058066e427a8)

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

/

**Additional documentation**:

/