### PR TITLE
Improve DataCiteXML robustness w.r.t. ROR

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/pidproviders/doi/XmlMetadataTemplate.java
+++ b/src/main/java/edu/harvard/iq/dataverse/pidproviders/doi/XmlMetadataTemplate.java
@@ -58,6 +58,7 @@ import edu.harvard.iq.dataverse.util.xml.XmlPrinter;
 import edu.harvard.iq.dataverse.util.xml.XmlWriterUtil;
 import jakarta.enterprise.inject.spi.CDI;
 import jakarta.json.JsonObject;
+import jakarta.json.JsonValue.ValueType;
 
 public class XmlMetadataTemplate {
 
@@ -621,7 +622,8 @@ public class XmlMetadataTemplate {
             if (externalIdentifier.isValidIdentifier(orgName)) {
                 isROR = true;
                 JsonObject jo = getExternalVocabularyValue(orgName);
-                if (jo != null) {
+                // Some ext. cvv configs store a JsonArray of multiple objects/values. In such cases, we'll leave orgName blank 
+                if (jo != null && jo.getValueType() == ValueType.STRING) {
                     orgName = jo.getString("termName");
                 }
             }


### PR DESCRIPTION
**What this PR does / why we need it**: In adapting to ROR v2 API, I hit a potential bug if the Ext. vocab configuration includes a whole array of names from ROR rather than a single one (as a JsonString) as with ROR v1. While this is something that can be handled by changing the configuration, it makes sense to have a check in the Dataverse code as well.

**Which issue(s) this PR closes**:

- Closes #

**Special notes for your reviewer**:

**Suggestions on how to test this**: Use the ORCID/ROR config in https://github.com/gdcc/dataverse-external-vocab-support/pull/46 and verify that you see a failure to export the DataCite XML when an author affiliation is used (e.g. "QDR"). With the fix, the DataCite xml should be generated and the ROR id included in it as the author affiliation (the org name will not be included).

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**: no? fixes an issue that would only be possible with the ROR v2 api

**Additional documentation**:
