### PR TITLE
DisplayOnCreate Fixes

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DatasetFieldServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetFieldServiceBean.java
@@ -944,7 +944,7 @@ public class DatasetFieldServiceBean implements java.io.Serializable {
         // Predicate for displayOnCreate in input level
         Predicate displayOnCreateInputLevelPredicate = criteriaBuilder.and(
             criteriaBuilder.equal(datasetFieldTypeRoot, datasetFieldTypeInputLevelJoin.get("datasetFieldType")),
-            criteriaBuilder.isTrue(datasetFieldTypeInputLevelJoin.get("displayOnCreate"))
+            criteriaBuilder.equal(datasetFieldTypeInputLevelJoin.get("displayOnCreate"), Boolean.TRUE)
         );
 
         // Create a subquery to check for the absence of a specific DataverseFieldTypeInputLevel.
@@ -953,7 +953,8 @@ public class DatasetFieldServiceBean implements java.io.Serializable {
         subquery.select(criteriaBuilder.literal(1L))
                 .where(
                         criteriaBuilder.equal(subqueryRoot.get("dataverse"), dataverseRoot),
-                        criteriaBuilder.equal(subqueryRoot.get("datasetFieldType"), datasetFieldTypeRoot)
+                        criteriaBuilder.equal(subqueryRoot.get("datasetFieldType"), datasetFieldTypeRoot),
+                        criteriaBuilder.isNotNull(subqueryRoot.get("displayOnCreate"))
                 );
 
         // Define a predicate to exclude DatasetFieldTypes that have no associated input level (i.e., the subquery does not return a result).

--- a/src/main/java/edu/harvard/iq/dataverse/DatasetFieldType.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetFieldType.java
@@ -273,21 +273,35 @@ public class DatasetFieldType implements Serializable, Comparable<DatasetFieldTy
      * Determines whether this field type is displayed in the form when creating
      * the Dataset (or only later when editing after the initial creation).
      */
-    @Column(name = "displayoncreate", nullable = true)
-    private Boolean displayOnCreate;
+    private boolean displayOnCreate;
 
-    public Boolean isDisplayOnCreate() {
+    public boolean isDisplayOnCreate() {
         return displayOnCreate;
     }
 
-    public Boolean getDisplayOnCreate() {
-        return displayOnCreate;
-    }
-
-    public void setDisplayOnCreate(Boolean displayOnCreate) {
+    public void setDisplayOnCreate(boolean displayOnCreate) {
         this.displayOnCreate = displayOnCreate;
     }
+
+    /**
+     * Determines whether this field type is displayed in the form when creating
+     * the Dataset (or only later when editing after the initial creation).
+     */
+    @Transient
+    private Boolean localDisplayOnCreate;
+
+    public Boolean getLocalDisplayOnCreate() {
+        return localDisplayOnCreate;
+    }
+
+    public void setLocalDisplayOnCreate(Boolean localDisplayOnCreate) {
+        this.localDisplayOnCreate = localDisplayOnCreate;
+    }
     
+    public boolean shouldDisplayOnCreate() {
+        return (localDisplayOnCreate == null) ? displayOnCreate : localDisplayOnCreate;
+    }
+        
     public boolean isControlledVocabulary() {
         return allowControlledVocabulary;
     }

--- a/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
@@ -1856,7 +1856,7 @@ public class DatasetPage implements java.io.Serializable {
                 if (dsf != null){
                     // Yes, call "setInclude"
                     dsf.setInclude(oneDSFieldTypeInputLevel.isInclude());
-                    Boolean displayOnCreate = oneDSFieldTypeInputLevel.isDisplayOnCreate();
+                    Boolean displayOnCreate = oneDSFieldTypeInputLevel.getDisplayOnCreate();
                     if (displayOnCreate!= null) {
                         dsf.getDatasetFieldType().setDisplayOnCreate(displayOnCreate);
                     }

--- a/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
@@ -1856,7 +1856,10 @@ public class DatasetPage implements java.io.Serializable {
                 if (dsf != null){
                     // Yes, call "setInclude"
                     dsf.setInclude(oneDSFieldTypeInputLevel.isInclude());
-                    dsf.getDatasetFieldType().setDisplayOnCreate(oneDSFieldTypeInputLevel.isDisplayOnCreate());
+                    Boolean displayOnCreate = oneDSFieldTypeInputLevel.isDisplayOnCreate();
+                    if (displayOnCreate!= null) {
+                        dsf.getDatasetFieldType().setDisplayOnCreate(displayOnCreate);
+                    }
                     // remove from hash
                     mapDatasetFields.remove(oneDSFieldTypeInputLevel.getDatasetFieldType().getId());
                 }

--- a/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
@@ -1858,7 +1858,7 @@ public class DatasetPage implements java.io.Serializable {
                     dsf.setInclude(oneDSFieldTypeInputLevel.isInclude());
                     Boolean displayOnCreate = oneDSFieldTypeInputLevel.getDisplayOnCreate();
                     if (displayOnCreate!= null) {
-                        dsf.getDatasetFieldType().setDisplayOnCreate(displayOnCreate);
+                        dsf.getDatasetFieldType().setLocalDisplayOnCreate(displayOnCreate);
                     }
                     // remove from hash
                     mapDatasetFields.remove(oneDSFieldTypeInputLevel.getDatasetFieldType().getId());

--- a/src/main/java/edu/harvard/iq/dataverse/Dataverse.java
+++ b/src/main/java/edu/harvard/iq/dataverse/Dataverse.java
@@ -438,6 +438,13 @@ public class Dataverse extends DvObjectContainer {
                 .anyMatch(inputLevel -> inputLevel.getDatasetFieldType().getId().equals(datasetFieldTypeId));
     }
 
+    public DataverseFieldTypeInputLevel getDatasetFieldTypeInInputLevels(Long datasetFieldTypeId) {
+        return dataverseFieldTypeInputLevels.stream()
+                .filter(inputLevel -> inputLevel.getDatasetFieldType().getId().equals(datasetFieldTypeId))
+                .findFirst()
+                .orElse(null);
+    }
+    
     public boolean isDatasetFieldTypeDisplayOnCreateAsInputLevel(Long datasetFieldTypeId) {
         return dataverseFieldTypeInputLevels.stream()
                 .anyMatch(inputLevel -> inputLevel.getDatasetFieldType().getId().equals(datasetFieldTypeId) 

--- a/src/main/java/edu/harvard/iq/dataverse/Dataverse.java
+++ b/src/main/java/edu/harvard/iq/dataverse/Dataverse.java
@@ -441,7 +441,7 @@ public class Dataverse extends DvObjectContainer {
     public boolean isDatasetFieldTypeDisplayOnCreateAsInputLevel(Long datasetFieldTypeId) {
         return dataverseFieldTypeInputLevels.stream()
                 .anyMatch(inputLevel -> inputLevel.getDatasetFieldType().getId().equals(datasetFieldTypeId) 
-                         && inputLevel.isDisplayOnCreate());
+                         && inputLevel.isDisplayOnCreate().booleanValue());
     }
 
     public Template getDefaultTemplate() {

--- a/src/main/java/edu/harvard/iq/dataverse/Dataverse.java
+++ b/src/main/java/edu/harvard/iq/dataverse/Dataverse.java
@@ -441,7 +441,7 @@ public class Dataverse extends DvObjectContainer {
     public boolean isDatasetFieldTypeDisplayOnCreateAsInputLevel(Long datasetFieldTypeId) {
         return dataverseFieldTypeInputLevels.stream()
                 .anyMatch(inputLevel -> inputLevel.getDatasetFieldType().getId().equals(datasetFieldTypeId) 
-                         && inputLevel.isDisplayOnCreate().booleanValue());
+                         && inputLevel.getDisplayOnCreate().booleanValue());
     }
 
     public Template getDefaultTemplate() {

--- a/src/main/java/edu/harvard/iq/dataverse/Dataverse.java
+++ b/src/main/java/edu/harvard/iq/dataverse/Dataverse.java
@@ -441,7 +441,7 @@ public class Dataverse extends DvObjectContainer {
     public boolean isDatasetFieldTypeDisplayOnCreateAsInputLevel(Long datasetFieldTypeId) {
         return dataverseFieldTypeInputLevels.stream()
                 .anyMatch(inputLevel -> inputLevel.getDatasetFieldType().getId().equals(datasetFieldTypeId) 
-                         && inputLevel.getDisplayOnCreate().booleanValue());
+                         && Boolean.TRUE.equals(inputLevel.getDisplayOnCreate()));
     }
 
     public Template getDefaultTemplate() {

--- a/src/main/java/edu/harvard/iq/dataverse/DataverseFieldTypeInputLevel.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DataverseFieldTypeInputLevel.java
@@ -6,6 +6,8 @@
 package edu.harvard.iq.dataverse;
 
 import java.io.Serializable;
+
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -58,11 +60,14 @@ public class DataverseFieldTypeInputLevel implements Serializable {
     private DatasetFieldType datasetFieldType;
     private boolean include;
     private boolean required;
-    private boolean displayOnCreate;
+    
+   
+    @Column(nullable = true)
+    private Boolean displayOnCreate;
     
     public DataverseFieldTypeInputLevel () {}
   
-    public DataverseFieldTypeInputLevel (DatasetFieldType fieldType, Dataverse dataverse, boolean required, boolean include, boolean displayOnCreate) {
+    public DataverseFieldTypeInputLevel (DatasetFieldType fieldType, Dataverse dataverse, boolean required, boolean include, Boolean displayOnCreate) {
         this.datasetFieldType = fieldType;
         this.dataverse = dataverse;
         this.required = required;
@@ -117,11 +122,11 @@ public class DataverseFieldTypeInputLevel implements Serializable {
         this.required = required;
     }
 
-    public boolean isDisplayOnCreate() {
+    public Boolean isDisplayOnCreate() {
         return displayOnCreate;
     }
 
-    public void setDisplayOnCreate(boolean displayOnCreate) {
+    public void setDisplayOnCreate(Boolean displayOnCreate) {
         this.displayOnCreate = displayOnCreate;
     }
 

--- a/src/main/java/edu/harvard/iq/dataverse/DataverseFieldTypeInputLevel.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DataverseFieldTypeInputLevel.java
@@ -122,7 +122,7 @@ public class DataverseFieldTypeInputLevel implements Serializable {
         this.required = required;
     }
 
-    public Boolean isDisplayOnCreate() {
+    public Boolean getDisplayOnCreate() {
         return displayOnCreate;
     }
 

--- a/src/main/java/edu/harvard/iq/dataverse/DataverseFieldTypeInputLevel.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DataverseFieldTypeInputLevel.java
@@ -40,8 +40,9 @@ import jakarta.persistence.UniqueConstraint;
         ,  uniqueConstraints={
             @UniqueConstraint(columnNames={"dataverse_id", "datasetfieldtype_id"})}
         , indexes = {@Index(columnList="dataverse_id")
-		, @Index(columnList="datasetfieldtype_id")
-		, @Index(columnList="required")}
+        , @Index(columnList="datasetfieldtype_id")
+        , @Index(columnList="required")
+        , @Index(columnList="displayOnCreate")}
 )
 @Entity
 public class DataverseFieldTypeInputLevel implements Serializable {

--- a/src/main/java/edu/harvard/iq/dataverse/DataversePage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DataversePage.java
@@ -1025,12 +1025,15 @@ public class DataversePage implements java.io.Serializable {
         if (dsfIl != null) {
             dsft.setRequiredDV(dsfIl.isRequired());
             dsft.setInclude(dsfIl.isInclude());
-            dsft.setDisplayOnCreate(dsfIl.isDisplayOnCreate());
+            Boolean displayOnCreate = dsfIl.isDisplayOnCreate();
+            if(displayOnCreate != null) {
+              dsft.setDisplayOnCreate(displayOnCreate);
+            }
         } else {
             // If there is no input level, use the default values
             dsft.setRequiredDV(dsft.isRequired());
             dsft.setInclude(true);
-            dsft.setDisplayOnCreate(false);
+            //dsft.setDisplayOnCreate(false);
         }
     }
 

--- a/src/main/java/edu/harvard/iq/dataverse/DataversePage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DataversePage.java
@@ -1025,15 +1025,11 @@ public class DataversePage implements java.io.Serializable {
         if (dsfIl != null) {
             dsft.setRequiredDV(dsfIl.isRequired());
             dsft.setInclude(dsfIl.isInclude());
-            Boolean displayOnCreate = dsfIl.isDisplayOnCreate();
-            if(displayOnCreate != null) {
-              dsft.setDisplayOnCreate(displayOnCreate);
-            }
+            dsft.setLocalDisplayOnCreate(dsfIl.getDisplayOnCreate());
         } else {
             // If there is no input level, use the default values
             dsft.setRequiredDV(dsft.isRequired());
             dsft.setInclude(true);
-            //dsft.setDisplayOnCreate(false);
         }
     }
 
@@ -1320,7 +1316,7 @@ public class DataversePage implements java.io.Serializable {
                 for (DatasetFieldType dsft : mdb.getDatasetFieldTypes()) {
                     if (dsft.getId().equals(dsftId)) {
                         // Update value in memory
-                        dsft.setDisplayOnCreate(!currentValue);
+                        dsft.setLocalDisplayOnCreate(!currentValue);
                         
                         // Update or create input level
                         DataverseFieldTypeInputLevel existingLevel = dataverseFieldTypeInputLevelService
@@ -1351,18 +1347,18 @@ public class DataversePage implements java.io.Serializable {
             .findByDataverseIdDatasetFieldTypeId(dataverse.getId(), dsft.getId());
         
         if (existingLevel != null) {
-            existingLevel.setDisplayOnCreate(dsft.isDisplayOnCreate());
+            existingLevel.setDisplayOnCreate(dsft.getLocalDisplayOnCreate());
             existingLevel.setInclude(dsft.isInclude());
             existingLevel.setRequired(dsft.isRequiredDV());
             listDFTIL.add(existingLevel);
-        } else if (dsft.isInclude() || dsft.isDisplayOnCreate() || dsft.isRequiredDV()) {
+        } else if (dsft.isInclude() || (dsft.getLocalDisplayOnCreate()!=null) || dsft.isRequiredDV()) {
             // Only create new input level if there is any specific configuration
             listDFTIL.add(new DataverseFieldTypeInputLevel(
                 dsft, 
                 dataverse, 
                 dsft.isRequiredDV(), 
                 dsft.isInclude(), 
-                dsft.isDisplayOnCreate()
+                dsft.getLocalDisplayOnCreate()
             ));
         }
     }

--- a/src/main/java/edu/harvard/iq/dataverse/DataverseServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DataverseServiceBean.java
@@ -959,11 +959,14 @@ public class DataverseServiceBean implements java.io.Serializable {
                     if (dsfIl != null) {
                         dsft.setRequiredDV(dsfIl.isRequired());
                         dsft.setInclude(dsfIl.isInclude());
-                        dsft.setDisplayOnCreate(dsfIl.isDisplayOnCreate());
+                        Boolean displayOnCreate = dsfIl.isDisplayOnCreate();
+                        if (displayOnCreate!= null) {
+                            dsft.setDisplayOnCreate(displayOnCreate);
+                        }
                     } else {
                         dsft.setRequiredDV(dsft.isRequired());
                         dsft.setInclude(true);
-                        dsft.setDisplayOnCreate(false);
+                        //dsft.setDisplayOnCreate(false);
                     }
                     List<String> childrenRequired = new ArrayList<>();
                     List<String> childrenAllowed = new ArrayList<>();
@@ -973,13 +976,16 @@ public class DataverseServiceBean implements java.io.Serializable {
                             if (dsfIlChild != null) {
                                 child.setRequiredDV(dsfIlChild.isRequired());
                                 child.setInclude(dsfIlChild.isInclude());
-                                child.setDisplayOnCreate(dsfIlChild.isDisplayOnCreate());
+                                Boolean displayOnCreate = dsfIlChild.isDisplayOnCreate();
+                                if (displayOnCreate!= null) {
+                                    child.setDisplayOnCreate(displayOnCreate);
+                                }
                             } else {
                                 // in the case of conditionally required (child = true, parent = false)
                                 // we set this to false; i.e this is the default "don't override" value
                                 child.setRequiredDV(child.isRequired() && dsft.isRequired());
                                 child.setInclude(true);
-                                child.setDisplayOnCreate(false);
+                                //child.setDisplayOnCreate(false);
                             }
                             if (child.isRequired()) {
                                 childrenRequired.add(child.getName());

--- a/src/main/java/edu/harvard/iq/dataverse/DataverseServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DataverseServiceBean.java
@@ -959,14 +959,10 @@ public class DataverseServiceBean implements java.io.Serializable {
                     if (dsfIl != null) {
                         dsft.setRequiredDV(dsfIl.isRequired());
                         dsft.setInclude(dsfIl.isInclude());
-                        Boolean displayOnCreate = dsfIl.isDisplayOnCreate();
-                        if (displayOnCreate!= null) {
-                            dsft.setDisplayOnCreate(displayOnCreate);
-                        }
+                        dsft.setLocalDisplayOnCreate(dsfIl.getDisplayOnCreate());
                     } else {
                         dsft.setRequiredDV(dsft.isRequired());
                         dsft.setInclude(true);
-                        //dsft.setDisplayOnCreate(false);
                     }
                     List<String> childrenRequired = new ArrayList<>();
                     List<String> childrenAllowed = new ArrayList<>();
@@ -976,16 +972,12 @@ public class DataverseServiceBean implements java.io.Serializable {
                             if (dsfIlChild != null) {
                                 child.setRequiredDV(dsfIlChild.isRequired());
                                 child.setInclude(dsfIlChild.isInclude());
-                                Boolean displayOnCreate = dsfIlChild.isDisplayOnCreate();
-                                if (displayOnCreate!= null) {
-                                    child.setDisplayOnCreate(displayOnCreate);
-                                }
+                                child.setLocalDisplayOnCreate(dsfIlChild.getDisplayOnCreate());
                             } else {
                                 // in the case of conditionally required (child = true, parent = false)
                                 // we set this to false; i.e this is the default "don't override" value
                                 child.setRequiredDV(child.isRequired() && dsft.isRequired());
                                 child.setInclude(true);
-                                //child.setDisplayOnCreate(false);
                             }
                             if (child.isRequired()) {
                                 childrenRequired.add(child.getName());

--- a/src/main/java/edu/harvard/iq/dataverse/MetadataBlock.java
+++ b/src/main/java/edu/harvard/iq/dataverse/MetadataBlock.java
@@ -102,8 +102,8 @@ public class MetadataBlock implements Serializable, Comparable {
     
     public boolean isDisplayOnCreate() {
         for (DatasetFieldType dsfType : datasetFieldTypes) {
-            Boolean displayOnCreate = dsfType.isDisplayOnCreate();
-            if (displayOnCreate != null && displayOnCreate) {
+            boolean shouldDisplayOnCreate = dsfType.shouldDisplayOnCreate();
+            if (shouldDisplayOnCreate) {
                 return true;
             }
         }

--- a/src/main/java/edu/harvard/iq/dataverse/MetadataBlockServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/MetadataBlockServiceBean.java
@@ -80,13 +80,22 @@ public class MetadataBlockServiceBean {
                 datasetFieldTypeInputLevelJoin.get("datasetFieldType").in(metadataBlockRoot.get("datasetFieldTypes")),
                 criteriaBuilder.isTrue(datasetFieldTypeInputLevelJoin.get("required")));
 
-            // Predicate for default displayOnCreate (when there is no input level)
-            Predicate defaultDisplayOnCreatePredicate = criteriaBuilder.and(
-                criteriaBuilder.not(criteriaBuilder.exists(inputLevelSubquery)),
-                criteriaBuilder.or(
-                    criteriaBuilder.isTrue(datasetFieldTypeJoin.get("displayOnCreate")),
+            // Predicate for default displayOnCreate (when there is no input level or when input level exists but doesn't have displayOnCreate set)
+            Predicate defaultDisplayOnCreatePredicate = criteriaBuilder.or(
+                // Case 1: No input level and required is true
+                criteriaBuilder.and(
+                    criteriaBuilder.not(criteriaBuilder.exists(inputLevelSubquery)),
                     criteriaBuilder.isTrue(datasetFieldTypeJoin.get("required"))
-                ));
+                ),
+                // Case 2: (No input level OR input level exists but displayOnCreate is null) AND displayOnCreate is true in datasetFieldType
+                criteriaBuilder.and(
+                    criteriaBuilder.or(
+                        criteriaBuilder.not(criteriaBuilder.exists(inputLevelSubquery)),
+                        criteriaBuilder.isNull(datasetFieldTypeInputLevelJoin.get("displayOnCreate"))
+                    ),
+                    criteriaBuilder.isTrue(datasetFieldTypeJoin.get("displayOnCreate"))
+                )
+            );
 
             Predicate unionPredicate = criteriaBuilder.or(
                 displayOnCreateInputLevelPredicate,

--- a/src/main/java/edu/harvard/iq/dataverse/MetadataBlockServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/MetadataBlockServiceBean.java
@@ -8,6 +8,7 @@ import jakarta.persistence.PersistenceContext;
 import jakarta.persistence.TypedQuery;
 import jakarta.persistence.criteria.*;
 
+import java.util.Comparator;
 import java.util.List;
 
 /**
@@ -52,78 +53,62 @@ public class MetadataBlockServiceBean {
     public List<MetadataBlock> listMetadataBlocksDisplayedOnCreate(Dataverse ownerDataverse) {
         CriteriaBuilder criteriaBuilder = em.getCriteriaBuilder();
         CriteriaQuery<MetadataBlock> criteriaQuery = criteriaBuilder.createQuery(MetadataBlock.class);
-        Root<MetadataBlock> metadataBlockRoot = criteriaQuery.from(MetadataBlock.class);
-        Join<MetadataBlock, DatasetFieldType> datasetFieldTypeJoin = metadataBlockRoot.join("datasetFieldTypes");
-        
+        Root<Dataverse> dataverseRoot = criteriaQuery.from(Dataverse.class);
+
+        // Join metadataBlocks from Dataverse
+        Join<Dataverse, MetadataBlock> metadataBlockJoin = dataverseRoot.join("metadataBlocks");
+
+        // Join datasetFieldTypes from MetadataBlock
+        Join<MetadataBlock, DatasetFieldType> datasetFieldTypeJoin = metadataBlockJoin.join("datasetFieldTypes");
+
+        Predicate displayOnCreatePredicate = criteriaBuilder.isTrue(datasetFieldTypeJoin.get("displayOnCreate"));
+        Predicate requiredPredicate = criteriaBuilder.isTrue(datasetFieldTypeJoin.get("required"));
+
         if (ownerDataverse != null) {
-            Root<Dataverse> dataverseRoot = criteriaQuery.from(Dataverse.class);
-            Join<Dataverse, DataverseFieldTypeInputLevel> datasetFieldTypeInputLevelJoin = 
-                dataverseRoot.join("dataverseFieldTypeInputLevels", JoinType.LEFT);
+            // Ensure we filter for the specific Dataverse
+            Predicate dataversePredicate = criteriaBuilder.equal(dataverseRoot.get("id"), ownerDataverse.getId());
 
-            // Subquery to check if the input level exists
-            Subquery<Long> inputLevelSubquery = criteriaQuery.subquery(Long.class);
-            Root<DataverseFieldTypeInputLevel> subqueryRoot = inputLevelSubquery.from(DataverseFieldTypeInputLevel.class);
-            inputLevelSubquery.select(criteriaBuilder.literal(1L))
-                .where(
-                    criteriaBuilder.equal(subqueryRoot.get("dataverse"), dataverseRoot),
-                    criteriaBuilder.equal(subqueryRoot.get("datasetFieldType"), datasetFieldTypeJoin)
-                );
+            // Join DataverseFieldTypeInputLevel (LEFT JOIN)
+            Join<Dataverse, DataverseFieldTypeInputLevel> datasetFieldTypeInputLevelJoin =
+                    dataverseRoot.join("dataverseFieldTypeInputLevels", JoinType.LEFT);
 
-            // Predicate for displayOnCreate in the input level
-            Predicate displayOnCreateInputLevelPredicate = criteriaBuilder.and(
-                datasetFieldTypeInputLevelJoin.get("datasetFieldType").in(metadataBlockRoot.get("datasetFieldTypes")),
-                criteriaBuilder.isNotNull(datasetFieldTypeInputLevelJoin.get("displayOnCreate")),
-                criteriaBuilder.isTrue(datasetFieldTypeInputLevelJoin.get("displayOnCreate")));
-
-            // Predicate for required fields
-            Predicate requiredPredicate = criteriaBuilder.and(
-                datasetFieldTypeInputLevelJoin.get("datasetFieldType").in(metadataBlockRoot.get("datasetFieldTypes")),
-                criteriaBuilder.isTrue(datasetFieldTypeInputLevelJoin.get("required")));
-
-            // Predicate for default displayOnCreate (when there is no input level or when input level exists but doesn't have displayOnCreate set)
-            Predicate defaultDisplayOnCreatePredicate = criteriaBuilder.or(
-                // Case 1: No input level and required is true
-                criteriaBuilder.and(
-                    criteriaBuilder.not(criteriaBuilder.exists(inputLevelSubquery)),
-                    criteriaBuilder.isTrue(datasetFieldTypeJoin.get("required"))
-                ),
-                // Case 2: (No input level OR input level exists but displayOnCreate is null) AND displayOnCreate is true in datasetFieldType
-                criteriaBuilder.and(
-                    criteriaBuilder.or(
-                        criteriaBuilder.not(criteriaBuilder.exists(inputLevelSubquery)),
-                        criteriaBuilder.isNull(datasetFieldTypeInputLevelJoin.get("displayOnCreate"))
-                    ),
-                    criteriaBuilder.isTrue(datasetFieldTypeJoin.get("displayOnCreate"))
-                )
+            // Check if input level explicitly defines displayOnCreate
+            Predicate inputLevelDisplayPredicate = criteriaBuilder.and(
+                    criteriaBuilder.equal(datasetFieldTypeInputLevelJoin.get("datasetFieldType"), datasetFieldTypeJoin),
+                    criteriaBuilder.isTrue(datasetFieldTypeInputLevelJoin.get("displayOnCreate"))
             );
 
-            Predicate unionPredicate = criteriaBuilder.or(
-                displayOnCreateInputLevelPredicate,
-                requiredPredicate,
-                defaultDisplayOnCreatePredicate
+            // Check if input level explicitly defines required
+            Predicate inputLevelRequiredPredicate = criteriaBuilder.and(
+                    criteriaBuilder.equal(datasetFieldTypeInputLevelJoin.get("datasetFieldType"), datasetFieldTypeJoin),
+                    criteriaBuilder.isTrue(datasetFieldTypeInputLevelJoin.get("required"))
             );
 
-            criteriaQuery.where(criteriaBuilder.and(
-                criteriaBuilder.equal(dataverseRoot.get("id"), ownerDataverse.getId()),
-                metadataBlockRoot.in(dataverseRoot.get("metadataBlocks")),
-                unionPredicate
-            ));
+            Predicate finalDisplayPredicate = criteriaBuilder.or(inputLevelDisplayPredicate, displayOnCreatePredicate);
+            Predicate finalRequiredPredicate = criteriaBuilder.or(inputLevelRequiredPredicate, requiredPredicate);
+
+            criteriaQuery.where(
+                    dataversePredicate,
+                    criteriaBuilder.or(finalDisplayPredicate, finalRequiredPredicate)
+            );
         } else {
             // When ownerDataverse is null, we need to include fields that are either displayOnCreate=true OR required=true
-            Predicate displayOnCreatePredicate = criteriaBuilder.isTrue(datasetFieldTypeJoin.get("displayOnCreate"));
-            Predicate requiredPredicate = criteriaBuilder.isTrue(datasetFieldTypeJoin.get("required"));
-            
             // We also need to ensure that fields from linked metadata blocks are included
             Predicate linkedFieldsPredicate = criteriaBuilder.and(
-                criteriaBuilder.isNotNull(datasetFieldTypeJoin.get("id")),
-                criteriaBuilder.or(displayOnCreatePredicate, requiredPredicate)
+                    criteriaBuilder.isNotNull(datasetFieldTypeJoin.get("id")),
+                    criteriaBuilder.or(displayOnCreatePredicate, requiredPredicate)
             );
-            
+
             criteriaQuery.where(linkedFieldsPredicate);
         }
 
-        criteriaQuery.select(metadataBlockRoot).distinct(true)
-                .orderBy(criteriaBuilder.desc(metadataBlockRoot.get("id")));
-        return em.createQuery(criteriaQuery).getResultList();
+        criteriaQuery.select(metadataBlockJoin).distinct(true);
+
+        List<MetadataBlock> result = em.createQuery(criteriaQuery).getResultList();
+
+        // Order by id
+        result.sort(Comparator.comparing(MetadataBlock::getId));
+
+        return result;
     }
 }

--- a/src/main/java/edu/harvard/iq/dataverse/MetadataBlockServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/MetadataBlockServiceBean.java
@@ -122,7 +122,8 @@ public class MetadataBlockServiceBean {
             criteriaQuery.where(linkedFieldsPredicate);
         }
 
-        criteriaQuery.select(metadataBlockRoot).distinct(true);
+        criteriaQuery.select(metadataBlockRoot).distinct(true)
+                .orderBy(criteriaBuilder.desc(metadataBlockRoot.get("id")));
         return em.createQuery(criteriaQuery).getResultList();
     }
 }

--- a/src/main/java/edu/harvard/iq/dataverse/TemplatePage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/TemplatePage.java
@@ -172,7 +172,10 @@ public class TemplatePage implements java.io.Serializable {
            );
            if (dsfIl != null) {
                dsf.setInclude(dsfIl.isInclude());
-               dsf.getDatasetFieldType().setDisplayOnCreate(dsfIl.isDisplayOnCreate());
+               Boolean displayOnCreate = dsfIl.isDisplayOnCreate();
+               if (displayOnCreate!= null) {
+                   dsf.getDatasetFieldType().setDisplayOnCreate(displayOnCreate);
+               }
            } else {
                dsf.setInclude(true);
                dsf.getDatasetFieldType().setDisplayOnCreate(false);

--- a/src/main/java/edu/harvard/iq/dataverse/TemplatePage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/TemplatePage.java
@@ -172,13 +172,9 @@ public class TemplatePage implements java.io.Serializable {
            );
            if (dsfIl != null) {
                dsf.setInclude(dsfIl.isInclude());
-               Boolean displayOnCreate = dsfIl.isDisplayOnCreate();
-               if (displayOnCreate!= null) {
-                   dsf.getDatasetFieldType().setDisplayOnCreate(displayOnCreate);
-               }
+               dsf.getDatasetFieldType().setLocalDisplayOnCreate(dsfIl.getDisplayOnCreate());
            } else {
                dsf.setInclude(true);
-               dsf.getDatasetFieldType().setDisplayOnCreate(false);
            } 
         }
     }

--- a/src/main/java/edu/harvard/iq/dataverse/api/Dataverses.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Dataverses.java
@@ -803,7 +803,10 @@ public class Dataverses extends AbstractApiBean {
 
             boolean required = inputLevel.getBoolean("required");
             boolean include = inputLevel.getBoolean("include");
-            boolean displayOnCreate = inputLevel.getBoolean("displayOnCreate", false);
+            Boolean displayOnCreate = null;
+            if(inputLevel.containsKey("displayOnCreate")) {
+                displayOnCreate = inputLevel.getBoolean("displayOnCreate", false);
+            }
 
             if (required && !include) {
                 String errorMessage = MessageFormat.format(BundleUtil.getStringFromBundle("dataverse.inputlevels.error.cannotberequiredifnotincluded"), datasetFieldTypeName);

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/AbstractWriteDataverseCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/AbstractWriteDataverseCommand.java
@@ -113,7 +113,7 @@ abstract class AbstractWriteDataverseCommand extends AbstractCommand<Dataverse> 
                     if (existingLevel != null) {
                         existingLevel.setRequired(inputLevel.isRequired());
                         existingLevel.setInclude(inputLevel.isInclude());
-                        existingLevel.setDisplayOnCreate(inputLevel.isDisplayOnCreate());
+                        existingLevel.setDisplayOnCreate(inputLevel.getDisplayOnCreate());
                         ctxt.fieldTypeInputLevels().save(existingLevel);
                     } else {
                         ctxt.fieldTypeInputLevels().create(inputLevel);

--- a/src/main/java/edu/harvard/iq/dataverse/util/json/BriefJsonPrinter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/json/BriefJsonPrinter.java
@@ -25,10 +25,10 @@ public class BriefJsonPrinter {
     
     public JsonObjectBuilder json( MetadataBlock blk ) {
         if (blk == null) return null;
-        Boolean displayOnCreate = blk.isDisplayOnCreate();
+        boolean displayOnCreate = blk.isDisplayOnCreate();
         return jsonObjectBuilder().add("id", blk.getId())
                     .add("displayName", blk.getDisplayName())
-                    .add("displayOnCreate", displayOnCreate == null ? false : displayOnCreate)
+                    .add("displayOnCreate", displayOnCreate)
                     .add("name", blk.getName())
                     ;
     }

--- a/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
@@ -751,7 +751,7 @@ public class JsonPrinter {
                         subFld.setInclude(childLevel.isInclude());
                     }
                 }
-                //Todo - other conditions? Can a child have displayOnCreate when the parent doesn't? Does this affect including the parent too?
+                //This assumes a child have can't be displayOnCreate=true when the parent isn't
                 if(subFld.isInclude()) {
                   subFieldsBld.add(subFld.getName(), JsonPrinter.json(subFld, ownerDataverse));
                 }

--- a/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
@@ -57,7 +57,6 @@ import jakarta.ejb.EJB;
 import jakarta.ejb.Singleton;
 import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
-import java.util.function.Predicate;
 
 /**
  * Convert objects to Json.
@@ -75,14 +74,9 @@ public class JsonPrinter {
     @EJB
     static DatasetFieldServiceBean datasetFieldService;
     
-    @EJB
-    static DataverseFieldTypeInputLevelServiceBean datasetFieldInputLevelService;
-    
     public static void injectSettingsService(SettingsServiceBean ssb, DatasetFieldServiceBean dfsb, DataverseFieldTypeInputLevelServiceBean dfils) {
             settingsService = ssb;
             datasetFieldService = dfsb;
-            datasetFieldInputLevelService = dfils;
-            
     }
 
     public JsonPrinter() {

--- a/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
@@ -667,7 +667,7 @@ public class JsonPrinter {
                 boolean inLevel = false;
                 if(ownerDataverse != null) {
                     inLevel = ownerDataverse.isDatasetFieldTypeInInputLevels(datasetFieldType.getId());
-                    datasetFieldType.setLocalDisplayOnCreate(ownerDataverse.isDatasetFieldTypeDisplayOnCreateAsInputLevel(datasetFieldType.getId()));
+                    datasetFieldType.setLocalDisplayOnCreate(inLevel ? ownerDataverse.isDatasetFieldTypeDisplayOnCreateAsInputLevel(datasetFieldType.getId()): null);
                     datasetFieldType.setRequiredDV(ownerDataverse.isDatasetFieldTypeRequiredAsInputLevel(datasetFieldType.getId()));
                 }
                 boolean fieldDisplayOnCreate = datasetFieldType.shouldDisplayOnCreate();
@@ -736,7 +736,8 @@ public class JsonPrinter {
             JsonObjectBuilder subFieldsBld = jsonObjectBuilder();
             for (DatasetFieldType subFld : fld.getChildDatasetFieldTypes()) {
                 if(ownerDataverse != null) {
-                    subFld.setLocalDisplayOnCreate(ownerDataverse.isDatasetFieldTypeDisplayOnCreateAsInputLevel(subFld.getId()));
+                    boolean childInLevel= ownerDataverse != null && ownerDataverse.isDatasetFieldTypeInInputLevels(subFld.getId());
+                    subFld.setLocalDisplayOnCreate(childInLevel ? ownerDataverse.isDatasetFieldTypeDisplayOnCreateAsInputLevel(subFld.getId()): null);
                     subFld.setRequiredDV(ownerDataverse.isDatasetFieldTypeRequiredAsInputLevel(subFld.getId()));
                 }
                 subFieldsBld.add(subFld.getName(), JsonPrinter.json(subFld, ownerDataverse));

--- a/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
@@ -1456,7 +1456,7 @@ public class JsonPrinter {
     }
 
     private static JsonObjectBuilder jsonDataverseInputLevel(DataverseFieldTypeInputLevel inputLevel) {
-        JsonObjectBuilder jsonObjectBuilder = NullSafeJsonBuilder.jsonObjectBuilder();
+        NullSafeJsonBuilder jsonObjectBuilder = NullSafeJsonBuilder.jsonObjectBuilder();
         jsonObjectBuilder.add("datasetFieldTypeName", inputLevel.getDatasetFieldType().getName());
         jsonObjectBuilder.add("required", inputLevel.isRequired());
         jsonObjectBuilder.add("include", inputLevel.isInclude());

--- a/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
@@ -664,18 +664,20 @@ public class JsonPrinter {
         
         for (DatasetFieldType datasetFieldType : datasetFieldTypes) {
             if (!datasetFieldType.isChild()) {
-                boolean inLevel = false;
+                DataverseFieldTypeInputLevel level = null;
                 datasetFieldType.setInclude(true);
-                if(ownerDataverse != null) {
-                    inLevel = ownerDataverse.isDatasetFieldTypeInInputLevels(datasetFieldType.getId());
-                    datasetFieldType.setLocalDisplayOnCreate(inLevel ? ownerDataverse.isDatasetFieldTypeDisplayOnCreateAsInputLevel(datasetFieldType.getId()): null);
-                    datasetFieldType.setRequiredDV(ownerDataverse.isDatasetFieldTypeRequiredAsInputLevel(datasetFieldType.getId()));
-                    if(inLevel) {
-                        datasetFieldType.setInclude(ownerDataverse.isDatasetFieldTypeIncludedAsInputLevel(datasetFieldType.getId()));
+                if (ownerDataverse != null) {
+                    level = ownerDataverse.getDatasetFieldTypeInInputLevels(datasetFieldType.getId());
+                    if (level != null) {
+                        datasetFieldType.setLocalDisplayOnCreate(level.getDisplayOnCreate());
+                        datasetFieldType.setRequiredDV(level.isRequired());
+                        datasetFieldType.setInclude(level.isInclude());
                     }
                 }
                 boolean fieldDisplayOnCreate = datasetFieldType.shouldDisplayOnCreate();
-                if (datasetFieldType.isInclude() && (!printOnlyDisplayedOnCreateDatasetFieldTypes || fieldDisplayOnCreate || datasetFieldType.isRequired() || (datasetFieldType.isRequiredDV() && inLevel))) {
+                if (datasetFieldType.isInclude() && (!printOnlyDisplayedOnCreateDatasetFieldTypes
+                        || fieldDisplayOnCreate || datasetFieldType.isRequired()
+                        || (datasetFieldType.isRequiredDV() && (level != null)))) {
                     fieldsBuilder.add(datasetFieldType.getName(), json(datasetFieldType, ownerDataverse));
                 }
             }
@@ -740,12 +742,13 @@ public class JsonPrinter {
             JsonObjectBuilder subFieldsBld = jsonObjectBuilder();
             for (DatasetFieldType subFld : fld.getChildDatasetFieldTypes()) {
                 subFld.setInclude(true);
-                if(ownerDataverse != null) {
-                    boolean childInLevel= ownerDataverse != null && ownerDataverse.isDatasetFieldTypeInInputLevels(subFld.getId());
-                    subFld.setLocalDisplayOnCreate(childInLevel ? ownerDataverse.isDatasetFieldTypeDisplayOnCreateAsInputLevel(subFld.getId()): null);
-                    subFld.setRequiredDV(ownerDataverse.isDatasetFieldTypeRequiredAsInputLevel(subFld.getId()));
-                    if(childInLevel) {
-                        subFld.setInclude(ownerDataverse.isDatasetFieldTypeIncludedAsInputLevel(subFld.getId()));
+                if (ownerDataverse != null) {
+                    DataverseFieldTypeInputLevel childLevel = ownerDataverse
+                            .getDatasetFieldTypeInInputLevels(subFld.getId());
+                    if (childLevel != null) {
+                        subFld.setLocalDisplayOnCreate(childLevel.getDisplayOnCreate());
+                        subFld.setRequiredDV(childLevel.isRequired());
+                        subFld.setInclude(childLevel.isInclude());
                     }
                 }
                 //Todo - other conditions? Can a child have displayOnCreate when the parent doesn't? Does this affect including the parent too?

--- a/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
@@ -656,8 +656,7 @@ public class JsonPrinter {
                 .add("name", metadataBlock.getName())
                 .add("displayName", metadataBlock.getDisplayName());
         
-        Boolean displayOnCreate = metadataBlock.isDisplayOnCreate();
-        jsonObjectBuilder.add("displayOnCreate", displayOnCreate == null ? false : displayOnCreate);
+        jsonObjectBuilder.add("displayOnCreate", metadataBlock.isDisplayOnCreate());
 
         List<DatasetFieldType> datasetFieldTypesList = metadataBlock.getDatasetFieldTypes();
         Set<DatasetFieldType> datasetFieldTypes = filterOutDuplicateDatasetFieldTypes(datasetFieldTypesList);
@@ -666,8 +665,8 @@ public class JsonPrinter {
         
         for (DatasetFieldType datasetFieldType : datasetFieldTypes) {
             if (!datasetFieldType.isChild()) {
-                Boolean fieldDisplayOnCreate = datasetFieldType.isDisplayOnCreate();
-                if (!printOnlyDisplayedOnCreateDatasetFieldTypes || (fieldDisplayOnCreate != null && fieldDisplayOnCreate)) {
+                boolean fieldDisplayOnCreate = datasetFieldType.shouldDisplayOnCreate();
+                if (!printOnlyDisplayedOnCreateDatasetFieldTypes || fieldDisplayOnCreate) {
                     fieldsBuilder.add(datasetFieldType.getName(), json(datasetFieldType, ownerDataverse));
                 }
             }
@@ -704,8 +703,7 @@ public class JsonPrinter {
         JsonObjectBuilder fieldsBld = jsonObjectBuilder();
         fieldsBld.add("name", fld.getName());
         fieldsBld.add("displayName", fld.getDisplayName());
-        Boolean displayOnCreate = fld.isDisplayOnCreate();
-        fieldsBld.add("displayOnCreate", displayOnCreate == null ? false : displayOnCreate);
+        fieldsBld.add("displayOnCreate", fld.shouldDisplayOnCreate());
         fieldsBld.add("title", fld.getTitle());
         fieldsBld.add("type", fld.getFieldType().toString());
         fieldsBld.add("typeClass", typeClassString(fld));
@@ -1438,7 +1436,7 @@ public class JsonPrinter {
             inputLevelJsonObject.add("datasetFieldTypeName", inputLevel.getDatasetFieldType().getName());
             inputLevelJsonObject.add("required", inputLevel.isRequired());
             inputLevelJsonObject.add("include", inputLevel.isInclude());
-            inputLevelJsonObject.add("displayOnCreate", inputLevel.isDisplayOnCreate());
+            inputLevelJsonObject.add("displayOnCreate", inputLevel.getDisplayOnCreate());
             jsonArrayOfInputLevels.add(inputLevelJsonObject);
         }
         return jsonArrayOfInputLevels;
@@ -1457,7 +1455,7 @@ public class JsonPrinter {
         jsonObjectBuilder.add("datasetFieldTypeName", inputLevel.getDatasetFieldType().getName());
         jsonObjectBuilder.add("required", inputLevel.isRequired());
         jsonObjectBuilder.add("include", inputLevel.isInclude());
-        jsonObjectBuilder.add("displayOnCreate", inputLevel.isDisplayOnCreate());
+        jsonObjectBuilder.add("displayOnCreate", inputLevel.getDisplayOnCreate());
         return jsonObjectBuilder;
     }
 

--- a/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
@@ -669,9 +669,10 @@ public class JsonPrinter {
                     inLevel = ownerDataverse.isDatasetFieldTypeInInputLevels(datasetFieldType.getId());
                     datasetFieldType.setLocalDisplayOnCreate(inLevel ? ownerDataverse.isDatasetFieldTypeDisplayOnCreateAsInputLevel(datasetFieldType.getId()): null);
                     datasetFieldType.setRequiredDV(ownerDataverse.isDatasetFieldTypeRequiredAsInputLevel(datasetFieldType.getId()));
+                    datasetFieldType.setInclude(inLevel? ownerDataverse.isDatasetFieldTypeIncludedAsInputLevel(datasetFieldType.getId()): true);
                 }
                 boolean fieldDisplayOnCreate = datasetFieldType.shouldDisplayOnCreate();
-                if (!printOnlyDisplayedOnCreateDatasetFieldTypes || fieldDisplayOnCreate || datasetFieldType.isRequired() || (datasetFieldType.isRequiredDV() && inLevel)) {
+                if (datasetFieldType.isInclude() && (!printOnlyDisplayedOnCreateDatasetFieldTypes || fieldDisplayOnCreate || datasetFieldType.isRequired() || (datasetFieldType.isRequiredDV() && inLevel))) {
                     fieldsBuilder.add(datasetFieldType.getName(), json(datasetFieldType, ownerDataverse));
                 }
             }
@@ -739,8 +740,12 @@ public class JsonPrinter {
                     boolean childInLevel= ownerDataverse != null && ownerDataverse.isDatasetFieldTypeInInputLevels(subFld.getId());
                     subFld.setLocalDisplayOnCreate(childInLevel ? ownerDataverse.isDatasetFieldTypeDisplayOnCreateAsInputLevel(subFld.getId()): null);
                     subFld.setRequiredDV(ownerDataverse.isDatasetFieldTypeRequiredAsInputLevel(subFld.getId()));
+                    subFld.setInclude(inLevel? ownerDataverse.isDatasetFieldTypeIncludedAsInputLevel(subFld.getId()): true);
                 }
-                subFieldsBld.add(subFld.getName(), JsonPrinter.json(subFld, ownerDataverse));
+                //Todo - other conditions? Can a child have displayOnCreate when the parent doesn't? Does this affect including the parent too?
+                if(subFld.isInclude()) {
+                  subFieldsBld.add(subFld.getName(), JsonPrinter.json(subFld, ownerDataverse));
+                }
             }
             fieldsBld.add("childFields", subFieldsBld);
         }

--- a/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
@@ -1453,7 +1453,7 @@ public class JsonPrinter {
     }
 
     private static JsonObjectBuilder jsonDataverseInputLevel(DataverseFieldTypeInputLevel inputLevel) {
-        JsonObjectBuilder jsonObjectBuilder = Json.createObjectBuilder();
+        JsonObjectBuilder jsonObjectBuilder = NullSafeJsonBuilder.jsonObjectBuilder();
         jsonObjectBuilder.add("datasetFieldTypeName", inputLevel.getDatasetFieldType().getName());
         jsonObjectBuilder.add("required", inputLevel.isRequired());
         jsonObjectBuilder.add("include", inputLevel.isInclude());

--- a/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
@@ -665,11 +665,14 @@ public class JsonPrinter {
         for (DatasetFieldType datasetFieldType : datasetFieldTypes) {
             if (!datasetFieldType.isChild()) {
                 boolean inLevel = false;
+                datasetFieldType.setInclude(true);
                 if(ownerDataverse != null) {
                     inLevel = ownerDataverse.isDatasetFieldTypeInInputLevels(datasetFieldType.getId());
                     datasetFieldType.setLocalDisplayOnCreate(inLevel ? ownerDataverse.isDatasetFieldTypeDisplayOnCreateAsInputLevel(datasetFieldType.getId()): null);
                     datasetFieldType.setRequiredDV(ownerDataverse.isDatasetFieldTypeRequiredAsInputLevel(datasetFieldType.getId()));
-                    datasetFieldType.setInclude(inLevel? ownerDataverse.isDatasetFieldTypeIncludedAsInputLevel(datasetFieldType.getId()): true);
+                    if(inLevel) {
+                        datasetFieldType.setInclude(ownerDataverse.isDatasetFieldTypeIncludedAsInputLevel(datasetFieldType.getId()));
+                    }
                 }
                 boolean fieldDisplayOnCreate = datasetFieldType.shouldDisplayOnCreate();
                 if (datasetFieldType.isInclude() && (!printOnlyDisplayedOnCreateDatasetFieldTypes || fieldDisplayOnCreate || datasetFieldType.isRequired() || (datasetFieldType.isRequiredDV() && inLevel))) {
@@ -736,11 +739,14 @@ public class JsonPrinter {
         if (!fld.getChildDatasetFieldTypes().isEmpty()) {
             JsonObjectBuilder subFieldsBld = jsonObjectBuilder();
             for (DatasetFieldType subFld : fld.getChildDatasetFieldTypes()) {
+                subFld.setInclude(true);
                 if(ownerDataverse != null) {
                     boolean childInLevel= ownerDataverse != null && ownerDataverse.isDatasetFieldTypeInInputLevels(subFld.getId());
                     subFld.setLocalDisplayOnCreate(childInLevel ? ownerDataverse.isDatasetFieldTypeDisplayOnCreateAsInputLevel(subFld.getId()): null);
                     subFld.setRequiredDV(ownerDataverse.isDatasetFieldTypeRequiredAsInputLevel(subFld.getId()));
-                    subFld.setInclude(inLevel? ownerDataverse.isDatasetFieldTypeIncludedAsInputLevel(subFld.getId()): true);
+                    if(childInLevel) {
+                        subFld.setInclude(ownerDataverse.isDatasetFieldTypeIncludedAsInputLevel(subFld.getId()));
+                    }
                 }
                 //Todo - other conditions? Can a child have displayOnCreate when the parent doesn't? Does this affect including the parent too?
                 if(subFld.isInclude()) {

--- a/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
@@ -751,7 +751,7 @@ public class JsonPrinter {
                         subFld.setInclude(childLevel.isInclude());
                     }
                 }
-                //This assumes a child have can't be displayOnCreate=true when the parent isn't
+                //This assumes a child have can't be displayOnCreate=false when the parent has it true (i.e. we're not excluding children based on testing displayOnCreate (or required) here.)
                 if(subFld.isInclude()) {
                   subFieldsBld.add(subFld.getName(), JsonPrinter.json(subFld, ownerDataverse));
                 }

--- a/src/main/resources/db/migration/V6.5.0.12.sql
+++ b/src/main/resources/db/migration/V6.5.0.12.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS index_dataversefieldtypeinputlevel_displayoncreate ON dataversefieldtypeinputlevel (displayoncreate);

--- a/src/main/webapp/metadataFragment.xhtml
+++ b/src/main/webapp/metadataFragment.xhtml
@@ -244,7 +244,7 @@
                         <div class="panel-body">
                             <ui:repeat value="#{metadataBlockVal.value}" var="dsf" varStatus="curField">
                                 <div class="form-group" role="group"
-                                     jsf:rendered="#{((editMode == 'METADATA' or dsf.datasetFieldType.isDisplayOnCreate() or !dsf.isEmpty() or dsf.required) and dsf.include) or (!datasetPage and dsf.include)}">
+                                     jsf:rendered="#{((editMode == 'METADATA' or dsf.datasetFieldType.shouldDisplayOnCreate() or !dsf.isEmpty() or dsf.required) and dsf.include) or (!datasetPage and dsf.include)}">
                                     <!-- Primitive fields -->
                                     <p:fragment id="editPrimitiveValueFragment" rendered="#{dsf.datasetFieldType.primitive}">
                                         <p:autoUpdate/>

--- a/src/test/java/edu/harvard/iq/dataverse/api/DataversesIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/DataversesIT.java
@@ -33,6 +33,8 @@ import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasItemInArray;
+import static org.hamcrest.Matchers.hasKey;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.nio.file.Files;
@@ -1975,6 +1977,14 @@ public class DataversesIT {
         updateResponse.then().assertThat()
                 .statusCode(OK.getStatusCode())
                 .body("data.inputLevels[0].displayOnCreate", equalTo(true))
+                .body("data.inputLevels[0].datasetFieldTypeName", equalTo("unitOfAnalysis"));
+        
+        // Update an inputlevel w/o displayOnCreate set
+        Response updateResponse2 = UtilIT.updateDataverseInputLevelDisplayOnCreate(
+            dataverseAlias, "unitOfAnalysis", null, apiToken);
+        updateResponse2.then().assertThat()
+                .statusCode(OK.getStatusCode())
+                .body("data.inputLevels[0]", not(hasKey("displayOnCreate")))
                 .body("data.inputLevels[0].datasetFieldTypeName", equalTo("unitOfAnalysis"));
     }
     

--- a/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
@@ -4609,13 +4609,15 @@ public class UtilIT {
                 .put(path);
     }
   
-    public static Response updateDataverseInputLevelDisplayOnCreate(String dataverseAlias, String fieldTypeName, boolean displayOnCreate, String apiToken) {
+    public static Response updateDataverseInputLevelDisplayOnCreate(String dataverseAlias, String fieldTypeName, Boolean displayOnCreate, String apiToken) {
         JsonArrayBuilder inputLevelsArrayBuilder = Json.createArrayBuilder();
         JsonObjectBuilder inputLevel = Json.createObjectBuilder()
                 .add("datasetFieldTypeName", fieldTypeName)
                 .add("required", false)
-                .add("include", true)
-                .add("displayOnCreate", displayOnCreate);
+                .add("include", true);
+        if(displayOnCreate != null) {
+            inputLevel.add("displayOnCreate", displayOnCreate);
+        }
         
         inputLevelsArrayBuilder.add(inputLevel);
         

--- a/src/test/java/edu/harvard/iq/dataverse/engine/command/impl/CreateDataverseCommandTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/engine/command/impl/CreateDataverseCommandTest.java
@@ -299,7 +299,7 @@ public class CreateDataverseCommandTest {
             i++;
         }
         
-        assertTrue( dftilsDeleted );
+        //assertTrue( dftilsDeleted );
         for ( DataverseFieldTypeInputLevel dftil : createdDftils ) {
             assertEquals( result, dftil.getDataverse() );
         }

--- a/src/test/java/edu/harvard/iq/dataverse/engine/command/impl/CreateDataverseCommandTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/engine/command/impl/CreateDataverseCommandTest.java
@@ -141,6 +141,12 @@ public class CreateDataverseCommandTest {
         public void deleteFacetsFor(Dataverse d) {
             dftilsDeleted = true;
         }
+        
+        @Override
+        public DataverseFieldTypeInputLevel findByDataverseIdDatasetFieldTypeId(Long dataverseId, Long dsftId) {
+            //ToDo - mock non-null reponse in some cases
+            return null;
+        }
     };
     
     DataverseFacetServiceBean facets = new DataverseFacetServiceBean() {

--- a/src/test/java/edu/harvard/iq/dataverse/engine/command/impl/CreateDataverseCommandTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/engine/command/impl/CreateDataverseCommandTest.java
@@ -307,7 +307,7 @@ public class CreateDataverseCommandTest {
             i++;
         }
         
-        //assertTrue( dftilsDeleted );
+        assertTrue( dftilsDeleted );
         for ( DataverseFieldTypeInputLevel dftil : createdDftils ) {
             assertEquals( result, dftil.getDataverse() );
         }

--- a/src/test/java/edu/harvard/iq/dataverse/engine/command/impl/CreateDataverseCommandTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/engine/command/impl/CreateDataverseCommandTest.java
@@ -150,17 +150,11 @@ public class CreateDataverseCommandTest {
         }
         
 
-
         @Override
         public void deleteDataverseFieldTypeInputLevelFor(Dataverse d) {
             dftilsDeleted = true;
         }
         
-        @Override
-        public DataverseFieldTypeInputLevel findByDataverseIdDatasetFieldTypeId(Long dataverseId, Long dsftId) {
-            //ToDo - mock non-null reponse in some cases
-            return null;
-        }
     };
     
     DataverseFacetServiceBean facets = new DataverseFacetServiceBean() {


### PR DESCRIPTION
**What this PR does / why we need it**: Addresses the bugs and performance issues found manually after the merge of #11312. Specific changes include:

- Reverting DatasetFieldType displayOnCreate to be boolean (non-nullable) - not needed
- Changing DataverseFieldTypeInputLevel  dsiplayOnCreate to be Boolean (nullable) - allows displayOnCreate to be optional in the Dataverse API, with default back to the DatasetFieldType value
- Change in the JsonPrinter logic to pick up the correct values from the inputlevel or type as appropriate - both w.r.t. whether to include fields and the values included when adding the types to the response.
- Update to the MetadataBlockServiceBean query to find displayOnCreate blocks to improve performance (from @GPortas) 

**Which issue(s) this PR closes**:

- Closes #

**Special notes for your reviewer**:

**Suggestions on how to test this**:

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
