### PR TITLE
Correct http method in storage quota example

### DIFF
--- a/doc/sphinx-guides/source/api/native-api.rst
+++ b/doc/sphinx-guides/source/api/native-api.rst
@@ -1167,7 +1167,7 @@ To set or change the storage allocation quota for a collection:
 
 .. code-block:: 
 
-  curl -X PUT -H "X-Dataverse-key:$API_TOKEN" "$SERVER_URL/api/dataverses/$ID/storage/quota/$SIZE_IN_BYTES"
+  curl -X POST -H "X-Dataverse-key:$API_TOKEN" "$SERVER_URL/api/dataverses/$ID/storage/quota/$SIZE_IN_BYTES"
 
 This is API is superuser-only.
   


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates storage quota http method to `POST` so that pushing storage quotas works as intended.

**Which issue(s) this PR closes**:
Closes #11530 

**Special notes for your reviewer**:
None.

**Suggestions on how to test this**:
Issue the api call for updating storage quotas as shown in the docs (https://guides.dataverse.org/en/latest/api/native-api.html#id2). It should fail at `PUT` indicating the "API endpoint does not support this method."

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
No.

**Is there a release notes update needed for this change?**:
No.

**Additional documentation**:
None.
