### PR TITLE
#11458 remove file page breadcrumbs

### DIFF
--- a/src/main/webapp/dataverse_header.xhtml
+++ b/src/main/webapp/dataverse_header.xhtml
@@ -244,7 +244,7 @@
                 </div>
             </div>
         </div>
-        <p:fragment id="breadCrumbPanel" rendered="#{dataverseHeaderFragment.breadcrumbs.size() > 1}">
+        <p:fragment id="breadCrumbPanel" rendered="#{dataverseHeaderFragment.breadcrumbs.size() > 1 and showDataverseHeader}">
         <div id="breadcrumbNavBlock" class="container" jsf:rendered="#{dataverseHeaderFragment.breadcrumbs.size() > 1}">
             <ui:repeat value="#{dataverseHeaderFragment.breadcrumbs}" var="breadcrumb" varStatus="status">
                 <h:outputText value=" > " styleClass="breadcrumbCarrot" rendered="#{!status.first}"/>

--- a/src/main/webapp/file.xhtml
+++ b/src/main/webapp/file.xhtml
@@ -17,6 +17,7 @@
         <ui:composition template="/dataverse_template.xhtml">
             <ui:param name="pageTitle" value="#{FilePage.fileMetadata.dataFile.displayName} - #{FilePage.file.owner.owner.displayName}"/>
             <ui:param name="dataverse" value="#{FilePage.file.owner.owner}"/>
+            <ui:param name="showDataverseHeader" value="#{!FilePage.isAnonymizedAccess()}"/>
             <ui:param name="showMessagePanel" value="#{true}"/>
             <!-- NOTE removed fileAccessRequest logic in order to always display the file access btn -->
             <ui:param name="showAccessFileButtonGroup" value="#{!FilePage.fileMetadata.datasetVersion.deaccessioned


### PR DESCRIPTION
**What this PR does / why we need it**: Suppresses the breadcrumbs on the file page when viewed with anonymized access.

**Which issue(s) this PR closes**:

- Closes #11458 

**Special notes for your reviewer**:
It's not clear to me why the additional change to the breadcrumb panel in the dataverse_header needed to be made. 

**Suggestions on how to test this**:
Set up the preview url to allow anonymized access by setting the Anonymized Dataset Field types:
**curl -X PUT -d 'author, datasetContact, contributor, depositor, grantNumber, publication' http://localhost:8080/api/admin/settings/:AnonymizedFieldTypeNames**

add a draft dataset with a file and create an anonymous preview url.

log out of dataverse

open the dataset draft via the anon url

click on the file to go to the file page.

make sure that the names of the owning Dataverse does not appear.


**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
