### PR TITLE
switch base.image.version back to non-revision (post 6.7 release)

### DIFF
--- a/modules/dataverse-parent/pom.xml
+++ b/modules/dataverse-parent/pom.xml
@@ -454,8 +454,8 @@
                     Once the release has been made (tag created), change this back to "${parsedVersion.majorVersion}.${parsedVersion.nextMinorVersion}"
                     (These properties are provided by the build-helper plugin below.)
                 -->
-                <!--<base.image.version>${parsedVersion.majorVersion}.${parsedVersion.nextMinorVersion}</base.image.version>-->
-                <base.image.version>${revision}</base.image.version>
+                <base.image.version>${parsedVersion.majorVersion}.${parsedVersion.nextMinorVersion}</base.image.version>
+                <!--<base.image.version>${revision}</base.image.version>-->
                 <!-- This is used by the maintenance CI jobs, no need to adapt during releases. -->
                 <app.image.version>${base.image.version}</app.image.version>
             </properties>


### PR DESCRIPTION
**What this PR does / why we need it**:

This step is part of publishing containers properly to Docker Hub.

It's documented here: https://guides.dataverse.org/en/6.7/developers/making-releases.html#update-the-container-base-image-version-property

**Which issue(s) this PR closes**:

- Closes #11651

**Special notes for your reviewer**:

None.

**Suggestions on how to test this**:

None, really. Automated tests will tell us if the war file compiles.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No.

**Is there a release notes update needed for this change?**:

No.

**Additional documentation**:

No.