### PR TITLE
OJS 3 is now supported (and OPS)

### DIFF
--- a/doc/release-notes/11518-ojs3.md
+++ b/doc/release-notes/11518-ojs3.md
@@ -1,0 +1,3 @@
+### OJS 3 is supported
+
+OJS 3 (version 3.3 and higher) is now supported as an integration with Dataverse. See [the guides](https://dataverse-guide--11518.org.readthedocs.build/en/11518/admin/integrations.html#open-journal-systems-ojs) for details.

--- a/doc/sphinx-guides/source/admin/integrations.rst
+++ b/doc/sphinx-guides/source/admin/integrations.rst
@@ -50,11 +50,11 @@ Open Journal Systems (OJS)
 
 Open Journal Systems (OJS) is a journal management and publishing system that has been developed by the Public Knowledge Project to expand and improve access to research.
 
-The OJS Dataverse Project Plugin adds data sharing and preservation to the OJS publication process.
+The OJS Dataverse Plugin adds data sharing and preservation to the OJS publication process.
 
-As of this writing only OJS 2.x is supported and instructions for getting started can be found at https://github.com/pkp/ojs/tree/ojs-stable-2_4_8/plugins/generic/dataverse
+OJS 3.3+ can use https://github.com/lepidus/dataversePlugin
 
-If you are interested in OJS 3.x supporting deposit to Dataverse installations, please leave a comment on https://github.com/pkp/pkp-lib/issues/1822
+OJS 2.x can use https://github.com/pkp/ojs/tree/ojs-2_4_8-5/plugins/generic/dataverse
 
 Renku
 +++++

--- a/doc/sphinx-guides/source/admin/integrations.rst
+++ b/doc/sphinx-guides/source/admin/integrations.rst
@@ -45,14 +45,16 @@ RSpace is an affordable and secure enterprise grade electronic lab notebook (ELN
 
 For instructions on depositing data from RSpace to your Dataverse installation, your researchers can visit https://www.researchspace.com/help-and-support-resources/dataverse-integration/
 
-Open Journal Systems (OJS)
-++++++++++++++++++++++++++
+Open Journal Systems (OJS) and OPS
+++++++++++++++++++++++++++++++++++
 
 Open Journal Systems (OJS) is a journal management and publishing system that has been developed by the Public Knowledge Project to expand and improve access to research.
 
-The OJS Dataverse Plugin adds data sharing and preservation to the OJS publication process.
+Open Preprint Systems (OPS) is similar, but for preprints.
 
-OJS 3.3+ can use https://github.com/lepidus/dataversePlugin
+The following plugin adds data sharing and preservation to the OJS/OPS publication process.
+
+OJS/OPS 3.x can use https://github.com/lepidus/dataversePlugin
 
 OJS 2.x can use https://github.com/pkp/ojs/tree/ojs-2_4_8-5/plugins/generic/dataverse
 

--- a/doc/sphinx-guides/source/api/apps.rst
+++ b/doc/sphinx-guides/source/api/apps.rst
@@ -143,9 +143,9 @@ https://github.com/IQSS/doi2pmh-server
 OJS
 ~~~
 
-The Open Journal Systems (OJS) Dataverse Software Plugin adds data sharing and preservation to the OJS publication process.
+The Open Journal Systems (OJS) Dataverse Plugin adds data sharing and preservation to the OJS publication process.
 
-https://github.com/pkp/ojs/tree/ojs-stable-2_4_8/plugins/generic/dataverse
+https://github.com/lepidus/dataversePlugin
 
 OpenScholar
 ~~~~~~~~~~~


### PR DESCRIPTION
**What this PR does / why we need it**:

We just got the good news that OJS 3 is now supported! https://groups.google.com/g/dataverse-community/c/cEQWBKVo634/m/Gf-yuOCDFwAJ

This PR updates our docs, which you can preview at https://dataverse-guide--11518.org.readthedocs.build/en/11518/admin/integrations.html#open-journal-systems-ojs