### PR TITLE
A dedicated rate-limiting command for the File page

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/CheckRateLimitForFilePageCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/CheckRateLimitForFilePageCommand.java
@@ -1,0 +1,17 @@
+package edu.harvard.iq.dataverse.engine.command.impl;
+
+import edu.harvard.iq.dataverse.DvObject;
+import edu.harvard.iq.dataverse.engine.command.AbstractVoidCommand;
+import edu.harvard.iq.dataverse.engine.command.CommandContext;
+import edu.harvard.iq.dataverse.engine.command.DataverseRequest;
+import edu.harvard.iq.dataverse.engine.command.exception.CommandException;
+
+public class CheckRateLimitForFilePageCommand  extends AbstractVoidCommand {
+
+    public CheckRateLimitForFilePageCommand(DataverseRequest aRequest, DvObject dvObject) {
+        super(aRequest, dvObject);
+    }
+
+    @Override
+    protected void executeImpl(CommandContext ctxt) throws CommandException { }
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This adds a "fake"/empty dedicated command that can be used to rate-limit access to the FilePage in the UI, similarly to the other 2 "workhorse" pages, DataversePage and CollectionPage. 

**Which issue(s) this PR closes**:

- Closes #11364

**Special notes for your reviewer**:

**Suggestions on how to test this**:

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
