### PR TITLE
feat: migrate personOrOrg settings to MPConfig

### DIFF
--- a/doc/sphinx-guides/source/installation/config.rst
+++ b/doc/sphinx-guides/source/installation/config.rst
@@ -3093,6 +3093,8 @@ Please note that this setting is experimental.
 The Schema.org metadata and OpenAIRE exports and the Schema.org metadata included in DatasetPages try to infer whether each entry in the various fields (e.g. Author, Contributor) is a Person or Organization. If you are sure that
 users are following the guidance to add people in the recommended family name, given name order, with a comma, you can set this true to always assume entries without a comma are for Organizations. The default is false.
 
+Can also be set via *MicroProfile Config API* sources, e.g. the environment variable ``DATAVERSE_PERSONORORG_ASSUMECOMMAINPERSONNAME``.
+
 .. _dataverse.personOrOrg.orgPhraseArray:
 
 dataverse.personOrOrg.orgPhraseArray
@@ -3102,8 +3104,9 @@ Please note that this setting is experimental.
 
 The Schema.org metadata and OpenAIRE exports and the Schema.org metadata included in DatasetPages try to infer whether each entry in the various fields (e.g. Author, Contributor) is a Person or Organization.
 If you have examples where an orgization name is being inferred to belong to a person, you can use this setting to force it to be recognized as an organization.
-The value is expected to be a JsonArray of strings. Any name that contains one of the strings is assumed to be an organization. For example, "Project" is a word that is not otherwise associated with being an organization. 
+The value is expected to be a comma-separated list of strings. Any name that contains one of the strings is assumed to be an organization. For example, "Project" is a word that is not otherwise associated with being an organization.
 
+Can also be set via *MicroProfile Config API* sources, e.g. the environment variable ``DATAVERSE_PERSONORORG_ORGPHRASEARRAY``.
 
 .. _dataverse.api.signature-secret:
 

--- a/src/main/java/edu/harvard/iq/dataverse/settings/JvmSettings.java
+++ b/src/main/java/edu/harvard/iq/dataverse/settings/JvmSettings.java
@@ -263,6 +263,11 @@ public enum JvmSettings {
     //CSL CITATION SETTINGS
     SCOPE_CSL(PREFIX, "csl"),
     CSL_COMMON_STYLES(SCOPE_CSL, "common-styles"),
+
+    // PersonOrOrgUtil SETTINGS
+    SCOPE_PERSONORORG(PREFIX, "personOrOrg"),
+    ASSUME_COMMA_IN_PERSON_NAME(SCOPE_PERSONORORG, "assumeCommaInPersonName"),
+    ORG_PHRASE_ARRAY(SCOPE_PERSONORORG, "orgPhraseArray"),
     ;
 
     private static final String SCOPE_SEPARATOR = ".";

--- a/src/test/java/edu/harvard/iq/dataverse/util/PersonOrOrgUtilTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/util/PersonOrOrgUtilTest.java
@@ -1,13 +1,17 @@
 package edu.harvard.iq.dataverse.util;
 
+import edu.harvard.iq.dataverse.settings.JvmSettings;
 import edu.harvard.iq.dataverse.util.json.JsonUtil;
 
+import edu.harvard.iq.dataverse.util.testing.JvmSetting;
+import edu.harvard.iq.dataverse.util.testing.LocalJvmSettings;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 
 import jakarta.json.JsonObject;
 
+@LocalJvmSettings
 public class PersonOrOrgUtilTest {
 
         public PersonOrOrgUtilTest() {
@@ -26,27 +30,39 @@ public class PersonOrOrgUtilTest {
             verifyIsOrganization("The Ford Foundation");
             verifyIsOrganization("United Nations Economic and Social Commission for Asia and the Pacific (UNESCAP)");
             verifyIsOrganization("Michael J. Fox Foundation for Parkinson's Research");
-            // The next example is one known to be asserted to be a Person without an entry
-            // in the OrgWordArray
-            // So we test with it in the array and then when the array is empty to verify
-            // the array works, resetting the array works, and the problem still exists in
+            // The next examples are known to be asserted to be a Person without an entry in the OrgWordArray
+            // So we test when no array is set via JvmSetting to verify the problem still exists in
             // the underlying algorithm
-            PersonOrOrgUtil.setOrgPhraseArray("[\"Portable\"]");
-            verifyIsOrganization("Portable Antiquities of the Netherlands");
-            PersonOrOrgUtil.setOrgPhraseArray(null);
             JsonObject obj = PersonOrOrgUtil.getPersonOrOrganization("Portable Antiquities of the Netherlands", false, false);
             assertTrue(obj.getBoolean("isPerson"));
+            JsonObject obj2 = PersonOrOrgUtil.getPersonOrOrganization("Max Mustermann GmbH", false, false);
+            assertTrue(obj2.getBoolean("isPerson"));
+        }
+
+        @Test
+        @JvmSetting(key = JvmSettings.ORG_PHRASE_ARRAY, value = "Portable,GmbH")
+        public void testOrganizationWithOrgPhraseArray() {
+            // The next examples are known to be asserted to be a Person without an entry in the OrgWordArray
+            // So we test with the array set via JvmSetting to verify the array works
+            verifyIsOrganization("Portable Antiquities of the Netherlands");
+            verifyIsOrganization("Max Mustermann GmbH");
         }
 
         @Test
         public void testOrganizationAcademicName() {
+            verifyIsOrganization("John Smith Center");
+            verifyIsOrganization("John Smith Group");
+            // An example the base algorithm doesn't handle:
+            JsonObject obj = PersonOrOrgUtil.getPersonOrOrganization("John Smith Project", false, false);
+            assertTrue(obj.getBoolean("isPerson"));
+        }
 
-        verifyIsOrganization("John Smith Center");
-        verifyIsOrganization("John Smith Group");
-        //An example the base algorithm doesn't handle:
-        PersonOrOrgUtil.setAssumeCommaInPersonName(true);
-        verifyIsOrganization("John Smith Project");
-        PersonOrOrgUtil.setAssumeCommaInPersonName(false);
+        @Test
+        @JvmSetting(key = JvmSettings.ASSUME_COMMA_IN_PERSON_NAME, value = "true")
+        public void testOrganizationAcademicNameWithAssumeComma() {
+            verifyIsOrganization("John Smith Center");
+            verifyIsOrganization("John Smith Group");
+            verifyIsOrganization("John Smith Project");
         }
 
         


### PR DESCRIPTION
**What this PR does / why we need it**:

As discussed on Zulip (https://dataverse.zulipchat.com/#narrow/channel/375707-community/topic/Setting.20dataverse.2Efiles.2Ehide-schema-dot-org-download-urls/with/514143249) for a different config option, this PR also migrates the options `dataverse.personOrOrg.orgPhraseArray` and `dataverse.personOrOrg.assumeCommaInPersonName` to MPConfig.

**Which issue(s) this PR closes**:

/

**Special notes for your reviewer**:

/

**Suggestions on how to test this**:

Running the tests: `mvn test -Dtest="PersonOrOrgUtilTest"`

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

/

**Is there a release notes update needed for this change?**:

I think that this PR contains a non-backwards-compatible change, with the expected format of the orgPhraseArray changing from a JSON array (e.g. `["Portable","GmbH"]`) to a comma-separated list of values (`Portable,GmbH`), and a release note should be added for that, unless we mitigate this in some other way. Please let me know what you think about this, because I am unsure.

**Additional documentation**:

/