### PR TITLE
HDV-247: Guestbook at Request - add space to options

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/SettingsWrapper.java
+++ b/src/main/java/edu/harvard/iq/dataverse/SettingsWrapper.java
@@ -732,11 +732,11 @@ public class SettingsWrapper implements java.io.Serializable {
             if (target.getOwner() == null) {
                 boolean defaultOption = gbDefault.get();
                 useDefault = (defaultOption ? atRequest : atDownload)
-                        + BundleUtil.getStringFromBundle("dataverse.default");
+                        + " " + BundleUtil.getStringFromBundle("dataverse.default");
             } else {
                 boolean defaultOption = target.getOwner().getEffectiveGuestbookEntryAtRequest();
                 useDefault = (defaultOption ? atRequest : atDownload)
-                        + BundleUtil.getStringFromBundle("dataverse.inherited");
+                        + " " + BundleUtil.getStringFromBundle("dataverse.inherited");
             }
             currentMap.put(DvObjectContainer.UNDEFINED_CODE, useDefault);
             currentMap.put(Boolean.toString(true), atRequest);


### PR DESCRIPTION
**What this PR does / why we need it**: As noted in https://github.com/IQSS/dataverse.harvard.edu/issues/247, a space is missing between the Guestbook option and the parenthetical note as to whether it is the (Default) or (Inherited from enclosing Dataverse). This PR adds the space programmatically, as is done for other functionality on that page.

**Which issue(s) this PR closes**:

- Closes #

**Special notes for your reviewer**:

**Suggestions on how to test this**: Enable Guestbook at request, check the options as shown in the issue and assure there's a space.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
