### PR TITLE
11692 search api bug

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DatasetVersionFilesServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetVersionFilesServiceBean.java
@@ -294,7 +294,8 @@ public class DatasetVersionFilesServiceBean implements Serializable {
         String searchText = searchCriteria.getSearchText();
         if (searchText != null && !searchText.isEmpty()) {
             searchText = searchText.trim().toLowerCase();
-            predicates.add(criteriaBuilder.like(fileMetadataRoot.get("label"), "%" + searchText + "%"));
+            predicates.add(criteriaBuilder.or(criteriaBuilder.like(criteriaBuilder.lower(fileMetadataRoot.get("label")), "%" + searchText + "%"),
+                    criteriaBuilder.like(criteriaBuilder.lower(fileMetadataRoot.get("description")), "%" + searchText + "%")));
         }
         return criteriaBuilder.and(predicates.toArray(new Predicate[]{}));
     }

--- a/src/test/java/edu/harvard/iq/dataverse/api/DatasetsIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/DatasetsIT.java
@@ -5360,16 +5360,16 @@ createDataset = UtilIT.createRandomDatasetViaNativeApi(dataverse1Alias, apiToken
         // Test search for file metadata description
 
         // Update file metadata
-        JsonArrayBuilder updateFileDescription = Json.createArrayBuilder();
-        updateFileDescription.add(Json.createObjectBuilder()
-                .add("dataFileId", testFileId2)
-                .add("description", "Updated description. Again"));
+        String updateDescription = "Updated description. Again";
 
-        Response authorizedUpdateResponse = UtilIT.updateDatasetFilesMetadata(datasetId.toString(), updateFileDescription.build(), apiToken);
-        authorizedUpdateResponse.then().assertThat()
-                .statusCode(OK.getStatusCode());
+        String updateJsonString = "{\"description\":\""+updateDescription+"\"}";
+        Response updateMetadataResponse = UtilIT.updateFileMetadata(testFileId2, updateJsonString, apiToken);
+        updateMetadataResponse.prettyPrint();
+        updateMetadataResponse.then().assertThat().statusCode(OK.getStatusCode());
         
         Response getVersionFilesResponseSearchTextDescription = UtilIT.getVersionFiles(datasetId, DS_VERSION_LATEST, null, null, null, null, null, null, "again", null, false, apiToken);
+        
+        getVersionFilesResponseSearchTextDescription.prettyPrint();
 
         getVersionFilesResponseSearchTextDescription.then().assertThat()
                 .statusCode(OK.getStatusCode())

--- a/src/test/java/edu/harvard/iq/dataverse/api/DatasetsIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/DatasetsIT.java
@@ -5356,6 +5356,29 @@ createDataset = UtilIT.createRandomDatasetViaNativeApi(dataverse1Alias, apiToken
 
         fileMetadatasCount = getVersionFilesResponseSearchText.jsonPath().getList("data").size();
         assertEquals(1, fileMetadatasCount);
+        
+        // Test search for file metadata description
+
+        // Update file metadata
+        JsonArrayBuilder updateFileDescription = Json.createArrayBuilder();
+        updateFileDescription.add(Json.createObjectBuilder()
+                .add("dataFileId", testFileId2)
+                .add("description", "Updated description. Again"));
+
+        Response authorizedUpdateResponse = UtilIT.updateDatasetFilesMetadata(datasetId.toString(), updateFileDescription.build(), apiToken);
+        authorizedUpdateResponse.then().assertThat()
+                .statusCode(OK.getStatusCode());
+        
+        Response getVersionFilesResponseSearchTextDescription = UtilIT.getVersionFiles(datasetId, DS_VERSION_LATEST, null, null, null, null, null, null, "again", null, false, apiToken);
+
+        getVersionFilesResponseSearchTextDescription.then().assertThat()
+                .statusCode(OK.getStatusCode())
+                .body("data[0].label", equalTo(testFileName2));
+
+        fileMetadatasCount = getVersionFilesResponseSearchText.jsonPath().getList("data").size();
+        assertEquals(1, fileMetadatasCount);
+
+
 
         // Test Deaccessioned
         Response publishDataverseResponse = UtilIT.publishDataverseViaNativeApi(dataverseAlias, apiToken);


### PR DESCRIPTION
**What this PR does / why we need it**: Fixes an issue with the get files versions api where the search text was not being compared properly - the target field was not being set to lower case as the search text was. Also adds a search on "description" which is noted in the doc, but not actually implemented in the code.

**Which issue(s) this PR closes**:

- Closes #11692

**Special notes for your reviewer**:
This doesn't address the inconsistency with the solr search ("Advanced Search") which does not return a result if the search term does not include the first letter(s) of the word in the title or description

**Suggestions on how to test this**:
Try the get files by version api and include a search term:
curl "http://localhost:8080/api/datasets/:persistentId/versions/3.0/files?persistentId=doi:10.5072/FK2/056AZX&searchText=kinsale"

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
No
**Is there a release notes update needed for this change?**:
probably not. (list under "other bug fixes")

**Additional documentation**:
