### PR TITLE
#11395 fix render

### DIFF
--- a/src/main/webapp/dataset-versions.xhtml
+++ b/src/main/webapp/dataset-versions.xhtml
@@ -135,7 +135,7 @@
         </p:column><!-- end: description column -->
         
         <!-- start: versionNote column -->
-        <p:column headerText="#{bundle['file.dataFilesTab.versions.headers.versionNote']}" class="col-sm-2">
+        <p:column headerText="#{bundle['file.dataFilesTab.versions.headers.versionNote']}" class="col-sm-2" rendered="#{versionNoteEnabled}">
             <ui:fragment rendered="#{versionNoteEnabled}">
                 <div><h:outputText value="#{versionTab.versionNote}" /></div>
             </ui:fragment>


### PR DESCRIPTION
**What this PR does / why we need it**:
Hides Version Notes column on version tab of the dataset page when Version Notes have not been enabled.

Not a killer bug but putting it in as a patch on 6.6 might prevent some questions from users.

**Which issue(s) this PR closes**:

- Closes #11395

**Special notes for your reviewer**:

**Suggestions on how to test this**:

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
