### PR TITLE
Fix copy label flow

### DIFF
--- a/.github/workflows/copy_labels.yml
+++ b/.github/workflows/copy_labels.yml
@@ -6,6 +6,9 @@ on:
 
 jobs:
   copy-labels:
+    if: "! github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]'"
+    permissions:
+      pull-requests: write
     runs-on: ubuntu-latest
     name: Copy labels from linked issues
     steps:

--- a/.github/workflows/copy_labels.yml
+++ b/.github/workflows/copy_labels.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   copy-labels:
+    # Avoid being triggered by forks
     if: "! github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]'"
     permissions:
       pull-requests: write


### PR DESCRIPTION
**What this PR does / why we need it**:
Don't run the copy label flow for PRs from forks

**Which issue(s) this PR closes**:

- Closes #11450

**Special notes for your reviewer**:
None

**Suggestions on how to test this**:
Open a PR from a fork, watch it not being executed

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
Nope

**Is there a release notes update needed for this change?**:
Nope

**Additional documentation**:
Nope