### PR TITLE
docs: fix typo 'orgization' → 'organization' in Installation config (#11820)

### DIFF
--- a/doc/sphinx-guides/source/installation/config.rst
+++ b/doc/sphinx-guides/source/installation/config.rst
@@ -3189,7 +3189,7 @@ dataverse.person-or-org.org-phrase-array
 Please note that this setting is experimental.
 
 The Schema.org metadata and OpenAIRE exports and the Schema.org metadata included in DatasetPages try to infer whether each entry in the various fields (e.g. Author, Contributor) is a Person or Organization.
-If you have examples where an orgization name is being inferred to belong to a person, you can use this setting to force it to be recognized as an organization.
+If you have examples where an organization name is being inferred to belong to a person, you can use this setting to force it to be recognized as an organization.
 The value is expected to be a comma-separated list of strings. Any name that contains one of the strings is assumed to be an organization. For example, "Project" is a word that is not otherwise associated with being an organization.
 
 Can also be set via *MicroProfile Config API* sources, e.g. the environment variable ``DATAVERSE_PERSON_OR_ORG_ORG_PHRASE_ARRAY``.


### PR DESCRIPTION
What this PR does / why we need it:
Fixes a one-word typo in the Installation Guide where "orgization" was incorrectly spelled. 
Changed it to "organization" so the documentation is accurate.

Which issue(s) this PR closes:
- Closes #11820

Special notes for your reviewer:
This is a simple documentation change; no code logic is affected.

Suggestions on how to test this:
Open the page generated from doc/sphinx-guides/source/installation/config.rst 
and verify that the sentence now reads "organization" instead of "orgization".

Does this PR introduce a user interface change? If mockups are available, please link/include them here:
No UI changes; documentation only.

Is there a release notes update needed for this change?:
No release notes needed.

Additional documentation:
None.