### PR TITLE
Include isAdvancedSearchFieldType property

### DIFF
--- a/doc/release-notes/11614-include-isAdvancedSeachField-property.md
+++ b/doc/release-notes/11614-include-isAdvancedSeachField-property.md
@@ -1,0 +1,3 @@
+The API endpoints `api/{dataverse-alias}/metadatablocks` and `/api/metadatablocks/{block_id}` have been extended to include the following field:
+
+- `isAdvancedSearchFieldType`: Wheter the field can be used in advanced search or not.

--- a/doc/release-notes/11614-include-isAdvancedSeachField-property.md
+++ b/doc/release-notes/11614-include-isAdvancedSeachField-property.md
@@ -1,3 +1,3 @@
 The API endpoints `api/{dataverse-alias}/metadatablocks` and `/api/metadatablocks/{block_id}` have been extended to include the following field:
 
-- `isAdvancedSearchFieldType`: Wheter the field can be used in advanced search or not.
+- `isAdvancedSearchFieldType`: Whether the field can be used in advanced search or not.

--- a/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
@@ -755,6 +755,7 @@ public class JsonPrinter {
         fieldsBld.add("description", fld.getDescription());
         fieldsBld.add("multiple", fld.isAllowMultiples());
         fieldsBld.add("isControlledVocabulary", fld.isControlledVocabulary());
+        fieldsBld.add("isAdvancedSearchFieldType", fld.isAdvancedSearchFieldType());
         fieldsBld.add("displayFormat", fld.getDisplayFormat());
         fieldsBld.add("displayOrder", fld.getDisplayOrder());
 

--- a/src/test/java/edu/harvard/iq/dataverse/api/MetadataBlocksIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/MetadataBlocksIT.java
@@ -75,7 +75,8 @@ public class MetadataBlocksIT {
                 .body("data.fields.subject.controlledVocabularyValues[0]", CoreMatchers.is("Agricultural Sciences"))
                 .body("data.fields.title.displayOrder", CoreMatchers.is(0))
                 .body("data.fields.title.typeClass", CoreMatchers.is("primitive"))
-                .body("data.fields.title.isRequired", CoreMatchers.is(true));
+                .body("data.fields.title.isRequired", CoreMatchers.is(true))
+                .body("data.fields.title.isAdvancedSearchFieldType", CoreMatchers.is(true));
     }
 
     @Test


### PR DESCRIPTION
**What this PR does / why we need it**:
Includes the `isAdvancedSearchFieldType` in the JSON response from the API endpoints `api/{dataverse-alias}/metadatablocks` and `/api/metadatablocks/{block_id}`

**Which issue(s) this PR closes**:

- Closes #11614 

**Suggestions on how to test this**:
The new property has been added to the existing test.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
No

**Is there a release notes update needed for this change?**:
Yes. Attached.
