### PR TITLE
IQSS/11778 speedup custom file retrieval

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/CustomizationFilesServlet.java
+++ b/src/main/java/edu/harvard/iq/dataverse/CustomizationFilesServlet.java
@@ -22,6 +22,7 @@ import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import edu.harvard.iq.dataverse.settings.SettingsServiceBean;
+import edu.harvard.iq.dataverse.util.FileUtil;
 import jakarta.ejb.EJB;
 import org.apache.commons.io.IOUtils;
 import org.apache.tika.Tika;
@@ -60,13 +61,11 @@ public class CustomizationFilesServlet extends HttpServlet {
         try {
             File fileIn = physicalPath.toFile();
             if (fileIn != null) {
-                Tika tika = new Tika();
-                try {
-                    String mimeType = tika.detect(fileIn);
-                    response.setContentType(mimeType);
-                } catch (Exception e) {
-                    logger.info("Error getting MIME Type for " + filePath + " : " + e.getMessage());
-                }
+                String filename = physicalPath.getFileName().toString();
+                int dotIndex = filename.lastIndexOf('.');
+                String ext = dotIndex >= 0 ? filename.substring(dotIndex) : "";
+                String mimeType = FileUtil.lookupFileTypeByExtension(ext);
+                response.setContentType(mimeType);
                 inputStream = new FileInputStream(fileIn);
 
                 in = new BufferedReader(new InputStreamReader(inputStream));

--- a/src/main/java/edu/harvard/iq/dataverse/util/FileUtil.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/FileUtil.java
@@ -598,7 +598,10 @@ public class FileUtil implements java.io.Serializable  {
         return lookupFileTypeByExtension(fileName);
     }
 
-    private static String lookupFileTypeByExtension(final String fileName) {
+    /** determineFileTypeByNameAndExtension should be used instead for any user supplied content. 
+     *
+     */
+    public static String lookupFileTypeByExtension(final String fileName) {
         final String mimetypesFileTypeMapResult = MIME_TYPE_MAP.getContentType(fileName);
         logger.fine("MimetypesFileTypeMap type by extension, for " + fileName + ": " + mimetypesFileTypeMapResult);
         if (mimetypesFileTypeMapResult == null) {


### PR DESCRIPTION
**What this PR does / why we need it**: Stops using tika to determine the mime type for custom files - saving ~80ms per file access, which can occur for multiple files and for every page

**Which issue(s) this PR closes**:

- Closes #11778

**Special notes for your reviewer**: As noted in the issue, I'd expect using the extension is good enough when the files are supplied by an admin (as in this case). If we really want to use tika to inspect these files, we should cache the results.

**Suggestions on how to test this**: Not sure this is easy to test as there are other factors to page load speed. That said, adding a custom header, footer, analytics file, and logo might add enough delay (est 1/3 second) that you might see a difference in average load time. (At QDR, I added code to time the tika call and the FileUtil calls.)

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**: No - the PR that changed this was post 6.7 so the slower pages shouldn't be deployed in production anywhere.

**Additional documentation**:
