### PR TITLE
show draft/unpublished in UI

### DIFF
--- a/doc/release-notes/7618-file-level-permissions-restricted-draft.md
+++ b/doc/release-notes/7618-file-level-permissions-restricted-draft.md
@@ -1,0 +1,3 @@
+File level permissions: Restricted files in Draft will now show a "Draft/Unpublished" tag in the UI when granting file access
+
+See #7618

--- a/src/main/java/edu/harvard/iq/dataverse/DataFile.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DataFile.java
@@ -303,7 +303,18 @@ public class DataFile extends DvObject implements Comparable {
     public void setDeleted(Boolean deleted) {
         this.deleted = deleted;
     }
-    
+
+    @Transient
+    private boolean unpublished;
+
+    public boolean getUnpublished() {
+        return unpublished;
+    }
+
+    public void setUnpublished(boolean unpublished) {
+        this.unpublished = unpublished;
+    }
+
     /*
     For use during file upload so that the user may delete 
     files that have already been uploaded to the current dataset version
@@ -596,7 +607,10 @@ public class DataFile extends DvObject implements Comparable {
         FileMetadata resultFileMetadata = null;
 
         if (fileMetadatas.size() == 1) {
+            setUnpublished(fileMetadatas.get(0).getDatasetVersion() == null || fileMetadatas.get(0).getDatasetVersion().getVersionState().equals(VersionState.DRAFT));
             return fileMetadatas.get(0);
+        } else {
+            setUnpublished(false); // Since only one can be in Draft assume there is a published version
         }
 
         for (FileMetadata fileMetadata : fileMetadatas) {

--- a/src/main/java/propertyFiles/Bundle.properties
+++ b/src/main/java/propertyFiles/Bundle.properties
@@ -1241,6 +1241,7 @@ dataverse.permissionsFiles.files.invalidMsg=There are no restricted files in thi
 dataverse.permissionsFiles.files.requested=Requested Files
 dataverse.permissionsFiles.files.selected=Selecting {0} of {1} {2}
 dataverse.permissionsFiles.files.includeDeleted=Include Deleted Files
+dataverse.permissionsFiles.files.draftUnpublished=Draft/Unpublished
 dataverse.permissionsFiles.viewRemoveDialog.header=File Access
 dataverse.permissionsFiles.viewRemoveDialog.removeBtn=Remove Access
 dataverse.permissionsFiles.viewRemoveDialog.removeBtn.confirmation=Are you sure you want to remove access to this file? Once access has been removed, the user or group will no longer be able to download this file.

--- a/src/main/webapp/permissions-manage-files.xhtml
+++ b/src/main/webapp/permissions-manage-files.xhtml
@@ -335,6 +335,7 @@
                                         <h:outputText rendered="#{!empty file.directoryLabel}" value="#{file.directoryLabel}/" styleClass="text-muted"/>
                                         <h:outputText value="#{file.displayName}"/>
                                         <h:outputText value=" (#{bundle['dataverse.permissionsFiles.files.deleted']}) " rendered="#{file.deleted}"/>
+                                        <h:outputText value=" (#{bundle['dataverse.permissionsFiles.files.draftUnpublished']}) "  rendered="#{file.unpublished}"/>
                                     </p:column>
                                 </p:dataTable>
                             </div>


### PR DESCRIPTION
**What this PR does / why we need it**: When you have a published dataset with restricted files, and you create a draft of the dataset with additional new restricted files, and you are assigning file level permission to the published version, the files in the draft dataset are showing up on the list of restricted files in the permissions page. There is no indication to the admin that the "draft dataset files" have yet to be published. This can cause admins to accidentally give access to files not intended for use. Draft file should not even show up here.

**Which issue(s) this PR closes**:https://github.com/IQSS/dataverse/issues/7618

- Closes #7618

**Special notes for your reviewer**:

**Suggestions on how to test this**: Follow the steps in the main issue

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
<img width="860" height="399" alt="image" src="https://github.com/user-attachments/assets/6deaa635-cfeb-4f60-b428-c078a24bba40" />


**Is there a release notes update needed for this change?**: Included

**Additional documentation**:
