### PR TITLE
Add VAST DataStore as a Reported Working S3-Compatible Storage

### DIFF
--- a/doc/sphinx-guides/source/installation/config.rst
+++ b/doc/sphinx-guides/source/installation/config.rst
@@ -1422,8 +1422,8 @@ And lastly, to start up the SeaweedFS server and various components you could us
 
 `VAST DataStore <https://www.vastdata.com/platform/datastore>`_
   VAST DataStore must be configured with an S3 gateway. A Dataverse bucket must be created. 
-Follow `VAST DataStore documentation <https://support.vastdata.com/s/document-item?bundleId=vast-cluster-administrator-s-guide4.7&topicId=managing-access-protocols/s3-object-storage-protocol.html&_LANG=enus>`_ to configure the S3 gateway.
-Set ``dataverse.files.<id>.path-style-access=true`` since VAST DataStore uses path style access.
+  Follow `VAST DataStore documentation <https://support.vastdata.com/s/document-item?bundleId=vast-cluster-administrator-s-guide4.7&topicId=managing-access-protocols/s3-object-storage-protocol.html&_LANG=enus>`_ to configure the S3 gateway.
+  Set ``dataverse.files.<id>.path-style-access=true`` since VAST DataStore uses path style access.
 
 **Additional Reported Working S3-Compatible Storage**
 

--- a/doc/sphinx-guides/source/installation/config.rst
+++ b/doc/sphinx-guides/source/installation/config.rst
@@ -1420,6 +1420,13 @@ And lastly, to start up the SeaweedFS server and various components you could us
 
   weed server -s3 -metricsPort=9327 -dir=/data -s3.config=/config.json
 
+`VAST DataStore <https://www.vastdata.com/platform/datastore>`_
+
+VAST DataStore must be configured with S3 gateway. Dataverse bucket must be created. 
+Follow `VAST DataStore documentation <https://support.vastdata.com/s/document-item?bundleId=vast-cluster-administrator-s-guide4.7&topicId=managing-access-protocols/s3-object-storage-protocol.html&_LANG=enus>`_ to configure S3 gateway.
+Set ``dataverse.files.<id>.path-style-access=true``, VAST DataStore uses path style access.
+
+
 **Additional Reported Working S3-Compatible Storage**
 
 If you are successfully using an S3 storage implementation not yet listed above, please feel free to

--- a/doc/sphinx-guides/source/installation/config.rst
+++ b/doc/sphinx-guides/source/installation/config.rst
@@ -1421,11 +1421,9 @@ And lastly, to start up the SeaweedFS server and various components you could us
   weed server -s3 -metricsPort=9327 -dir=/data -s3.config=/config.json
 
 `VAST DataStore <https://www.vastdata.com/platform/datastore>`_
-
-VAST DataStore must be configured with S3 gateway. Dataverse bucket must be created. 
-Follow `VAST DataStore documentation <https://support.vastdata.com/s/document-item?bundleId=vast-cluster-administrator-s-guide4.7&topicId=managing-access-protocols/s3-object-storage-protocol.html&_LANG=enus>`_ to configure S3 gateway.
-Set ``dataverse.files.<id>.path-style-access=true``, VAST DataStore uses path style access.
-
+  VAST DataStore must be configured with an S3 gateway. A Dataverse bucket must be created. 
+Follow `VAST DataStore documentation <https://support.vastdata.com/s/document-item?bundleId=vast-cluster-administrator-s-guide4.7&topicId=managing-access-protocols/s3-object-storage-protocol.html&_LANG=enus>`_ to configure the S3 gateway.
+Set ``dataverse.files.<id>.path-style-access=true`` since VAST DataStore uses path style access.
 
 **Additional Reported Working S3-Compatible Storage**
 


### PR DESCRIPTION
**What this PR does / why we need it**:
It describes how to connect VAST DataStore S3 bucket to dataverse

**Which issue(s) this PR closes**:

- Closes #

**Special notes for your reviewer**:

**Suggestions on how to test this**:

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
