### PR TITLE
Link to https://dataverse.org in main template

### DIFF
--- a/src/main/webapp/dataverse_footer.xhtml
+++ b/src/main/webapp/dataverse_footer.xhtml
@@ -44,7 +44,7 @@
                     <div class="#{widgetView ? 'col-xs-5' : 'col-sm-4'} text-right">
                         <div class="poweredbylogo">
                             <span>#{bundle['footer.poweredby']}</span>
-                            <a href="http://dataverse.org/" title="#{bundle['footer.dataverseProject']}" target="_blank" rel="noopener"><img src="/resources/images/dataverse_project_logo.svg" width="118" height="40" onerror="this.src='/resources/images/dataverseproject_logo.png'" alt="#{of:format1(bundle['alt.logo'], bundle['footer.dataverseProject'])}"/></a>
+                            <a href="https://dataverse.org/" title="#{bundle['footer.dataverseProject']}" target="_blank" rel="noopener"><img src="/resources/images/dataverse_project_logo.svg" width="118" height="40" onerror="this.src='/resources/images/dataverseproject_logo.png'" alt="#{of:format1(bundle['alt.logo'], bundle['footer.dataverseProject'])}"/></a>
                             <h:outputText class="version" value="v. #{settingsWrapper.appVersionWithBuildNumber}" rendered="#{!widgetView}"/>
                         </div>
                     </div>


### PR DESCRIPTION
**What this PR does / why we need it**: The footer of each page on every (or most) Dataverse installations includes a link to the project homepage. This link is currently using the `http` scheme, while dataverse.org is accessible via `https`. This PR makes the URL `https://dataverse.org`.

**Which issue(s) this PR closes**:

- n/a
- relates to #9068 but this is a web UI template

**Special notes for your reviewer**: Thank you for reviewing! I know this still targets JSF, but it's a small change with little impact.

**Suggestions on how to test this**: See that the URL for "Powered by The Dataverse Project" link uses HTTPS.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: no

**Is there a release notes update needed for this change?**: no

**Additional documentation**: no
