### PR TITLE
IQSS/11418 Fix after poi update

### DIFF
--- a/modules/dataverse-parent/pom.xml
+++ b/modules/dataverse-parent/pom.xml
@@ -156,7 +156,7 @@
     
         <!-- Basic libs, logging -->
         <slf4j.version>1.7.35</slf4j.version>
-        <commons.io.version>2.15.1</commons.io.version>
+        <commons.io.version>2.19.0</commons.io.version>
         <commons.logging.version>1.2</commons.logging.version>
         <commons.lang3.version>3.12.0</commons.lang3.version>
         <commons.compress.version>1.26.0</commons.compress.version>


### PR DESCRIPTION
**What this PR does / why we need it**: The Dependabot PR #11418 looks like it broke full text indexing of some MS files (doc, docx, xlsx, ?). This PR updates the apache commons-io library to fix the error seen: 

 Full-text indexing for ... failed due to Error: java.lang.NoSuchMethodError : 'org.apache.commons.io.input.BoundedInputStream$Builder org.apache.commons.io.input.BoundedInputStream.builder()']]
**Which issue(s) this PR closes**:

- Closes #

**Special notes for your reviewer**:

**Suggestions on how to test this**: Could test full text indexing of a docx file - docx on data.qdr.syr.edu could be used but I expect any machine with docx files would be OK. Full text indexing should succeed/at least not have the error shown above in the log.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
