### PR TITLE
Fixing ror v2 api access for cvoc

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DatasetFieldServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetFieldServiceBean.java
@@ -794,7 +794,7 @@ public class DatasetFieldServiceBean implements java.io.Serializable {
                 }
 
             } else {
-                if (NumberUtils.isCreatable(pathParts[index])) {
+                if ((curPath instanceof JsonArray) && NumberUtils.isCreatable(pathParts[index])) {
                     try {
                         int indexNumber = Integer.parseInt(pathParts[index]);
                         curPath = ((JsonArray) curPath).get(indexNumber);
@@ -805,7 +805,7 @@ public class DatasetFieldServiceBean implements java.io.Serializable {
                     curPath = ((JsonObject) curPath).get(pathParts[index]);
                 }
                 // curPath = ((JsonObject) curPath).get(pathParts[index]);
-                logger.fine("Found next Path object " + curPath.toString());
+                logger.fine("Found next Path object " + ((curPath == null) ? "null" : curPath.toString()));
                 return processPathSegment(index + 1, pathParts, curPath, termUri);
             }
         } else {


### PR DESCRIPTION
**What this PR does / why we need it**:
The ROR-API has changed during the last weeks. In the future ROR API v1 will be deprecated.

The old search path for the termName in the old CVOC ROR script was "/value"
In version 2 of the ROR API this will no longer work. So the new search path in the cvocConf.json should be 
""termName": {
                "pattern": "{0}",
                "params": [
                    "/names/0/value"
                ]
            },"

Unfortunately the current implementation in DV 6.7.1 cannot handle the "0" index. It reads it as a String but it must be an Integer number regarding the JSON output from ROR V2.

This pull request provides a fix the specific implementation and it can handle now both String and Number as values for the ROR JSON output.

In cvocJson.conf after applying this pull request. Your can use the new ROR API endpoint: "https://api.ror.org/organizations/{0}"

**Which issue(s) this PR closes**:

- Closes #

**Special notes for your reviewer**:

**Suggestions on how to test this**:

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:

This pull request is only necessary for the ROR API V2.
