### PR TITLE
avoid NPE when deciding between Croissant and Schema.org JSON-LD

### DIFF
--- a/src/main/webapp/dataset.xhtml
+++ b/src/main/webapp/dataset.xhtml
@@ -71,14 +71,12 @@
             <ui:define name="jsonld_header">
                 <ui:fragment rendered="#{!DatasetPage.anonymizedAccess}">
                     <script type="application/ld+json">
-                        <c:choose>
-                            <c:when test="#{empty DatasetPage.croissant}">
-                                <h:outputText value="#{DatasetPage.jsonLd}"/>
-                            </c:when>
-                            <c:otherwise>
-                                <h:outputText value="#{DatasetPage.croissant}"/>
-                            </c:otherwise>
-                        </c:choose>
+                        <ui:fragment rendered="#{DatasetPage.croissant == null}">
+                            <h:outputText value="#{DatasetPage.jsonLd}"/>
+                        </ui:fragment>
+                        <ui:fragment rendered="#{DatasetPage.croissant != null}">
+                            <h:outputText value="#{DatasetPage.croissant}"/>
+                        </ui:fragment>
                     </script>
                 </ui:fragment>
             </ui:define>


### PR DESCRIPTION
**What this PR does / why we need it**:

People are reporting sometimes getting an NPE when creating a dataset.

**Which issue(s) this PR closes**:

- Closes #10848
- Closes #11442

**Special notes for your reviewer**:

We don't seem to use `<c:choose> / <c:when>` anywhere else (it was added in #10382), so I switched to our usual `<ui:fragment rendered` pattern.

**Suggestions on how to test this**:

Test with and without Croissant enabled. See https://github.com/gdcc/exporter-croissant for installation instructions.

Under `<head>` you should see Schema.org JSON-LD when Croissant isn't enabled and Croissant when Croissant is enabled.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No.

**Is there a release notes update needed for this change?**:

I can add one if you want.

**Additional documentation**:

None.