### PR TITLE
MDC - updateCitationsForDataset API may end up in infinite loop

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/api/MakeDataCountApi.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/MakeDataCountApi.java
@@ -170,7 +170,7 @@ public class MakeDataCountApi extends AbstractApiBean {
             boolean nextPage = true;
             JsonArrayBuilder dataBuilder = Json.createArrayBuilder();
 
-            int totalPages = 10000; // Default max page number to avoid infinite loop
+            int totalPages = 1000; // Default max page number to avoid infinite loop
             int currentPage = 0;
             String previousUrl = url.toString();
             do {


### PR DESCRIPTION

Hi everyone :) 
Our team identified a issue with `api/admin/makeDataCount/:persistentId/updateCitationsForDataset?persistentId=$DOI`  endpoint that could end up in infinite loop if Datacite result is paginated.
There is 2 reasons for this : 
1) Dataverse depends on Datacite json reponse content to got out of a while loop : https://github.com/IQSS/dataverse/blob/develop/src/main/java/edu/harvard/iq/dataverse/api/MakeDataCountApi.java#L172-L201
`if (links.containsKey("next")) {` can always be true.

2) Datacite seems to have an issue with HATEOAS implementation as it always contains a `next` link even when you are out of page range or on the last page. Standard recommendation is to remove `next` link or set it to empty or null on last page. I'll report this issue to Datacite.

Ex: 
First page : https://api.datacite.org/events?doi=10.12763/SMDGR1&source=crossref&page[size]=1000 
```json
"meta": {
    "total": 10276,
    "total-pages": 11,

"links": {
    "self": "https://api.datacite.org/events?doi=10.12763/SMDGR1&source=crossref&page[size]=1000",
    "next": "https://api.datacite.org/events?doi=10.12763%2FSMDGR1&page%5Bnumber%5D=2&page%5Bsize%5D=1000"
  }
```

Page number 11 : https://api.datacite.org/events?doi=10.12763%2FSMDGR1&page%5Bnumber%5D=11&page%5Bsize%5D=1000
Still displays a next link : 
```json
"links": {
    "self": "https://api.datacite.org/events?doi=10.12763%2FSMDGR1&page%5Bnumber%5D=11&page%5Bsize%5D=1000",
    "next": "https://api.datacite.org/events?doi=10.12763%2FSMDGR1&page%5Bnumber%5D=11&page%5Bsize%5D=1000"
  }
```

This code aims both to work better with Datacite as is and have a default condition max iteration condition to avoid infinite loop.

Note : worst case scenario, a default max page number of 1000 x 1000 items seems enough regarding crossref... 