### PR TITLE
11391 display on create with template

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DatasetVersionUI.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetVersionUI.java
@@ -458,6 +458,10 @@ public class DatasetVersionUI implements Serializable {
                         mdb.setEmpty(false);
                         datasetFieldsForView.add(dsf);
                     }
+                    //Seeting Local Display on Create on mdb when there are any set at dataverse level 
+                    if ( dsf.getDatasetFieldType().getLocalDisplayOnCreate() != null ){
+                       mdb.setLocalDisplayOnCreate(dsf.getDatasetFieldType().getLocalDisplayOnCreate());
+                    }
                 }
             }
 

--- a/src/main/java/edu/harvard/iq/dataverse/DatasetVersionUI.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetVersionUI.java
@@ -458,7 +458,7 @@ public class DatasetVersionUI implements Serializable {
                         mdb.setEmpty(false);
                         datasetFieldsForView.add(dsf);
                     }
-                    //Seeting Local Display on Create on mdb when there are any set at dataverse level 
+                    //Setting Local Display on Create on mdb when there are any set at dataverse level 
                     if ( dsf.getDatasetFieldType().getLocalDisplayOnCreate() != null ){
                        mdb.setLocalDisplayOnCreate(dsf.getDatasetFieldType().getLocalDisplayOnCreate());
                     }

--- a/src/main/java/edu/harvard/iq/dataverse/ManageTemplatesPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/ManageTemplatesPage.java
@@ -121,7 +121,7 @@ public class ManageTemplatesPage implements java.io.Serializable {
         Template newOne = templateIn.cloneNewTemplate(templateIn);
         String name = BundleUtil.getStringFromBundle("page.copy") +" " + templateIn.getName();
         newOne.setName(name);
-        newOne.setUsageCount(new Long(0));
+        newOne.setUsageCount(Long.valueOf(0));
         newOne.setCreateTime(new Timestamp(new Date().getTime()));
         newOne.setDataverse(dataverse);
 

--- a/src/main/java/edu/harvard/iq/dataverse/MetadataBlock.java
+++ b/src/main/java/edu/harvard/iq/dataverse/MetadataBlock.java
@@ -101,13 +101,29 @@ public class MetadataBlock implements Serializable, Comparable {
     }
     
     public boolean isDisplayOnCreate() {
+        // relying on "should" doesn't seem to work in context of a template 
+        // adding a transient that is updated in the DatasetVersionUI to fix
         for (DatasetFieldType dsfType : datasetFieldTypes) {
             boolean shouldDisplayOnCreate = dsfType.shouldDisplayOnCreate();
             if (shouldDisplayOnCreate) {
                 return true;
             }
         }
+        if (getLocalDisplayOnCreate() != null){
+            return getLocalDisplayOnCreate();
+        }
         return false;
+    }
+    
+    @Transient
+    private Boolean localDisplayOnCreate;
+
+    public Boolean getLocalDisplayOnCreate() {
+        return localDisplayOnCreate;
+    }
+
+    public void setLocalDisplayOnCreate(Boolean localDisplayOnCreate) {
+        this.localDisplayOnCreate = localDisplayOnCreate;
     }
 
     public String getDisplayName() {


### PR DESCRIPTION
**What this PR does / why we need it**: Makes fields set "display on Create" at the Dataverse level visible on dataset create in the presence of a default template for that dataset (especially if the template does not have default values for that Metadata block)

**Which issue(s) this PR closes**:

- Closes #11391 

**Special notes for your reviewer**: Not sure why the "isDisplayOnCreate" in the Metadata block doesn't work. I added a transient boolean that is updated in the DatasetVersionUI when the metadata blocks are added.

**Suggestions on how to test this**: 
Set dataset field types outside of the citation block to "displayOnCreate" for a given Dataverse - 
```
curl -X PUT -H "X-Dataverse-key:27987dd2-8ae1-4b6d-b3f8-78a2ccfcad4d" -H "Content-Type:application/json" "http://localhost:8080/api/dataverses/temp-doc/inputLevels" -d '[{"datasetFieldTypeName":"geographicCoverage", "required":false, "include":true,  "displayOnCreate":true}, {"datasetFieldTypeName":"country", "required":false, "include":true, "displayOnCreate":true}]'
``` 

Add a template to the dataset, but don't set default values in the metadata block where you set "displayOnCreate". Make that template the default.

Add a dataset - the dataset fields set as display on create should be available for edit.

Also, you can try it with no default template but select one after "add dataset" - as above, the dataset fields set as display on create should be available for edit.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
