### PR TITLE
fix reload docker by setting "LINUX_PASSWORD", "PAYARA_ADMIN_PASSWORD…

### DIFF
--- a/modules/container-base/src/main/docker/scripts/init_1_change_passwords.sh
+++ b/modules/container-base/src/main/docker/scripts/init_1_change_passwords.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -euo pipefail
+set -uo pipefail
 
 # NOTE: ALL PASSWORD ENV VARS WILL BE SCRAMBLED IN startInForeground.sh FOR SECURITY!
 #       This is to avoid possible attack vectors where someone could extract the sensitive information


### PR DESCRIPTION
…", "DOMAIN_PASSWORD"

**What this PR does / why we need it**:
docker

**Which issue(s) this PR closes**:

- Closes #10998

**Special notes for your reviewer**:
If you normally start the Docker image with docker-compose and Docker is configured to restart all running Docker instances upon a system restart, the error occurs. This happens because the script specifies that if a program does not return exit 0, the script should terminate, and as a result, the entire startup process fails.

**Suggestions on how to test this**:
During the normal start, all three or at least one of the following parameters must be specified: LINUX_PASSWORD, PAYARA_ADMIN_PASSWORD, DOMAIN_PASSWORD.

