### PR TITLE
support read/unread status for notifications

### DIFF
--- a/doc/release-notes/11650-unread.md
+++ b/doc/release-notes/11650-unread.md
@@ -1,0 +1,11 @@
+## API Updates 
+
+### Support read/unread status for notifications
+
+The API for managing notifications has been extended. 
+
+- displayAsRead boolean added to "get all"
+- new GET unreadCount API endpoint
+- new PUT markAsRead API endpoint
+
+See also [the guides](https://dataverse-guide--11664.org.readthedocs.build/en/11664/api/native-api.html#notifications), #11650, and #11664.

--- a/doc/sphinx-guides/source/api/native-api.rst
+++ b/doc/sphinx-guides/source/api/native-api.rst
@@ -5925,7 +5925,7 @@ You can get a count of your unread notifications as shown below.
 
 .. code-block:: bash
 
-  curl -H "X-Dataverse-key:$API_TOKEN" -X PUT "$SERVER_URL/api/notifications/unreadCount"
+  curl -H "X-Dataverse-key:$API_TOKEN" -X GET "$SERVER_URL/api/notifications/unreadCount"
 
 Mark Notification As Read
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/sphinx-guides/source/api/native-api.rst
+++ b/doc/sphinx-guides/source/api/native-api.rst
@@ -5921,7 +5921,7 @@ The expected OK (200) response looks something like this:
 Get Unread Count
 ~~~~~~~~~~~~~~~~
 
-You can get a count of your unread messages as shown below.
+You can get a count of your unread notifications as shown below.
 
 .. code-block:: bash
 
@@ -5930,7 +5930,7 @@ You can get a count of your unread messages as shown below.
 Mark Notification As Read
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-After finding the ID of a notification using :ref:`get-all-notifications`, you can pass it to the "markAsRead" API endpoint as shown below. Note that this endpoint is idempotent; you can mark an already-read message as read over and over.
+After finding the ID of a notification using :ref:`get-all-notifications`, you can pass it to the "markAsRead" API endpoint as shown below. Note that this endpoint is idempotent; you can mark an already-read notification as read over and over.
 
 .. code-block:: bash
 

--- a/doc/sphinx-guides/source/api/native-api.rst
+++ b/doc/sphinx-guides/source/api/native-api.rst
@@ -5889,6 +5889,8 @@ Notifications
 
 See :ref:`account-notifications` in the User Guide for an overview. For a list of all the notification types mentioned below (e.g. ASSIGNROLE), see :ref:`mute-notifications` in the Admin Guide.
 
+.. _get-all-notifications:
+
 Get All Notifications by User
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -5897,6 +5899,52 @@ Each user can get a dump of their notifications by passing in their API token:
 .. code-block:: bash
 
   curl -H "X-Dataverse-key:$API_TOKEN" "$SERVER_URL/api/notifications/all"
+
+The expected OK (200) response looks something like this:
+
+.. code-block:: text
+
+  {
+      "status": "OK",
+      "data": {
+          "notifications": [
+              {
+                  "id": 38,
+                  "type": "CREATEACC",
+                  "displayAsRead": true,
+                  "subjectText": "Root: Your account has been created",
+                  "messageText": "Hello, \nWelcome to...",
+                  "sentTimestamp": "2025-07-21T19:15:37Z"
+              }
+  ...
+
+Get Unread Count
+~~~~~~~~~~~~~~~~
+
+You can get a count of your unread messages as shown below.
+
+.. code-block:: bash
+
+  curl -H "X-Dataverse-key:$API_TOKEN" -X PUT "$SERVER_URL/api/notifications/unreadCount"
+
+Mark Notification As Read
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+After finding the ID of a notification using :ref:`get-all-notifications`, you can pass it to the "markAsRead" API endpoint as shown below. Note that this endpoint is idempotent; you can mark an already-read message as read over and over.
+
+.. code-block:: bash
+
+  export API_TOKEN=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+  export SERVER_URL=https://demo.dataverse.org
+  export NOTIFICATION_ID=555
+
+  curl -H "X-Dataverse-key:$API_TOKEN" -X PUT "$SERVER_URL/api/notifications/$NOTIFICATION_ID/markAsRead"
+
+The fully expanded example above (without environment variables) looks like this:
+
+.. code-block:: bash
+
+  curl -H "X-Dataverse-key:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" -X PUT "https://demo.dataverse.org/api/notifications/555/markAsRead"
 
 Delete Notification by User
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/main/java/edu/harvard/iq/dataverse/UserNotificationServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/UserNotificationServiceBean.java
@@ -87,7 +87,12 @@ public class UserNotificationServiceBean {
     public UserNotification save(UserNotification userNotification) {
         return em.merge(userNotification);
     }
-    
+
+    public UserNotification markAsRead(UserNotification userNotification) {
+        userNotification.setReadNotification(true);
+        return em.merge(userNotification);
+    }
+
     public void delete(UserNotification userNotification) {
         em.remove(em.merge(userNotification));
     }

--- a/src/main/java/edu/harvard/iq/dataverse/authorization/providers/builtin/DataverseUserPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/authorization/providers/builtin/DataverseUserPage.java
@@ -563,6 +563,7 @@ public class DataverseUserPage implements java.io.Serializable {
             userNotification.setDisplayAsRead(userNotification.isReadNotification());
             if (userNotification.isReadNotification() == false) {
                 userNotification.setReadNotification(true);
+                // consider switching to userNotificationService.markAsRead
                 userNotificationService.save(userNotification);
             }
         }

--- a/src/test/java/edu/harvard/iq/dataverse/api/NotificationsIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/NotificationsIT.java
@@ -5,6 +5,7 @@ import io.restassured.path.json.JsonPath;
 import io.restassured.response.Response;
 import java.util.logging.Logger;
 import static jakarta.ws.rs.core.Response.Status.CREATED;
+import static jakarta.ws.rs.core.Response.Status.NOT_FOUND;
 import static jakarta.ws.rs.core.Response.Status.OK;
 import static org.hamcrest.CoreMatchers.equalTo;
 import org.junit.jupiter.api.BeforeAll;
@@ -29,6 +30,12 @@ public class NotificationsIT {
         String authorUsername = UtilIT.getUsernameFromResponse(createAuthor);
         String authorApiToken = UtilIT.getApiTokenFromResponse(createAuthor);
 
+        Response nopermsUser = UtilIT.createRandomUser();
+        nopermsUser.prettyPrint();
+        nopermsUser.then().assertThat()
+                .statusCode(OK.getStatusCode());
+        String nopermsApiToken = UtilIT.getApiTokenFromResponse(nopermsUser);
+
         // Some API calls don't generate a notification: https://github.com/IQSS/dataverse/issues/1342
         Response createDataverseResponse = UtilIT.createRandomDataverse(authorApiToken);
         createDataverseResponse.prettyPrint();
@@ -41,22 +48,50 @@ public class NotificationsIT {
         createDataset.prettyPrint();
         createDataset.then().assertThat()
                 .statusCode(CREATED.getStatusCode());
+
         Response getNotifications = UtilIT.getNotifications(authorApiToken);
         getNotifications.prettyPrint();
         getNotifications.then().assertThat()
                 .body("data.notifications[0].type", equalTo("CREATEACC"))
+                .body("data.notifications[0].displayAsRead", equalTo(false))
                 .body("data.notifications[1]", equalTo(null))
                 .statusCode(OK.getStatusCode());
 
-        long id = JsonPath.from(getNotifications.getBody().asString()).getLong("data.notifications[0].id");
+        Response unreadCount = UtilIT.getUnreadNotificationsCount(authorApiToken);
+        unreadCount.prettyPrint();
+        unreadCount.then().assertThat()
+                .statusCode(OK.getStatusCode())
+                .body("data.unreadCount", equalTo(1));
 
-        Response deleteNotification = UtilIT.deleteNotification(id, authorApiToken);
-        deleteNotification.prettyPrint();
-        deleteNotification.then().assertThat().statusCode(OK.getStatusCode());
+        long createAccountId = JsonPath.from(getNotifications.getBody().asString()).getLong("data.notifications[0].id");
+
+        Response markReadNoPerms = UtilIT.markNotificationAsRead(createAccountId, nopermsApiToken);
+        markReadNoPerms.prettyPrint();
+        markReadNoPerms.then().assertThat().statusCode(NOT_FOUND.getStatusCode());
+
+        Response markRead = UtilIT.markNotificationAsRead(createAccountId, authorApiToken);
+        markRead.prettyPrint();
+        markRead.then().assertThat().statusCode(OK.getStatusCode());
 
         Response getNotifications2 = UtilIT.getNotifications(authorApiToken);
         getNotifications2.prettyPrint();
         getNotifications2.then().assertThat()
+                .body("data.notifications[0].type", equalTo("CREATEACC"))
+                .body("data.notifications[0].displayAsRead", equalTo(true))
+                .body("data.notifications[1]", equalTo(null))
+                .statusCode(OK.getStatusCode());
+
+        Response deleteNotificationNoPerms = UtilIT.deleteNotification(createAccountId, nopermsApiToken);
+        deleteNotificationNoPerms.prettyPrint();
+        deleteNotificationNoPerms.then().assertThat().statusCode(NOT_FOUND.getStatusCode());
+
+        Response deleteNotification = UtilIT.deleteNotification(createAccountId, authorApiToken);
+        deleteNotification.prettyPrint();
+        deleteNotification.then().assertThat().statusCode(OK.getStatusCode());
+
+        Response getNotifications3 = UtilIT.getNotifications(authorApiToken);
+        getNotifications3.prettyPrint();
+        getNotifications3.then().assertThat()
                 .body("data.notifications[0]", equalTo(null))
                 .statusCode(OK.getStatusCode());
 

--- a/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
@@ -1710,6 +1710,24 @@ public class UtilIT {
         return requestSpecification.get("/api/notifications/all");
     }
 
+    static Response getUnreadNotificationsCount(String apiToken) {
+        RequestSpecification requestSpecification = given();
+        if (apiToken != null) {
+            requestSpecification = given()
+                    .header(UtilIT.API_TOKEN_HTTP_HEADER, apiToken);
+        }
+        return requestSpecification.get("/api/notifications/unreadCount");
+    }
+
+    static Response markNotificationAsRead(long id, String apiToken) {
+        RequestSpecification requestSpecification = given();
+        if (apiToken != null) {
+            requestSpecification = given()
+                    .header(UtilIT.API_TOKEN_HTTP_HEADER, apiToken);
+        }
+        return requestSpecification.put("/api/notifications/" + id + "/markAsRead");
+    }
+
     static Response deleteNotification(long id, String apiToken) {
         RequestSpecification requestSpecification = given();
         if (apiToken != null) {


### PR DESCRIPTION
**What this PR does / why we need it**:

- displayAsRead boolean added to "get all"
- new GET unreadCount API endpoint
- new PUT markAsRead API endpoint

**Which issue(s) this PR closes**:

- Closes #11650

**Special notes for your reviewer**:

NotificationsIT points out two APIs that don't generate notifications at all:

- UtilIT.createRandomDataverse
- UtilIT.createRandomDatasetViaNativeApi

They probably should! And there are probably others. I opened this issue a while ago (10+ years!) about this:

- #1342


As I mentioned [in Slack](https://iqss.slack.com/archives/C04MJ76A34Z/p1753124183266819), we could maybe go with just "read", "unread" (what GitHub [uses](https://docs.github.com/en/rest/activity/notifications?apiVersion=2022-11-28#list-notifications-for-the-authenticated-user)), or "hasBeenRead" instead of "displayAsRead" (which comes from a transient [variable](https://github.com/IQSS/dataverse/blob/23d47a3063576c69a4efaad1bd07e9e89b0a3151/src/main/java/edu/harvard/iq/dataverse/UserNotification.java#L98) used by JSF).

Existing methods in Notifications.java use a funny pattern to get an authenticated user. Methods I added use our standard getRequestAuthenticatedUserOrDie.

@ekraffmiller mentioned that #11648 is related and I plan to take a look, at least. I think a fix might be better as a follow up pull request. Update: a draft, for now:

- #11665

Here are some related GitHub APIs I looked at:

- https://docs.github.com/en/rest/activity/notifications?apiVersion=2022-11-28#mark-notifications-as-read
- https://docs.github.com/en/rest/activity/notifications?apiVersion=2022-11-28#mark-a-thread-as-read

They obviously store timestamps for when notifications were read but we only store booleans.

**Suggestions on how to test this**:

Try the endpoints mentioned in the docs for this PR.

Automated tests are also included. Make sure they are passing.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No.

**Is there a release notes update needed for this change?**:

Yes, included.

**Additional documentation**:

Preview at https://dataverse-guide--11664.org.readthedocs.build/en/11664/api/native-api.html#notifications