### PR TITLE
SignedUrl Fix when using http connector

### DIFF
--- a/doc/sphinx-guides/source/api/external-tools.rst
+++ b/doc/sphinx-guides/source/api/external-tools.rst
@@ -171,6 +171,10 @@ The signed URL mechanism is more secure than exposing API tokens and therefore r
 - For tools invoked via a GET call, Dataverse will include a callback query parameter with a Base64 encoded value. The decoded value is a signed URL that can be called to retrieve a JSON response containing all of the queryParameters and allowedApiCalls specified in the manfiest.
 - For tools invoked via POST, Dataverse will send a JSON body including the requested queryParameters and allowedApiCalls. Dataverse expects the response to the POST to indicate a redirect which Dataverse will use to open the tool.
 
+.. note::
+
+   **For Dataverse site administrators:** When Dataverse is behind a proxy, signed URLs may not work correctly due to protocol mismatches (HTTP vs HTTPS). Please refer to the :ref:`signed-urls-forwarded-proto-header` section to ensure signed URLs work properly in proxy environments.
+
 API Token
 ^^^^^^^^^
 

--- a/doc/sphinx-guides/source/installation/config.rst
+++ b/doc/sphinx-guides/source/installation/config.rst
@@ -94,6 +94,16 @@ First of all, confirm that access is denied! If you are in fact able to access t
 
 Still feel like activating this option in your configuration? - Have fun and be safe!
 
+.. _signed-urls-forwarded-proto-header:
+
+Using X-Forwarded-Proto for Signed Urls
++++++++++++++++++++++++++++++++++++++++
+
+If you use an Apache or Nginx proxy, or have a firewall such as Anubis, and they are configured to forward traffic to Dataverse over http
+(i.e. your proxy receives user calls over https but forwards locally to Dataverse over http), signed urls, used by external tools and 
+upload apps (such as DVWebloader), are likely to fail unless you configure your proxy to send an X-ForwardedProto HTTP Header.
+This allows Dataverse to recognize that the communication from the user was over https and that validation of signed urls should assume 
+they started with https:// (rather than http:// as received from the proxy).
 
 .. _PrivacyConsiderations:
 

--- a/src/main/java/edu/harvard/iq/dataverse/api/auth/SignedUrlAuthMechanism.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/auth/SignedUrlAuthMechanism.java
@@ -16,6 +16,7 @@ import jakarta.ws.rs.core.UriInfo;
 
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
+import java.util.logging.Logger;
 
 import static edu.harvard.iq.dataverse.util.UrlSignerUtil.SIGNED_URL_TOKEN;
 import static edu.harvard.iq.dataverse.util.UrlSignerUtil.SIGNED_URL_USER;
@@ -33,6 +34,8 @@ public class SignedUrlAuthMechanism implements AuthMechanism {
     @Inject
     protected PrivateUrlServiceBean privateUrlSvc;
     
+    private static final Logger logger = Logger.getLogger(SignedUrlAuthMechanism.class.getCanonicalName());
+
     @Override
     public User findUserFromRequest(ContainerRequestContext containerRequestContext) throws WrappedAuthErrorResponse {
         String signedUrlRequestParameter = getSignedUrlRequestParameter(containerRequestContext);
@@ -73,9 +76,9 @@ public class SignedUrlAuthMechanism implements AuthMechanism {
         if (targetUser != null && userApiToken != null) {
             String signedUrl = URLDecoder.decode(uriInfo.getRequestUri().toString(), StandardCharsets.UTF_8);
             
-            System.out.println("Orig URL: " + containerRequestContext.getUriInfo().getRequestUri().toString());
+            logger.fine("Original URL: " + containerRequestContext.getUriInfo().getRequestUri().toString());
             String forwardedProto = containerRequestContext.getHeaderString("X-Forwarded-Proto");
-            System.out.println("XFP: " + forwardedProto);
+            logger.fine("X-Forwarded-Proto is: " + forwardedProto);
             
 
             if (forwardedProto != null && !forwardedProto.isEmpty()) {

--- a/src/main/java/edu/harvard/iq/dataverse/api/auth/SignedUrlAuthMechanism.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/auth/SignedUrlAuthMechanism.java
@@ -72,6 +72,18 @@ public class SignedUrlAuthMechanism implements AuthMechanism {
         }
         if (targetUser != null && userApiToken != null) {
             String signedUrl = URLDecoder.decode(uriInfo.getRequestUri().toString(), StandardCharsets.UTF_8);
+            
+            System.out.println("Orig URL: " + containerRequestContext.getUriInfo().getRequestUri().toString());
+            String forwardedProto = containerRequestContext.getHeaderString("X-Forwarded-Proto");
+            System.out.println("XFP: " + forwardedProto);
+            
+
+            if (forwardedProto != null && !forwardedProto.isEmpty()) {
+                if ("https".equalsIgnoreCase(forwardedProto) && signedUrl.startsWith("http:")) {
+                    signedUrl = "https" + signedUrl.substring(4);
+                }
+            }
+
             String requestMethod = containerRequestContext.getMethod();
             String signedUrlSigningKey = JvmSettings.API_SIGNING_SECRET.lookupOptional().orElse("") + userApiToken.getTokenString();
             boolean isSignedUrlValid = UrlSignerUtil.isValidUrl(signedUrl, userId, requestMethod, signedUrlSigningKey);


### PR DESCRIPTION
**What this PR does / why we need it**:
In proxy configurations where the SSL connection is terminated in the proxy and Dataverse is then contacted over http (e.g. using 
 `proxy_pass            http://localhost:8080/;`
in nginx, signed URLs currently fail because they are signed as https://... urls but Dataverse receives a call to the http://... form of the URL (hence the url strings being signed/verified differ by one 's' character.

This has also been seen when using Anubis and it's forwarding to Dataverse.

This PR adds support for Dataverse to use the value of the X-Forwarded-Proto HTTP header and, if that is 'https', to restore the original https form of the URL before trying to test the signature. The result is that signatures can work in such configurations.

**Which issue(s) this PR closes**:

- Closes #

**Special notes for your reviewer**:

**Suggestions on how to test this**:
Should be able to configure Anubis (as on demo) or adjust an nginx or apache proxy to forward to Dataverse over http - verify that signed URLs for external tools fail if the X-Forwarded-Proto Header is missing or (easier to test) is set incorrectly to http. Turning on the fine logging for the SignedUrlAuthMechanism class will show when the signed url is received starting with http and the X-Forwarded-Proto header is set to https allowing the signed url to be validated.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
