### PR TITLE
User Guide: Add information about admin role of dataverse collections

### DIFF
--- a/doc/sphinx-guides/source/installation/config.rst
+++ b/doc/sphinx-guides/source/installation/config.rst
@@ -246,6 +246,8 @@ If you are running an installation with Apache and Payara on the same server, an
 
 You should **NOT** use the configuration option above if you are running in a load-balanced environment, or otherwise have the web server on a different host than the application server.
 
+.. _root-collection-permissions:
+
 Root Dataverse Collection Permissions
 -------------------------------------
 

--- a/doc/sphinx-guides/source/user/dataverse-management.rst
+++ b/doc/sphinx-guides/source/user/dataverse-management.rst
@@ -111,7 +111,7 @@ Dataverse installation user accounts can be granted roles that define which acti
 
 Roles and permissions may also be granted to groups. Groups can be defined as a collection of Dataverse installation user accounts, a collection of IP addresses (e.g. all users of a library's computers), or a collection of all users who log in using a particular institutional login (e.g. everyone who logs in with a particular university's account credentials).
 
-The user who creates a dataverse is given the "Admin" role on that dataverse (see :doc:`/installation/installation/config.rst#root-dataverse-collection-permissions`). Admins of a Dataverse collection can assign roles and permissions to the users of that Dataverse collection. If you are an admin on a Dataverse collection, then you will find the link to the Permissions page under the Edit dropdown on the Dataverse collection page. 
+The user who creates a dataverse is given the "Admin" role on that dataverse (see :ref:`root-collection-permissions`). Admins of a Dataverse collection can assign roles and permissions to the users of that Dataverse collection. If you are an admin on a Dataverse collection, then you will find the link to the Permissions page under the Edit dropdown on the Dataverse collection page.
 
 |image2|
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Users who create a dataverse collection are granted automatically with the admin role.
This information is given in the configuration guide, but it is missing in the user guide, where users will search for it at first place.

**Which issue(s) this PR closes**:

- Closes #11802

**Special notes for your reviewer**:

**Suggestions on how to test this**:

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
