### PR TITLE
Improved Featured item efficiency during publication

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/dataverse/featured/DataverseFeaturedItemServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/dataverse/featured/DataverseFeaturedItemServiceBean.java
@@ -79,7 +79,6 @@ public class DataverseFeaturedItemServiceBean implements Serializable {
                 if (df.isRestricted() || df.isInDatasetVersion(latestVersion)) {
                     logger.fine("Deleting invalidated Featured Item for " + (df.isRestricted() ? "Restricted" : "Deleted") + " Datafile ID: " + df.getId());
                     deleteAllByDvObjectId(df.getId());
-                    continue;
                 }
             }
         }


### PR DESCRIPTION
**What this PR does / why we need it**: The original code streamed through all files in the latest dataset version to create a list of all file ids, and did so once for each featured item, as a way to see if a datafile used in a FeaturedItem was in the latest version. This PR just checks that directly via df.isInDatasetVersion().

**Which issue(s) this PR closes**:

- Closes #

**Special notes for your reviewer**: Just ran across this while hunting for an optimistic lock exception.

**Suggestions on how to test this**: Just regression test that publishing a dataset with FeaturedItems for some of its files deletes the items at publication time if the files are restricted in or deleted from the latest version.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
