### PR TITLE
when cutting a release, base.image.version needs to be "revision" #11700

### DIFF
--- a/modules/dataverse-parent/pom.xml
+++ b/modules/dataverse-parent/pom.xml
@@ -454,8 +454,8 @@
                     Once the release has been made (tag created), change this back to "${parsedVersion.majorVersion}.${parsedVersion.nextMinorVersion}"
                     (These properties are provided by the build-helper plugin below.)
                 -->
-                <base.image.version>${parsedVersion.majorVersion}.${parsedVersion.nextMinorVersion}</base.image.version>
-                <!--<base.image.version>${revision}</base.image.version>-->
+                <!--<base.image.version>${parsedVersion.majorVersion}.${parsedVersion.nextMinorVersion}</base.image.version>-->
+                <base.image.version>${revision}</base.image.version>
                 <!-- This is used by the maintenance CI jobs, no need to adapt during releases. -->
                 <app.image.version>${base.image.version}</app.image.version>
             </properties>


### PR DESCRIPTION
I made a mistake when creating the hotfix branch/PR for 6.7.1:

- #11700

I toggled the base.image.version properly in the parent pom.xml when I should have left it alone. As the comment says just above these lines:

`When cutting a release by changing the revision property above, set this to "${revision}"`

So that's what this PR does. As with the PR that wasn't quite right, this is targeting the master branch.

All this base.image.version stuff comes into play when we publish the release and GitHub Action jobs get kicked off to push images to Docker Hub. We want those images to be made properly, hence this PR.