### PR TITLE
fix: don't store duplicates in subtreePaths

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/search/IndexServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/search/IndexServiceBean.java
@@ -2104,7 +2104,7 @@ public class IndexServiceBean {
         } catch (Exception ex) {
             logger.info("failed to find dataverseSegments for dataversePaths for " + SearchFields.SUBTREE + ": " + ex);
         }        
-        List<String> dataversePaths = getDataversePathsFromSegments(dataverseSegments);
+        Set<String> dataversePaths = new HashSet<>(getDataversePathsFromSegments(dataverseSegments));
         if (dataversePaths.size() > 0 && dvo.isInstanceofDataverse()) {
             // removing the dataverse's own id from the paths
             // fixes bug where if my parent dv was linked my dv was shown as linked to myself
@@ -2114,7 +2114,7 @@ public class IndexServiceBean {
         add linking paths
         */
         dataversePaths.addAll(findLinkingDataversePaths(findAllLinkingDataverses(dvo)));
-        return dataversePaths;
+        return new ArrayList<>(dataversePaths);
     }
 
     public String delete(Dataverse doomed) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the issue described in #11568.

**Which issue(s) this PR closes**:

- Closes #11568 

**Special notes for your reviewer**:

/

**Suggestions on how to test this**:

1. Create + publish dataverse
2. Create + publish dataset in that dataverse
3. Create + publish child dataverse (inside dataverse from step 1)
4. Link dataset from step 2 into child dataverse from step 3
5. Check dataset in Solr and see no duplicate entries in `subtreePaths`:

```
      "subtreePaths":["/2","/4","/2/5"],
```

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

/

**Is there a release notes update needed for this change?**:

Maybe not.

**Additional documentation**:

/