### PR TITLE
DD-1988 - Fix /api/admin/validate/dataset/files/{id} error response

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/api/Admin.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Admin.java
@@ -1243,6 +1243,14 @@ public class Admin extends AbstractApiBean {
     @Produces({"application/json"})
     public Response validateDatasetDatafiles(@PathParam("id") String id) {
         
+        Dataset dataset;
+        // First check if the dataset exists before starting the streaming output
+        try {
+            dataset = findDatasetOrDie(id);
+        } catch (WrappedResponse wr) {
+            return wr.getResponse(); // This will return the proper 404 Not Found response
+        }
+        
         // Streaming output: the API will start producing 
         // the output right away, as it goes through the list 
         // of the datafiles in the dataset.
@@ -1252,23 +1260,13 @@ public class Admin extends AbstractApiBean {
             @Override
             public void write(OutputStream os) throws IOException,
                     WebApplicationException {
-                Dataset dataset;
-        
-                try {
-                    dataset = findDatasetOrDie(id);
-                } catch (Exception ex) {
-                    throw new IOException(ex.getMessage());
-                }
                 
                 os.write("{\"dataFiles\": [\n".getBytes());
                 
                 boolean wroteObject = false;
                 for (DataFile dataFile : dataset.getFiles()) {
-                    // Potentially, there's a godzillion datasets in this Dataverse. 
-                    // This is why we go through the list of ids here, and instantiate 
-                    // only one dataset at a time. 
+
                     boolean success = false;
-                    boolean constraintViolationDetected = false;
                      
                     JsonObjectBuilder output = Json.createObjectBuilder();
                     output.add("datafileId", dataFile.getId());


### PR DESCRIPTION
**What this PR does / why we need it**: As reported internally at DANS (DD-1988), when the /api/admin/validate/dataset/files/{id} API call is called with a non-existent PID/id, the error response is 500 rather than 404. This PR corrects that.

**Which issue(s) this PR closes**:

- Closes #

**Special notes for your reviewer**:

**Suggestions on how to test this**: Call the api above with a made up PID/id, verify that it produces a 500 error before and a 404 error after the PR.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
