### PR TITLE
API Changelog: move version note to 6.6 where it belongs

### DIFF
--- a/doc/sphinx-guides/source/api/changelog.rst
+++ b/doc/sphinx-guides/source/api/changelog.rst
@@ -10,17 +10,18 @@ This API changelog is experimental and we would love feedback on its usefulness.
 v6.6
 ----
 
+- The JSON representation for a datasetVersion sent or received in API calls has changed such that
+
+  - "versionNote" -> "deaccessionNote"
+  -  "archiveNote" --> "deaccessionLink"
+  - These may be non-null for deaccessioned versions and an optional new "versionNote" field indicating the reason a version was created may be present on any datasetversion. 
+
 - **/api/metadatablocks** is no longer returning duplicated metadata properties and does not omit metadata properties when called.
 - **/api/roles**: :ref:`show-role` now properly returns 403 Forbidden instead of 401 Unauthorized when you pass a working API token that doesn't have the right permission.
 - The content type for the ``schema.org`` dataset metadata export format has been corrected. It was ``application/json`` and now it is ``application/ld+json``. See also :ref:`export-dataset-metadata-api`.
 
 v6.5
 ----
-
-- The JSON representation for a datasetVersion sent or received in API calls has changed such that
-  - "versionNote" -> "deaccessionNote"
-  -  "archiveNote" --> "deaccessionLink"
-  These may be non-null for deaccessioned versions and an optional new "versionNote" field indicating the reason a version was created may be present on any datasetversion. 
 
 - **/api/datasets/{identifier}/links**: The response from :ref:`list-collections-linked-from-dataset` has been improved to provide a more structured (but backward-incompatible) JSON response.
 


### PR DESCRIPTION
When the note was added in #11068 it was assumed the feature would land in 6.5 but it didn't get merged until 6.6.