### PR TITLE
Feature Request: API endpoint for analytics.html

### DIFF
--- a/doc/release-notes/11448-api-endpoint-for-analytics-html.md
+++ b/doc/release-notes/11448-api-endpoint-for-analytics-html.md
@@ -1,0 +1,5 @@
+### Feature Request: API endpoint for analytics.html
+
+New API to get the analytics.html from settings for SPA
+
+See also [the guides](https://dataverse-guide--11359.org.readthedocs.build/en/11359/installation/config.html#web-analytics-code), #11448.

--- a/doc/sphinx-guides/source/api/native-api.rst
+++ b/doc/sphinx-guides/source/api/native-api.rst
@@ -7609,3 +7609,20 @@ Parameters:
 
 ``per_page`` Number of results returned per page.
 
+
+Customization: Web Analytics Code
+---------------------------------
+
+The Customization API is used to retrieve the analytics-code.html. See also :ref:`web-analytics-code` in the Configuration section of the Installation Guide.
+
+The content is returned in type="text/html; charset=UTF-8"
+
+A curl example getting the analytics-code
+
+.. code-block:: bash
+
+  export SERVER_URL=https://demo.dataverse.org
+
+  curl "$SERVER_URL/api/customization/analytics"
+
+.. _customization-analytics:

--- a/src/main/java/edu/harvard/iq/dataverse/api/CustomizationApi.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/CustomizationApi.java
@@ -1,0 +1,29 @@
+package edu.harvard.iq.dataverse.api;
+
+import edu.harvard.iq.dataverse.settings.SettingsServiceBean;
+import jakarta.ejb.EJB;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.Response;
+
+@Path("customization")
+public class CustomizationApi extends AbstractApiBean {
+
+    @EJB
+    SettingsServiceBean settingsService;
+
+    @GET
+    @Path("analytics")
+    @Produces({"text/html; charset=UTF-8"})
+    public Response getAnalyticsHTML() {
+        return getFromSettings(SettingsServiceBean.Key.WebAnalyticsCode, "text/html; charset=UTF-8");
+    }
+
+    private Response getFromSettings(SettingsServiceBean.Key key, String type) {
+        String value = settingsService.getValueForKey(key);
+        if (value != null) {
+            return Response.ok(value).type(type).build();
+        } else {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+    }
+}

--- a/src/test/java/edu/harvard/iq/dataverse/api/CustomizationIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/CustomizationIT.java
@@ -1,0 +1,46 @@
+package edu.harvard.iq.dataverse.api;
+
+import edu.harvard.iq.dataverse.settings.SettingsServiceBean;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+
+public class CustomizationIT {
+
+    @AfterEach
+    public void after() {
+        UtilIT.deleteSetting(SettingsServiceBean.Key.WebAnalyticsCode);
+    }
+    @Test
+    public void testGetCustomAnalytics() {
+        String html = """
+                <!-- Global Site Tag (gtag.js) - Google Analytics -->
+                <script async="async" src="https://www.googletagmanager.com/gtag/js?id=YOUR-ACCOUNT-CODE"></script>
+                <script>
+                    //<![CDATA[
+                    window.dataLayer = window.dataLayer || [];
+                    function gtag(){dataLayer.push(arguments);}
+                    gtag('js', new Date());
+                                
+                    gtag('config', 'YOUR-ACCOUNT-CODE');
+                    //]]>
+                </script>""";
+
+        UtilIT.setSetting(SettingsServiceBean.Key.WebAnalyticsCode, html).prettyPrint();
+
+        Response getResponse = UtilIT.getCustomAnalyticsHTML();
+        getResponse.prettyPrint();
+        getResponse.then().assertThat()
+                .statusCode(200)
+                .body(equalTo(html));
+
+        UtilIT.deleteSetting(SettingsServiceBean.Key.WebAnalyticsCode).prettyPrint();
+
+        getResponse = UtilIT.getCustomAnalyticsHTML();
+        getResponse.prettyPrint();
+        getResponse.then().assertThat()
+                .statusCode(404);
+    }
+}

--- a/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
@@ -4737,4 +4737,10 @@ public class UtilIT {
         return given().header(API_TOKEN_HTTP_HEADER, apiToken).contentType(ContentType.JSON).body(jsonArray.toString())
                 .post("/api/datasets/" + idInPath + "/files/metadata" + optionalQueryParam);
     }
+
+    public static Response getCustomAnalyticsHTML() {
+        return given()
+                .contentType("text/html; charset=UTF-8")
+                .get("/api/customization/analytics");
+    }
 }


### PR DESCRIPTION
**What this PR does / why we need it**: For the SPA, we need an API endpoint that returns, if set, the installation analytics.html.

**Which issue(s) this PR closes**:https://github.com/IQSS/dataverse/issues/11448

- Closes #11448

**Special notes for your reviewer**:

**Suggestions on how to test this**:

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**: included

**Additional documentation**:
