### PR TITLE
Fix Cache test failure

### DIFF
--- a/src/test/java/edu/harvard/iq/dataverse/util/cache/CacheFactoryBeanTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/util/cache/CacheFactoryBeanTest.java
@@ -121,6 +121,7 @@ public class CacheFactoryBeanTest {
         Hazelcast.shutdownAll();
     }
     @Test
+    @ResourceLock(value = "cache")
     public void testGuestUserGettingRateLimited() {
         Command action = new ListDataverseContentCommand(null,null);
         boolean rateLimited = false;
@@ -137,6 +138,7 @@ public class CacheFactoryBeanTest {
     }
 
     @Test
+    @ResourceLock(value = "cache")
     public void testAdminUserExemptFromGettingRateLimited() {
         Command action = new ListExplicitGroupsCommand(null,null);
         authUser.setSuperuser(true);


### PR DESCRIPTION
**What this PR does / why we need it**: I just saw the following error on #11619, which doesn't affect the cache:
`CacheFactoryBeanTest.testAuthenticatedUserGettingRateLimited:171 expected: <120> but was: <122>`
This PR should fix that by avoiding parallel execution with other tests that can affect the cache.

**Which issue(s) this PR closes**:

- Closes #

**Special notes for your reviewer**: Looking at the test, I see I had earlier added an @ResourceLock("cache") annotation on the test that just failed, but I failed to add the same annotation to the other tests that use the cache. It looks like all three tests need it to avoid the potential test fail.

**Suggestions on how to test this**: Verify that the CacheFactoryBeanTests succeed.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
