### PR TITLE
Fix @AutoService classes not being loaded at runtime when using JDK23+ for compilation

### DIFF
--- a/doc/sphinx-guides/source/developers/dev-environment.rst
+++ b/doc/sphinx-guides/source/developers/dev-environment.rst
@@ -30,7 +30,7 @@ Detailed Steps
 Install Java
 ~~~~~~~~~~~~
 
-The Dataverse Software requires Java 17.
+The recommended version is Java 17 because it's the version we test with. See https://github.com/IQSS/dataverse/pull/9764.
 
 On Mac and Windows, we suggest using `SDKMAN <https://sdkman.io>`_ to install Temurin (Eclipe's name for its OpenJDK distribution). Type ``sdk install java 17`` and then hit the "tab" key until you get to a version that ends with ``-tem`` and then hit enter.
 

--- a/doc/sphinx-guides/source/installation/prerequisites.rst
+++ b/doc/sphinx-guides/source/installation/prerequisites.rst
@@ -19,7 +19,7 @@ We assume you plan to run your Dataverse installation on Linux and we recommend 
 Java
 ----
 
-The Dataverse Software requires Java SE 17 (or higher).
+The recommended version is Java 17 because it's the version we test with.
 
 Installing Java
 ===============

--- a/modules/dataverse-parent/pom.xml
+++ b/modules/dataverse-parent/pom.xml
@@ -362,7 +362,7 @@
                             <rules>
                                 <banDuplicatePomDependencyVersions/>
                                 <requireJavaVersion>
-                                    <version>[${target.java.version},18]</version>
+                                    <version>[${target.java.version}.0,)</version>
                                 </requireJavaVersion>
                             </rules>
                         </configuration>

--- a/modules/dataverse-parent/pom.xml
+++ b/modules/dataverse-parent/pom.xml
@@ -362,7 +362,7 @@
                             <rules>
                                 <banDuplicatePomDependencyVersions/>
                                 <requireJavaVersion>
-                                    <version>[${target.java.version}.0,)</version>
+                                    <version>[${target.java.version},18]</version>
                                 </requireJavaVersion>
                             </rules>
                         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
         
         <reload4j.version>1.2.18.4</reload4j.version>
         <flyway.version>10.19.0</flyway.version>
+        <auto-service.version>1.1.1</auto-service.version>
         <jhove.version>1.20.1</jhove.version>
         <poi.version>5.4.0</poi.version>
         <tika.version>2.9.2</tika.version>
@@ -526,7 +527,7 @@
         <dependency>
             <groupId>com.google.auto.service</groupId>
             <artifactId>auto-service</artifactId>
-            <version>1.1.1</version>
+            <version>${auto-service.version}</version>
             <optional>true</optional>
             <type>jar</type>
         </dependency>
@@ -831,6 +832,14 @@
                     <release>${target.java.version}</release>
                     <!-- for use with `mvn -DcompilerArgument=-Xlint:unchecked compile` -->
                     <compilerArgument>${compilerArgument}</compilerArgument>
+                    <!-- Ensure the annotation processor for @AutoService is picked up. Especially important as of JDK 23 -->
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>com.google.auto.service</groupId>
+                            <artifactId>auto-service</artifactId>
+                            <version>${auto-service.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
**What this PR does / why we need it**:

Both @JR-1991 and @ofahimIQSS have had trouble getting the containerized environment working because they had a version of Java that was too new. (For Jan it was Java 23, [see discussion](https://dataverse.zulipchat.com/#narrow/channel/375812-containers/topic/.E2.9C.94.20Stuck.20at.20Payara.20page/near/502162168).) They're using our dev [quickstart](https://guides.dataverse.org/en/6.6/developers/dev-environment.html#quickstart): `mvn -Pct clean package docker:run`

**Special notes for your reviewer**:
None. Merely adding the missing compile plugin config bits [according to the auto-services docs](https://github.com/google/auto/blob/bb4d48e4ca0bda0e75b3b67f6ff4f464db9304e4/service/README.md).

**Suggestions on how to test this**:
1. Use SDKMAN to have multiple JDK versions at the ready.
2. Install JDK 17, 21, and 23
3. With all these versions run `mvn clean compile`. Confirm all the necessary (3) files are present at `target/classes/META-INF/services`
4. If you have Docker on your machine, you can use `mvn -Pct clean package docker:run` and JDK 23 to verify it works now.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
Nope

**Is there a release notes update needed for this change?**:
Nope

**Additional documentation**:
None

~~We've been using the maven-enforcer-plugin plugin and its [requireJavaVersion](https://maven.apache.org/enforcer/enforcer-rules/requireJavaVersion.html) rule since d6c3f7a but it's set for "Java 17 or newer".~~

~~In this pull request, I'm suggesting we set it to "Java 17 and not newer". See also "Version Range Specification" at https://maven.apache.org/enforcer/enforcer-rules/versionRanges.html~~

~~I'm also simplifying the syntax because I don't think we need `.0` in there.~~

~~Here's how the output looks (as of this pull request) when you try to use a version of Java that's too new:~~

~~`[ERROR] Detected JDK version 21.0.4 (JAVA_HOME=/Users/PDurbin/.sdkman/candidates/java/21.0.4-tem) is not in the allowed range [17,18].`~~