### PR TITLE
Don't push images with buildx we haven't build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1146,6 +1146,8 @@
                                     <name>${app.image}</name>
                                     <build>
                                         <skip>${app.skipBuild}</skip>
+                                        <skipPush>${app.skipBuild}</skipPush>
+                                        <skipTag>${app.skipBuild}</skipTag>
                                         <buildx>
                                             <platforms>
                                                 <platform>${docker.platforms}</platform>
@@ -1178,6 +1180,8 @@
                                     <name>${conf.image}</name>
                                     <build>
                                         <skip>${conf.skipBuild}</skip>
+                                        <skipPush>${conf.skipBuild}</skipPush>
+                                        <skipTag>${conf.skipBuild}</skipTag>
                                         <buildx>
                                             <platforms>
                                                 <platform>${docker.platforms}</platform>


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixing #11477 last step of pushing images to the Hub. This could not be tested before without messing up Docker Hub images.

**Which issue(s) this PR closes**:

- Closes #11477 

**Special notes for your reviewer**:
Sorry for not catching this earlier - I though skipping the build was enough and would also skip the pushing. Apparently it doesn't.

**Suggestions on how to test this**:
Merge, then run the maintenance workflow manually, including the force option.

