### PR TITLE
Revert "Added a control to publishing a Dataset and cleaning dataversesubjects table"

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/FinalizeDatasetPublicationCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/FinalizeDatasetPublicationCommand.java
@@ -334,16 +334,12 @@ public class FinalizeDatasetPublicationCommand extends AbstractPublishDatasetCom
                 while (dv != null) {
                     boolean newSubjectsAdded = false;
                     for (ControlledVocabularyValue cvv : dsf.getControlledVocabularyValues()) {                   
-                        if (!cvv.getStrValue().equals(DatasetField.NA_VALUE)) {
-                            if (!dv.getDataverseSubjects().contains(cvv)) {
-                                logger.fine("dv "+dv.getAlias()+" does not have subject "+cvv.getStrValue());
-                                newSubjectsAdded = true;
-                                dv.getDataverseSubjects().add(cvv);
-                            } else {
-                                logger.fine("dv "+dv.getAlias()+" already has subject "+cvv.getStrValue());
-                            }
+                        if (!dv.getDataverseSubjects().contains(cvv)) {
+                            logger.fine("dv "+dv.getAlias()+" does not have subject "+cvv.getStrValue());
+                            newSubjectsAdded = true;
+                            dv.getDataverseSubjects().add(cvv);
                         } else {
-                            logger.fine("Subject is not recognized : " + cvv.getStrValue());
+                            logger.fine("dv "+dv.getAlias()+" already has subject "+cvv.getStrValue());
                         }
                     }
                     if (newSubjectsAdded) {

--- a/src/main/resources/db/migration/V6.7.0.1.sql
+++ b/src/main/resources/db/migration/V6.7.0.1.sql
@@ -1,2 +1,0 @@
--- remove dataversesubjects entries with a controlledvocabularyvalue_id matching "N/A"
-DELETE FROM dataversesubjects WHERE controlledvocabularyvalue_id = 1 ;


### PR DESCRIPTION
- Reverts IQSS/dataverse#11551

We're reverting this because we didn't notice until after it was merged that the Flyway script had the wrong number.

As of this writing it should be V6.7.1.2.sql

Our docs on number are here: https://guides.dataverse.org/en/6.7.1/developers/sql-upgrade-scripts.html

This one slipped through the cracks because we had an unexpected point release (6.7.1). At the time the PR was approved the number was correct.