### PR TITLE
Update the Container Base Image Version Property

### DIFF
--- a/modules/dataverse-parent/pom.xml
+++ b/modules/dataverse-parent/pom.xml
@@ -453,8 +453,8 @@
                     Once the release has been made (tag created), change this back to "${parsedVersion.majorVersion}.${parsedVersion.nextMinorVersion}"
                     (These properties are provided by the build-helper plugin below.)
                 -->
-                <!--<base.image.version>${parsedVersion.majorVersion}.${parsedVersion.nextMinorVersion}</base.image.version>-->
-                <base.image.version>${revision}</base.image.version>
+                <base.image.version>${parsedVersion.majorVersion}.${parsedVersion.nextMinorVersion}</base.image.version>
+                <!--<base.image.version>${revision}</base.image.version>-->
             </properties>
     
             <build>


### PR DESCRIPTION
**What this PR does / why we need it**: Reset the pom file after the release

**Which issue(s) this PR closes**:

- Closes #

**Special notes for your reviewer**:

**Suggestions on how to test this**: If you try to build the docker image and get this error:

[INFO] DOCKER> [gdcc/dataverse:unstable] "dev_dataverse": Created docker-build.tar in 1 second 
[ERROR] DOCKER> Unable to build image [gdcc/dataverse:unstable] : "manifest for gdcc/base:6.7-noble-p6.2025.2-j17 not found: manifest unknown: manifest unknown"  ["manifest for gdcc/base:6.7-noble-p6.2025.2-j17 not found: manifest unknown: manifest unknown" ]

Run this command:
cd modules/container-base
mvn -Pct clean install

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
