### PR TITLE
Fix ct image releasing

### DIFF
--- a/.github/workflows/scripts/containers/maintain-base.sh
+++ b/.github/workflows/scripts/containers/maintain-base.sh
@@ -120,6 +120,13 @@ for BRANCH in "$@"; do
   CURRENT_REV_TAG="${BASE_IMAGE_REF#*:}-r$REV"
   NEXT_REV_TAG="${BASE_IMAGE_REF#*:}-r$(( REV + 1 ))"
 
+  # 6a. Determine if we must newly release an "r0" because a rolling tag from development is now released.
+  IS_NEW_RELEASE=0
+  if ! (( IS_DEV )) && [ "$REV" = "-1" ]; then
+    echo "This is a newly released version of Dataverse - forcing build, as no r0 image is present on Docker Hub"
+    IS_NEW_RELEASE=1
+  fi
+
   # 7. Let's put together what tags we want added to this build run
   TAG_OPTIONS=""
   if ! (( IS_DEV )); then
@@ -139,7 +146,7 @@ for BRANCH in "$@"; do
 
   # 8. Let's build the base image if necessary
   NEWER_IMAGE=0
-  if (( NEWER_JAVA_IMAGE + NEWER_PKGS + FORCE_BUILD > 0 )); then
+  if (( NEWER_JAVA_IMAGE + NEWER_PKGS + IS_NEW_RELEASE + FORCE_BUILD > 0 )); then
     if ! (( DRY_RUN )); then
       # shellcheck disable=SC2046
       mvn -Pct -f modules/container-base deploy -Ddocker.noCache -Ddocker.platforms="${PLATFORMS}" \


### PR DESCRIPTION
**What this PR does / why we need it**:

Add another build trigger for base images in case there is no "r0" tag on the hub, the base image needs no updates, but we're maintaining a release.

**Which issue(s) this PR closes**:

- Closes #11659

**Special notes for your reviewer**:
None

**Suggestions on how to test this**:
Copy the added bits into a separate test script at `.github/workflows/scripts/containers/test.sh`:
```shell
#!/usr/bin/bash

BASE_IMAGE_REF="gdcc/base:6.8-noble"
IS_DEV=0

source "$( dirname "$0" )/utils.sh"
REV=$( current_revision "$BASE_IMAGE_REF" )

IS_NEW_RELEASE=0
if ! (( IS_DEV )) && [ "$REV" = "-1" ]; then
  echo "This is a newly released version of Dataverse - forcing build, as no r0 image is present on Docker Hub"
  IS_NEW_RELEASE=1
fi

echo "is_new_release: ${IS_NEW_RELEASE}"
```
Running the script should print:
```
This is a newly released version of Dataverse - forcing build, as no r0 image is present on Docker Hub
is_new_release: 1
```
Changing `IS_DEV=1` or changing the `BASE_IMAGE_REF` to point to e.g. `6.6-noble` should print `is_new_release=0`.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
Nope.

**Is there a release notes update needed for this change?**:
Nope.

**Additional documentation**:
None.