### PR TITLE
Switch to new apache client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,9 +125,9 @@
              java.net.HttpUrlConnection is used, sometimes Apache, sometimes Unirest and what not.
              A big pile of historically grown mess. Some poor dev should take a Kleenex and call for "payback time". -->
         <dependency>
-            <groupId>commons-httpclient</groupId>
-            <artifactId>commons-httpclient</artifactId>
-            <version>3.1</version>
+            <groupId>org.apache.httpcomponents.client5</groupId>
+            <artifactId>httpclient5</artifactId>
+            <version>5.2.1</version>
         </dependency>
     
         <!-- BEGIN Data Deposit API v1 (SWORD v2) -->

--- a/src/main/java/edu/harvard/iq/dataverse/DatasetFieldServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetFieldServiceBean.java
@@ -42,7 +42,6 @@ import jakarta.persistence.TypedQuery;
 
 import jakarta.persistence.criteria.*;
 import org.apache.commons.codec.digest.DigestUtils;
-import org.apache.commons.httpclient.HttpException;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpResponseInterceptor;
@@ -554,7 +553,7 @@ public class DatasetFieldServiceBean implements java.io.Serializable {
                 try (CloseableHttpClient httpClient = HttpClients.custom()
                         .addInterceptorLast(new HttpResponseInterceptor() {
                             @Override
-                            public void process(HttpResponse response, HttpContext context) throws HttpException, IOException {
+                            public void process(HttpResponse response, HttpContext context) throws IOException {
                                 int statusCode = response.getStatusLine().getStatusCode();
                                 if (statusCode == 504) {
                                     //Throwing an exception triggers the retry handler

--- a/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
@@ -109,8 +109,6 @@ import org.primefaces.event.FileUploadEvent;
 import org.primefaces.model.file.UploadedFile;
 
 import jakarta.validation.ConstraintViolation;
-import org.apache.commons.httpclient.HttpClient;
-//import org.primefaces.context.RequestContext;
 import java.util.Arrays;
 import java.util.HashSet;
 import jakarta.faces.model.SelectItem;
@@ -4231,12 +4229,6 @@ public class DatasetPage implements java.io.Serializable {
     	} catch (IOException ex) {
     		logger.info("Failed to issue a redirect to file download url.");
     	}
-    }
-
-    private HttpClient getClient() {
-        // TODO:
-        // cache the http client? -- L.A. 4.0 alpha
-        return new HttpClient();
     }
 
     public void refreshLock() {

--- a/src/main/java/edu/harvard/iq/dataverse/EditDatafilesPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/EditDatafilesPage.java
@@ -76,9 +76,7 @@ import jakarta.json.JsonObject;
 import jakarta.json.JsonObjectBuilder;
 import jakarta.json.JsonArray;
 import jakarta.json.JsonReader;
-import org.apache.commons.httpclient.HttpClient;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.httpclient.methods.GetMethod;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Set;
@@ -89,6 +87,11 @@ import jakarta.servlet.ServletOutputStream;
 import jakarta.servlet.http.HttpServletResponse;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.mutable.MutableBoolean;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.core5.http.ClassicHttpResponse;
+import org.apache.hc.core5.http.HttpEntity;
 import org.primefaces.PrimeFaces;
 
 /**
@@ -1336,46 +1339,6 @@ public class EditDatafilesPage implements java.io.Serializable {
         return returnToDatasetOnly();
     }
 
-    /* deprecated; super inefficient, when called repeatedly on a long list 
-       of files! 
-       leaving the code here, commented out, for illustration purposes. -- 4.6
-    public boolean isDuplicate(FileMetadata fileMetadata) {
-
-        Map<String, Integer> MD5Map = new HashMap<String, Integer>();
-
-        // TODO: 
-        // think of a way to do this that doesn't involve populating this 
-        // map for every file on the page? 
-        // may not be that much of a problem, if we paginate and never display 
-        // more than a certain number of files... Still, needs to be revisited
-        // before the final 4.0. 
-        // -- L.A. 4.0
-
-        // make a "defensive copy" to avoid java.util.ConcurrentModificationException from being thrown
-        // when uploading 100+ files
-        List<FileMetadata> wvCopy = new ArrayList<>(workingVersion.getFileMetadatas());
-        Iterator<FileMetadata> fmIt = wvCopy.iterator();
-
-        while (fmIt.hasNext()) {
-            FileMetadata fm = fmIt.next();
-            String md5 = fm.getDataFile().getChecksumValue();
-            if (md5 != null) {
-                if (MD5Map.get(md5) != null) {
-                    MD5Map.put(md5, MD5Map.get(md5).intValue() + 1);
-                } else {
-                    MD5Map.put(md5, 1);
-                }
-            }
-        }
-
-        return MD5Map.get(thisMd5) != null && MD5Map.get(thisMd5).intValue() > 1;
-    }*/
-    private HttpClient getClient() {
-        // TODO: 
-        // cache the http client? -- L.A. 4.0 alpha
-        return new HttpClient();
-    }
-
     /**
      * Is this page in File Replace mode
      *
@@ -1414,30 +1377,35 @@ public class EditDatafilesPage implements java.io.Serializable {
      * @param fileLink
      * @return
      */
-    private InputStream getDropBoxInputStream(String fileLink, GetMethod dropBoxMethod) {
-
+    private InputStream getDropBoxInputStream(String fileLink) {
         if (fileLink == null) {
             return null;
         }
 
-        // -----------------------------------------------------------
-        // Make http call, download the file: 
-        // -----------------------------------------------------------
-        int status = 0;
-        //InputStream dropBoxStream = null;
-
         try {
-            status = getClient().executeMethod(dropBoxMethod);
+            CloseableHttpClient httpClient = HttpClients.createDefault();
+            HttpGet httpGet = new HttpGet(fileLink);
+            
+            // Use the non-deprecated execute method with ClassicHttpResponse
+            ClassicHttpResponse response = httpClient.executeOpen(null, httpGet, null);
+            
+            int status = response.getCode();
+            
             if (status == 200) {
-                return dropBoxMethod.getResponseBodyAsStream();
+                HttpEntity entity = response.getEntity();
+                if (entity != null) {
+                    // Return the content as a stream directly
+                    return entity.getContent();
+                }
             }
+            
+            logger.log(Level.WARNING, "Failed to get DropBox InputStream for file: {0}. Status code: {1}", new Object[]{fileLink, status});
+            response.close();
+            return null;
         } catch (IOException ex) {
             logger.log(Level.WARNING, "Failed to access DropBox url: {0}!", fileLink);
             return null;
         }
-
-        logger.log(Level.WARNING, "Failed to get DropBox InputStream for file: {0}", fileLink);
-        return null;
     } // end: getDropBoxInputStream
 
     /**
@@ -1464,7 +1432,6 @@ public class EditDatafilesPage implements java.io.Serializable {
         // Iterate through the Dropbox file information (JSON)
         // -----------------------------------------------------------
         DataFile dFile = null;
-        GetMethod dropBoxMethod = null;
         String localWarningMessage = null;
         for (int i = 0; i < dbArray.size(); i++) {
             JsonObject dbObject = dbArray.getJsonObject(i);
@@ -1497,14 +1464,13 @@ public class EditDatafilesPage implements java.io.Serializable {
             }
 
             dFile = null;
-            dropBoxMethod = new GetMethod(fileLink);
 
             // -----------------------------------------------------------
             // Download the file
             // -----------------------------------------------------------
-            InputStream dropBoxStream = this.getDropBoxInputStream(fileLink, dropBoxMethod);
+            InputStream dropBoxStream = this.getDropBoxInputStream(fileLink);
             if (dropBoxStream == null) {
-                logger.severe("Could not retrieve dropgox input stream for: " + fileLink);
+                logger.severe("Could not retrieve dropbox input stream for: " + fileLink);
                 continue;  // Error skip this file
             }
 
@@ -1542,14 +1508,6 @@ public class EditDatafilesPage implements java.io.Serializable {
                 this.logger.log(Level.SEVERE, "Error during ingest of DropBox file {0} from link {1}: {2}", new Object[]{fileName, fileLink, ex.getMessage()});
                 continue;
             }*/ finally {
-                // -----------------------------------------------------------
-                // release connection for dropBoxMethod
-                // -----------------------------------------------------------
-
-                if (dropBoxMethod != null) {
-                    dropBoxMethod.releaseConnection();
-                }
-
                 // -----------------------------------------------------------
                 // close the  dropBoxStream
                 // -----------------------------------------------------------

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/DeletePidCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/DeletePidCommand.java
@@ -13,7 +13,6 @@ import edu.harvard.iq.dataverse.engine.command.exception.PermissionException;
 import edu.harvard.iq.dataverse.pidproviders.PidProvider;
 import edu.harvard.iq.dataverse.pidproviders.PidUtil;
 import edu.harvard.iq.dataverse.util.BundleUtil;
-import org.apache.commons.httpclient.HttpException;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -50,13 +49,8 @@ public class DeletePidCommand extends AbstractVoidCommand {
             dataset.setGlobalIdCreateTime(null);
             dataset.setIdentifierRegistered(false);
             ctxt.datasets().merge(dataset);
-        } catch (HttpException hex) {
-            String message = BundleUtil.getStringFromBundle("pids.deletePid.failureExpected",
-                    Arrays.asList(dataset.getGlobalId().asString(), Integer.toString(hex.getReasonCode())));
-            logger.info(message);
-            throw new IllegalCommandException(message, this);
         } catch (Exception ex) {
-            String message = BundleUtil.getStringFromBundle("pids.deletePid.failureOther",
+            String message = BundleUtil.getStringFromBundle("pids.deletePid.failure",
                     Arrays.asList(dataset.getGlobalId().asString(), ex.getLocalizedMessage()));
             logger.info(message);
             throw new IllegalCommandException(message, this);

--- a/src/main/java/edu/harvard/iq/dataverse/pidproviders/doi/UnmanagedDOIProvider.java
+++ b/src/main/java/edu/harvard/iq/dataverse/pidproviders/doi/UnmanagedDOIProvider.java
@@ -3,7 +3,6 @@ package edu.harvard.iq.dataverse.pidproviders.doi;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
-import org.apache.commons.httpclient.HttpException;
 import org.apache.commons.lang3.NotImplementedException;
 
 import edu.harvard.iq.dataverse.DvObject;
@@ -54,7 +53,7 @@ public class UnmanagedDOIProvider extends AbstractDOIProvider {
     }
 
     @Override
-    public void deleteIdentifier(DvObject dvObject) throws IOException, HttpException {
+    public void deleteIdentifier(DvObject dvObject) throws IOException {
         throw new NotImplementedException();
     }
 

--- a/src/main/java/edu/harvard/iq/dataverse/pidproviders/doi/crossref/CrossRefDOIProvider.java
+++ b/src/main/java/edu/harvard/iq/dataverse/pidproviders/doi/crossref/CrossRefDOIProvider.java
@@ -26,7 +26,7 @@ public class CrossRefDOIProvider extends AbstractDOIProvider {
     }
 
     @Override
-    public boolean alreadyRegistered(GlobalId pid, boolean noProviderDefault) throws Exception {
+    public boolean alreadyRegistered(GlobalId pid, boolean noProviderDefault) {
         logger.info("CrossRef alreadyRegistered");
         if (pid == null || pid.asString().isEmpty()) {
             logger.fine("No identifier sent.");

--- a/src/main/java/edu/harvard/iq/dataverse/pidproviders/doi/ezid/EZIdDOIProvider.java
+++ b/src/main/java/edu/harvard/iq/dataverse/pidproviders/doi/ezid/EZIdDOIProvider.java
@@ -68,7 +68,7 @@ public class EZIdDOIProvider extends AbstractDOIProvider {
     }
 
     @Override
-    public boolean alreadyRegistered(GlobalId pid, boolean noProviderDefault) throws Exception {
+    public boolean alreadyRegistered(GlobalId pid, boolean noProviderDefault) throws EZIDException {
         logger.log(Level.FINE,"alreadyRegistered");
         try {
             HashMap<String, String> result = ezidService.getMetadata(pid.asString());

--- a/src/main/java/edu/harvard/iq/dataverse/pidproviders/handle/HandlePidProvider.java
+++ b/src/main/java/edu/harvard/iq/dataverse/pidproviders/handle/HandlePidProvider.java
@@ -326,7 +326,7 @@ public class HandlePidProvider extends AbstractPidProvider {
     }
 
     @Override
-    public boolean alreadyRegistered(DvObject dvObject) throws Exception {
+    public boolean alreadyRegistered(DvObject dvObject) {
         String handle = getDvObjectHandle(dvObject);
         return isHandleRegistered(handle);
     }

--- a/src/main/java/edu/harvard/iq/dataverse/workflow/internalspi/HttpSendReceiveClientStep.java
+++ b/src/main/java/edu/harvard/iq/dataverse/workflow/internalspi/HttpSendReceiveClientStep.java
@@ -7,27 +7,23 @@ import edu.harvard.iq.dataverse.workflow.step.Pending;
 import edu.harvard.iq.dataverse.workflow.step.WorkflowStep;
 import edu.harvard.iq.dataverse.workflow.step.WorkflowStepResult;
 import static edu.harvard.iq.dataverse.workflow.step.WorkflowStepResult.OK;
+
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
-import org.apache.commons.httpclient.HttpClient;
-import org.apache.commons.httpclient.HttpMethodBase;
-import org.apache.commons.httpclient.URI;
-import org.apache.commons.httpclient.URIException;
-import org.apache.commons.httpclient.methods.DeleteMethod;
-import org.apache.commons.httpclient.methods.EntityEnclosingMethod;
-import org.apache.commons.httpclient.methods.GetMethod;
-import org.apache.commons.httpclient.methods.PostMethod;
-import org.apache.commons.httpclient.methods.PutMethod;
-import org.apache.commons.httpclient.methods.StringRequestEntity;
 
-/**
- * A workflow step that sends a HTTP request, and then pauses, waiting for a response.
- * 
- * @author michael
- */
+import org.apache.hc.client5.http.classic.methods.*;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.core5.http.ClassicHttpRequest;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.io.entity.StringEntity;
+
 public class HttpSendReceiveClientStep implements WorkflowStep {
     private static final Logger logger = Logger.getLogger(HttpSendReceiveClientStep.class.getName());
     private final Map<String,String> params;
@@ -38,21 +34,19 @@ public class HttpSendReceiveClientStep implements WorkflowStep {
     
     @Override
     public WorkflowStepResult run(WorkflowContext context) {
-        HttpClient client = new HttpClient();
-        
-        try {
-            // build method
-            HttpMethodBase mtd = buildMethod(false, context);
+        try (CloseableHttpClient client = HttpClients.createDefault()) {
+            ClassicHttpRequest request = buildRequest(false, context);
             // execute
-            int responseStatus = client.executeMethod(mtd);
-            if (responseStatus>=200 && responseStatus<300 ) {
-                // HTTP OK range
-                return new Pending();
-            } else {
-                String responseBody = mtd.getResponseBodyAsString();
-                return new Failure("Error communicating with server. Server response: " + responseBody + " (" + responseStatus + ").");
-            }
+            return client.execute(request, response -> {
             
+                int responseStatus = response.getCode();
+                if (responseStatus >= 200 && responseStatus < 300) {
+                    return new Pending();
+                } else {
+                    String responseBody = new String(response.getEntity().getContent().readAllBytes());
+                    return new Failure("Error communicating with server. Server response: " + responseBody + " (" + responseStatus + ").");
+                }
+            });
         } catch (Exception ex) {
             logger.log(Level.SEVERE, "Error communicating with remote server: " + ex.getMessage(), ex);
             return new Failure("Error executing request: " + ex.getLocalizedMessage(), "Cannot communicate with remote server.");
@@ -63,92 +57,92 @@ public class HttpSendReceiveClientStep implements WorkflowStep {
     public WorkflowStepResult resume(WorkflowContext context, Map<String, String> internalData, String externalData) {
         Pattern pat = Pattern.compile(params.get("expectedResponse"));
         String response = externalData.trim();
-        if ( pat.matcher(response).matches() ) {
+        if (pat.matcher(response).matches()) {
             return OK;
         } else {
-            logger.log(Level.WARNING, "Remote system returned a bad reposonse: {0}", externalData);
+            logger.log(Level.WARNING, "Remote system returned a bad response: {0}", externalData);
             return new Failure("Response from remote server did not match expected one (response:" + response + ")");
         }
     }
 
     @Override
     public void rollback(WorkflowContext context, Failure reason) {
-        HttpClient client = new HttpClient();
-        
-        try {
-            // build method
-            HttpMethodBase mtd = buildMethod(true, context);
+        try (CloseableHttpClient client = HttpClients.createDefault()) {
+            ClassicHttpRequest request = buildRequest(true, context);
             
-            // execute
-            int responseStatus = client.executeMethod(mtd);
-            if (responseStatus<200 || responseStatus>=300 ) {
-                // out of HTTP OK range
-                String responseBody = mtd.getResponseBodyAsString();
-                Logger.getLogger(HttpSendReceiveClientStep.class.getName()).log(Level.WARNING, 
-                        "Bad response from remote server while rolling back step: {0}", responseBody);
-            }
-            
+            client.execute(request, response -> {
+                int responseStatus = response.getCode();
+                if (responseStatus < 200 || responseStatus >= 300) {
+                    String responseBody = new String(response.getEntity().getContent().readAllBytes());
+                    logger.log(Level.WARNING, "Bad response from remote server while rolling back step: {0}", responseBody);
+                }
+                return null;
+            });
         } catch (Exception ex) {
-            Logger.getLogger(HttpSendReceiveClientStep.class.getName()).log(Level.WARNING, "IO error rolling back step: " + ex.getMessage(), ex);
+            logger.log(Level.WARNING, "IO error rolling back step: " + ex.getMessage(), ex);
         }
     }
     
-    HttpMethodBase buildMethod(boolean rollback, WorkflowContext ctxt) throws Exception {
+    ClassicHttpRequest buildRequest(boolean rollback, WorkflowContext ctxt) throws Exception {
         String methodName = params.getOrDefault("method" + (rollback ? "-rollback":""), "GET").trim().toUpperCase();
-        HttpMethodBase m = null;
-        switch (methodName) {
-            case "GET":    m = new GetMethod(); m.setFollowRedirects(true); break;
-            case "POST":   m = new PostMethod(); break;
-            case "PUT":    m = new PutMethod(); break;
-            case "DELETE": m = new DeleteMethod(); m.setFollowRedirects(true); break;
-            default: throw new IllegalStateException("Unsupported HTTP method: '" + methodName + "'");
-        }
-        
         
         Map<String,String> templateParams = new HashMap<>();
-        templateParams.put( "invocationId", ctxt.getInvocationId() );
-        templateParams.put( "dataset.id", Long.toString(ctxt.getDataset().getId()) );
-        templateParams.put( "dataset.identifier", ctxt.getDataset().getIdentifier() );
-        templateParams.put( "dataset.globalId", ctxt.getDataset().getGlobalId().asString() );
-        templateParams.put( "dataset.displayName", ctxt.getDataset().getDisplayName() );
-        templateParams.put( "dataset.citation", ctxt.getDataset().getCitation() );
-        templateParams.put( "minorVersion", Long.toString(ctxt.getNextMinorVersionNumber()) );
-        templateParams.put( "majorVersion", Long.toString(ctxt.getNextVersionNumber()) );
-        templateParams.put( "releaseStatus", (ctxt.getType()==TriggerType.PostPublishDataset) ? "done":"in-progress" );
-        
-        m.addRequestHeader("Content-Type", params.getOrDefault("contentType", "text/plain"));
+        templateParams.put("invocationId", ctxt.getInvocationId());
+        templateParams.put("dataset.id", Long.toString(ctxt.getDataset().getId()));
+        templateParams.put("dataset.identifier", ctxt.getDataset().getIdentifier());
+        templateParams.put("dataset.globalId", ctxt.getDataset().getGlobalId().asString());
+        templateParams.put("dataset.displayName", ctxt.getDataset().getDisplayName());
+        templateParams.put("dataset.citation", ctxt.getDataset().getCitation());
+        templateParams.put("minorVersion", Long.toString(ctxt.getNextMinorVersionNumber()));
+        templateParams.put("majorVersion", Long.toString(ctxt.getNextVersionNumber()));
+        templateParams.put("releaseStatus", (ctxt.getType()==TriggerType.PostPublishDataset) ? "done":"in-progress");
         
         String urlKey = rollback ? "rollbackUrl":"url";
         String url = params.get(urlKey);
+        String processedUrl = process(url, templateParams);
+        
+        ClassicHttpRequest request;
         try {
-            m.setURI(new URI(process(url,templateParams), true) );
-        } catch (URIException ex) {
-            throw new IllegalStateException("Illegal URL: '" + url + "'");
+            URI uri = new URI(processedUrl);
+            switch (methodName) {
+                case "GET":    request = new HttpGet(uri); break;
+                case "POST":   request = new HttpPost(uri); break;
+                case "PUT":    request = new HttpPut(uri); break;
+                case "DELETE": request = new HttpDelete(uri); break;
+                default: throw new IllegalStateException("Unsupported HTTP method: '" + methodName + "'");
+            }
+        } catch (URISyntaxException ex) {
+            throw new IllegalStateException("Illegal URL: '" + processedUrl + "'", ex);
         }
+        
+        request.setHeader("Content-Type", params.getOrDefault("contentType", "text/plain"));
         
         String bodyKey = (rollback ? "rollbackBody" : "body");
-        if ( params.containsKey(bodyKey) && m instanceof EntityEnclosingMethod ) {
+        if (params.containsKey(bodyKey) && (request instanceof HttpPost || request instanceof HttpPut)) {
             String body = params.get(bodyKey);
-            ((EntityEnclosingMethod)m).setRequestEntity(new StringRequestEntity(process( body, templateParams)));
+            request.setEntity(
+                new StringEntity(process(body, templateParams), 
+                    ContentType.create(request.getFirstHeader("Content-Type").getValue())
+                )
+            );
         }
         
-        return m;
+        return request;
     }
     
-    String process(String template, Map<String,String> values ) {
+    String process(String template, Map<String,String> values) {
         String curValue = template;
-        for ( Map.Entry<String, String> ent : values.entrySet() ) {
+        for (Map.Entry<String, String> ent : values.entrySet()) {
             String val = ent.getValue();
-            if ( val == null ) { 
-                val = "" ;
+            if (val == null) { 
+                val = "";
             }
             String varRef = "${" + ent.getKey() + "}";
-            while ( curValue.contains(varRef) ) {
+            while (curValue.contains(varRef)) {
                 curValue = curValue.replace(varRef, val);
             }
         }
         
         return curValue;
     }
-    
 }

--- a/src/main/java/propertyFiles/Bundle.properties
+++ b/src/main/java/propertyFiles/Bundle.properties
@@ -3126,8 +3126,7 @@ api.admin.datasetfield.load.GeneralErrorMessage=Error parsing metadata block in 
 #PIDs
 pids.api.reservePid.success=PID reserved for {0}
 pids.api.deletePid.success=PID deleted for {0}
-pids.deletePid.failureExpected=Unable to delete PID {0}. Status code: {1}.
-pids.deletePid.failureOther=Problem deleting PID {0}: {1}
+pids.deletePid.failure=Unable to delete PID {0}: {1}
 pids.datacite.errors.noResponseCode=Problem getting HTTP status code from {0}. Is it in DNS? Is doi.dataciterestapiurlstring configured properly?
 pids.datacite.errors.DoiOnly=Only doi: is supported.
 


### PR DESCRIPTION
**What this PR does / why we need it**: Addresses https://github.com/IQSS/dataverse/security/dependabot/25 which points out that the version of the Apache HttpClient we used is EOL. This PR does a fairly direct update to use the newer library, staying with 'classic' rather than going to non-blocking calls.

**Which issue(s) this PR closes**:

- Closes #

**Special notes for your reviewer**: Did some minor cleanup to drop unneeded throws Exception statements. Two of the example workflow steps changed - not sure how those can be tested other than manually, but not sure they're used (is it worth setting them up?)

**Suggestions on how to test this**: Check that DataCite PIDs get added/deleted when you create/delete draft datasets.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
