### PR TITLE
IQSS/11776 indexing new files

### DIFF
--- a/doc/release-notes/11776- index fix.md
+++ b/doc/release-notes/11776- index fix.md
@@ -1,0 +1,1 @@
+A bug, introduced in v6.7, that caused files in draft versions that were added after the initial dataset version was published, has been fixed.

--- a/src/main/java/edu/harvard/iq/dataverse/FileMetadata.java
+++ b/src/main/java/edu/harvard/iq/dataverse/FileMetadata.java
@@ -94,9 +94,10 @@ import jakarta.validation.constraints.Pattern;
                 "        )",
                 resultSetMapping = "IdToLongMapping"
     )
+/* When this mapping was to Long.class, Postgres was still returning an Integer, causing indexing failures - see #11776 */ 
 @SqlResultSetMapping(
         name = "IdToLongMapping",
-        columns = @ColumnResult(name = "id", type = Long.class)
+        columns = @ColumnResult(name = "id", type = Integer.class)
     )
 @Entity
 public class FileMetadata implements Serializable {

--- a/src/main/java/edu/harvard/iq/dataverse/search/IndexServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/search/IndexServiceBean.java
@@ -69,6 +69,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Future;
@@ -1428,7 +1429,31 @@ public class IndexServiceBean {
                 query.setParameter(1, dataset.getReleasedVersion().getId());
                 query.setParameter(2, datasetVersion.getId());
 
-                changedFileMetadataIds.addAll(query.getResultList());
+                /*
+                 * When the query was configured to return Long, it was returning Integer. The query has been changed to return Integer now. The code here is robust if that changes in the future.
+                 */
+                List<Object> queryResults = query.getResultList();
+                for (Object result : queryResults) {
+                    if (result != null) {
+                        // Ensure we're adding Long objects to the list
+                        if (result instanceof Integer intResult) {
+                            logger.finest("Converted Integer result to Long: " + result);
+                            changedFileMetadataIds.add(Long.valueOf(intResult));
+                        } else if (result instanceof Long longResult) {
+                            // Already a Long, add directly
+                            logger.finest("Added existing Long to list: " + result);
+                            changedFileMetadataIds.add(longResult);
+                        } else {
+                            // If it's not a Long, convert it to one via String
+                            try {
+                                changedFileMetadataIds.add(Long.valueOf(result.toString()));
+                                logger.finest("Converted non-Long result to Long: " + result + " of type " + result.getClass().getName());
+                            } catch (NumberFormatException e) {
+                                logger.warning("Could not convert query result to Long: " + result);
+                            }
+                        }
+                    }
+                }
                 logger.fine(
                         "We are indexing a draft version of a dataset that has a released version. We'll be checking file metadatas if they are exact clones of the released versions.");
             } else if (datasetVersion.isDraft()) {
@@ -1515,6 +1540,8 @@ public class IndexServiceBean {
 
                     SolrInputDocument datafileSolrInputDocument = new SolrInputDocument();
                     Long fileEntityId = datafile.getId();
+                    logger.finest("Indexing file " + fileEntityId);
+
                     datafileSolrInputDocument.addField(SearchFields.ENTITY_ID, fileEntityId);
                     datafileSolrInputDocument.addField(SearchFields.DATAVERSE_VERSION_INDEXED_BY, dataverseVersion);
                     datafileSolrInputDocument.addField(SearchFields.IDENTIFIER, fileEntityId);

--- a/src/main/java/edu/harvard/iq/dataverse/search/IndexServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/search/IndexServiceBean.java
@@ -1537,7 +1537,7 @@ public class IndexServiceBean {
                             logger.fine("This file metadata hasn't changed since the released version; skipping indexing.");
                         }
                     } else {
-                        logger.warning("File is not in released version when trying to compare variable metadata, fileId: " + datafile.getId()););
+                        logger.warning("File is not in released version when trying to compare variable metadata, fileId: " + datafile.getId());
                     }
                 }
                 if (indexThisFile) {

--- a/src/main/java/edu/harvard/iq/dataverse/search/IndexServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/search/IndexServiceBean.java
@@ -1527,6 +1527,8 @@ public class IndexServiceBean {
                 if (indexThisMetadata && (isReleasedVersion || changedFileMetadataIds.contains(fileMetadata.getId()))) {
                     indexThisFile = true;
                 } else if (indexThisMetadata) {
+                    // Draft version, file is not new or all file metadata matches the released version
+                    // The only thing left to check is variable-level metadata, index if there is a difference
                     logger.fine("Checking if this file metadata is a duplicate.");
                     FileMetadata getFromMap = fileMap.get(datafile.getId());
                     if (getFromMap != null) {
@@ -1534,6 +1536,8 @@ public class IndexServiceBean {
                             indexThisFile = true;
                             logger.fine("This file metadata hasn't changed since the released version; skipping indexing.");
                         }
+                    } else {
+                        logger.warning("File is not in released version when trying to compare variable metadata, fileId: " + datafile.getId()););
                     }
                 }
                 if (indexThisFile) {

--- a/src/test/java/edu/harvard/iq/dataverse/api/SearchIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/SearchIT.java
@@ -2397,7 +2397,7 @@ public class SearchIT {
         assertEquals(200, makeSuperUser.getStatusCode());
         
         // Delete the dataset
-        Response deleteDatasetResponse = UtilIT.deleteDatasetViaNativeApi(datasetId, apiToken);
+        Response deleteDatasetResponse = UtilIT.destroyDataset(datasetId, apiToken);
         deleteDatasetResponse.prettyPrint();
         deleteDatasetResponse.then().assertThat()
                 .statusCode(OK.getStatusCode());

--- a/src/test/java/edu/harvard/iq/dataverse/api/SearchIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/SearchIT.java
@@ -2391,13 +2391,16 @@ public class SearchIT {
                 .statusCode(OK.getStatusCode());
 
         // Clean up - delete dataset, dataverse, and user
-        try {
+
             // Delete the dataset
             Response deleteDatasetResponse = UtilIT.deleteDatasetViaNativeApi(datasetId, apiToken);
             deleteDatasetResponse.prettyPrint();
             deleteDatasetResponse.then().assertThat()
                     .statusCode(OK.getStatusCode());
 
+            Response makeSuperUser = UtilIT.setSuperuserStatus(username, true);
+            assertEquals(200, makeSuperUser.getStatusCode());
+            
             // Delete the dataverse
             Response deleteDataverseResponse = UtilIT.deleteDataverse(dataverseAlias, apiToken);
             deleteDataverseResponse.prettyPrint();
@@ -2409,10 +2412,6 @@ public class SearchIT {
             deleteUserResponse.prettyPrint();
             deleteUserResponse.then().assertThat()
                     .statusCode(OK.getStatusCode());
-        } catch (Exception e) {
-            // Log any cleanup failures but don't fail the test
-            System.out.println("Error during cleanup: " + e.getMessage());
-        }
     }
 
 }

--- a/src/test/java/edu/harvard/iq/dataverse/api/SearchIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/SearchIT.java
@@ -2391,15 +2391,16 @@ public class SearchIT {
                 .statusCode(OK.getStatusCode());
 
         // Clean up - delete dataset, dataverse, and user
-
+        
+        //Superuser to delete published dataset
+        Response makeSuperUser = UtilIT.setSuperuserStatus(username, true);
+        assertEquals(200, makeSuperUser.getStatusCode());
+        
         // Delete the dataset
         Response deleteDatasetResponse = UtilIT.deleteDatasetViaNativeApi(datasetId, apiToken);
         deleteDatasetResponse.prettyPrint();
         deleteDatasetResponse.then().assertThat()
                 .statusCode(OK.getStatusCode());
-
-        Response makeSuperUser = UtilIT.setSuperuserStatus(username, true);
-        assertEquals(200, makeSuperUser.getStatusCode());
 
         // Delete the dataverse
         Response deleteDataverseResponse = UtilIT.deleteDataverse(dataverseAlias, apiToken);

--- a/src/test/java/edu/harvard/iq/dataverse/api/SearchIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/SearchIT.java
@@ -2402,6 +2402,12 @@ public class SearchIT {
         deleteDatasetResponse.then().assertThat()
                 .statusCode(OK.getStatusCode());
 
+        try {
+            // give the bag time to generate
+            Thread.sleep(3000);
+        } catch (InterruptedException ex) {
+        }
+
         // Delete the dataverse
         Response deleteDataverseResponse = UtilIT.deleteDataverse(dataverseAlias, apiToken);
         deleteDataverseResponse.prettyPrint();

--- a/src/test/java/edu/harvard/iq/dataverse/api/SearchIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/SearchIT.java
@@ -2392,26 +2392,26 @@ public class SearchIT {
 
         // Clean up - delete dataset, dataverse, and user
 
-            // Delete the dataset
-            Response deleteDatasetResponse = UtilIT.deleteDatasetViaNativeApi(datasetId, apiToken);
-            deleteDatasetResponse.prettyPrint();
-            deleteDatasetResponse.then().assertThat()
-                    .statusCode(OK.getStatusCode());
+        // Delete the dataset
+        Response deleteDatasetResponse = UtilIT.deleteDatasetViaNativeApi(datasetId, apiToken);
+        deleteDatasetResponse.prettyPrint();
+        deleteDatasetResponse.then().assertThat()
+                .statusCode(OK.getStatusCode());
 
-            Response makeSuperUser = UtilIT.setSuperuserStatus(username, true);
-            assertEquals(200, makeSuperUser.getStatusCode());
-            
-            // Delete the dataverse
-            Response deleteDataverseResponse = UtilIT.deleteDataverse(dataverseAlias, apiToken);
-            deleteDataverseResponse.prettyPrint();
-            deleteDataverseResponse.then().assertThat()
-                    .statusCode(OK.getStatusCode());
+        Response makeSuperUser = UtilIT.setSuperuserStatus(username, true);
+        assertEquals(200, makeSuperUser.getStatusCode());
 
-            // Delete the user
-            Response deleteUserResponse = UtilIT.deleteUser(username);
-            deleteUserResponse.prettyPrint();
-            deleteUserResponse.then().assertThat()
-                    .statusCode(OK.getStatusCode());
+        // Delete the dataverse
+        Response deleteDataverseResponse = UtilIT.deleteDataverse(dataverseAlias, apiToken);
+        deleteDataverseResponse.prettyPrint();
+        deleteDataverseResponse.then().assertThat()
+                .statusCode(OK.getStatusCode());
+
+        // Delete the user
+        Response deleteUserResponse = UtilIT.deleteUser(username);
+        deleteUserResponse.prettyPrint();
+        deleteUserResponse.then().assertThat()
+                .statusCode(OK.getStatusCode());
     }
 
 }

--- a/src/test/java/edu/harvard/iq/dataverse/api/SearchIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/SearchIT.java
@@ -2377,7 +2377,7 @@ public class SearchIT {
         Integer fileId = JsonPath.from(uploadFileResponse.getBody().asString()).getInt("data.files[0].dataFile.id");
 
         // Wait for indexing to complete
-        String searchQuery = "parentId:" + fileId;
+        String searchQuery = "entityId:" + fileId;
         assertTrue(UtilIT.sleepForSearch(searchQuery, apiToken, "", 1, UtilIT.MAXIMUM_INGEST_LOCK_DURATION), 
                    "Failed test if search exceeds max duration " + searchQuery);
 

--- a/src/test/java/edu/harvard/iq/dataverse/api/SearchIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/SearchIT.java
@@ -2328,5 +2328,91 @@ public class SearchIT {
                 ));
 
     }
+    
+    @Test
+    public void testFileAddedAfterPublicationIsIndexed() {
+        // Create user
+        Response createUser = UtilIT.createRandomUser();
+        createUser.prettyPrint();
+        String username = UtilIT.getUsernameFromResponse(createUser);
+        String apiToken = UtilIT.getApiTokenFromResponse(createUser);
+
+        // Create dataverse
+        Response createDataverseResponse = UtilIT.createRandomDataverse(apiToken);
+        createDataverseResponse.prettyPrint();
+        String dataverseAlias = UtilIT.getAliasFromResponse(createDataverseResponse);
+
+        // Create dataset
+        Response createDatasetResponse = UtilIT.createRandomDatasetViaNativeApi(dataverseAlias, apiToken);
+        createDatasetResponse.prettyPrint();
+        Integer datasetId = UtilIT.getDatasetIdFromResponse(createDatasetResponse);
+        String datasetPersistentId = UtilIT.getDatasetPersistentIdFromResponse(createDatasetResponse);
+
+        // Publish dataverse and dataset
+        Response publishDataverse = UtilIT.publishDataverseViaSword(dataverseAlias, apiToken);
+        publishDataverse.prettyPrint();
+        publishDataverse.then().assertThat()
+                .statusCode(OK.getStatusCode());
+
+        Response publishDataset = UtilIT.publishDatasetViaNativeApi(datasetId, "major", apiToken);
+        publishDataset.prettyPrint();
+        publishDataset.then().assertThat()
+                .statusCode(OK.getStatusCode());
+
+        // Verify no files in search results initially
+        Response searchBeforeFileUpload = UtilIT.search("parentId:" + datasetId, apiToken);
+        searchBeforeFileUpload.prettyPrint();
+        searchBeforeFileUpload.then().assertThat()
+                .body("data.total_count", CoreMatchers.is(0))
+                .statusCode(OK.getStatusCode());
+
+        // Upload a file after publication
+        String pathToFile = "src/main/webapp/resources/images/dataverseproject.png";
+        Response uploadFileResponse = UtilIT.uploadFileViaNative(datasetId.toString(), pathToFile, apiToken);
+        uploadFileResponse.prettyPrint();
+        uploadFileResponse.then().assertThat()
+                .statusCode(OK.getStatusCode());
+
+        // Get file ID from the upload response
+        Integer fileId = JsonPath.from(uploadFileResponse.getBody().asString()).getInt("data.files[0].dataFile.id");
+
+        // Wait for indexing to complete
+        String searchQuery = "parentId:" + fileId;
+        assertTrue(UtilIT.sleepForSearch(searchQuery, apiToken, "", 1, UtilIT.MAXIMUM_INGEST_LOCK_DURATION), 
+                   "Failed test if search exceeds max duration " + searchQuery);
+
+        // Search for the file and verify it's indexed
+        Response searchAfterFileUpload = UtilIT.search(searchQuery, apiToken);
+        searchAfterFileUpload.prettyPrint();
+        searchAfterFileUpload.then().assertThat()
+                .body("data.total_count", CoreMatchers.is(1))
+                .body("data.items[0].name", is("dataverseproject.png"))
+                .body("data.items[0].file_content_type", CoreMatchers.is("image/png"))
+                .statusCode(OK.getStatusCode());
+
+        // Clean up - delete dataset, dataverse, and user
+        try {
+            // Delete the dataset
+            Response deleteDatasetResponse = UtilIT.deleteDatasetViaNativeApi(datasetId, apiToken);
+            deleteDatasetResponse.prettyPrint();
+            deleteDatasetResponse.then().assertThat()
+                    .statusCode(OK.getStatusCode());
+
+            // Delete the dataverse
+            Response deleteDataverseResponse = UtilIT.deleteDataverse(dataverseAlias, apiToken);
+            deleteDataverseResponse.prettyPrint();
+            deleteDataverseResponse.then().assertThat()
+                    .statusCode(OK.getStatusCode());
+
+            // Delete the user
+            Response deleteUserResponse = UtilIT.deleteUser(username);
+            deleteUserResponse.prettyPrint();
+            deleteUserResponse.then().assertThat()
+                    .statusCode(OK.getStatusCode());
+        } catch (Exception e) {
+            // Log any cleanup failures but don't fail the test
+            System.out.println("Error during cleanup: " + e.getMessage());
+        }
+    }
 
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR closes**:

- Closes #11776

**Special notes for your reviewer**: This was tricky - the original code defined the query as returning Long file ids, but a) the database decided to send Integers anyway, and b) this then caused `changedFileMetadataIds.contains(fileMetadata.getId())` to fail even with a numeric match (Long(1) != Integer(1)).  That failure made it look like the file was the same in the released and draft versions, which we would not reindex (unless there was a variable-level metadata change).

The fix changes to return the file Ids as Integers - that should be a no-op, but may stop someone from assuming Long, and then checks the class returned from the query to assure Longs are getting into the changedFileMetadataIds array. I also added a warning if `changedFileMetadataIds.contains(fileMetadata.getId()) == false while the fileMap entry for the file is null (line 1531) which means the file wasn't in the released version (this shouldn't happen if the query and changedFileMetadataIds works as it should).

**Suggestions on how to test this**: There's an IT test - you should be able to add a dataset, publish, add a file, and verify you can't find the datafile via search or use the index/status api call and see that the file is in the db and not indexed. After the PR, this should be fixed (can recreate a new dataset or just reindex the existing one (by changing the dataset metadata for example).

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**: added

**Additional documentation**:
