### PR TITLE
#11542 get all type counts after first page

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/api/Search.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Search.java
@@ -114,8 +114,9 @@ public class Search extends AbstractApiBean {
                 if (!types.isEmpty()) {
                     // Query to get the totals if needed.
                     // Only needed if the list of types doesn't include all types since missing types will default to count of 0
-                    // Only get the totals for the first page (paginationStart == 0) for speed
-                    if (showTypeCounts && types.size() < objectTypeCountsMap.size() && paginationStart == 0) {
+                    // Only get the totals for the first page (paginationStart == 0) for speed removing paginationStart == 0 for 11542 SEK 06/04/25
+                    // how slow is it to leave pagination start == 0 out? SEK 06/04/2025? ref11542
+                    if (showTypeCounts && types.size() < objectTypeCountsMap.size()) {
                         List<String> totalFilterQueries = new ArrayList<>();
                         totalFilterQueries.addAll(filterQueries);
                         totalFilterQueries.add(SearchFields.TYPE + allTypes);


### PR DESCRIPTION
**What this PR does / why we need it**: Gets counts by type of dvObject for pages beyond the first page

**Which issue(s) this PR closes**:

- Closes #11542

**Special notes for your reviewer**:
Note in code references speed as reason for not implementing in original. With a small DB - not easy to see a time saving?

**Suggestions on how to test this**: see original ticket. access search api with show_type_counts=true and &start=10 (>0)

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:  no

**Is there a release notes update needed for this change?**: no

**Additional documentation**: none
