### PR TITLE
added ISSN-L as an alternative value for lissn

### DIFF
--- a/scripts/api/data/metadatablocks/citation.tsv
+++ b/scripts/api/data/metadatablocks/citation.tsv
@@ -107,7 +107,7 @@
 	publicationIDType	isbn		8											
 	publicationIDType	issn		9											
 	publicationIDType	istc		10											
-	publicationIDType	lissn		11											
+	publicationIDType	lissn		11	ISSN-L										
 	publicationIDType	lsid		12											
 	publicationIDType	pmid		13											
 	publicationIDType	purl		14											


### PR DESCRIPTION
**What this PR does / why we need it**:
Following incertainties on the identifier behind "lissn" (cf. [Zulip topic ](https://dataverse.zulipchat.com/#narrow/channel/375707-community/topic/publication.20ID.20Type.20.22lissn.22/with/527139071)), adding an alternative value "ISSN-L" to lissn for future reference.

**Special notes for your reviewer**:
Similar to other alternative values additions to the tsv file, e.g. https://github.com/IQSS/dataverse/pull/8689

**Is there a release notes update needed for this change?**:
No
