### PR TITLE
remove unused show_my_data Search API parameter

### DIFF
--- a/doc/release-notes/11287-show_my_data.md
+++ b/doc/release-notes/11287-show_my_data.md
@@ -1,0 +1,3 @@
+### Backward Incompatibilities
+
+An undocumented Search API parameter called "show_my_data" has been removed. It was never exercised by tests and is believed to be unused. API users should use the [MyData] API instead. See the [API changelog](https://dataverse-guide--11375.org.readthedocs.build/en/11375/api/changelog.html), #11287 and #11375.

--- a/doc/sphinx-guides/source/api/changelog.rst
+++ b/doc/sphinx-guides/source/api/changelog.rst
@@ -7,6 +7,11 @@ This API changelog is experimental and we would love feedback on its usefulness.
     :local:
     :depth: 1
 
+v6.7
+----
+
+- An undocumented :doc:`search` parameter called "show_my_data" has been removed. It was never exercised by tests and is believed to be unused. API users should use the :ref:`api-mydata` API instead.
+
 v6.6
 ----
 

--- a/doc/sphinx-guides/source/api/native-api.rst
+++ b/doc/sphinx-guides/source/api/native-api.rst
@@ -7423,6 +7423,8 @@ As a superuser::
 
 Note that this API is probably only useful for testing.
 
+.. _api-mydata:
+
 MyData
 ------
 

--- a/src/main/java/edu/harvard/iq/dataverse/api/Search.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Search.java
@@ -66,7 +66,6 @@ public class Search extends AbstractApiBean {
             @QueryParam("fq") final List<String> filterQueries,
             @QueryParam("show_entity_ids") boolean showEntityIds,
             @QueryParam("show_api_urls") boolean showApiUrls,
-            @QueryParam("show_my_data") boolean showMyData,
             @QueryParam("query_entities") boolean queryEntities,
             @QueryParam("metadata_fields") List<String> metadataFields,
             @QueryParam("geo_point") String geoPointRequested,
@@ -97,8 +96,8 @@ public class Search extends AbstractApiBean {
             objectTypeCountsMap.put(SearchConstants.UI_DATASETS, 0L);
             objectTypeCountsMap.put(SearchConstants.UI_FILES, 0L);
 
-            // users can't change these (yet anyway)
-            boolean dataRelatedToMe = showMyData; //getDataRelatedToMe();
+            // hard-coded to false since dataRelatedToMe is only used by MyData (DataRetrieverAPI)
+            boolean dataRelatedToMe = false;
 
             try {
                 // we have to add "" (root) otherwise there is no permissions check
@@ -288,15 +287,6 @@ public class Search extends AbstractApiBean {
         boolean tokenLessSearchAllowed = settingsSvc.isFalseForKey(SettingsServiceBean.Key.SearchApiRequiresToken, outOfBoxBehavior);
         logger.fine("tokenLessSearchAllowed: " + tokenLessSearchAllowed);
         return tokenLessSearchAllowed;
-    }
-
-    private boolean getDataRelatedToMe() {
-        /**
-         * @todo support Data Related To Me:
-         * https://github.com/IQSS/dataverse/issues/1299
-         */
-        boolean dataRelatedToMe = false;
-        return dataRelatedToMe;
     }
 
     private int getNumberOfResultsPerPage(int numResultsPerPage) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Having this unused parameter lying around is confusing.

**Which issue(s) this PR closes**:

- None. Relates to #11287

**Special notes for your reviewer**:

In the issue I linked to some old related commits and issues if you're interested.

**Suggestions on how to test this**:

- Make sure API tests pass.
- You could try passing the parameter. It shouldn't change anything.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

Yes, included.

**Additional documentation**:

https://dataverse-guide--11375.org.readthedocs.build/en/11375/api/changelog.html