### PR TITLE
Database Options: idempotent mass operations and necessary cleanup

### DIFF
--- a/doc/sphinx-guides/source/api/native-api.rst
+++ b/doc/sphinx-guides/source/api/native-api.rst
@@ -5299,13 +5299,13 @@ Builtin users are known as "Username/Email and Password" users in the :doc:`/use
 Create a Builtin User
 ~~~~~~~~~~~~~~~~~~~~~
 
-For security reasons, builtin users cannot be created via API unless the team who runs the Dataverse installation has populated a database setting called ``BuiltinUsers.KEY``, which is described under :ref:`securing-your-installation` and :ref:`database-settings` sections of Configuration in the Installation Guide. You will need to know the value of ``BuiltinUsers.KEY`` before you can proceed.
+For security reasons, builtin users cannot be created via API unless the team who runs the Dataverse installation has populated a database setting called ``:BuiltinUsersKey``, which is described under :ref:`securing-your-installation` and :ref:`database-settings` sections of Configuration in the Installation Guide. You will need to know the value of ``:BuiltinUsersKey`` before you can proceed.
 
 To create a builtin user via API, you must first construct a JSON document.  You can download :download:`user-add.json <../_static/api/user-add.json>` or copy the text below as a starting point and edit as necessary.
 
 .. literalinclude:: ../_static/api/user-add.json
 
-Place this ``user-add.json`` file in your current directory and run the following curl command, substituting variables as necessary. Note that both the password of the new user and the value of ``BuiltinUsers.KEY`` are passed as query parameters::
+Place this ``user-add.json`` file in your current directory and run the following curl command, substituting variables as necessary. Note that both the password of the new user and the value of ``:BuiltinUsersKey`` are passed as query parameters::
 
   curl -d @user-add.json -H "Content-type:application/json" "$SERVER_URL/api/builtin-users?password=$NEWUSER_PASSWORD&key=$BUILTIN_USERS_KEY"
 

--- a/doc/sphinx-guides/source/developers/testing.rst
+++ b/doc/sphinx-guides/source/developers/testing.rst
@@ -209,7 +209,7 @@ The Burrito Key
 
 For reasons that have been lost to the mists of time, the Dataverse software really wants you to to have a burrito. Specifically, if you're trying to run REST Assured tests and see the error "Dataverse config issue: No API key defined for built in user management", you must run the following curl command (or make an equivalent change to your database):
 
-``curl -X PUT -d 'burrito' http://localhost:8080/api/admin/settings/BuiltinUsers.KEY``
+``curl -X PUT -d 'burrito' http://localhost:8080/api/admin/settings/:BuiltinUsersKey``
 
 Without this "burrito" key in place, REST Assured will not be able to create users. We create users to create objects we want to test, such as collections, datasets, and files.
 

--- a/doc/sphinx-guides/source/installation/config.rst
+++ b/doc/sphinx-guides/source/installation/config.rst
@@ -25,7 +25,7 @@ The default password for the "dataverseAdmin" superuser account is "admin", as m
 Blocking API Endpoints
 ++++++++++++++++++++++
 
-The :doc:`/api/native-api` contains a useful but potentially dangerous set of API endpoints called "admin" that allows you to change system settings, make ordinary users into superusers, and more. The "builtin-users" endpoints let admins do tasks such as creating a local/builtin user account if they know the key defined in :ref:`BuiltinUsers.KEY`.
+The :doc:`/api/native-api` contains a useful but potentially dangerous set of API endpoints called "admin" that allows you to change system settings, make ordinary users into superusers, and more. The "builtin-users" endpoints let admins do tasks such as creating a local/builtin user account if they know the key defined in :ref:`:BuiltinUsersKey`.
 
 By default in the code, most of these API endpoints can be operated on remotely and a number of endpoints do not require authentication. However, the endpoints "admin" and "builtin-users" are limited to localhost out of the box by the installer, using the JvmSettings :ref:`dataverse.api.blocked.endpoints` and :ref:`dataverse.api.blocked.policy`.
 
@@ -779,7 +779,7 @@ Both Local and Remote Auth
 
 The ``authenticationproviderrow`` database table controls which "authentication providers" are available within a Dataverse installation. Out of the box, a single row with an id of "builtin" will be present. For each user in a Dataverse installation, the ``authenticateduserlookup`` table will have a value under ``authenticationproviderid`` that matches this id. For example, the default "dataverseAdmin" user will have the value "builtin" under  ``authenticationproviderid``. Why is this important? Users are tied to a specific authentication provider but conversion mechanisms are available to switch a user from one authentication provider to the other. As explained in the :doc:`/user/account` section of the User Guide, a graphical workflow is provided for end users to convert from the "builtin" authentication provider to a remote provider. Conversion from a remote authentication provider to the builtin provider can be performed by a sysadmin with access to the "admin" API. See the :doc:`/api/native-api` section of the API Guide for how to list users and authentication providers as JSON.
 
-Adding and enabling a second authentication provider (:ref:`native-api-add-auth-provider` and :ref:`api-toggle-auth-provider`) will result in the Log In page showing additional providers for your users to choose from. By default, the Log In page will show the "builtin" provider, but you can adjust this via the :ref:`conf-default-auth-provider` configuration option. Further customization can be achieved by setting :ref:`conf-allow-signup` to "false", thus preventing users from creating local accounts via the web interface. Please note that local accounts can also be created through the API by enabling the ``builtin-users`` endpoint (:ref:`:BlockedApiEndpoints`) and setting the ``BuiltinUsers.KEY`` database setting (:ref:`BuiltinUsers.KEY`).
+Adding and enabling a second authentication provider (:ref:`native-api-add-auth-provider` and :ref:`api-toggle-auth-provider`) will result in the Log In page showing additional providers for your users to choose from. By default, the Log In page will show the "builtin" provider, but you can adjust this via the :ref:`conf-default-auth-provider` configuration option. Further customization can be achieved by setting :ref:`conf-allow-signup` to "false", thus preventing users from creating local accounts via the web interface. Please note that local accounts can also be created through the API by enabling the ``builtin-users`` endpoint (:ref:`:BlockedApiEndpoints`) and setting the ``:BuiltinUsersKey`` database setting (:ref:`:BuiltinUsersKey`).
 
 To configure Shibboleth see the :doc:`shibboleth` section and to configure OAuth see the :doc:`oauth2` section.
 
@@ -3878,14 +3878,16 @@ Now that ``:BlockedApiKey`` has been enabled, blocked APIs can be accessed using
 
 ``curl https://demo.dataverse.org/api/admin/settings?unblock-key=theKeyYouChose``
 
-.. _BuiltinUsers.KEY:
+.. _:BuiltinUsersKey:
 
-BuiltinUsers.KEY
+:BuiltinUsersKey
 ++++++++++++++++
 
 The key required to create users via API as documented at :doc:`/api/native-api`. Unlike other database settings, this one doesn't start with a colon.
 
-``curl -X PUT -d builtInS3kretKey http://localhost:8080/api/admin/settings/BuiltinUsers.KEY``
+``curl -X PUT -d builtInS3kretKey http://localhost:8080/api/admin/settings/:BuiltinUsersKey``
+
+Note: this key used to be named ``BuiltinUsers.KEY`` until Dataverse 6.8.
 
 :SearchApiRequiresToken
 +++++++++++++++++++++++

--- a/doc/sphinx-guides/source/installation/config.rst
+++ b/doc/sphinx-guides/source/installation/config.rst
@@ -4318,30 +4318,45 @@ In the UI, users trying to download a zip file larger than the Dataverse install
 :TabularIngestSizeLimit
 +++++++++++++++++++++++
 
-Threshold in bytes for limiting whether or not "ingest" it attempted for tabular files (which can be resource intensive). For example, with the below in place, files greater than 2 GB in size will not go through the ingest process:
+Threshold in bytes for limiting whether or not "ingest" is attempted for an uploaded tabular file (which can be resource intensive).
+For example, with the below in place, files greater than 2 GB in size will not go through the ingest process:
 
 ``curl -X PUT -d 2000000000 http://localhost:8080/api/admin/settings/:TabularIngestSizeLimit``
 
-(You can set this value to 0 to prevent files from being ingested at all.)
+You can set this value to ``0`` to prevent files from being ingested at all.
+The default is ``-1``, meaning no file size limit is applied.
 
-You can override this global setting on a per-format basis for the following formats:
+Using a JSON-based setting, you can override this global setting on a per-format basis for the following formats:
 
 - DTA
 - POR
 - SAV
 - Rdata
 - CSV
-- XLSX (in lower-case)
+- XLSX
 
-For example :
+The JSON follows this form, all fields optional:
 
-* if you want your Dataverse installation to not attempt to ingest Rdata files larger than 1 MB, use this setting:
+.. code:: json
 
-``curl -X PUT -d 1000000 http://localhost:8080/api/admin/settings/:TabularIngestSizeLimit:Rdata``
+  {
+    "default": -1,
+    "formatX": 0,
+    "formatY": 10,
+    "formatZ": 100
+  }
 
-* if you want your Dataverse installation to not attempt to ingest XLSX files at all, use this setting:
+The ``default`` key represents the global default, with it being absent meaning the global default of ``-1`` applies.
+Add a format name (as listed above) to change the limit for this particular format.
 
-``curl -X PUT -d 0 http://localhost:8080/api/admin/settings/:TabularIngestSizeLimit:xlsx``
+Examples:
+
+1. If you want your Dataverse installation to not attempt to ingest Rdata files larger than 1 MB but otherwise unlimited:
+
+   ``curl -X PUT -d '{"Rdata":1000000}' http://localhost:8080/api/admin/settings/:TabularIngestSizeLimit``
+2. If you want your Dataverse installation to not attempt to ingest XLSX files at all and apply a global limit of 512 MiB, use this setting:
+
+   ``curl -X PUT -d '{"default":536870912, "XSLX":0}' http://localhost:8080/api/admin/settings/:TabularIngestSizeLimit``
 
 :ZipUploadFilesLimit
 ++++++++++++++++++++

--- a/doc/sphinx-guides/source/installation/config.rst
+++ b/doc/sphinx-guides/source/installation/config.rst
@@ -4340,23 +4340,24 @@ The JSON follows this form, all fields optional:
 .. code:: json
 
   {
-    "default": -1,
-    "formatX": 0,
-    "formatY": 10,
-    "formatZ": 100
+    "default": "-1",
+    "formatX": "0",
+    "formatY": "10",
+    "formatZ": "100"
   }
 
-The ``default`` key represents the global default, with it being absent meaning the global default of ``-1`` applies.
+The ``default`` key represents the global default (with it being absent meaning the implicit global default of ``-1`` applies).
 Add a format name (as listed above) to change the limit for this particular format.
+Any size limits must be provided as string literals (in quotes), not number literals!
 
 Examples:
 
 1. If you want your Dataverse installation to not attempt to ingest Rdata files larger than 1 MB but otherwise unlimited:
 
-   ``curl -X PUT -d '{"Rdata":1000000}' http://localhost:8080/api/admin/settings/:TabularIngestSizeLimit``
+   ``curl -X PUT -d '{"Rdata":"1000000"}' http://localhost:8080/api/admin/settings/:TabularIngestSizeLimit``
 2. If you want your Dataverse installation to not attempt to ingest XLSX files at all and apply a global limit of 512 MiB, use this setting:
 
-   ``curl -X PUT -d '{"default":536870912, "XSLX":0}' http://localhost:8080/api/admin/settings/:TabularIngestSizeLimit``
+   ``curl -X PUT -d '{"default":"536870912", "XSLX":"0"}' http://localhost:8080/api/admin/settings/:TabularIngestSizeLimit``
 
 :ZipUploadFilesLimit
 ++++++++++++++++++++

--- a/modules/container-configbaker/scripts/bootstrap/demo/init.sh
+++ b/modules/container-configbaker/scripts/bootstrap/demo/init.sh
@@ -31,7 +31,7 @@ fi
 
 echo ""
 echo "Revoke the key that allows for creation of builtin users..."
-curl -sS -X DELETE "${DATAVERSE_URL}/api/admin/settings/BuiltinUsers.KEY"
+curl -sS -X DELETE "${DATAVERSE_URL}/api/admin/settings/:BuiltinUsersKey"
 
 # TODO: stop using these deprecated database settings. See https://github.com/IQSS/dataverse/pull/11454
 echo ""

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,8 @@
         <skipUnitTests>false</skipUnitTests>
         <skipIntegrationTests>false</skipIntegrationTests>
         <it.groups>integration</it.groups>
+        <surefire.jacoco.args></surefire.jacoco.args>
+        <failsafe.jacoco.args></failsafe.jacoco.args>
         
         <!-- By default, this module will produce a WAR file. -->
         <!-- This will be switched within the container profile! -->

--- a/scripts/api/post-install-api-block.sh
+++ b/scripts/api/post-install-api-block.sh
@@ -4,7 +4,7 @@
 # the sensitive API endpoints, in order to block it for the general public.
 
 # First, revoke the authentication token from the built-in user: 
-curl -X DELETE $SERVER/admin/settings/BuiltinUsers.KEY
+curl -X DELETE "$SERVER/admin/settings/:BuiltinUsersKey"
 
 # Block the sensitive endpoints:
 # Relevant settings:

--- a/scripts/api/setup-all.sh
+++ b/scripts/api/setup-all.sh
@@ -57,7 +57,7 @@ echo  "- Allow internal signup"
 curl -X PUT -d yes "${DATAVERSE_URL}/api/admin/settings/:AllowSignUp"
 curl -X PUT -d "/dataverseuser.xhtml?editMode=CREATE" "${DATAVERSE_URL}/api/admin/settings/:SignUpUrl"
 
-curl -X PUT -d burrito "${DATAVERSE_URL}/api/admin/settings/BuiltinUsers.KEY"
+curl -X PUT -d burrito "${DATAVERSE_URL}/api/admin/settings/:BuiltinUsersKey"
 curl -X PUT -d localhost-only "${DATAVERSE_URL}/api/admin/settings/:BlockedApiPolicy"
 curl -X PUT -d 'native/http' "${DATAVERSE_URL}/api/admin/settings/:UploadMethods"
 echo
@@ -91,7 +91,7 @@ if [ $SECURESETUP = 1 ]
 then
     # Revoke the "burrito" super-key; 
     # Block sensitive API endpoints;
-    curl -X DELETE "${DATAVERSE_URL}/api/admin/settings/BuiltinUsers.KEY"
+    curl -X DELETE "${DATAVERSE_URL}/api/admin/settings/:BuiltinUsersKey"
     curl -X PUT -d 'admin,builtin-users' "${DATAVERSE_URL}/api/admin/settings/:BlockedApiEndpoints"
     echo "Access to the /api/admin and /api/test is now disabled, except for connections from localhost."
 else 

--- a/scripts/api/setup-users.sh
+++ b/scripts/api/setup-users.sh
@@ -5,7 +5,7 @@ SERVER=http://localhost:8080/api
 echo Setting up users on $SERVER
 echo ==============================================
 
-curl -X PUT -d burrito $SERVER/admin/settings/BuiltinUsers.KEY
+curl -X PUT -d burrito "$SERVER/admin/settings/:BuiltinUsersKey"
 
 
 peteResp=$(curl -s -H "Content-type:application/json" -X POST -d @data/userPete.json "$SERVER/builtin-users?password=pete&key=burrito")

--- a/scripts/issues/2454/run-test.sh
+++ b/scripts/issues/2454/run-test.sh
@@ -39,7 +39,7 @@ if [ $SETUP_NEEDED == "yes" ]; then
 	echo $ROOT_USER api key is $ROOT_KEY
 
 	# Create @anAuthUser
-	USER_CREATION_KEY=$($DB "SELECT content FROM setting WHERE name='BuiltinUsers.KEY'")
+	USER_CREATION_KEY=$($DB "SELECT content FROM setting WHERE name=':BuiltinUsersKey'")
 	AN_AUTH_USER_KEY=$( curl -s -X POST -d@anAuthUser.json -H"Content-type:application/json" $ENDPOINT/builtin-users?password=XXX\&key=$USER_CREATION_KEY | jq .data.apiToken | tr -d \")
 	ANOTHER_AUTH_USER_KEY=$( curl -s -X POST -d@anotherAuthUser.json -H"Content-type:application/json" $ENDPOINT/builtin-users?password=XXX\&key=$USER_CREATION_KEY | jq .data.apiToken | tr -d \")
 	echo

--- a/src/main/java/edu/harvard/iq/dataverse/EditDatafilesPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/EditDatafilesPage.java
@@ -383,7 +383,7 @@ public class EditDatafilesPage implements java.io.Serializable {
     public String populateHumanPerFormatTabularLimits() {
         String keyPrefix = ":TabularIngestSizeLimit:";
         List<String> formatLimits = new ArrayList<>();
-        for (Setting setting : settingsService.listAll()) {
+        for (Setting setting : settingsService.listAllWithoutLocalizations()) {
             String name = setting.getName();
             if (!name.startsWith(keyPrefix)) {
                 continue;

--- a/src/main/java/edu/harvard/iq/dataverse/EditDatafilesPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/EditDatafilesPage.java
@@ -81,6 +81,8 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Set;
 import java.util.logging.Level;
+import java.util.stream.Collectors;
+
 import jakarta.faces.event.AjaxBehaviorEvent;
 import jakarta.faces.event.FacesEvent;
 import jakarta.servlet.ServletOutputStream;
@@ -381,19 +383,11 @@ public class EditDatafilesPage implements java.io.Serializable {
     }
 
     public String populateHumanPerFormatTabularLimits() {
-        String keyPrefix = ":TabularIngestSizeLimit:";
-        List<String> formatLimits = new ArrayList<>();
-        for (Setting setting : settingsService.listAllWithoutLocalizations()) {
-            String name = setting.getName();
-            if (!name.startsWith(keyPrefix)) {
-                continue;
-            }
-            String tabularName = setting.getName().substring(keyPrefix.length());
-            String bytes = setting.getContent();
-            String humanReadableSize = FileSizeChecker.bytesToHumanReadable(Long.valueOf(bytes));
-            formatLimits.add(tabularName + ": " + humanReadableSize);
-        }
-        return String.join(", ", formatLimits);
+        return systemConfig.getTabularIngestSizeLimits().entrySet().stream()
+            // The human-readable list shall not contain the setting for non-matching formats
+            .filter(entry -> ! entry.getKey().equals(SystemConfig.TABULAR_INGEST_SIZE_LIMITS_DEFAULT_KEY))
+            .map(entry -> entry.getKey() + ": " + FileSizeChecker.bytesToHumanReadable(entry.getValue()))
+            .collect(Collectors.joining(", "));
     }
 
     public Integer getFileUploadsAvailable() {

--- a/src/main/java/edu/harvard/iq/dataverse/SettingsWrapper.java
+++ b/src/main/java/edu/harvard/iq/dataverse/SettingsWrapper.java
@@ -218,7 +218,7 @@ public class SettingsWrapper implements java.io.Serializable {
     private void initSettingsMap() {
         // initialize settings map
         settingsMap = new HashMap<>();
-        for (Setting setting : settingsService.listAll()) {
+        for (Setting setting : settingsService.listAllWithoutLocalizations()) {
             settingsMap.put(setting.getName(), setting.getContent());
         }
     }

--- a/src/main/java/edu/harvard/iq/dataverse/api/Admin.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Admin.java
@@ -226,8 +226,8 @@ public class Admin extends AbstractApiBean {
             }
             
             // Transfer to domain objects and deeper validation to be handled by the service layer.
-            settingsSvc.setAllFromJson(settings);
-            return ok("All database options successfully updated.");
+            JsonObjectBuilder successfullOperations = settingsSvc.setAllFromJson(settings);
+            return ok("All database options successfully updated.", successfullOperations);
             
         } catch (IllegalArgumentException iae) {
             return error(Response.Status.BAD_REQUEST, iae.getMessage());

--- a/src/main/java/edu/harvard/iq/dataverse/api/Admin.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Admin.java
@@ -198,7 +198,7 @@ public class Admin extends AbstractApiBean {
     @GET
     public Response listAllSettings() {
         JsonObjectBuilder bld = jsonObjectBuilder();
-        settingsSvc.listAll().forEach(s -> bld.add(s.getName(), s.getContent()));
+        settingsSvc.listAllWithoutLocalizations().forEach(s -> bld.add(s.getName(), s.getContent()));
         return ok(bld);
     }
 

--- a/src/main/java/edu/harvard/iq/dataverse/api/Admin.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Admin.java
@@ -132,6 +132,11 @@ import jakarta.persistence.Query;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.StreamingOutput;
+import org.eclipse.microprofile.openapi.annotations.media.Content;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
+
 import java.nio.file.Paths;
 import java.util.TreeMap;
 
@@ -193,13 +198,17 @@ public class Admin extends AbstractApiBean {
 
     public static final String listUsersPartialAPIPath = "list-users";
     public static final String listUsersFullAPIPath = "/api/admin/" + listUsersPartialAPIPath;
-
+    
     @Path("settings")
     @GET
+    @APIResponses({
+        @APIResponse(responseCode = "200",
+            description = "All database options successfully queried",
+            // The schema may be extended later to better describe what the JSON object looks like.
+            content = @Content(schema = @Schema(implementation = JsonObject.class))),
+    })
     public Response listAllSettings() {
-        JsonObjectBuilder bld = jsonObjectBuilder();
-        settingsSvc.listAllWithoutLocalizations().forEach(s -> bld.add(s.getName(), s.getContent()));
-        return ok(bld);
+        return ok(settingsSvc.listAllAsJson());
     }
 
     @Path("settings/{name}")

--- a/src/main/java/edu/harvard/iq/dataverse/api/Admin.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Admin.java
@@ -70,7 +70,6 @@ import java.io.InputStream;
 import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.function.Predicate;
@@ -212,28 +211,11 @@ public class Admin extends AbstractApiBean {
         return ok(settingsSvc.listAllAsJson());
     }
     
-    private void validateSettingName(String name) throws IllegalArgumentException {
-        if (SettingsServiceBean.Key.parse(name) == null) {
-            // If there is more than one colon, this may be someone trying to use the old suffix settings.
-            // Change the error message for that slightly.
-            if (name.replace(":","").length() < name.length() - 1) {
-                throw new IllegalArgumentException("The name of the setting may not have a colon separated suffix since Dataverse 6.8. Please update your scripts.");
-            }
-            throw new IllegalArgumentException("The name of the setting is required.");
-        }
-    }
-    
-    private void validateSettingLang(String lang) throws IllegalArgumentException {
-        if (lang == null || lang.length() != 2 || !Arrays.asList(Locale.getISOLanguages()).contains(lang)) {
-            throw new IllegalArgumentException("The language '" + lang + "' is not a valid ISO 639-1 language code.");
-        }
-    }
-
     @Path("settings/{name}")
     @PUT
     public Response putSetting(@PathParam("name") String name, String content) {
         try {
-            validateSettingName(name);
+            SettingsServiceBean.validateSettingName(name);
             
             Setting s = settingsSvc.set(name, content);
             return ok("Setting " + name + " added.");
@@ -246,8 +228,8 @@ public class Admin extends AbstractApiBean {
     @PUT
     public Response putSettingLang(@PathParam("name") String name, @PathParam("lang") String lang, String content) {
         try {
-            validateSettingName(name);
-            validateSettingLang(lang);
+            SettingsServiceBean.validateSettingName(name);
+            SettingsServiceBean.validateSettingLang(lang);
             
             Setting s = settingsSvc.set(name, lang, content);
             return ok("Setting " + name + " added for language " + lang + ".");
@@ -260,7 +242,7 @@ public class Admin extends AbstractApiBean {
     @GET
     public Response getSetting(@PathParam("name") String name) {
         try {
-            validateSettingName(name);
+            SettingsServiceBean.validateSettingName(name);
             
             String content = settingsSvc.get(name);
             return (content != null) ? ok(content) : notFound("Setting " + name + " not found.");
@@ -273,8 +255,8 @@ public class Admin extends AbstractApiBean {
     @GET
     public Response getSetting(@PathParam("name") String name, @PathParam("lang") String lang) {
         try {
-            validateSettingName(name);
-            validateSettingLang(lang);
+            SettingsServiceBean.validateSettingName(name);
+            SettingsServiceBean.validateSettingLang(lang);
             
             String content = settingsSvc.get(name, lang);
             return (content != null) ? ok(content) : notFound("Setting " + name + " for language " + lang + " not found.");
@@ -287,7 +269,7 @@ public class Admin extends AbstractApiBean {
     @DELETE
     public Response deleteSetting(@PathParam("name") String name) {
         try {
-            validateSettingName(name);
+            SettingsServiceBean.validateSettingName(name);
             
             settingsSvc.delete(name);
             return ok("Setting " + name + " deleted.");
@@ -300,8 +282,8 @@ public class Admin extends AbstractApiBean {
     @DELETE
     public Response deleteSettingLang(@PathParam("name") String name, @PathParam("lang") String lang) {
         try {
-            validateSettingName(name);
-            validateSettingLang(lang);
+            SettingsServiceBean.validateSettingName(name);
+            SettingsServiceBean.validateSettingLang(lang);
             
             settingsSvc.delete(name, lang);
             return ok("Setting " + name + " for language " + lang + " deleted.");

--- a/src/main/java/edu/harvard/iq/dataverse/api/Admin.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Admin.java
@@ -63,6 +63,7 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import static edu.harvard.iq.dataverse.util.json.NullSafeJsonBuilder.jsonObjectBuilder;
 
@@ -209,6 +210,28 @@ public class Admin extends AbstractApiBean {
     })
     public Response listAllSettings() {
         return ok(settingsSvc.listAllAsJson());
+    }
+    
+    @Path("settings")
+    @PUT
+    @Consumes(MediaType.APPLICATION_JSON)
+    @APIResponses({
+        @APIResponse(responseCode = "200", description = "All database options successfully updated")
+    })
+    public Response putAllSettings(JsonObject settings) {
+        try {
+            // Basic JSON structure validation only
+            if (settings == null || settings.isEmpty()) {
+                return error(Response.Status.BAD_REQUEST, "Empty or invalid JSON object");
+            }
+            
+            // Transfer to domain objects and deeper validation to be handled by the service layer.
+            settingsSvc.setAllFromJson(settings);
+            return ok("All database options successfully updated.");
+            
+        } catch (IllegalArgumentException iae) {
+            return error(Response.Status.BAD_REQUEST, iae.getMessage());
+        }
     }
     
     @Path("settings/{name}")

--- a/src/main/java/edu/harvard/iq/dataverse/api/BuiltinUsers.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/BuiltinUsers.java
@@ -40,8 +40,6 @@ public class BuiltinUsers extends AbstractApiBean {
 
     private static final Logger logger = Logger.getLogger(BuiltinUsers.class.getName());
 
-    private static final String API_KEY_IN_SETTINGS = "BuiltinUsers.KEY";
-
     @EJB
     protected BuiltinUserServiceBean builtinUserSvc;
 
@@ -129,7 +127,7 @@ public class BuiltinUsers extends AbstractApiBean {
     }
     
     private Response internalSave(BuiltinUser user, String password, String key, Boolean sendEmailNotification) {
-        String expectedKey = settingsSvc.get(API_KEY_IN_SETTINGS);
+        String expectedKey = settingsSvc.getValueForKey(SettingsServiceBean.Key.BuiltinUsersKey);
         
         if (expectedKey == null) {
             return error(Status.SERVICE_UNAVAILABLE, "Dataverse config issue: No API key defined for built in user management");

--- a/src/main/java/edu/harvard/iq/dataverse/settings/Setting.java
+++ b/src/main/java/edu/harvard/iq/dataverse/settings/Setting.java
@@ -40,7 +40,7 @@ public class Setting implements Serializable {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(columnDefinition = "TEXT")
+    @Column(length = 200, nullable = false)
     private String name;
     
     /**
@@ -59,8 +59,9 @@ public class Setting implements Serializable {
     }
 
     public Setting(String name, String content) {
-       this.name = name;
-       this.content = content;
+        Objects.requireNonNull(name, "Setting name cannot be null");
+        this.name = name;
+        this.content = content;
     }
     
     /**
@@ -73,6 +74,7 @@ public class Setting implements Serializable {
      * @throws NullPointerException if the name or lang parameters are null
      */
     public Setting(String name, String lang, String content) {
+        Objects.requireNonNull(name, "Setting name cannot be null");
         Objects.requireNonNull(lang, "Setting lang cannot be null");
         this.name = name;
         this.lang = lang;
@@ -84,6 +86,7 @@ public class Setting implements Serializable {
     }
 
     public void setName(String name) {
+        Objects.requireNonNull(name, "Setting name cannot be null");
         this.name = name;
     }
 

--- a/src/main/java/edu/harvard/iq/dataverse/settings/Setting.java
+++ b/src/main/java/edu/harvard/iq/dataverse/settings/Setting.java
@@ -18,13 +18,13 @@ import jakarta.persistence.UniqueConstraint;
  */
 @NamedQueries({
     @NamedQuery( name="Setting.deleteByName",
-                query="DELETE FROM Setting s WHERE s.name=:name AND s.lang IS NULL"),
+                query="DELETE FROM Setting s WHERE s.name=:name AND s.lang=''"),
     @NamedQuery( name="Setting.findAll",
                 query="SELECT s FROM Setting s"),
     @NamedQuery( name="Setting.findAllWithoutLang",
-                query="SELECT s FROM Setting s WHERE s.lang IS NULL"),
+                query="SELECT s FROM Setting s WHERE s.lang=''"),
     @NamedQuery( name="Setting.findByName",
-            query = "SELECT s FROM Setting s WHERE s.name=:name AND s.lang IS NULL" ),
+                query="SELECT s FROM Setting s WHERE s.name=:name AND s.lang=''"),
     @NamedQuery( name="Setting.deleteByNameAndLang",
                 query="DELETE FROM Setting s WHERE s.name=:name AND s.lang=:lang"),
     @NamedQuery( name="Setting.findByNameAndLang",
@@ -42,9 +42,15 @@ public class Setting implements Serializable {
 
     @Column(columnDefinition = "TEXT")
     private String name;
-
-    @Column(columnDefinition = "TEXT")
-    private String lang;
+    
+    /**
+     * The default value is an empty string, which indicates no specific language is set.
+     * Using a NULL value here instead would allow the UNIQUE constraint to fail blocking duplicate settings.
+     * Allowing multiple null within a UNIQUE constraint is part of the SQL standard, which Postgres follows.
+     * As it stores ISO codes, 10 chars is good enough (ISO codes are 2-8 chars by spec)
+     */
+    @Column(length = 10, nullable = false)
+    private String lang = "";
 
     @Column(columnDefinition = "TEXT")
     private String content;
@@ -56,11 +62,21 @@ public class Setting implements Serializable {
        this.name = name;
        this.content = content;
     }
-
+    
+    /**
+     * Constructs a new Setting object with the specified name, language, and content.
+     *
+     * @param name the name of the setting; must not be null
+     * @param lang the language of the setting, represented as an ISO code; must not be null;
+     *             may be empty to represent a non-localized setting.
+     * @param content the content or value associated with this setting
+     * @throws NullPointerException if the name or lang parameters are null
+     */
     public Setting(String name, String lang, String content) {
+        Objects.requireNonNull(lang, "Setting lang cannot be null");
         this.name = name;
-        this.content = content;
         this.lang = lang;
+        this.content = content;
     }
 
     public String getName() {
@@ -78,12 +94,28 @@ public class Setting implements Serializable {
     public void setContent(String content) {
         this.content = content;
     }
-
+    
+    /**
+     * Retrieves the language associated with this Setting instance.
+     * The language is represented as an ISO code string.
+     * An empty string indicates that no specific localization is set.
+     *
+     * @return the language code of this Setting; never null
+     */
     public String getLang() {
         return lang;
     }
-
+    
+    /**
+     * Sets the language for this Setting instance.
+     * The language is represented as a non-null ISO code string.
+     * An empty string indicates that no specific localization shall be set.
+     *
+     * @param lang the language code to set; must not be null
+     * @throws NullPointerException if the provided lang parameter is null
+     */
     public void setLang(String lang) {
+        Objects.requireNonNull(lang, "Setting lang cannot be null");
         this.lang = lang;
     }
 

--- a/src/main/java/edu/harvard/iq/dataverse/settings/Setting.java
+++ b/src/main/java/edu/harvard/iq/dataverse/settings/Setting.java
@@ -9,6 +9,8 @@ import jakarta.persistence.NamedQueries;
 import jakarta.persistence.NamedQuery;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 
 /**
  * A single value in the config of dataverse.
@@ -29,6 +31,9 @@ import jakarta.persistence.GenerationType;
                 query="SELECT s FROM Setting s WHERE s.name=:name AND s.lang=:lang")
 })
 @Entity
+@Table(uniqueConstraints = {
+    @UniqueConstraint(name = "UC_setting_name_lang", columnNames = {"name", "lang"}),
+})
 public class Setting implements Serializable {
 
     @Id

--- a/src/main/java/edu/harvard/iq/dataverse/settings/Setting.java
+++ b/src/main/java/edu/harvard/iq/dataverse/settings/Setting.java
@@ -19,6 +19,8 @@ import jakarta.persistence.GenerationType;
                 query="DELETE FROM Setting s WHERE s.name=:name AND s.lang IS NULL"),
     @NamedQuery( name="Setting.findAll",
                 query="SELECT s FROM Setting s"),
+    @NamedQuery( name="Setting.findAllWithoutLang",
+                query="SELECT s FROM Setting s WHERE s.lang IS NULL"),
     @NamedQuery( name="Setting.findByName",
             query = "SELECT s FROM Setting s WHERE s.name=:name AND s.lang IS NULL" ),
     @NamedQuery( name="Setting.deleteByNameAndLang",

--- a/src/main/java/edu/harvard/iq/dataverse/settings/Setting.java
+++ b/src/main/java/edu/harvard/iq/dataverse/settings/Setting.java
@@ -55,7 +55,9 @@ public class Setting implements Serializable {
     @Column(columnDefinition = "TEXT")
     private String content;
 
-    public Setting() {
+    protected Setting() {
+        // Intentionally left blank - no empty settings allowed.
+        // Protected visibility to allow JPA to work.
     }
 
     public Setting(String name, String content) {
@@ -124,26 +126,33 @@ public class Setting implements Serializable {
 
     @Override
     public int hashCode() {
-        int hash = 7;
-        hash = 73 * hash + Objects.hashCode(this.name);
-        return hash;
+        return Objects.hash(name, lang);
     }
-
+    
+    /**
+     * Compares this Setting instance to another object for equality. Two Setting
+     * objects are considered equal if their {@code name} and {@code lang} fields are
+     * both equal.
+     * @implNote We do not use the {@code id} and {@code content} fields for the comparison.
+     *           This is due to how these objects usually are used:
+     *           - Mutable content to use for comparison may break collections.
+     *           - Configuration management requires stable identity based on setting's name and localization.
+     *             The content of the settings is irrelevant for lookups.
+     *
+     * @param obj the object to compare this Setting with
+     * @return {@code true} if the specified object is equal to this Setting, {@code false} otherwise
+     */
     @Override
     public boolean equals(Object obj) {
-        if (obj == null) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof Setting other)) {
             return false;
         }
-        if ( !(obj instanceof Setting) ) {
-            return false;
-        }
-        final Setting other = (Setting) obj;
-        if (!Objects.equals(this.name, other.name)) {
-            return false;
-        }
-        return Objects.equals(this.content, other.content);
+        return Objects.equals(this.name, other.name) && Objects.equals(this.lang, other.lang);
     }
-
+    
     @Override
     public String toString() {
         return "[Setting name:" + getName() + " value:" + getContent() + "]";

--- a/src/main/java/edu/harvard/iq/dataverse/settings/Setting.java
+++ b/src/main/java/edu/harvard/iq/dataverse/settings/Setting.java
@@ -24,10 +24,9 @@ import jakarta.persistence.GenerationType;
     @NamedQuery( name="Setting.findByName",
             query = "SELECT s FROM Setting s WHERE s.name=:name AND s.lang IS NULL" ),
     @NamedQuery( name="Setting.deleteByNameAndLang",
-            query="DELETE FROM Setting s WHERE s.name=:name AND s.lang=:lang"),
+                query="DELETE FROM Setting s WHERE s.name=:name AND s.lang=:lang"),
     @NamedQuery( name="Setting.findByNameAndLang",
-                query = "SELECT s FROM Setting s WHERE s.name=:name AND s.lang=:lang" )
-
+                query="SELECT s FROM Setting s WHERE s.name=:name AND s.lang=:lang")
 })
 @Entity
 public class Setting implements Serializable {

--- a/src/main/java/edu/harvard/iq/dataverse/settings/SettingsServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/settings/SettingsServiceBean.java
@@ -694,6 +694,38 @@ public class SettingsServiceBean {
         public String toString() {
             return ":" + name();
         }
+        
+        /**
+         * Parses the input string to match a corresponding {@code SettingsServiceBean.Key}.
+         * The method expects the input string to start with a colon (:) followed by the key name.
+         * If the key name matches one of the existing {@code SettingsServiceBean.Key} enumerations,
+         * the corresponding key is returned. The check is case-sensitive.
+         *
+         * @param key the input string in the format ":KeyName", where "KeyName" corresponds
+         *        to the name of an enumeration in {@code SettingsServiceBean.Key}.
+         *        If {@code key} is null, blank, does not start with a colon (:), or does not
+         *        match any known key, the method returns {@code null}.
+         * @return the corresponding {@code SettingsServiceBean.Key} if the key matches one
+         *         of the predefined keys, or {@code null} if no match is found.
+         */
+        public static SettingsServiceBean.Key parse(String key) {
+            // Null safety and format check
+            if (key == null || key.isBlank() || key.charAt(0) != ':') return null;
+            
+            // Cut off the ":" we verified is present before
+            String normalizedKey = key.substring(1);
+            
+            // Iterate through all the known keys and return on match (case sensitive!)
+            // We are case sensitive here because Dataverse implicitely uses case sensitive keys everywhere!
+            for (SettingsServiceBean.Key k : SettingsServiceBean.Key.values()) {
+                if (k.name().equals(normalizedKey)) {
+                    return k;
+                }
+            }
+            
+            // Fall through on no match
+            return null;
+        }
     }
     
     @PersistenceContext

--- a/src/main/java/edu/harvard/iq/dataverse/settings/SettingsServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/settings/SettingsServiceBean.java
@@ -16,10 +16,12 @@ import jakarta.json.JsonValue;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 
+import jakarta.transaction.Transactional;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -1078,6 +1080,31 @@ public class SettingsServiceBean {
     }
     
     /**
+     * Updates all settings by replacing them with the settings provided in the given JSON object.
+     * This method validates the keys and values from the JSON object, converts them into
+     * a list of Setting objects, and performs an atomic update of the internal settings.
+     *
+     * @param settings a JsonObject containing the new settings to apply.
+     *                 Each key corresponds to a setting name, and each value corresponds
+     *                 to its respective value. The keys and values will be validated before
+     *                 applying the updates.
+     * @throws IllegalArgumentException if the JSON object contains invalid keys or invalid settings.
+     */
+    public void setAllFromJson(JsonObject settings) {
+        // Validate the input
+        List<String> invalidKeys = validateKeys(settings);
+        if (!invalidKeys.isEmpty()) {
+            throw new IllegalArgumentException("Invalid key(s): " + String.join(", ", invalidKeys));
+        }
+        
+        // Convert JSON to Setting objects
+        List<Setting> newSettings = convertJsonToSettings(settings);
+        
+        // Perform atomic update (replace all settings)
+        replaceAllSettings(newSettings);
+    }
+    
+    /**
      * Converts a JSON object representing settings into a list of Setting objects.
      * Each entry in the JSON object is processed to create a Setting instance.
      * If the key includes a language (indicated by a separator), the language
@@ -1110,6 +1137,21 @@ public class SettingsServiceBean {
                 }
             })
             .collect(Collectors.toList());
+    }
+    
+    /**
+     * Replaces all existing settings with a new list of settings within a single transaction.
+     * The operation is atomic, ensuring that either all changes are applied or none in case of a failure.
+     *
+     * @param newSettings the list of new {@link Setting} objects to replace the existing settings.
+     *                     Must not be null; an empty list clears all settings.
+     */
+    @Transactional
+    public void replaceAllSettings(List<Setting> newSettings) {
+        // Implementation for atomic replacement
+        // This would involve clearing existing settings and inserting new ones
+        // within the same transaction
+        throw new IllegalStateException("Not yet implemented");
     }
     
     public Map<String, String> getBaseMetadataLanguageMap(Map<String,String> languageMap, boolean refresh) {

--- a/src/main/java/edu/harvard/iq/dataverse/settings/SettingsServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/settings/SettingsServiceBean.java
@@ -1127,10 +1127,16 @@ public class SettingsServiceBean {
         // Convert JSON to Setting objects
         Set<Setting> newSettings = convertJsonToSettings(settings);
         
-        // Execute the update (in one atomic operation using a transaction)
-        Map<Setting, Op> operationalDetails = replaceAllSettings(newSettings);
+        // Perform atomic update (replace all settings)
+        // We don't allow to completely wipe all settings coming from JSON here, so no acciddents happen.
+        // (It's completely unrealistic someone would try to remove all settings and leave it at that.)
+        if (newSettings != null && !newSettings.isEmpty()) {
+            // Execute the update (in one atomic operation using a transaction)
+            Map<Setting, Op> operationalDetails = replaceAllSettings(newSettings);
             
-        return Op.convertToJson(operationalDetails);
+            return Op.convertToJson(operationalDetails);
+        }
+        throw new IllegalArgumentException("Settings cannot be empty - you'd wipe the entire configuration.");
     }
     
     /**

--- a/src/main/java/edu/harvard/iq/dataverse/settings/SettingsServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/settings/SettingsServiceBean.java
@@ -167,6 +167,15 @@ public class SettingsServiceBean {
         BlockedApiPolicy,
         
         /**
+         * A special secret that, if set, needs to be given when trying to manage internal users.
+         * This key was formerly known as "BuiltinUsers.KEY", which never was a setting name aligning with the others.
+         * At some future point this setting should be moved to JvmSettings (so we consume proper secrets)
+         * or plainly removed with the transition to the SPA frontend requiring an external IdP.
+         */
+        @Deprecated(forRemoval = true, since = "2025-08-01")
+        BuiltinUsersKey,
+        
+        /**
          * For development only (see dev guide for details). Backed by an enum
          * of possible account types.
          */

--- a/src/main/java/edu/harvard/iq/dataverse/settings/SettingsServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/settings/SettingsServiceBean.java
@@ -896,6 +896,9 @@ public class SettingsServiceBean {
     }
 
     public String get(String name, String lang, String defaultValue ) {
+        // Database safeguard, as the default is an empty string
+        if (lang == null) lang = "";
+        
         List<Setting> tokens = em.createNamedQuery("Setting.findByNameAndLang", Setting.class)
                 .setParameter("name", name )
                 .setParameter("lang", lang )
@@ -912,6 +915,9 @@ public class SettingsServiceBean {
     }
 
     public String getValueForKey( Key key, String lang, String defaultValue ) {
+        // Database safeguard, as the default is an empty string
+        if (lang == null) lang = "";
+        
         return get( key.toString(), lang, defaultValue );
     }
      
@@ -939,6 +945,9 @@ public class SettingsServiceBean {
     }
 
     public Setting set( String name, String lang, String content ) {
+        // Database safeguard, as the default is an empty string
+        if (lang == null) lang = "";
+        
         Setting s = null; 
         
         List<Setting> tokens = em.createNamedQuery("Setting.findByNameAndLang", Setting.class)
@@ -1008,6 +1017,9 @@ public class SettingsServiceBean {
     }
 
     public void delete( String name, String lang ) {
+        // Database safeguard, as the default is an empty string
+        if (lang == null) lang = "";
+        
         actionLogSvc.log( new ActionLogRecord(ActionLogRecord.ActionType.Setting, "delete")
                 .setInfo(name));
         em.createNamedQuery("Setting.deleteByNameAndLang")
@@ -1066,7 +1078,7 @@ public class SettingsServiceBean {
         
         // Iterate over all the settings and add them to the response.
         settings.forEach(setting -> {
-            String name = setting.getName() + (setting.getLang() == null ? "" : L10N_KEY_SEPARATOR + setting.getLang());
+            String name = setting.getName() + (setting.getLang().isEmpty() ? "" : L10N_KEY_SEPARATOR + setting.getLang());
             
             // In case the setting is a JSON object, treat it a such in the output (so the API can return valid JSON)
             if (setting.getContent().trim().startsWith("{"))

--- a/src/main/java/edu/harvard/iq/dataverse/settings/SettingsServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/settings/SettingsServiceBean.java
@@ -1087,7 +1087,7 @@ public class SettingsServiceBean {
         
         // Iterate over all the settings and add them to the response.
         settings.forEach(setting -> {
-            String name = setting.getName() + (setting.getLang().isEmpty() ? "" : L10N_KEY_SEPARATOR + setting.getLang());
+            String name = convertToJsonKey(setting);
             
             // In case the setting is a JSON object, treat it a such in the output (so the API can return valid JSON)
             if (setting.getContent().trim().startsWith("{"))
@@ -1221,6 +1221,10 @@ public class SettingsServiceBean {
         initLocaleSettings(configuredLocales);
         langs.addAll(configuredLocales.keySet());
         return langs;
+    }
+    
+    public static String convertToJsonKey(Setting setting) {
+        return setting.getName() + (setting.getLang().isEmpty() ? "" : L10N_KEY_SEPARATOR + setting.getLang());
     }
     
     /**

--- a/src/main/java/edu/harvard/iq/dataverse/settings/SettingsServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/settings/SettingsServiceBean.java
@@ -1121,7 +1121,7 @@ public class SettingsServiceBean {
         }
         
         // Convert JSON to Setting objects
-        List<Setting> newSettings = convertJsonToSettings(settings);
+        Set<Setting> newSettings = convertJsonToSettings(settings);
         
         // Perform atomic update (replace all settings)
         replaceAllSettings(newSettings);
@@ -1133,14 +1133,15 @@ public class SettingsServiceBean {
      * If the key includes a language (indicated by a separator), the language
      * information is extracted and included in the Setting object.
      * Note: This method expects a pre-validated JsonObject and will happily create
-     *       nonsense settings for you otherwise.
+     *       nonsense settings for you otherwise. This is a reason for the package visibility.
      *
      * @param settings a (pre-validated) {@link JsonObject} containing key-value pairs where
      *                 each key represents a setting name (and optionally a language code),
      *                 and each value represents the associated content.
      * @return a {@link List} of {@link Setting} objects parsed from the input JSON object.
      */
-    static List<Setting> convertJsonToSettings(JsonObject settings) {
+    static Set<Setting> convertJsonToSettings(JsonObject settings) {
+        Objects.requireNonNull(settings, "The settings object cannot be null.");
         return settings.entrySet().stream()
             .map(entry -> {
                 String key = entry.getKey();
@@ -1159,7 +1160,7 @@ public class SettingsServiceBean {
                     return new Setting(key, value);
                 }
             })
-            .collect(Collectors.toList());
+            .collect(Collectors.toSet());
     }
     
     /**

--- a/src/main/java/edu/harvard/iq/dataverse/settings/SettingsServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/settings/SettingsServiceBean.java
@@ -1124,7 +1124,35 @@ public class SettingsServiceBean {
         langs.addAll(configuredLocales.keySet());
         return langs;
     }
-
+    
+    /**
+     * Validates the keys in the provided settings JSON object.
+     * This method checks if each key follows the required format and rules.
+     * If a key is invalid, it is added to the list of invalid keys.
+     *
+     * @param settings the JsonObject containing the keys to be validated
+     * @return a list of invalid keys as an unmodifiable list
+     */
+    public static List<String> validateKeys(JsonObject settings) {
+        List<String> invalidKeys = new ArrayList<>();
+        for (String key : settings.keySet()) {
+            try {
+                // Case A: localized setting, validate setting and language
+                if (key.contains(L10N_KEY_SEPARATOR)) {
+                    String name = key.substring(0, key.indexOf(L10N_KEY_SEPARATOR));
+                    String lang = key.substring(key.indexOf(L10N_KEY_SEPARATOR) + L10N_KEY_SEPARATOR.length());
+                    validateSettingName(name);
+                    validateSettingLang(lang);
+                // Case B: Simple, non-localized setting name
+                } else {
+                    validateSettingName(key);
+                }
+            } catch (IllegalArgumentException iae) {
+                invalidKeys.add(key);
+            }
+        }
+        return Collections.unmodifiableList(invalidKeys);
+    }
     
     /**
      * Validates the provided setting name to ensure it meets the required format.

--- a/src/main/java/edu/harvard/iq/dataverse/settings/SettingsServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/settings/SettingsServiceBean.java
@@ -1009,8 +1009,14 @@ public class SettingsServiceBean {
                 .executeUpdate();
     }
     
-    public Set<Setting> listAll() {
-        return new HashSet<>(em.createNamedQuery("Setting.findAll", Setting.class).getResultList());
+    /**
+     * Retrieves all settings that do not have any language localizations.
+     * This method uses a named query to fetch settings where the language field is null.
+     *
+     * @return a set of {@code Setting} objects that do not have language localizations.
+     */
+    public Set<Setting> listAllWithoutLocalizations() {
+        return new HashSet<>(em.createNamedQuery("Setting.findAllWithoutLang", Setting.class).getResultList());
     }
     
     public Map<String, String> getBaseMetadataLanguageMap(Map<String,String> languageMap, boolean refresh) {

--- a/src/main/java/edu/harvard/iq/dataverse/settings/SettingsServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/settings/SettingsServiceBean.java
@@ -1104,17 +1104,16 @@ public class SettingsServiceBean {
     }
     
     /**
-     * Updates all settings by replacing them with the settings provided in the given JSON object.
-     * This method validates the keys and values from the JSON object, converts them into
-     * a list of Setting objects, and performs an atomic update of the internal settings.
+     * Updates all current settings from the specified JSON object. Validates the input JSON,
+     * converts it to a set of settings, and replaces all existing settings with the new ones
+     * in an atomic operation. If the settings object is null, contains invalid keys, or if the new
+     * set of settings is empty, the method throws an appropriate exception.
      *
-     * @param settings a JsonObject containing the new settings to apply.
-     *                 Each key corresponds to a setting name, and each value corresponds
-     *                 to its respective value. The keys and values will be validated before
-     *                 applying the updates.
-     * @throws IllegalArgumentException if the JSON object contains invalid keys or invalid settings.
+     * @param settings the JSON object containing the new configuration settings to be applied; must not be null
+     * @return a JsonObjectBuilder representing the operational details of the applied updates
+     * @throws IllegalArgumentException if the settings object is null, contains invalid keys, or results in empty settings
      */
-    public void setAllFromJson(JsonObject settings) {
+    public JsonObjectBuilder setAllFromJson(JsonObject settings) {
         if (settings == null) {
             throw new IllegalArgumentException("Settings cannot be null");
         }
@@ -1128,8 +1127,10 @@ public class SettingsServiceBean {
         // Convert JSON to Setting objects
         Set<Setting> newSettings = convertJsonToSettings(settings);
         
-        // Perform atomic update (replace all settings)
-        replaceAllSettings(newSettings);
+        // Execute the update (in one atomic operation using a transaction)
+        Map<Setting, Op> operationalDetails = replaceAllSettings(newSettings);
+            
+        return Op.convertToJson(operationalDetails);
     }
     
     /**

--- a/src/main/java/edu/harvard/iq/dataverse/settings/SettingsServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/settings/SettingsServiceBean.java
@@ -31,6 +31,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.function.Function;
@@ -1114,6 +1115,10 @@ public class SettingsServiceBean {
      * @throws IllegalArgumentException if the JSON object contains invalid keys or invalid settings.
      */
     public void setAllFromJson(JsonObject settings) {
+        if (settings == null) {
+            throw new IllegalArgumentException("Settings cannot be null");
+        }
+        
         // Validate the input
         List<String> invalidKeys = validateKeys(settings);
         if (!invalidKeys.isEmpty()) {
@@ -1331,6 +1336,7 @@ public class SettingsServiceBean {
      * @return a list of invalid keys as an unmodifiable list
      */
     public static List<String> validateKeys(JsonObject settings) {
+        Objects.requireNonNull(settings, "The settings object cannot be null.");
         List<String> invalidKeys = new ArrayList<>();
         for (String key : settings.keySet()) {
             try {

--- a/src/main/java/edu/harvard/iq/dataverse/settings/SettingsServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/settings/SettingsServiceBean.java
@@ -20,11 +20,13 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.StringTokenizer;
@@ -1123,4 +1125,42 @@ public class SettingsServiceBean {
         return langs;
     }
 
+    
+    /**
+     * Validates the provided setting name to ensure it meets the required format.
+     * Throws an {@code IllegalArgumentException} if the name is invalid, including cases
+     * where it contains a colon-separated suffix that is no longer supported.
+     *
+     * @param name The name of the setting to be validated.
+     *             It must adhere to the allowable setting name format.
+     *             Names with more than one colon, which may indicate deprecated suffix formats, are not allowed.
+     * @throws IllegalArgumentException if the setting name is invalid.
+     */
+    public static void validateSettingName(String name) {
+        if (SettingsServiceBean.Key.parse(name) == null) {
+            // If there is more than one colon, this may be someone trying to use the old suffix settings.
+            // Change the error message for that slightly.
+            if (name.replace(":","").length() < name.length() - 1) {
+                throw new IllegalArgumentException("The name of the setting may not have a colon separated suffix since Dataverse 6.8. Please update your scripts.");
+            }
+            throw new IllegalArgumentException("The name of the setting is invalid.");
+        }
+    }
+    
+    /**
+     * Validates the provided language code to ensure it adheres to the ISO 639-1 format.
+     * This method checks that the language code is not null, has a length of 2 characters,
+     * and exists within the list of valid ISO 639-1 language codes. If the validation
+     * fails, an {@code IllegalArgumentException} is thrown.
+     *
+     * @param lang the language code to be validated. It must be a non-null,
+     *             2-character string representing a valid ISO 639-1 language code.
+     * @throws IllegalArgumentException if the language code is invalid.
+     */
+    public static void validateSettingLang(String lang) {
+        if (lang == null || lang.length() != 2 || !Arrays.asList(Locale.getISOLanguages()).contains(lang)) {
+            throw new IllegalArgumentException("The language '" + lang + "' is not a valid ISO 639-1 language code.");
+        }
+    }
+    
 }

--- a/src/main/java/edu/harvard/iq/dataverse/util/SystemConfig.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/SystemConfig.java
@@ -530,8 +530,12 @@ public class SystemConfig {
                         try {
                             Long sizeOption = Long.valueOf(limits.getString(formatName));
                             limitsMap.put(lowercaseFormatName, sizeOption);
+                        } catch (ClassCastException cce) {
+                            logger.warning("Could not convert " + SettingsServiceBean.Key.TabularIngestSizeLimit + " to long from JSON integer. You must provide the long number as string (use quotes) for format " + formatName);
+                            logger.warning("Disabling all tabular ingest completely until fixed!");
+                            return Map.of(TABULAR_INGEST_SIZE_LIMITS_DEFAULT_KEY, 0L);
                         } catch (NumberFormatException nfe) {
-                            logger.warning("Could not convert " + SettingsServiceBean.Key.TabularIngestSizeLimit + " to long: " + nfe);
+                            logger.warning("Could not convert " + SettingsServiceBean.Key.TabularIngestSizeLimit + " to long for format " + formatName + " (not a number)");
                             logger.warning("Disabling all tabular ingest completely until fixed!");
                             return Map.of(TABULAR_INGEST_SIZE_LIMITS_DEFAULT_KEY, 0L);
                         }

--- a/src/main/java/edu/harvard/iq/dataverse/util/SystemConfig.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/SystemConfig.java
@@ -11,6 +11,7 @@ import edu.harvard.iq.dataverse.authorization.providers.oauth2.AbstractOAuth2Aut
 import edu.harvard.iq.dataverse.settings.JvmSettings;
 import edu.harvard.iq.dataverse.settings.SettingsServiceBean;
 import edu.harvard.iq.dataverse.validation.PasswordValidatorUtil;
+import jakarta.json.stream.JsonParsingException;
 import org.passay.CharacterRule;
 
 import jakarta.ejb.EJB;
@@ -27,6 +28,7 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.time.Year;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -484,49 +486,106 @@ public class SystemConfig {
         }
         return null;
     }
-
-    public long getTabularIngestSizeLimit() {
-        // This method will return the blanket ingestable size limit, if 
-        // set on the system. I.e., the universal limit that applies to all 
-        // tabular ingests, regardless of fromat: 
-        
-        String limitEntry = settingsService.getValueForKey(SettingsServiceBean.Key.TabularIngestSizeLimit); 
-        
+    
+    /**
+     * The default key used to identify tabular ingest size limits.
+     * This value represents the standard or fallback configuration.
+     * For any other valid format strings, see implementations of {@code TabularDataFileReader.getFormatName()}.
+     */
+    public static final String TABULAR_INGEST_SIZE_LIMITS_DEFAULT_KEY = "default";
+    
+    /**
+     * Retrieves the tabular ingest size limits based on the system configuration.
+     * The size limits can be defined as a JSON object with format-specific limits, a single numeric value
+     * applied to all formats, or might not exist, in which case the default limit is applied.
+     *
+     * Note that the format names in the configuration will be transformed to lowercase for user convenience
+     * of how people like to write their formats best.
+     *
+     * If the configuration contains invalid data (e.g., unparsable JSON or non-numeric values),
+     * all tabular ingest operations are disabled by setting size limits to 0.
+     *
+     * TODO: At some later point, if and when the DB lookups or JSON parsing takes a toll to heavy to bear,
+     *       we may introduce a caching singleton for these. (With TTL or using events to invalidate on update.)
+     *
+     * @return a map where the keys represent format names or a default key, and the values represent the maximum allowed size for each format.
+     */
+    public Map<String, Long> getTabularIngestSizeLimits() {
+        String limitEntry = settingsService.getValueForKey(SettingsServiceBean.Key.TabularIngestSizeLimit);
         if (limitEntry != null) {
-            try {
-                Long sizeOption = Long.valueOf(limitEntry);
-                return sizeOption;
-            } catch (NumberFormatException nfe) {
-                logger.warning("Invalid value for TabularIngestSizeLimit option? - " + limitEntry);
+            // Case A: the setting is using JSON to support multiple formats
+            if (limitEntry.trim().startsWith("{")) {
+                try {
+                    JsonObject limits = Json.createReader(new StringReader(limitEntry)).readObject();
+                    
+                    Map<String, Long> limitsMap = new HashMap<>();
+                    // We add the default in case the JSON does not contain the default (which is optional).
+                    limitsMap.put(TABULAR_INGEST_SIZE_LIMITS_DEFAULT_KEY, -1L);
+                    
+                    for (String formatName : limits.keySet()) {
+                        // We deliberatly do not validate the formatNames here for backward compatibility.
+                        // But we transform to lowercase here, so the casing doesn't matter for lookups.
+                        String lowercaseFormatName = formatName.toLowerCase();
+                        
+                        try {
+                            Long sizeOption = Long.valueOf(limits.getString(formatName));
+                            limitsMap.put(lowercaseFormatName, sizeOption);
+                        } catch (NumberFormatException nfe) {
+                            logger.warning("Could not convert " + SettingsServiceBean.Key.TabularIngestSizeLimit + " to long: " + nfe);
+                            logger.warning("Disabling all tabular ingest completely until fixed!");
+                            return Map.of(TABULAR_INGEST_SIZE_LIMITS_DEFAULT_KEY, 0L);
+                        }
+                    }
+                    
+                    return Collections.unmodifiableMap(limitsMap);
+                } catch (JsonParsingException e) {
+                    logger.warning("Invalid TabularIngestSizeLimit option found, cannot parse JSON: " + e.getMessage());
+                    logger.warning("Disabling all tabular ingest completely until fixed!");
+                    return Map.of(TABULAR_INGEST_SIZE_LIMITS_DEFAULT_KEY, 0L);
+                }
+            // Case B: It might be just a simple Long, providing a default for all formats.
+            } else {
+                try {
+                    Long limit = Long.valueOf(limitEntry);
+                    return Map.of(TABULAR_INGEST_SIZE_LIMITS_DEFAULT_KEY, limit);
+                } catch (NumberFormatException nfe) {
+                    logger.warning("Could not convert " + SettingsServiceBean.Key.TabularIngestSizeLimit + " to long: " + nfe);
+                    logger.warning("Disabling all tabular ingest completely until fixed!");
+                    return Map.of(TABULAR_INGEST_SIZE_LIMITS_DEFAULT_KEY, 0L);
+                }
             }
         }
-        // -1 means no limit is set; 
-        // 0 on the other hand would mean that ingest is fully disabled for 
-        // tabular data. 
-        return -1; 
+        
+        // Default is not to limit at all
+        return Map.of(TABULAR_INGEST_SIZE_LIMITS_DEFAULT_KEY, -1L);
     }
     
+    /**
+     * This method will return the blanket ingestable size limit, if set on the system.
+     * I.e., the universal limit that applies to all tabular ingests, regardless of fromat.
+     * @return -1 = unlimited if not set, 0 if disabled or invalid, some long number of bytes otherwise
+     */
+    public long getTabularIngestSizeLimit() {
+        return getTabularIngestSizeLimits().get(TABULAR_INGEST_SIZE_LIMITS_DEFAULT_KEY);
+    }
+    
+    /**
+     * Retrieves the size limit for tabular data ingestion based on the provided format name.
+     * The format name will be converted to lowercase, making sure the casing doesn't matter.
+     *
+     * @param formatName The name of the format for which the size limit is requested
+     *                   See also implementations of {@code TabularDataFileReader.getFormatName()} for examples.
+     * @return The size limit in bytes for tabular data ingestion associated with the specified format name,
+     *         or the default size limit if no format-specific limit is found or its name is invalid (null, blank, ...).
+     *         -1 = unlimited if not set, 0 if disabled or invalid, some long number of bytes otherwise
+     */
     public long getTabularIngestSizeLimit(String formatName) {
-        // This method returns the size limit set specifically for this format name,
-        // if available, otherwise - the blanket limit that applies to all tabular 
-        // ingests regardless of a format. 
-        
-        if (formatName == null || formatName.equals("")) {
-            return getTabularIngestSizeLimit(); 
+        if (formatName != null && !formatName.isBlank()) {
+            // We convert to lowercase so it doesn't matter which variant someone uses in the JSON config
+            String convertedFormatName = formatName.toLowerCase();
+            return getTabularIngestSizeLimits().getOrDefault(convertedFormatName, getTabularIngestSizeLimit());
         }
-        
-        String limitEntry = settingsService.get(SettingsServiceBean.Key.TabularIngestSizeLimit.toString() + ":" + formatName); 
-                
-        if (limitEntry != null) {
-            try {
-                Long sizeOption = Long.valueOf(limitEntry);
-                return sizeOption;
-            } catch (NumberFormatException nfe) {
-                logger.warning("Invalid value for TabularIngestSizeLimit:" + formatName + "? - " + limitEntry );
-            }
-        }
-        
-        return getTabularIngestSizeLimit();        
+        return getTabularIngestSizeLimit();
     }
 
     public boolean isOAIServerEnabled() {

--- a/src/main/resources/db/migration/V6.7.0.1.sql
+++ b/src/main/resources/db/migration/V6.7.0.1.sql
@@ -1,5 +1,6 @@
--- Migrates the old TabularIngestSizeLimit database setting using format suffixes to a JSON based approach. See #11639
-
+-- Migrates the old database setting to their valid and aligned successors. #11639
+-- 1. ":TabularIngestSizeLimit" database setting used format suffixes, move to a JSON-based approach
+-- 2. (see below) "BuiltinUsers.KEY" was never aligned with any of the other settings names.
 DO $$
     DECLARE
         base_setting_content TEXT;
@@ -75,4 +76,13 @@ DO $$
           AND lang IS NULL;
 
         RAISE NOTICE 'Successfully migrated TabularIngestSizeLimit settings to JSON format: %', json_object::TEXT;
+    END $$;
+
+-- 2. Migrate BuiltinUsers.KEY to the new setting name
+DO $$
+    BEGIN
+        IF EXISTS (SELECT 1 FROM Setting WHERE name = 'BuiltinUsers.KEY') THEN
+            INSERT INTO Setting (name, lang, content) VALUES (':BuiltinUsersKey', NULL, (SELECT content FROM Setting WHERE name = 'BuiltinUsers.KEY'));
+            DELETE FROM Setting WHERE name = 'BuiltinUsers.KEY';
+        END IF;
     END $$;

--- a/src/main/resources/db/migration/V6.7.0.1.sql
+++ b/src/main/resources/db/migration/V6.7.0.1.sql
@@ -1,0 +1,78 @@
+-- This script migrates the old TabularIngestSizeLimit database setting using format suffixes to a JSON based approach.
+
+DO $$
+    DECLARE
+        base_setting_content TEXT;
+        format_settings_cursor CURSOR FOR
+            SELECT name, content
+            FROM Setting
+            WHERE name LIKE ':TabularIngestSizeLimit:%'
+              AND lang IS NULL;
+        format_record RECORD;
+        format_name TEXT;
+        format_value BIGINT;
+        json_object JSONB := '{}';
+        has_format_settings BOOLEAN := FALSE;
+        warning_message TEXT;
+    BEGIN
+        -- Check if there are any format-specific settings
+        SELECT EXISTS(
+            SELECT 1 FROM Setting
+            WHERE name LIKE ':TabularIngestSizeLimit:%'
+              AND lang IS NULL
+        ) INTO has_format_settings;
+
+        -- Only proceed if we have format-specific settings
+        IF NOT has_format_settings THEN
+            RAISE NOTICE 'No format-specific TabularIngestSizeLimit settings found. Skipping migration.';
+            RETURN;
+        END IF;
+
+        -- Get the base setting (without format suffix) if it exists
+        SELECT content INTO base_setting_content
+        FROM Setting
+        WHERE name = ':TabularIngestSizeLimit'
+          AND lang IS NULL;
+
+        -- Add base setting to JSON object if it exists
+        IF base_setting_content IS NOT NULL THEN
+            -- Validate that base setting is numeric
+            BEGIN
+                format_value := base_setting_content::BIGINT;
+                json_object := json_object || jsonb_build_object('default', format_value);
+            EXCEPTION WHEN invalid_text_representation THEN
+                RAISE WARNING 'Base TabularIngestSizeLimit setting contains non-numeric value: %. Setting to 0 (disabling ingest!).', base_setting_content;
+                json_object := json_object || jsonb_build_object('default', 0);
+            END;
+        END IF;
+
+        -- Process format-specific settings
+        FOR format_record IN format_settings_cursor LOOP
+                -- Extract format name (everything after ":TabularIngestSizeLimit:")
+                format_name := substring(format_record.name from ':TabularIngestSizeLimit:(.*)');
+
+                -- Validate and convert the content to numeric
+                BEGIN
+                    format_value := format_record.content::BIGINT;
+                    json_object := json_object || jsonb_build_object(format_name, format_value);
+                EXCEPTION WHEN invalid_text_representation THEN
+                    warning_message := format('Format-specific TabularIngestSizeLimit setting %s contains non-numeric value: %s. Setting to 0 (disabling ingest!).',
+                                              format_record.name, format_record.content);
+                    RAISE WARNING '%', warning_message;
+                    json_object := json_object || jsonb_build_object(format_name, 0);
+                END;
+            END LOOP;
+
+        -- Insert or update the new JSON-based setting
+        INSERT INTO Setting (name, content, lang)
+        VALUES (':TabularIngestSizeLimit', json_object::TEXT, NULL)
+        ON CONFLICT (name) WHERE lang IS NULL
+            DO UPDATE SET content = EXCLUDED.content;
+
+        -- Delete all format-specific settings
+        DELETE FROM Setting
+        WHERE name LIKE ':TabularIngestSizeLimit:%'
+          AND lang IS NULL;
+
+        RAISE NOTICE 'Successfully migrated TabularIngestSizeLimit settings to JSON format: %', json_object::TEXT;
+    END $$;

--- a/src/main/resources/db/migration/V6.7.0.1.sql
+++ b/src/main/resources/db/migration/V6.7.0.1.sql
@@ -1,4 +1,4 @@
--- This script migrates the old TabularIngestSizeLimit database setting using format suffixes to a JSON based approach.
+-- Migrates the old TabularIngestSizeLimit database setting using format suffixes to a JSON based approach. See #11639
 
 DO $$
     DECLARE

--- a/src/main/resources/db/migration/V6.7.0.2.sql
+++ b/src/main/resources/db/migration/V6.7.0.2.sql
@@ -1,0 +1,35 @@
+-- Update Setting table structure for changes from #11639
+-- 1. Change column types from TEXT to VARCHAR for better performance
+-- 2. Update lang column to use empty string default instead of NULL (avoid non-unique pairs)
+-- 3. Add NOT NULL constraints and unique constraint for name+lang pairs
+
+-- First, update any existing NULL lang values to empty string
+UPDATE Setting SET lang = '' WHERE lang IS NULL;
+
+-- Postgres doesn't support IF NOT EXISTS for ALTER COLUMN or ADD CONSTRAINT, so we need conditional logic
+DO $$
+BEGIN
+    -- Only alter columns if they need to be changed
+    IF EXISTS (SELECT 1 FROM information_schema.columns
+               WHERE table_name = 'Setting' AND column_name = 'name'
+               AND (data_type = 'text' OR is_nullable = 'YES')) THEN
+        ALTER TABLE setting ALTER COLUMN name TYPE VARCHAR(255);
+        ALTER TABLE Setting ALTER COLUMN name SET NOT NULL;
+    END IF;
+
+    IF EXISTS (SELECT 1 FROM information_schema.columns
+               WHERE table_name = 'Setting' AND column_name = 'lang'
+               AND (data_type = 'text' OR is_nullable = 'YES')) THEN
+        ALTER TABLE Setting ALTER COLUMN lang TYPE VARCHAR(10);
+        ALTER TABLE Setting ALTER COLUMN lang SET NOT NULL;
+        ALTER TABLE Setting ALTER COLUMN lang SET DEFAULT '';
+    END IF;
+
+    IF NOT EXISTS (SELECT 1 FROM information_schema.table_constraints
+                   WHERE table_name = 'Setting'
+                     AND constraint_name = 'UC_setting_name_lang'
+                     AND constraint_type = 'UNIQUE') THEN
+        ALTER TABLE Setting ADD CONSTRAINT UC_setting_name_lang UNIQUE (name, lang);
+    END IF;
+
+END $$;

--- a/src/test/java/edu/harvard/iq/dataverse/EditDatafilesPageTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/EditDatafilesPageTest.java
@@ -1,0 +1,64 @@
+package edu.harvard.iq.dataverse;
+
+import edu.harvard.iq.dataverse.util.SystemConfig;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+class EditDatafilesPageTest {
+    
+    @InjectMocks
+    private EditDatafilesPage editDatafilesPage;
+    
+    @Mock
+    private SystemConfig systemConfig;
+    
+    public EditDatafilesPageTest() {
+        MockitoAnnotations.openMocks(this);
+    }
+    
+    @Test
+    void testPopulateHumanPerFormatTabularLimits_WithEmptyLimits() {
+        Map<String, Long> tabularLimits = new HashMap<>();
+        when(systemConfig.getTabularIngestSizeLimits()).thenReturn(tabularLimits);
+        
+        String result = editDatafilesPage.populateHumanPerFormatTabularLimits();
+        
+        assertEquals("", result, "Expected no formatted limits when the map is empty");
+    }
+    
+    @Test
+    void testPopulateHumanPerFormatTabularLimits_WithNonDefaultLimits() {
+        Map<String, Long> tabularLimits = new HashMap<>();
+        tabularLimits.put("csv", 10485760L); // 10MB
+        tabularLimits.put("tsv", 5242880L);  // 5MB
+        when(systemConfig.getTabularIngestSizeLimits()).thenReturn(tabularLimits);
+        
+        String result = editDatafilesPage.populateHumanPerFormatTabularLimits();
+        
+        assertTrue(result.contains("csv: 10.0 MB"), "Expected CSV limit in human-readable format, but got: " + result);
+        assertTrue(result.contains("tsv: 5.0 MB"), "Expected TSV limit in human-readable format, but got: " + result);
+    }
+    
+    @Test
+    void testPopulateHumanPerFormatTabularLimits_WithDefaultKey() {
+        Map<String, Long> tabularLimits = new HashMap<>();
+        tabularLimits.put(SystemConfig.TABULAR_INGEST_SIZE_LIMITS_DEFAULT_KEY, 2097152L); // 2MB
+        tabularLimits.put("csv", 10485760L); // 10MB
+        when(systemConfig.getTabularIngestSizeLimits()).thenReturn(tabularLimits);
+        
+        String result = editDatafilesPage.populateHumanPerFormatTabularLimits();
+        
+        assertTrue(result.contains("csv: 10.0 MB"), "Expected CSV limit in human-readable format, but got: " + result);
+        assertFalse(result.contains("default"), "Default key should be excluded from the output");
+    }
+}

--- a/src/test/java/edu/harvard/iq/dataverse/settings/SettingsServiceBeanTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/settings/SettingsServiceBeanTest.java
@@ -1,0 +1,48 @@
+package edu.harvard.iq.dataverse.settings;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class SettingsServiceBeanTest {
+    
+    @Nested
+    class KeyEnumTest {
+        static List<Arguments> parseTestParameters() {
+            return List.of(
+                Arguments.of(null, null),
+                Arguments.of("", null),
+                Arguments.of("    ", null),
+                Arguments.of("foobar", null),
+                Arguments.of("ShowMuteOptions", null),
+                Arguments.of(":FooBar", null),
+                Arguments.of(":ShowMuteOptions", SettingsServiceBean.Key.ShowMuteOptions)
+            );
+        }
+        
+        @MethodSource("parseTestParameters")
+        @ParameterizedTest
+        void testParse(String sut, SettingsServiceBean.Key expected) {
+            assertEquals(expected, SettingsServiceBean.Key.parse(sut));
+        }
+        
+        @Test
+        void testToString() {
+            // Make sure we test the intended behavior so it doesn't change by accident.
+            assertEquals(":ShowMuteOptions", SettingsServiceBean.Key.ShowMuteOptions.toString());
+        }
+        
+        @Test
+        void testRoundtrip() {
+            for (SettingsServiceBean.Key key : SettingsServiceBean.Key.values()) {
+                assertEquals(key, SettingsServiceBean.Key.parse(key.toString()));
+            }
+        }
+    }
+}

--- a/src/test/java/edu/harvard/iq/dataverse/settings/SettingsServiceBeanTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/settings/SettingsServiceBeanTest.java
@@ -16,6 +16,7 @@ import org.mockito.ArgumentMatchers;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -247,13 +248,15 @@ class SettingsServiceBeanTest {
                 .build();
             
             // When
-            List<Setting> result = SettingsServiceBean.convertJsonToSettings(input);
+            Set<Setting> result = SettingsServiceBean.convertJsonToSettings(input);
             
             // Then
             assertEquals(3, result.size());
-            assertEquals(new Setting(":Key1", "Value1"), result.get(0));
-            assertEquals(new Setting(":Key2", "123456"), result.get(1));
-            assertEquals(new Setting(":Key3", "123456"), result.get(2));
+            assertEquals(
+                Set.of(new Setting(":Key1", "Value1"),
+                       new Setting(":Key2", "123456"),
+                       new Setting(":Key3", "123456")
+                ), result);
         }
         
         @Test
@@ -265,12 +268,14 @@ class SettingsServiceBeanTest {
                 .build();
             
             // When
-            List<Setting> result = SettingsServiceBean.convertJsonToSettings(input);
+            Set<Setting> result = SettingsServiceBean.convertJsonToSettings(input);
             
             // Then
             assertEquals(2, result.size());
-            assertEquals(new Setting(":LocalizedKey", "en", "EnglishValue"), result.get(0));
-            assertEquals(new Setting(":LocalizedKey", "fr", "FrenchValue"), result.get(1));
+            assertEquals(
+                Set.of(new Setting(":LocalizedKey", "en", "EnglishValue"),
+                       new Setting(":LocalizedKey", "fr", "FrenchValue")
+                ), result);
         }
         
         @Test
@@ -279,7 +284,7 @@ class SettingsServiceBeanTest {
             JsonObject input = Json.createObjectBuilder().build();
             
             // When
-            List<Setting> result = SettingsServiceBean.convertJsonToSettings(input);
+            Set<Setting> result = SettingsServiceBean.convertJsonToSettings(input);
             
             // Then
             assertEquals(0, result.size());
@@ -299,13 +304,13 @@ class SettingsServiceBeanTest {
                 .build();
             
             // When
-            List<Setting> result = SettingsServiceBean.convertJsonToSettings(input);
+            Set<Setting> result = SettingsServiceBean.convertJsonToSettings(input);
             
             // Then
             assertEquals(1, result.size());
             assertEquals(new Setting(":MaxFileUploadSizeInBytes",
                     "{\"default\":\"2147483648\",\"fileOne\":\"4000000000\",\"s3\":\"8000000000\"}"),
-                result.get(0));
+                result.stream().toList().get(0));
         }
         
         

--- a/src/test/java/edu/harvard/iq/dataverse/settings/SettingsServiceBeanTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/settings/SettingsServiceBeanTest.java
@@ -1,14 +1,22 @@
 package edu.harvard.iq.dataverse.settings;
 
+import jakarta.json.JsonObject;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.TypedQuery;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentMatchers;
 
+import java.util.Collections;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class SettingsServiceBeanTest {
     
@@ -43,6 +51,78 @@ class SettingsServiceBeanTest {
             for (SettingsServiceBean.Key key : SettingsServiceBean.Key.values()) {
                 assertEquals(key, SettingsServiceBean.Key.parse(key.toString()));
             }
+        }
+    }
+    
+    @Nested
+    class ListAllAsJsonTest {
+        
+        static TypedQuery<Setting> typedQuery = mock(TypedQuery.class);
+        static EntityManager em = mock(EntityManager.class);
+        static SettingsServiceBean settingsServiceBean = new SettingsServiceBean();
+        
+        @BeforeAll
+        static void setup() {
+            settingsServiceBean.em = em;
+            
+            when(em.createNamedQuery(
+                ArgumentMatchers.eq("Setting.findAll"),
+                ArgumentMatchers.eq(Setting.class)))
+                .thenReturn(typedQuery);
+        }
+        
+        @Test
+        void testListAllAsJson_noSettings() {
+            // Given
+            List<Setting> emptyList = Collections.emptyList();
+            when(typedQuery.getResultList()).thenReturn(emptyList);
+            
+            // When
+            JsonObject result = settingsServiceBean.listAllAsJson();
+            
+            // Then
+            assertEquals(0, result.size());
+        }
+        
+        @Test
+        void testListAllAsJson_nonLocalizedSettings() {
+            // Given
+            List<Setting> resultList = List.of(
+                new Setting("testKey1", "testValue1"),
+                new Setting("testKey2", "testValue2")
+            );
+            when(typedQuery.getResultList()).thenReturn(resultList);
+            
+            // When
+            JsonObject result = settingsServiceBean.listAllAsJson();
+            
+            // Then
+            assertEquals(2, result.size());
+            assertEquals("testValue1", result.getString("testKey1"));
+            assertEquals("testValue2", result.getString("testKey2"));
+        }
+        
+        @Test
+        void testListAllAsJson_localizedSettings() {
+            // Given
+            List<Setting> resultList = List.of(
+                new Setting("localizedKey", "value_base"),
+                new Setting("localizedKey", "en", "value_en"),
+                new Setting("localizedKey", "fr", "value_fr")
+            );
+            when(typedQuery.getResultList()).thenReturn(resultList);
+            
+            // When
+            JsonObject result = settingsServiceBean.listAllAsJson();
+            
+            // Then
+            assertEquals(1, result.size());
+            JsonObject localizedSetting = result.getJsonObject("localizedKey");
+            
+            assertEquals(3, localizedSetting.size());
+            assertEquals("value_base", localizedSetting.getString("base"));
+            assertEquals("value_en", localizedSetting.getString("en"));
+            assertEquals("value_fr", localizedSetting.getString("fr"));
         }
     }
 }

--- a/src/test/java/edu/harvard/iq/dataverse/settings/SettingsServiceBeanTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/settings/SettingsServiceBeanTest.java
@@ -89,7 +89,7 @@ class SettingsServiceBeanTest {
             // Given
             List<Setting> resultList = List.of(
                 new Setting("testKey1", "testValue1"),
-                new Setting("testKey2", "testValue2")
+                new Setting("testKey2", "12345")
             );
             when(typedQuery.getResultList()).thenReturn(resultList);
             
@@ -99,7 +99,29 @@ class SettingsServiceBeanTest {
             // Then
             assertEquals(2, result.size());
             assertEquals("testValue1", result.getString("testKey1"));
-            assertEquals("testValue2", result.getString("testKey2"));
+            assertEquals("12345", result.getString("testKey2"));
+        }
+        
+        @Test
+        void testListAllAsJson_jsonSetting() {
+            // Given
+            JsonObject expected = Json.createObjectBuilder()
+                .add("default", "2147483648")
+                .add("fileOne", "4000000000")
+                .add("s3", "8000000000")
+                .build();
+            
+            List<Setting> resultList = List.of(
+                new Setting(SettingsServiceBean.Key.MaxFileUploadSizeInBytes.toString(), "{\"default\":\"2147483648\",\"fileOne\":\"4000000000\",\"s3\":\"8000000000\"}")
+            );
+            when(typedQuery.getResultList()).thenReturn(resultList);
+            
+            // When
+            JsonObject result = settingsServiceBean.listAllAsJson();
+            
+            // Then
+            assertEquals(1, result.size());
+            assertEquals(expected.toString(), result.getJsonObject(SettingsServiceBean.Key.MaxFileUploadSizeInBytes.toString()).toString());
         }
         
         @Test

--- a/src/test/java/edu/harvard/iq/dataverse/settings/SettingsServiceBeanTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/settings/SettingsServiceBeanTest.java
@@ -106,6 +106,42 @@ class SettingsServiceBeanTest {
     }
     
     @Nested
+    class ValidateKeysTest {
+        static List<Arguments> validateKeysTestParameters() {
+            return List.of(
+                Arguments.of(
+                    Json.createObjectBuilder()
+                        .add(":ApplicationTermsOfUse", "validValue1")
+                        .add(":ApplicationTermsOfUse/lang/en", "validValue2")
+                        .build(),
+                    List.of()
+                ),
+                Arguments.of(
+                    Json.createObjectBuilder()
+                        .add(":Invalid:Key", "value1")
+                        .add(":NonExistentKey/lang/fr", "value2")
+                        .build(),
+                    List.of(":Invalid:Key", ":NonExistentKey/lang/fr")
+                ),
+                Arguments.of(
+                    Json.createObjectBuilder()
+                        .add(":ApplicationTermsOfUse", "value3")
+                        .add("NoColonKey", "value4")
+                        .build(),
+                    List.of("NoColonKey")
+                )
+            );
+        }
+        
+        @MethodSource("validateKeysTestParameters")
+        @ParameterizedTest
+        void testValidateKeys(JsonObject input, List<String> expectedInvalidKeys) {
+            List<String> result = SettingsServiceBean.validateKeys(input);
+            assertEquals(expectedInvalidKeys, result);
+        }
+    }
+    
+    @Nested
     class ListAllAsJsonTest {
         
         static TypedQuery<Setting> typedQuery = mock(TypedQuery.class);

--- a/src/test/java/edu/harvard/iq/dataverse/settings/SettingsServiceBeanTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/settings/SettingsServiceBeanTest.java
@@ -116,13 +116,10 @@ class SettingsServiceBeanTest {
             JsonObject result = settingsServiceBean.listAllAsJson();
             
             // Then
-            assertEquals(1, result.size());
-            JsonObject localizedSetting = result.getJsonObject("localizedKey");
-            
-            assertEquals(3, localizedSetting.size());
-            assertEquals("value_base", localizedSetting.getString("base"));
-            assertEquals("value_en", localizedSetting.getString("en"));
-            assertEquals("value_fr", localizedSetting.getString("fr"));
+            assertEquals(3, result.size());
+            assertEquals("value_base", result.getString("localizedKey"));
+            assertEquals("value_en", result.getString("localizedKey/lang/en"));
+            assertEquals("value_fr", result.getString("localizedKey/lang/fr"));
         }
     }
 }

--- a/src/test/java/edu/harvard/iq/dataverse/util/SystemConfigTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/util/SystemConfigTest.java
@@ -203,6 +203,20 @@ class SystemConfigTest {
     }
     
     @Test
+    void testGetTabularIngestSizeLimitsWithJsonButUnsupportedJsonInt() {
+        // given
+        String invalidJson = "{\"default\": 0}";
+        doReturn(invalidJson).when(settingsService).getValueForKey(SettingsServiceBean.Key.TabularIngestSizeLimit);
+        
+        // when
+        Map<String, Long> result = systemConfig.getTabularIngestSizeLimits();
+        
+        // then
+        assertEquals(1, result.size());
+        assertEquals(0L, (long) result.get(SystemConfig.TABULAR_INGEST_SIZE_LIMITS_DEFAULT_KEY));
+    }
+    
+    @Test
     void testGetTabularIngestSizeLimitsWithInvalidJson() {
         // given
         String invalidJson = "{invalid:}";

--- a/src/test/java/edu/harvard/iq/dataverse/util/SystemConfigTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/util/SystemConfigTest.java
@@ -12,6 +12,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Map;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doReturn;
@@ -142,5 +144,89 @@ class SystemConfigTest {
         assertEquals(1000000l, SystemConfig.getThumbnailSizeLimit("PDF"));
         assertEquals(0l, SystemConfig.getThumbnailSizeLimit("NoSuchType"));
     }
-
+    
+    @Test
+    void testGetTabularIngestSizeLimitsWithoutSetting() {
+        // given
+        doReturn(null).when(settingsService).getValueForKey(SettingsServiceBean.Key.TabularIngestSizeLimit);
+        
+        // when
+        Map<String, Long> result = systemConfig.getTabularIngestSizeLimits();
+        
+        // then
+        assertEquals(1, result.size());
+        assertEquals(-1L, (long) result.get(SystemConfig.TABULAR_INGEST_SIZE_LIMITS_DEFAULT_KEY));
+    }
+    
+    @Test
+    void testGetTabularIngestSizeLimitsWithValidJson() {
+        // given
+        String validJson = "{\"csV\": \"5000\", \"tSv\": \"10000\"}";
+        doReturn(validJson).when(settingsService).getValueForKey(SettingsServiceBean.Key.TabularIngestSizeLimit);
+        
+        // when
+        Map<String, Long> result = systemConfig.getTabularIngestSizeLimits();
+        
+        // then
+        assertEquals(3, result.size());
+        assertEquals(-1L, (long) result.get(SystemConfig.TABULAR_INGEST_SIZE_LIMITS_DEFAULT_KEY));
+        assertEquals(5000L, result.get("csv"));
+        assertEquals(10000L, result.get("tsv"));
+    }
+    
+    @Test
+    void testGetTabularIngestSizeLimitsWithSingleValue() {
+        // given
+        String singleValue = "8000";
+        doReturn(singleValue).when(settingsService).getValueForKey(SettingsServiceBean.Key.TabularIngestSizeLimit);
+        
+        // when
+        Map<String, Long> result = systemConfig.getTabularIngestSizeLimits();
+        
+        // then
+        assertEquals(1, result.size());
+        assertEquals(8000L, (long) result.get(SystemConfig.TABULAR_INGEST_SIZE_LIMITS_DEFAULT_KEY));
+    }
+    
+    @Test
+    void testGetTabularIngestSizeLimitsWithSingleInvalidValue() {
+        // given
+        String singleValue = "this-aint-no-number";
+        doReturn(singleValue).when(settingsService).getValueForKey(SettingsServiceBean.Key.TabularIngestSizeLimit);
+        
+        // when
+        Map<String, Long> result = systemConfig.getTabularIngestSizeLimits();
+        
+        // then
+        assertEquals(1, result.size());
+        assertEquals(0L, (long) result.get(SystemConfig.TABULAR_INGEST_SIZE_LIMITS_DEFAULT_KEY));
+    }
+    
+    @Test
+    void testGetTabularIngestSizeLimitsWithInvalidJson() {
+        // given
+        String invalidJson = "{invalid:}";
+        doReturn(invalidJson).when(settingsService).getValueForKey(SettingsServiceBean.Key.TabularIngestSizeLimit);
+        
+        // when
+        Map<String, Long> result = systemConfig.getTabularIngestSizeLimits();
+        
+        // then
+        assertEquals(1, result.size());
+        assertEquals(0L, (long) result.get(SystemConfig.TABULAR_INGEST_SIZE_LIMITS_DEFAULT_KEY));
+    }
+    
+    @Test
+    void testGetTabularIngestSizeLimitsWithInvalidNumberInValidJson() {
+        // given
+        String invalidJson = "{\"csv\": \"this-is-not-a-number\", \"tSv\": \"10000\"}";
+        doReturn(invalidJson).when(settingsService).getValueForKey(SettingsServiceBean.Key.TabularIngestSizeLimit);
+        
+        // when
+        Map<String, Long> result = systemConfig.getTabularIngestSizeLimits();
+        
+        // then
+        assertEquals(1, result.size());
+        assertEquals(0L, (long) result.get(SystemConfig.TABULAR_INGEST_SIZE_LIMITS_DEFAULT_KEY));
+    }
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Enable setting all the database settings in one go, using an atomic database operation.

Open TODOs to make this ready for review:
- [ ] Include release note snippet, highlight keys changed, explain usage
- [ ] Add / Enhance endpoint docs to API guides
- [ ] Add note about bulk endpoints to Install->Config Guide
- [ ] Add integration and/or API E2E tests for endpoints
- [ ] Choose whether to add the configbaker script to this already large PR

**Which issue(s) this PR closes**:

- Closes #11639

**Special notes for your reviewer**:
Aside from the bulk operation itself, it required a lot more work to actually implement this properly. Unfortunately, this makes this PR a lot larger than anticipated, but hopefully it's worth it. (I suppose DB opts are not going to go away anytime soon...)

1. I had to migrate any non-aligned database setting names. Reshaped them into a form that makes it easier to do input validation in the code. But also makes it easier for sysadmins to use, as there are no longer three different naming schemes for them. (This affects the infamous BuiltinUsers.KEY and limits for tabular file ingests.)
2. All Admin API endpoints for settings didn't do any input validation *at all*. You could basically do whatever you want, even accidentally. This has been mitigated.
3. The way the `Setting`class was setup it impeded performance and did not enforce any constraints to avoid duplicated settings.
4. The endpoint to retrieve all settings as JSON was faulty: it did not take the localization into account.
5. Most of the code around DB settings was untested. For bits I added, I added tests to make sure things work as intended.

**Suggestions on how to test this**:
- Run the included tests
- Roundtrip! Get all settings as JSON and put them back in.
- Apply DB migrations on a DB dump from a real instance using Flyway Maven Plugin to verify before deploying
- ...?

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
 Nope

**Is there a release notes update needed for this change?**:
To Be Done

**Additional documentation**:
None
