### PR TITLE
extend list dataverse collection links api

### DIFF
--- a/doc/release-notes/11724-extend-list-dataverse-collection-links.md
+++ b/doc/release-notes/11724-extend-list-dataverse-collection-links.md
@@ -1,0 +1,1 @@
+The [API for listing the collections a dataverse has been linked to](https://guides.dataverse.org/en/latest/admin/dataverses-datasets.html#list-dataverse-collection-links) (`api/dataverses/$dataverse-alias/links`) has been refactored to return a new Json format. This is a breaking API.

--- a/src/main/java/edu/harvard/iq/dataverse/api/Dataverses.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Dataverses.java
@@ -1692,13 +1692,21 @@ public class Dataverses extends AbstractApiBean {
             List<Dataverse> dvsThisDvHasLinkedToList = dataverseSvc.findDataversesThisIdHasLinkedTo(dv.getId());
             JsonArrayBuilder dvsThisDvHasLinkedToBuilder = Json.createArrayBuilder();
             for (Dataverse dataverse : dvsThisDvHasLinkedToList) {
-                dvsThisDvHasLinkedToBuilder.add(dataverse.getAlias());
+                JsonObjectBuilder job = Json.createObjectBuilder();
+                job.add("id", dataverse.getId());
+                job.add("alias", dataverse.getAlias());
+                job.add("displayName", dataverse.getDisplayName());
+                dvsThisDvHasLinkedToBuilder.add(job);
             }
 
             List<Dataverse> dvsThatLinkToThisDvList = dataverseSvc.findDataversesThatLinkToThisDvId(dv.getId());
             JsonArrayBuilder dvsThatLinkToThisDvBuilder = Json.createArrayBuilder();
             for (Dataverse dataverse : dvsThatLinkToThisDvList) {
-                dvsThatLinkToThisDvBuilder.add(dataverse.getAlias());
+                JsonObjectBuilder job = Json.createObjectBuilder();
+                job.add("id", dataverse.getId());
+                job.add("alias", dataverse.getAlias());
+                job.add("displayName", dataverse.getDisplayName());
+                dvsThatLinkToThisDvBuilder.add(job);
             }
 
             List<Dataset> datasetsThisDvHasLinkedToList = dataverseSvc.findDatasetsThisIdHasLinkedTo(dv.getId());

--- a/src/test/java/edu/harvard/iq/dataverse/api/LinkIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/LinkIT.java
@@ -121,6 +121,7 @@ public class LinkIT {
         Response createDataverseResponse2 = UtilIT.createRandomDataverse(apiToken);
         createDataverseResponse2.prettyPrint();
         String dataverseAlias2 = UtilIT.getAliasFromResponse(createDataverseResponse2);
+        Integer dataverseId2 = UtilIT.getDataverseIdFromResponse(createDataverseResponse2);
 
         Response createLinkingDataverseResponse = UtilIT.createDataverseLink(dataverseAlias, dataverseAlias2, apiToken);
         createLinkingDataverseResponse.prettyPrint();
@@ -138,12 +139,16 @@ public class LinkIT {
         getLinksResponse.prettyPrint();
         getLinksResponse.then().assertThat()
                 .statusCode(OK.getStatusCode())
-                .body("data.dataversesLinkingToThis[0]", equalTo(dataverseAlias2));
+                .body("data.dataversesLinkingToThis[0].id", equalTo(dataverseId2))
+                .body("data.dataversesLinkingToThis[0].alias", equalTo(dataverseAlias2))
+                .body("data.dataversesLinkingToThis[0].displayName", equalTo(dataverseAlias2));
         getLinksResponse = UtilIT.getDataverseLinks(dataverseAlias2, apiToken);
         getLinksResponse.prettyPrint();
         getLinksResponse.then().assertThat()
                 .statusCode(OK.getStatusCode())
-                .body("data.linkedDataverses[0]", equalTo(dataverseAlias));
+                .body("data.linkedDataverses[0].id", equalTo(dataverseId))
+                .body("data.linkedDataverses[0].alias", equalTo(dataverseAlias))
+                .body("data.linkedDataverses[0].displayName", equalTo(dataverseAlias));
 
         Response deleteLinkingDataverseResponse = UtilIT.deleteDataverseLink(dataverseAlias, dataverseAlias2, apiToken);
         deleteLinkingDataverseResponse.prettyPrint();


### PR DESCRIPTION
**What this PR does / why we need it**: SPA needs more information about the collections being returned.
Currently only the alias is being returned. 

**Which issue(s) this PR closes**:https://github.com/IQSS/dataverse/issues/11724

- Closes #11724 

**Special notes for your reviewer**: change log doc was already updated for this api as another pr modified it as well

**Suggestions on how to test this**: See LinkIT tests

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**: included

**Additional documentation**:
