### PR TITLE
11391 display on create with template

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DatasetVersionUI.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetVersionUI.java
@@ -458,10 +458,11 @@ public class DatasetVersionUI implements Serializable {
                         mdb.setEmpty(false);
                         datasetFieldsForView.add(dsf);
                     }
-                    //Setting Local Display on Create on mdb when there are any set at dataverse level 
-                       if (dsf.getDatasetFieldType().getLocalDisplayOnCreate() != null && dsf.getDatasetFieldType().getLocalDisplayOnCreate()){
-                            mdb.setLocalDisplayOnCreate(true);
-                       }
+                    // Setting Local Display on Create on mdb when there are any set at dataverse
+                    // level
+                    if (dsf.getDatasetFieldType().shouldDisplayOnCreate()) {
+                        mdb.setLocalDisplayOnCreate(true);
+                    }
                 }
             }
 

--- a/src/main/java/edu/harvard/iq/dataverse/MetadataBlock.java
+++ b/src/main/java/edu/harvard/iq/dataverse/MetadataBlock.java
@@ -101,16 +101,17 @@ public class MetadataBlock implements Serializable, Comparable {
     }
     
     public boolean isDisplayOnCreate() {
-        // relying on "should" doesn't seem to work in context of a template 
-        // adding a transient that is updated in the DatasetVersionUI to fix
+        //Localize case - e.g. being called in the context of a specific collection 
+        if (getLocalDisplayOnCreate() != null){
+            return getLocalDisplayOnCreate();
+        }
+        // Non-localized case - the datasetFieldTypes are straight from the database and
+        // never have dsfType.localDsiplayOnCreate set.
         for (DatasetFieldType dsfType : datasetFieldTypes) {
-            boolean shouldDisplayOnCreate = dsfType.shouldDisplayOnCreate();
+            boolean shouldDisplayOnCreate = dsfType.isDisplayOnCreate();
             if (shouldDisplayOnCreate) {
                 return true;
             }
-        }
-        if (getLocalDisplayOnCreate() != null){
-            return getLocalDisplayOnCreate();
         }
         return false;
     }


### PR DESCRIPTION
**What this PR does / why we need it**:

The change in DatasetField is just a refactor to remove duplicate code per https://github.com/IQSS/dataverse/pull/11411/files#r2072692564

The second change (DatasetVersionUI, MetadataBlock) is just some cleanup after figuring out why shouldDisplayOnCreate in MetadataBlock wasn't working re: discussion in https://github.com/IQSS/dataverse/pull/11411/files#r2072686331.