### PR TITLE
Refer to configured datastore id when migrating from local datastore to S3

### DIFF
--- a/doc/sphinx-guides/source/developers/deployment.rst
+++ b/doc/sphinx-guides/source/developers/deployment.rst
@@ -110,14 +110,16 @@ Migrating Datafiles from Local Storage to S3
 
 A number of pilot Dataverse installations start on local storage, then administrators are tasked with migrating datafiles into S3 or similar object stores. The files may be copied with a command-line utility such as `s3cmd <https://s3tools.org/s3cmd>`_. You will want to retain the local file hierarchy, keeping the authority (for example: 10.5072) at the bucket "root."
 
-The below example queries may assist with updating dataset and datafile locations in the Dataverse installation's PostgresQL database. Depending on the initial version of the Dataverse Software and subsequent upgrade path, Datafile storage identifiers may or may not include a ``file://`` prefix, so you'll want to catch both cases.
+The below example queries may assist with updating dataset and datafile locations in the Dataverse installation's PostgresQL database. Depending on the initial version of the Dataverse Software and subsequent upgrade path, Datafile storage identifiers may or may not include a ``file://`` prefix, so you'll want to catch both cases. 
+
+In the following queries, ``<id>://`` refers to the ``id`` you have set for the datastore in the configuration (see the :ref:`file-storage` section of the Installation Guide).
 
 To Update Dataset Location to S3, Assuming a ``file://`` Prefix
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 ::
 
-  UPDATE dvobject SET storageidentifier=REPLACE(storageidentifier,'file://','s3://')
+  UPDATE dvobject SET storageidentifier=REPLACE(storageidentifier,'file://','<id>://')
     WHERE dtype='Dataset';
 
 To Update Datafile Location to your-s3-bucket, Assuming a ``file://`` Prefix
@@ -126,17 +128,17 @@ To Update Datafile Location to your-s3-bucket, Assuming a ``file://`` Prefix
 ::
 
   UPDATE dvobject
-    SET storageidentifier=REPLACE(storageidentifier,'file://','s3://your-s3-bucket:')
+    SET storageidentifier=REPLACE(storageidentifier,'file://','<id>://your-s3-bucket:')
     WHERE id IN (SELECT o.id FROM dvobject o, dataset s WHERE o.dtype = 'DataFile'
     AND s.id = o.owner_id AND s.harvestingclient_id IS null
-    AND o.storageidentifier NOT LIKE 's3://%');
+    AND o.storageidentifier NOT LIKE '<id>://%');
 
 To Update Datafile Location to your-s3-bucket, Assuming no ``file://`` Prefix
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 ::
 
-  UPDATE dvobject SET storageidentifier=CONCAT('s3://your-s3-bucket:', storageidentifier)
+  UPDATE dvobject SET storageidentifier=CONCAT('<id>://your-s3-bucket:', storageidentifier)
 	  WHERE id IN (SELECT o.id FROM dvobject o, dataset s WHERE o.dtype = 'DataFile'
 	  AND s.id = o.owner_id AND s.harvestingclient_id IS null
 	  AND o.storageidentifier NOT LIKE '%://%');


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request is related to topic [#large-data > Filesystem -&gt; S3 migration documentation still valid?](https://dataverse.zulipchat.com/#narrow/channel/432390-large-data/topic/Filesystem.20-.3E.20S3.20migration.20documentation.20still.20valid.3F/with/537695359) in the chat.

Since Dataverse supports multiple datastores, including multiple S3-stores with user defined datastore ids, it is more clear if in example update queries do not use string `S3` as a placeholder for datastore id.


