### PR TITLE
Reduce useless warnings about missing vocab values

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/ControlledVocabularyValue.java
+++ b/src/main/java/edu/harvard/iq/dataverse/ControlledVocabularyValue.java
@@ -8,6 +8,7 @@ package edu.harvard.iq.dataverse;
 
 import edu.harvard.iq.dataverse.util.BundleUtil;
 import org.apache.commons.lang3.StringUtils;
+import org.eclipse.persistence.logging.LogLevel;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -15,6 +16,7 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.Locale;
 import java.util.Objects;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.MissingResourceException;
 import jakarta.persistence.CascadeType;
@@ -148,7 +150,11 @@ public class ControlledVocabularyValue implements Serializable  {
                 return sendDefault ? strValue : null;
             }
         } catch (MissingResourceException | NullPointerException e) {
-            logger.warning("Error finding " + "controlledvocabulary." + fieldTypeName + "." + key + " in " + ((locale==null)? "defaultLang" : locale.getLanguage()) + " : " + e.getLocalizedMessage());
+            //If we're using the default local and can return the default value, this shouldn't be a warning
+            if (locale != null && !locale.equals(Locale.getDefault()) && sendDefault) {
+                logger.log(((locale != null && !locale.equals(Locale.getDefault()) && ! sendDefault) ? Level.WARNING:Level.FINE),"Error finding " + "controlledvocabulary." + fieldTypeName + "." + key + " in "
+                        + ((locale == null) ? "defaultLang" : locale.getLanguage()) + " : " + e.getLocalizedMessage());
+            }
             return sendDefault ? strValue : null;
         }
     }


### PR DESCRIPTION
**What this PR does / why we need it**: To support i18n, we have a warning when looking up CVV values if an entry can't be found in a .properties file for the relevant block/language. However, when the request is for the default language, the value in the block tsv file is used as a default and the fact that there's no property file for the default lang, or its out of date, etc. doesn't matter as much since the user sees the same thing regardless.

This PR just tweaks the logging to only warn for the non-default-lang case and switches to fine logging if someone wants to see the default case.

Hopefully a useful reduction in log volume, particularly with custom metadata blocks/non-i18n installations.

**Which issue(s) this PR closes**:

Thought there was one but I don't see it.

- Closes #

**Special notes for your reviewer**:

**Suggestions on how to test this**: Try on a machine with the CAFE block - verify the "Error finding ..." warnings are gone.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
