### PR TITLE
bump to 6.7 and update base.image.version

### DIFF
--- a/doc/sphinx-guides/source/conf.py
+++ b/doc/sphinx-guides/source/conf.py
@@ -70,7 +70,7 @@ copyright = u'%d, The President & Fellows of Harvard College' % datetime.now().y
 # built documents.
 #
 # The short X.Y version.
-version = '6.6'
+version = '6.7'
 # The full version, including alpha/beta/rc tags.
 release = version
 

--- a/doc/sphinx-guides/source/versions.rst
+++ b/doc/sphinx-guides/source/versions.rst
@@ -8,6 +8,7 @@ This list provides a way to refer to the documentation for previous and future v
 
 - pre-release `HTML (not final!) <http://preview.guides.gdcc.io/en/develop/>`__ and `PDF (experimental!) <http://preview.guides.gdcc.io/_/downloads/en/develop/pdf/>`__ built from the :doc:`develop </developers/version-control>` branch :doc:`(how to contribute!) </contributor/documentation>`
 - |version|
+- `6.6 </en/6.6/>`__
 - `6.5 </en/6.5/>`__
 - `6.4 </en/6.4/>`__
 - `6.3 </en/6.3/>`__

--- a/modules/dataverse-parent/pom.xml
+++ b/modules/dataverse-parent/pom.xml
@@ -132,7 +132,7 @@
  
     <properties>
         <!-- This is a special Maven property name, do not change! -->
-        <revision>6.6</revision>
+        <revision>6.7</revision>
     
         <target.java.version>17</target.java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -454,8 +454,8 @@
                     Once the release has been made (tag created), change this back to "${parsedVersion.majorVersion}.${parsedVersion.nextMinorVersion}"
                     (These properties are provided by the build-helper plugin below.)
                 -->
-                <base.image.version>${parsedVersion.majorVersion}.${parsedVersion.nextMinorVersion}</base.image.version>
-                <!--<base.image.version>${revision}</base.image.version>-->
+                <!--<base.image.version>${parsedVersion.majorVersion}.${parsedVersion.nextMinorVersion}</base.image.version>-->
+                <base.image.version>${revision}</base.image.version>
                 <!-- This is used by the maintenance CI jobs, no need to adapt during releases. -->
                 <app.image.version>${base.image.version}</app.image.version>
             </properties>


### PR DESCRIPTION
**What this PR does / why we need it**:

Our normal "bump the version" PR.

**Which issue(s) this PR closes**:

None, but this is the first step of the following issue:

- #11371

**Special notes for your reviewer**:

As a reminder, the base.image.version change in this PR is a necessary step for Docker, documented at https://guides.dataverse.org/en/6.6/developers/making-releases.html#prepare-release-branch . Just after we release, we'll switch it back (as usual) in this step: https://guides.dataverse.org/en/6.6/developers/making-releases.html#update-the-container-base-image-version-property . This is nothing brand new. We've done this for the last few releases. We definitely want to get these steps right because we want 6.7 to have tagged version on DockerHub (for the first time!).

The process for bumping Sphinx has changed slightly. @poikilotherm simplified things for us recently (thanks!), somewhere in #11477.