### PR TITLE
Fix DDI Exception

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/export/DDIExporter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/export/DDIExporter.java
@@ -47,25 +47,11 @@ public class DDIExporter implements XMLExporter {
 
     @Override
     public void exportDataset(ExportDataProvider dataProvider, OutputStream outputStream) throws ExportException {
-        XMLStreamWriter xmlw = null;
-        //XMLStreamWriter is not auto-closable - can't use try-with-resources here
         try {
-            xmlw = XMLOutputFactory.newInstance().createXMLStreamWriter(outputStream);
-            xmlw.writeStartDocument();
-            xmlw.flush();
             DdiExportUtil.datasetJson2ddi(dataProvider.getDatasetJson(), dataProvider.getDatasetFileDetails(),
                     outputStream);
         } catch (XMLStreamException xse) {
             throw new ExportException("Caught XMLStreamException performing DDI export", xse);
-        } finally {
-            if (xmlw != null) {
-                try {
-                    xmlw.close();
-                } catch (XMLStreamException e) {
-                    // Log this exception, but don't rethrow as it's not the primary issue
-                    e.printStackTrace();
-                }
-            }
         }
     }
 


### PR DESCRIPTION
**What this PR does / why we need it**: The recently merged #11417 caused an exception in the logs: 
  javax.xml.stream.XMLStreamException: Trying to write END_DOCUMENT when document has no root (ie. trying to output empty document).
        at com.ctc.wstx.sw.BaseStreamWriter.throwOutputError(BaseStreamWriter.java:1596)
        at com.ctc.wstx.sw.BaseStreamWriter.reportNwfStructure(BaseStreamWriter.java:1625)
        at com.ctc.wstx.sw.BaseStreamWriter._finishDocument(BaseStreamWriter.java:1451)
        at com.ctc.wstx.sw.BaseStreamWriter.close(BaseStreamWriter.java:247)
        at edu.harvard.iq.dataverse.export.DDIExporter.exportDataset(DDIExporter.java:63)

This was not noticed during review/QA. Investigating, it appears that the reason for the exception is that the XMLStreamWriter was never used (and thus closing it raised the empty doc exception). This PR fixes the problem by removing the unused writer.

**Which issue(s) this PR closes**:

- Closes #

**Special notes for your reviewer**: Perhaps this means that there was indeed a resource leak in this class that removing the writer will now fix.

**Suggestions on how to test this**: re-export a dataset or publish a dataset and verify there's no exception in the logs.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
