### PR TITLE
docs: nest "MyData Collection List" under "MyData"

### DIFF
--- a/doc/sphinx-guides/source/api/native-api.rst
+++ b/doc/sphinx-guides/source/api/native-api.rst
@@ -7998,7 +7998,7 @@ Parameters:
 ``per_page`` Number of results returned per page.
 
 MyData Collection List
-----------------------
+~~~~~~~~~~~~~~~~~~~~~~
 
 The MyData Collection List API is used to get a list of the collections an authenticated user can create a Dataset in.
 Param userIdentifier={userName} is used by a superuser to get the collections for a specific user.


### PR DESCRIPTION
**What this PR does / why we need it**:

"MyData Collection List" (added in #11681) shouldn't be a top-level heading. This PR nests it under "MyData".

Before:

<img width="368" height="98" alt="Screenshot 2025-09-15 at 2 44 57 PM" src="https://github.com/user-attachments/assets/865b9372-d704-47d8-bce0-97af87e9c591" />

After:

<img width="368" height="98" alt="Screenshot 2025-09-15 at 2 45 53 PM" src="https://github.com/user-attachments/assets/cc905fd8-54f9-4627-920f-620e0442988f" />
