### PR TITLE
Docs: Restrict Payara http-listener-1 to localhost when proxied

### DIFF
--- a/doc/sphinx-guides/source/installation/config.rst
+++ b/doc/sphinx-guides/source/installation/config.rst
@@ -115,6 +115,23 @@ See the :ref:`payara` section of :doc:`prerequisites` for details and init scrip
 
 Related to this is that you should remove ``/root/.payara/pass`` to ensure that Payara isn't ever accidentally started as root. Without the password, Payara won't be able to start as root, which is a good thing.
 
+.. _payara-ports-localhost-only:
+
+Restricting Payara's Ports to localhost
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In the recommended setup of Dataverse, you do not expose Payara's ports directly to the Internet. Rather, you front Payara with a proxy such as Apache.
+
+If you are running Payara and your proxy on the same server, we recommend having Payara listen only to localhost, which is how your proxy talks to it, with the following command:
+
+``./asadmin set server-config.network-config.network-listeners.network-listener.http-listener-1.address=127.0.0.1``
+
+(You should **NOT** use the configuration option above if you are running in a load-balanced environment, or otherwise have your proxy on a different host than Payara.)
+
+To test that Payara is now only listening on localhost, try hitting port 8080 from the Internet. Payara should not respond.
+
+See also :ref:`network-ports`.
+
 .. _secure-password-storage:
 
 Secure Password Storage
@@ -245,6 +262,8 @@ If you are running an installation with Apache and Payara on the same server, an
 ``./asadmin set server-config.network-config.network-listeners.network-listener.http-listener-1.address=127.0.0.1``
 
 You should **NOT** use the configuration option above if you are running in a load-balanced environment, or otherwise have the web server on a different host than the application server.
+
+This security tip is also mentioned at :ref:`payara-ports-localhost-only`.
 
 .. _root-collection-permissions:
 


### PR DESCRIPTION
Adds a section to `doc/sphinx-guides/source/installation/config.rst` recommending binding
Payara’s `http-listener-1` (port 8080) to `127.0.0.1` when fronted by Apache/Nginx.

Scope:
- Only `installation/config.rst` changed
- No Quickstart docs included
- Follow-up to IQSS/dataverse#11743 (per Phil's feedback to submit a clean PR off `develop`)

Why:
- Prevents exposing Payara’s `:8080` directly
- Keeps Apache/Nginx serving on ports 80/443
- Allows local access via `127.0.0.1:8080`

https://dataverse-guide--11756.org.readthedocs.build/en/11756/installation/config.html#restricting-payara-s-ports-to-localhost