### PR TITLE
IQSS/11394 version note bug fix

### DIFF
--- a/doc/release-notes/11394-versionNoteBug.md
+++ b/doc/release-notes/11394-versionNoteBug.md
@@ -1,0 +1,3 @@
+### versionNote Bug fix
+
+An issue causing more than one edit of a versionNote to fail, when done without a page refresh, has been fixed. 

--- a/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
@@ -6803,10 +6803,10 @@ public class DatasetPage implements java.io.Serializable {
         return AbstractDOIProvider.DOI_PROTOCOL.equals(dataset.getGlobalId().getProtocol());
     }
     
-    public void saveVersionNote() {
+    public String saveVersionNote() {
         this.editMode=EditMode.VERSIONNOTE;
         publishDialogVersionNote = workingVersion.getVersionNote();
-        save();
+        return save();
     }
     String publishDialogVersionNote = null;
     


### PR DESCRIPTION
**What this PR does / why we need it**:  Doing more than one update to a versionNote without refreshing the page would cause all edits but the first to be lost. The PR fixes that by making the versionNote edit work like other edits, returning you to the main page.

**Which issue(s) this PR closes**:

- Closes #11394

**Special notes for your reviewer**: It's not clear to me what would have to be refreshed to allow multiple edits in place. This PR just adds the standard returnToDraftVersion that we do for metadata/terms edits which resolves the problem - because it refreshes the whole page.

**Suggestions on how to test this**: Configure to use versionNotes. Edit the version note, see the page refresh, confirm that the new value is in the version table. Similarly, edit the note in the table and then publish and edit the note in the publish dialog. Confirm that the value from the publish dialog is what's in the table for the newly published version.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:inc.

**Additional documentation**:
