### PR TITLE
MakeDataCount API may end up in infinite loop

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/api/MakeDataCountApi.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/MakeDataCountApi.java
@@ -160,7 +160,7 @@ public class MakeDataCountApi extends AbstractApiBean {
                 url = new URI(JvmSettings.DATACITE_REST_API_URL.lookup(pidProvider.getId()) +
                               "/events?doi=" +
                               authorityPlusIdentifier +
-                              "&source=crossref&page[size]=1000").toURL();
+                              "&source=crossref&page[size]=1000&page[cursor]=1").toURL();
             } catch (URISyntaxException e) {
                 //Nominally this means a config error/ bad DATACITE_REST_API_URL for this provider
                 logger.warning("Unable to create URL for " + persistentId + ", pidProvider " + pidProvider.getId());


### PR DESCRIPTION
Hi everyone :) 
Our team identified a issue with `api/admin/makeDataCount/:persistentId/updateCitationsForDataset?persistentId=$DOI` that could end up in infinite loop if Datacite result is paginated.

While using [Datacite API pagination by page number](https://support.datacite.org/docs/pagination#method-1-page-number-up-to-10000-records) + using `next` link : it will keep sending the same content page after page 10 and `next` link will exists forever.
Moreover, using this method is limited to a retrieve of 10,000 records (After page 10, all pages display page content of page n°10)

Ex: 
First page : https://api.datacite.org/events?doi=10.12763/SMDGR1&source=crossref&page[size]=1000 
```json
"meta": {
    "total": 10276,
    "total-pages": 11,

"links": {
    "self": "https://api.datacite.org/events?doi=10.12763/SMDGR1&source=crossref&page[size]=1000",
    "next": "https://api.datacite.org/events?doi=10.12763%2FSMDGR1&page%5Bnumber%5D=2&page%5Bsize%5D=1000"
  }
```

Page number 11 : https://api.datacite.org/events?doi=10.12763%2FSMDGR1&page%5Bnumber%5D=11&page%5Bsize%5D=1000
Still displays a next link : 
```json
"links": {
    "self": "https://api.datacite.org/events?doi=10.12763%2FSMDGR1&page%5Bnumber%5D=11&page%5Bsize%5D=1000",
    "next": "https://api.datacite.org/events?doi=10.12763%2FSMDGR1&page%5Bnumber%5D=11&page%5Bsize%5D=1000"
  }
```

This code is now using [Datacite API pagination by Cursor](https://support.datacite.org/docs/pagination#method-2-cursor) that will remove `next` link at last page, fixing the infinite loop issue while increasing the search capability to its maximum.