### PR TITLE
make text under Cite Data not bold

### DIFF
--- a/doc/sphinx-guides/source/user/find-use-data.rst
+++ b/doc/sphinx-guides/source/user/find-use-data.rst
@@ -96,8 +96,7 @@ Files can be organized in one or more folders (directories) within a dataset. If
 Cite Data
 ---------
 
-You can find the citation for the dataset at the top of the dataset page in a blue box. Additionally, there is a Cite Data button that offers the option to download the citation as EndNote XML, RIS Format, or BibTeX Format,
- or to cut/paste the citation in any of the 1000+ standard journal/socienty/other formats defined via the `Citation Style Language <https://citationstyles.org/>`_.
+You can find the citation for the dataset at the top of the dataset page in a blue box. Additionally, there is a Cite Data button that offers the option to download the citation as EndNote XML, RIS Format, or BibTeX Format, or to cut/paste the citation in any of the 1000+ standard journal/socienty/other formats defined via the `Citation Style Language <https://citationstyles.org/>`_.
 
 .. _download_files:
 


### PR DESCRIPTION
#11163 added some bold text that shouldn't be:

![Screenshot 2025-03-12 at 12 19 39 PM](https://github.com/user-attachments/assets/adf65301-377b-42a3-a489-bf149560888d)

This PR fixes it.