### PR TITLE
feature to extend the get storage driver API

### DIFF
--- a/doc/release-notes/11695-change-api-get-storage-driver.md
+++ b/doc/release-notes/11695-change-api-get-storage-driver.md
@@ -1,0 +1,10 @@
+## Get Dataset/Dataverse Storage Driver API
+
+### Changed Json response - breaking change!
+
+The API for getting the Storage Driver info has been changed/extended.
+/api/datasets/{identifier}/storageDriver
+/api/admin/dataverse/{dataverse-alias}/storageDriver
+changed "message" to "name" and added "type" and "label"
+
+See also [the guides](https://dataverse-guide--11664.org.readthedocs.build/en/11664/api/native-api.html#configure-a-dataset-to-store-all-new-files-in-a-specific-file-store), #11695, and #11664.

--- a/doc/sphinx-guides/source/api/changelog.rst
+++ b/doc/sphinx-guides/source/api/changelog.rst
@@ -13,6 +13,7 @@ v6.8
 - For POST /api/files/{id}/metadata passing an empty string ("description":"")  or array ("categories":[]) will no longer be ignored. Empty fields will now clear out the values in the file's metadata. To ignore the fields simply do not include them in the JSON string.
 - For PUT /api/datasets/{id}/editMetadata the query parameter "sourceInternalVersionNumber" has been removed and replaced with "sourceLastUpdateTime" to verify that the data being edited hasn't been modified and isn't stale.
 - For GET /api/dataverses/$dataverse-alias/links the Json response has changed breaking the backward compatibility of the API.
+- For GET /api/admin/dataverse/{dataverse-alias}/storageDriver and /api/datasets/{identifier}/storageDriver the driver name is no longer returned in data.message. This value is now returned in data.name.
 
 v6.7
 ----

--- a/src/main/java/edu/harvard/iq/dataverse/api/Admin.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Admin.java
@@ -20,6 +20,7 @@ import edu.harvard.iq.dataverse.api.auth.AuthRequired;
 import edu.harvard.iq.dataverse.settings.JvmSettings;
 import edu.harvard.iq.dataverse.util.StringUtil;
 import edu.harvard.iq.dataverse.util.cache.CacheFactoryBean;
+import edu.harvard.iq.dataverse.util.json.JsonPrinter;
 import edu.harvard.iq.dataverse.util.json.NullSafeJsonBuilder;
 import edu.harvard.iq.dataverse.validation.EMailValidator;
 import edu.harvard.iq.dataverse.EjbDataverseEngine;
@@ -2196,7 +2197,7 @@ public class Admin extends AbstractApiBean {
             return wr.getResponse();
         }
         //Note that this returns what's set directly on this dataverse. If null/DataAccess.UNDEFINED_STORAGE_DRIVER_IDENTIFIER, the user would have to recurse the chain of parents to find the effective storageDriver
-        return ok(dataverse.getStorageDriverId());
+        return ok(JsonPrinter.jsonStorageDriver(dataverse.getStorageDriverId()));
     }
     
     @PUT

--- a/src/main/java/edu/harvard/iq/dataverse/api/Datasets.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Datasets.java
@@ -3701,7 +3701,7 @@ public class Datasets extends AbstractApiBean {
             return error(Response.Status.NOT_FOUND, "No such dataset");
         }
 
-        return response(req -> ok(dataset.getEffectiveStorageDriverId()), getRequestUser(crc));
+        return ok(JsonPrinter.jsonStorageDriver(dataset.getStorageDriverId()));
     }
 
     @PUT

--- a/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
@@ -39,6 +39,7 @@ import static edu.harvard.iq.dataverse.util.json.NullSafeJsonBuilder.jsonObjectB
 import edu.harvard.iq.dataverse.workflow.Workflow;
 import edu.harvard.iq.dataverse.workflow.step.WorkflowStepData;
 
+import java.io.IOException;
 import java.util.*;
 import jakarta.json.Json;
 import jakarta.json.JsonArrayBuilder;
@@ -1609,5 +1610,14 @@ public class JsonPrinter {
         }
 
         return jsonArrayBuilder;
+    }
+
+    public static JsonObjectBuilder jsonStorageDriver(String storageDriverId) {
+        JsonObjectBuilder jsonObjectBuilder = new NullSafeJsonBuilder();
+        jsonObjectBuilder.add("name", storageDriverId);
+        jsonObjectBuilder.add("type", DataAccess.getDriverType(storageDriverId));
+        jsonObjectBuilder.add("label", DataAccess.getStorageDriverLabelFor(storageDriverId));
+
+        return jsonObjectBuilder;
     }
 }

--- a/src/test/java/edu/harvard/iq/dataverse/api/DatasetsIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/DatasetsIT.java
@@ -5983,6 +5983,37 @@ createDataset = UtilIT.createRandomDatasetViaNativeApi(dataverse1Alias, apiToken
     }
 
     @Test
+    public void testSetGetDatasetStorageDriver() {
+        Response createUser = UtilIT.createRandomUser();
+        createUser.then().assertThat().statusCode(OK.getStatusCode());
+        String apiToken = UtilIT.getApiTokenFromResponse(createUser);
+        String username = UtilIT.getUsernameFromResponse(createUser);
+        Response makeSuperUser = UtilIT.makeSuperUser(username);
+        assertEquals(200, makeSuperUser.getStatusCode());
+        Response createDataverse = UtilIT.createRandomDataverse(apiToken);
+        String dataverseAlias = UtilIT.getAliasFromResponse(createDataverse);
+        Response createDataset = UtilIT.createRandomDatasetViaNativeApi(dataverseAlias, apiToken);
+        Integer datasetId = UtilIT.getDatasetIdFromResponse(createDataset);
+
+        Response storageDrivers = UtilIT.listStorageDrivers(apiToken);
+        storageDrivers.prettyPrint();
+        JsonObject data = JsonUtil.getJsonObject(storageDrivers.getBody().asString());
+        String first = data.getJsonObject("data").keySet().iterator().next();
+        String name = data.getJsonObject("data").getString(first);
+
+        Response setDriver = UtilIT.setDatasetStorageDriver(datasetId, first, apiToken);
+        setDriver.prettyPrint();
+        assertEquals(200, setDriver.getStatusCode());
+        Response getDriver = UtilIT.getDatasetStorageDriver(datasetId, apiToken);
+        getDriver.prettyPrint();
+        assertEquals(200, getDriver.getStatusCode());
+        getDriver.then().assertThat()
+                .body("data.name", CoreMatchers.equalTo(name))
+                .body("data.type", CoreMatchers.notNullValue())
+                .statusCode(OK.getStatusCode());
+    }
+
+    @Test
     public void testGetCanDownloadAtLeastOneFile() {
         Response createUserResponse = UtilIT.createRandomUser();
         createUserResponse.then().assertThat().statusCode(OK.getStatusCode());

--- a/src/test/java/edu/harvard/iq/dataverse/api/S3AccessIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/S3AccessIT.java
@@ -142,7 +142,7 @@ public class S3AccessIT {
         Response originalStorageDriver = UtilIT.getStorageDriver(dataverseAlias, superuserApiToken);
         originalStorageDriver.prettyPrint();
         originalStorageDriver.then().assertThat()
-                .body("data.message", equalTo("undefined"))
+                .body("data.name", equalTo("undefined"))
                 .statusCode(200);
 
         Response setStorageDriverToS3 = UtilIT.setStorageDriver(dataverseAlias, driverLabel, superuserApiToken);
@@ -273,7 +273,7 @@ public class S3AccessIT {
         Response originalStorageDriver = UtilIT.getStorageDriver(dataverseAlias, superuserApiToken);
         originalStorageDriver.prettyPrint();
         originalStorageDriver.then().assertThat()
-                .body("data.message", equalTo("undefined"))
+                .body("data.name", equalTo("undefined"))
                 .statusCode(200);
 
         Response setStorageDriverToS3 = UtilIT.setStorageDriver(dataverseAlias, driverLabel, superuserApiToken);
@@ -491,7 +491,7 @@ public class S3AccessIT {
         Response originalStorageDriver = UtilIT.getStorageDriver(dataverseAlias, superuserApiToken);
         originalStorageDriver.prettyPrint();
         originalStorageDriver.then().assertThat()
-                .body("data.message", equalTo("undefined"))
+                .body("data.name", equalTo("undefined"))
                 .statusCode(200);
 
         Response setStorageDriverToS3 = UtilIT.setStorageDriver(dataverseAlias, driverLabel, superuserApiToken);
@@ -689,7 +689,7 @@ public class S3AccessIT {
         Response originalStorageDriver = UtilIT.getStorageDriver(dataverseAlias, superuserApiToken);
         originalStorageDriver.prettyPrint();
         originalStorageDriver.then().assertThat()
-                .body("data.message", equalTo("undefined"))
+                .body("data.name", equalTo("undefined"))
                 .statusCode(200);
 
         Response setStorageDriverToS3 = UtilIT.setStorageDriver(dataverseAlias, driverLabel, superuserApiToken);

--- a/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
@@ -4505,6 +4505,12 @@ public class UtilIT {
                 .put("/api/datasets/" + datasetId + "/storageDriver");
     }
 
+    static Response getDatasetStorageDriver(Integer datasetId, String apiToken) {
+        return given()
+                .header(API_TOKEN_HTTP_HEADER, apiToken)
+                .get("/api/datasets/" + datasetId + "/storageDriver");
+    }
+
     /** GET on /api/admin/savedsearches/list */
     static Response getSavedSearchList() {
         return given().get("/api/admin/savedsearches/list");


### PR DESCRIPTION
**What this PR does / why we need it**: SPA needs more information in the Json response to get the storage driver info

**Which issue(s) this PR closes**:https://github.com/IQSS/dataverse/issues/11695

- Closes #11695

**Special notes for your reviewer**: backward incompatible Json response.

**Suggestions on how to test this**:

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**: included

**Additional documentation**: changelog updated
