### PR TITLE
Revert #11301 and bump version to 6.7.1

### DIFF
--- a/doc/sphinx-guides/source/conf.py
+++ b/doc/sphinx-guides/source/conf.py
@@ -70,7 +70,7 @@ copyright = u'%d, The President & Fellows of Harvard College' % datetime.now().y
 # built documents.
 #
 # The short X.Y version.
-version = '6.7'
+version = '6.7.1'
 # The full version, including alpha/beta/rc tags.
 release = version
 

--- a/doc/sphinx-guides/source/versions.rst
+++ b/doc/sphinx-guides/source/versions.rst
@@ -8,6 +8,7 @@ This list provides a way to refer to the documentation for previous and future v
 
 - pre-release `HTML (not final!) <http://preview.guides.gdcc.io/en/develop/>`__ and `PDF (experimental!) <http://preview.guides.gdcc.io/_/downloads/en/develop/pdf/>`__ built from the :doc:`develop </developers/version-control>` branch :doc:`(how to contribute!) </contributor/documentation>`
 - |version|
+- `6.7 </en/6.7/>`__
 - `6.6 </en/6.6/>`__
 - `6.5 </en/6.5/>`__
 - `6.4 </en/6.4/>`__

--- a/modules/dataverse-parent/pom.xml
+++ b/modules/dataverse-parent/pom.xml
@@ -132,7 +132,7 @@
  
     <properties>
         <!-- This is a special Maven property name, do not change! -->
-        <revision>6.7</revision>
+        <revision>6.7.1</revision>
     
         <target.java.version>17</target.java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/modules/dataverse-parent/pom.xml
+++ b/modules/dataverse-parent/pom.xml
@@ -454,8 +454,8 @@
                     Once the release has been made (tag created), change this back to "${parsedVersion.majorVersion}.${parsedVersion.nextMinorVersion}"
                     (These properties are provided by the build-helper plugin below.)
                 -->
-                <!--<base.image.version>${parsedVersion.majorVersion}.${parsedVersion.nextMinorVersion}</base.image.version>-->
-                <base.image.version>${revision}</base.image.version>
+                <base.image.version>${parsedVersion.majorVersion}.${parsedVersion.nextMinorVersion}</base.image.version>
+                <!--<base.image.version>${revision}</base.image.version>-->
                 <!-- This is used by the maintenance CI jobs, no need to adapt during releases. -->
                 <app.image.version>${base.image.version}</app.image.version>
             </properties>

--- a/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
@@ -331,7 +331,6 @@ public class DatasetPage implements java.io.Serializable {
     private List<SelectItem> linkingDVSelectItems;
     private Dataverse linkingDataverse;
     private Dataverse selectedHostDataverse;
-    private boolean hasDataversesToChoose;
 
     public Dataverse getSelectedHostDataverse() {
         return selectedHostDataverse;
@@ -1771,11 +1770,6 @@ public class DatasetPage implements java.io.Serializable {
 
     public void setDataverseTemplates(List<Template> dataverseTemplates) {
         this.dataverseTemplates = dataverseTemplates;
-    }
-
-    public boolean isHasDataversesToChoose() {
-        this.hasDataversesToChoose = dataverseService.findAll().size() > 1;
-        return this.hasDataversesToChoose;
     }
 
     public Template getDefaultTemplate() {

--- a/src/main/java/edu/harvard/iq/dataverse/DataverseConverter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DataverseConverter.java
@@ -13,30 +13,19 @@ import jakarta.faces.context.FacesContext;
 import jakarta.faces.convert.Converter;
 import jakarta.faces.convert.FacesConverter;
 
-import java.util.logging.Logger;
-
 /**
  *
  * @author skraffmiller
  */
 @FacesConverter("dataverseConverter")
 public class DataverseConverter implements Converter {
-    private static final Logger logger = Logger.getLogger(DatasetPage.class.getCanonicalName());
-
     
     //@EJB
     DataverseServiceBean dataverseService = CDI.current().select(DataverseServiceBean.class).get();
 
     @Override
     public Object getAsObject(FacesContext facesContext, UIComponent component, String submittedValue) {
-        if (submittedValue == null || !submittedValue.matches("[0-9]+")) {
-            logger.fine("Submitted value is not a host dataverse number but: " + submittedValue);
-            return CDI.current().select(DatasetPage.class).get().getSelectedHostDataverse();
-        }
-        else {
-            return dataverseService.find(Long.valueOf(submittedValue));
-        }
-        //return dataverseService.findByAlias(submittedValue);
+        return dataverseService.findByAlias(submittedValue);
     }
 
     @Override

--- a/src/main/webapp/dataset.xhtml
+++ b/src/main/webapp/dataset.xhtml
@@ -753,7 +753,7 @@
                     <!-- Create/Edit editMode -->
                     <ui:fragment rendered="#{DatasetPage.editMode == 'METADATA' or DatasetPage.editMode == 'CREATE'}">
                         <p:focus context="datasetForm"/>
-                        <div class="form-group" jsf:rendered="#{DatasetPage.hasDataversesToChoose and DatasetPage.editMode == 'CREATE'}">
+                        <div class="form-group">
                             <label jsf:for="#{DatasetPage.editMode == 'CREATE' ? 'selectHostDataverse_input' : 'select_HostDataverse_Static'}" class="col-md-3 control-label">
                                 #{bundle.hostDataverse}
                                 <span class="glyphicon glyphicon-question-sign tooltip-icon"


### PR DESCRIPTION
**What this PR does / why we need it**:

After [deploying](https://github.com/IQSS/dataverse.harvard.edu/issues/345) 6.7 to Harvard Dataverse, we found a serious performance problem:

- #11698

The problem is being caused by this PR:

- #11301

We [decided](https://docs.google.com/document/d/13ci_BIgdejyW9d1ogg-xAqGQicyIRbklheYvXqDzuX8/edit?usp=sharing) to create a 6.7.1 hotfix release and revert the problematic PR above.

**Which issue(s) this PR closes**:

- Closes #11698

**Special notes for your reviewer**:

We haven't done a hotfix release in a while. Things to note:

- Yes, we are intentionally merging to master.
- I had to revert #11301 manually. I think I got it right, but please review it carefully.
- This PR contains the normal "bump version and change base image" commits for any release.
- I already bumped the version in Jenkins, so I'm hoping API tests will pass. Please confirm this.
- I'm making a PR to update the "making releases" doc based on this experience: FIXME

**Suggestions on how to test this**:

On a server with a lot of collections (such as the QA server) try bringing up the "create dataset" and "edit dataset" screens on 6.7. This should be quite slow (for me on Harvard Dataverse it timed out after about 2.5 minutes). Compare with this PR.

Also, on 6.7 the "host dataverse" field will sometimes be absent. "Do not show the _host dataverse_ field when there is nothing to choose." As of this PR the "host dataverse" field will always be present. See the release note snippet in #11301 (there's also language about not erasing your input).

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

Yes. See above.

**Is there a release notes update needed for this change?**:

**Additional documentation**:
