### PR TITLE
Metrics Fix

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/api/Metrics.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Metrics.java
@@ -662,6 +662,13 @@ public class Metrics extends AbstractApiBean {
         } catch (IllegalArgumentException ex) {
             return error(Response.Status.BAD_REQUEST, ex.getMessage());
         }
+        if (country != null) {
+            country = country.toLowerCase();
+
+            if (!MakeDataCountUtil.isValidCountryCode(country)) {
+                return error(Response.Status.BAD_REQUEST, "Country must be one of the ISO 1366 Country Codes");
+            }
+        }
         String metricName = "MDC-" + metricType.toString() + ((country == null) ? "" : "-" + country);
 
         JsonArray jsonArray = MetricsUtil.stringToJsonArray(metricsSvc.returnUnexpiredCacheAllTime(metricName, null, d));

--- a/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
@@ -2979,6 +2979,15 @@ public class UtilIT {
         return requestSpecification.get("/api/info/metrics/datasets/bySubject/toMonth/" + month + optionalQueryParams);
     }
     
+    public static Response makeDataCountMetricTimeSeries(String metricType, String queryParams) {
+        String apiPath = "/api/v1/metrics/makeDataCount/" + metricType + "/monthly";
+        
+        Response response = given()
+                .get(apiPath + (queryParams != null && !queryParams.isEmpty() ? "?" + queryParams : ""));
+        
+        return response;
+    }
+    
     static Response clearMetricCache() {
         RequestSpecification requestSpecification = given();
         return requestSpecification.delete("/api/admin/clearMetricsCache");
@@ -4627,4 +4636,5 @@ public class UtilIT {
                 .contentType(ContentType.JSON)
                 .put("/api/dataverses/" + dataverseAlias + "/inputLevels");
      }
+
 }


### PR DESCRIPTION
**What this PR does / why we need it**: One of the methods allowing the country code does not verify that the code is valid.

**Which issue(s) this PR closes**:

- Closes #

**Special notes for your reviewer**:

**Suggestions on how to test this**: Try the affected method with a country code not in https://github.com/IQSS/dataverse/blob/917bd83fb6f1cd00da92dca1e5e8b7919d335be6/src/main/java/edu/harvard/iq/dataverse/makedatacount/MakeDataCountUtil.java#L51-L55 and verify the response is 400 (as in the IT test).

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
