### PR TITLE
Dashboard: fix npe from breadcrumbs

### DIFF
--- a/src/main/webapp/dashboard-movedataset.xhtml
+++ b/src/main/webapp/dashboard-movedataset.xhtml
@@ -15,7 +15,7 @@
             <f:viewAction action="#{dataverseSession.updateLocaleInViewRoot}"/>
             <f:viewAction action="#{DashboardMoveDatasetPage.init}"/>
             <f:viewAction action="#{dataverseHeaderFragment.initBreadcrumbs(dataverseServiceBean.findRootDataverse())}"/>
-            <f:viewAction action="#{dataverseHeaderFragment.addBreadcrumb('/dashboard.xhtml?dataverseId='.concat(param.dataverseId), bundle['dashboard.title'])}"/> 
+            <f:viewAction action="#{dataverseHeaderFragment.addBreadcrumb('/dashboard.xhtml'.concat(empty param.dataverseId ? '': '?dataverseId='.concat(param.dataverseId)), bundle['dashboard.title'])}"/> 
             <f:viewAction action="#{dataverseHeaderFragment.addBreadcrumb(bundle['dashboard.card.move.dataset.manage'])}"/>
         </f:metadata>
 

--- a/src/main/webapp/dashboard-movedataset.xhtml
+++ b/src/main/webapp/dashboard-movedataset.xhtml
@@ -15,7 +15,7 @@
             <f:viewAction action="#{dataverseSession.updateLocaleInViewRoot}"/>
             <f:viewAction action="#{DashboardMoveDatasetPage.init}"/>
             <f:viewAction action="#{dataverseHeaderFragment.initBreadcrumbs(dataverseServiceBean.findRootDataverse())}"/>
-            <f:viewAction action="#{dataverseHeaderFragment.addBreadcrumb('/dashboard.xhtml?dataverseId='.concat(dataverse.id), bundle['dashboard.title'])}"/> 
+            <f:viewAction action="#{dataverseHeaderFragment.addBreadcrumb('/dashboard.xhtml?dataverseId='.concat(param.dataverseId), bundle['dashboard.title'])}"/> 
             <f:viewAction action="#{dataverseHeaderFragment.addBreadcrumb(bundle['dashboard.card.move.dataset.manage'])}"/>
         </f:metadata>
 

--- a/src/main/webapp/dashboard-movedataverse.xhtml
+++ b/src/main/webapp/dashboard-movedataverse.xhtml
@@ -15,7 +15,7 @@
             <f:viewAction action="#{dataverseSession.updateLocaleInViewRoot}"/>
             <f:viewAction action="#{DashboardMoveDataversePage.init}"/>
             <f:viewAction action="#{dataverseHeaderFragment.initBreadcrumbs(dataverseServiceBean.findRootDataverse())}"/>
-            <f:viewAction action="#{dataverseHeaderFragment.addBreadcrumb('/dashboard.xhtml?dataverseId='.concat(dataverse.id), bundle['dashboard.title'])}"/> 
+            <f:viewAction action="#{dataverseHeaderFragment.addBreadcrumb('/dashboard.xhtml?dataverseId='.concat(param.dataverseId), bundle['dashboard.title'])}"/> 
             <f:viewAction action="#{dataverseHeaderFragment.addBreadcrumb(bundle['dashboard.move.dataverse.message.summary'])}"/>
         </f:metadata>
 

--- a/src/main/webapp/dashboard-movedataverse.xhtml
+++ b/src/main/webapp/dashboard-movedataverse.xhtml
@@ -15,7 +15,7 @@
             <f:viewAction action="#{dataverseSession.updateLocaleInViewRoot}"/>
             <f:viewAction action="#{DashboardMoveDataversePage.init}"/>
             <f:viewAction action="#{dataverseHeaderFragment.initBreadcrumbs(dataverseServiceBean.findRootDataverse())}"/>
-            <f:viewAction action="#{dataverseHeaderFragment.addBreadcrumb('/dashboard.xhtml?dataverseId='.concat(param.dataverseId), bundle['dashboard.title'])}"/> 
+            <f:viewAction action="#{dataverseHeaderFragment.addBreadcrumb('/dashboard.xhtml'.concat(empty param.dataverseId ? '': '?dataverseId='.concat(param.dataverseId)), bundle['dashboard.title'])}"/> 
             <f:viewAction action="#{dataverseHeaderFragment.addBreadcrumb(bundle['dashboard.move.dataverse.message.summary'])}"/>
         </f:metadata>
 

--- a/src/main/webapp/dashboard-users.xhtml
+++ b/src/main/webapp/dashboard-users.xhtml
@@ -15,7 +15,7 @@
             <f:viewAction action="#{dataverseSession.updateLocaleInViewRoot}"/>
             <f:viewAction action="#{DashboardUsersPage.init}"/>
             <f:viewAction action="#{dataverseHeaderFragment.initBreadcrumbs(dataverseServiceBean.findRootDataverse())}"/>
-            <f:viewAction action="#{dataverseHeaderFragment.addBreadcrumb('/dashboard.xhtml?dataverseId='.concat(dataverse.id), bundle['dashboard.title'])}"/> 
+            <f:viewAction action="#{dataverseHeaderFragment.addBreadcrumb('/dashboard.xhtml?dataverseId='.concat(param.dataverseId), bundle['dashboard.title'])}"/> 
             <f:viewAction action="#{dataverseHeaderFragment.addBreadcrumb(bundle['dashboard.card.users.manage'])}"/>
         </f:metadata>
 

--- a/src/main/webapp/dashboard-users.xhtml
+++ b/src/main/webapp/dashboard-users.xhtml
@@ -15,7 +15,7 @@
             <f:viewAction action="#{dataverseSession.updateLocaleInViewRoot}"/>
             <f:viewAction action="#{DashboardUsersPage.init}"/>
             <f:viewAction action="#{dataverseHeaderFragment.initBreadcrumbs(dataverseServiceBean.findRootDataverse())}"/>
-            <f:viewAction action="#{dataverseHeaderFragment.addBreadcrumb('/dashboard.xhtml?dataverseId='.concat(param.dataverseId), bundle['dashboard.title'])}"/> 
+            <f:viewAction action="#{dataverseHeaderFragment.addBreadcrumb('/dashboard.xhtml'.concat(empty param.dataverseId ? '': '?dataverseId='.concat(param.dataverseId)), bundle['dashboard.title'])}"/> 
             <f:viewAction action="#{dataverseHeaderFragment.addBreadcrumb(bundle['dashboard.card.users.manage'])}"/>
         </f:metadata>
 

--- a/src/main/webapp/harvestclients.xhtml
+++ b/src/main/webapp/harvestclients.xhtml
@@ -15,7 +15,7 @@
             <f:viewAction action="#{dataverseSession.updateLocaleInViewRoot}"/>
             <f:viewAction action="#{harvestingClientsPage.init}"/>
             <f:viewAction action="#{dataverseHeaderFragment.initBreadcrumbs(dataverseServiceBean.findRootDataverse())}"/>
-            <f:viewAction action="#{dataverseHeaderFragment.addBreadcrumb('/dashboard.xhtml?dataverseId='.concat(dataverse.id), bundle['dashboard.title'])}"/>
+            <f:viewAction action="#{dataverseHeaderFragment.addBreadcrumb('/dashboard.xhtml?dataverseId='.concat(param.dataverseId), bundle['dashboard.title'])}"/>
             <f:viewAction action="#{dataverseHeaderFragment.addBreadcrumb(bundle['harvestclients.title'])}"/>
         </f:metadata>
         <ui:composition template="/dataverse_template.xhtml">

--- a/src/main/webapp/harvestclients.xhtml
+++ b/src/main/webapp/harvestclients.xhtml
@@ -15,7 +15,7 @@
             <f:viewAction action="#{dataverseSession.updateLocaleInViewRoot}"/>
             <f:viewAction action="#{harvestingClientsPage.init}"/>
             <f:viewAction action="#{dataverseHeaderFragment.initBreadcrumbs(dataverseServiceBean.findRootDataverse())}"/>
-            <f:viewAction action="#{dataverseHeaderFragment.addBreadcrumb('/dashboard.xhtml?dataverseId='.concat(param.dataverseId), bundle['dashboard.title'])}"/>
+            <f:viewAction action="#{dataverseHeaderFragment.addBreadcrumb('/dashboard.xhtml'.concat(empty param.dataverseId ? '': '?dataverseId='.concat(param.dataverseId)), bundle['dashboard.title'])}"/>
             <f:viewAction action="#{dataverseHeaderFragment.addBreadcrumb(bundle['harvestclients.title'])}"/>
         </f:metadata>
         <ui:composition template="/dataverse_template.xhtml">

--- a/src/main/webapp/harvestsets.xhtml
+++ b/src/main/webapp/harvestsets.xhtml
@@ -15,7 +15,7 @@
             <f:viewAction action="#{dataverseSession.updateLocaleInViewRoot}"/>
             <f:viewAction action="#{harvestingSetsPage.init}"/>
             <f:viewAction action="#{dataverseHeaderFragment.initBreadcrumbs(dataverseServiceBean.findRootDataverse())}"/>
-            <f:viewAction action="#{dataverseHeaderFragment.addBreadcrumb('/dashboard.xhtml?dataverseId='.concat(param.dataverseId), bundle['dashboard.title'])}"/>   
+            <f:viewAction action="#{dataverseHeaderFragment.addBreadcrumb('/dashboard.xhtml'.concat(empty param.dataverseId ? '': '?dataverseId='.concat(param.dataverseId)), bundle['dashboard.title'])}"/>   
             <f:viewAction action="#{dataverseHeaderFragment.addBreadcrumb(bundle['harvestserver.title'])}"/>
         </f:metadata>
         <ui:composition template="/dataverse_template.xhtml">

--- a/src/main/webapp/harvestsets.xhtml
+++ b/src/main/webapp/harvestsets.xhtml
@@ -15,7 +15,7 @@
             <f:viewAction action="#{dataverseSession.updateLocaleInViewRoot}"/>
             <f:viewAction action="#{harvestingSetsPage.init}"/>
             <f:viewAction action="#{dataverseHeaderFragment.initBreadcrumbs(dataverseServiceBean.findRootDataverse())}"/>
-            <f:viewAction action="#{dataverseHeaderFragment.addBreadcrumb('/dashboard.xhtml?dataverseId='.concat(dataverse.id), bundle['dashboard.title'])}"/>   
+            <f:viewAction action="#{dataverseHeaderFragment.addBreadcrumb('/dashboard.xhtml?dataverseId='.concat(param.dataverseId), bundle['dashboard.title'])}"/>   
             <f:viewAction action="#{dataverseHeaderFragment.addBreadcrumb(bundle['harvestserver.title'])}"/>
         </f:metadata>
         <ui:composition template="/dataverse_template.xhtml">


### PR DESCRIPTION
**What this PR does / why we need it**: Fixes the dashboard problem
**Which issue(s) this PR closes**:

- Closes #11328 

**Special notes for your reviewer**: As far as I can tell, the dataverseId parameter does nothing and the dashboard never uses anything but the root dataverse id (in fact the code hardcodes the dataverseId view param to the root dataverse id regardless of what is sent in the URL). Seems like this could all be removed, but to avoid new issues for 6.6, I've just replaced the null value with param.dataverseId if sent and removed the dataverseId param completely if it isn't.

**Suggestions on how to test this**: Try all the buttons on the dashboard. 

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
