### PR TITLE
Install `bc` in configbaker image so conf/solr/update-fields.sh will run

### DIFF
--- a/conf/solr/update-fields.sh
+++ b/conf/solr/update-fields.sh
@@ -68,10 +68,10 @@ while getopts ":hp" opt; do
 done
 
 # Check for ed and bc being present
-exists ed || error "Please ensure ed, bc, sed + awk are installed"
-exists bc || error "Please ensure ed, bc, sed + awk are installed"
-exists awk || error "Please ensure ed, bc, sed + awk are installed"
-exists sed || error "Please ensure ed, bc, sed + awk are installed"
+exists ed || error "Please ensure ed, bc, sed + awk are installed (ed is missing)"
+exists bc || error "Please ensure ed, bc, sed + awk are installed (bc is missing)"
+exists awk || error "Please ensure ed, bc, sed + awk are installed (awk is missing)"
+exists sed || error "Please ensure ed, bc, sed + awk are installed (sed is missing)"
 
 # remove all the parsed options
 shift $((OPTIND-1))

--- a/doc/release-notes/11722-configbaker-bc-missing.md
+++ b/doc/release-notes/11722-configbaker-bc-missing.md
@@ -1,0 +1,1 @@
+When following the container demo tutorial, it was not possible to update Solr fields after adding additional metadata blocks. This has been fixed. See #11722 and #11723

--- a/modules/container-configbaker/Dockerfile
+++ b/modules/container-configbaker/Dockerfile
@@ -20,7 +20,7 @@ ENV SCRIPT_DIR="/scripts" \
 ENV PATH="${PATH}:${SCRIPT_DIR}" \
     BOOTSTRAP_DIR="${SCRIPT_DIR}/bootstrap"
 
-ARG PKGS="curl dnsutils dumb-init ed jq netcat-openbsd postgresql-client"
+ARG PKGS="bc curl dnsutils dumb-init ed jq netcat-openbsd postgresql-client"
 # renovate: datasource=github-releases depName=wait4x/wait4x
 ARG WAIT4X_VERSION="v3.2.0"
 # renovate: datasource=pypi depName=awscli


### PR DESCRIPTION
**What this PR does / why we need it**:

People can't run update-fields.sh in configbaker without this fix

**Which issue(s) this PR closes**:

- Closes #11722

**Special notes for your reviewer**:

There are a few more details in the issue.

**Suggestions on how to test this**:

Try running this on develop:

`curl http://localhost:8080/api/admin/index/solr/schema | docker run -i --rm -v ./docker-dev-volumes/solr/data:/var/solr gdcc/configbaker:unstable update-fields.sh /var/solr/data/collection1/conf/schema.xml`

(To see the command in context: https://guides.dataverse.org/en/6.7.1/container/running/demo.html#additional-metadata-blocks )

Then build configbaker: https://guides.dataverse.org/en/6.7.1/container/configbaker-image.html#build-instructions

Then try running the command above again.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No.

**Is there a release notes update needed for this change?**:

Yes, included.

**Additional documentation**:

None.