### PR TITLE
Fix MailServiceBeanIT

### DIFF
--- a/src/test/java/edu/harvard/iq/dataverse/MailServiceBeanIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/MailServiceBeanIT.java
@@ -75,7 +75,7 @@ class MailServiceBeanIT {
     @Container
     static GenericContainer<?> maildev = new GenericContainer<>("dockage/mailcatcher")
         .withExposedPorts(PORT_HTTP, PORT_SMTP)
-        .waitingFor(Wait.forHttp("/"));
+        .waitingFor(Wait.forHttp("/").forPort(PORT_HTTP));
     
     static String tcSmtpHost() {
         return maildev.getHost();


### PR DESCRIPTION
**What this PR does / why we need it**:
Without pinning down the port, sometimes Testcontainers thinks it should apply the waiting strategy on the SMTP port. Telling it explicitely which port to use fixes this.

**Which issue(s) this PR closes**:

- Closes #11472

**Special notes for your reviewer**:
None

**Suggestions on how to test this**:
Watch the integration tests not fail in CI

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
Nope

**Is there a release notes update needed for this change?**:
Nope

**Additional documentation**:
Nope