### PR TITLE
fix: work around breaking json-ld export by incomplete html tags in file descriptions

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DatasetVersion.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetVersion.java
@@ -2133,7 +2133,7 @@ public class DatasetVersion implements Serializable {
                 fileObject.add("name", fileMetadata.getLabel());
                 fileObject.add("encodingFormat", fileMetadata.getDataFile().getContentType());
                 fileObject.add("contentSize", fileMetadata.getDataFile().getFilesize());
-                fileObject.add("description", fileMetadata.getDescription());
+                fileObject.add("description", MarkupChecker.stripAllTags(fileMetadata.getDescription()));
                 fileObject.add("@id", filePidUrlAsString);
                 fileObject.add("identifier", filePidUrlAsString);
                 boolean hideFilesBoolean = JvmSettings.HIDE_SCHEMA_DOT_ORG_DOWNLOAD_URLS.lookupOptional(Boolean.class).orElse(false);


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently incomplete HTML tags or similar string (e.g. `<img`, `<CSP` not the missing `>`) will cause a truncation of the json-ld string for published datasets. Such datasets cannot be rendered anymore and lead to a server-side 500 error.

**Which issue(s) this PR closes**:

- Closes #11597 

**Special notes for your reviewer**:

This does **not** fix the string sanitation itself. The issue probably lies within `Jsoup.clean` and hence upstream. What is does though is sanitizing the description field first (which still is truncated). This potentially truncated description then does not impact the stripping of tags from the whole json-ld string.

The proper/sane way to do this would probably be to make sure all user-provided fields are individually stripped of (harmful) html tags before the json-ld is constructed. The sanitation of the final json-ld string could then be safely ommited.

**Suggestions on how to test this**:

1. Create a dataset with a file attachment and add a description to this file containing e.g. `<CSP` (note the missing `>`). 
2. Publish the dataset
3. Try to view the dataset or export metadata as JSON-LD. Note: In the docker-based dev environment this failed silently for me: The dataset view worked, however the json-ld export returned an empty page.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

N/A

**Is there a release notes update needed for this change?**:

Probably not.

**Additional documentation**:
