### PR TITLE
QDR: Multiple transactions for permission reindexing

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/search/SolrIndexServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/search/SolrIndexServiceBean.java
@@ -356,7 +356,7 @@ public class SolrIndexServiceBean {
                 self.indexDatasetBatchInNewTransaction(batchIds, counter, fileQueryMin);
                 numObjects += batchIds.size();
 
-                logger.info("Processed batch " + (i / batchSize + 1) + " of " +
+                logger.info("Permission reindexing: Processed batch " + (i/batchSize + 1) + " of " + 
                         (int) Math.ceil(datasetIds.size() / (double) batchSize) +
                         " dataset batches for dataverse " + dataverse.getId());
             }
@@ -455,24 +455,25 @@ public class SolrIndexServiceBean {
         }
     }
 
-    private String reindexFilesInBatches(List<DataFileProxy> filesToReindexAsBatch, List<String> cachedPerms, Long versionId, String solrIdEnd) {
+    private void reindexFilesInBatches(List<DataFileProxy> filesToReindexAsBatch, List<String> cachedPerms, Long versionId, String solrIdEnd) {
         List<SolrInputDocument> docs = new ArrayList<>();
         try {
             // Assume all files have the same owner
             if (filesToReindexAsBatch.isEmpty()) {
-                return "No files to reindex";
+                logger.warning("reindexFilesInBatches called incorrectly with an empty file list");
             }
 
-                    for (DataFileProxy file : filesToReindexAsBatch) {
+            for (DataFileProxy file : filesToReindexAsBatch) {
 
-                            DvObjectSolrDoc fileSolrDoc = constructDatafileSolrDoc(file, cachedPerms, versionId, solrIdEnd);
-                            SolrInputDocument solrDoc = SearchUtil.createSolrDoc(fileSolrDoc);
-                            docs.add(solrDoc);
-                    }
+                DvObjectSolrDoc fileSolrDoc = constructDatafileSolrDoc(file, cachedPerms, versionId, solrIdEnd);
+                SolrInputDocument solrDoc = SearchUtil.createSolrDoc(fileSolrDoc);
+                docs.add(solrDoc);
+            }
             persistToSolr(docs);
-            return " " + filesToReindexAsBatch.size() + " files indexed across " + docs.size() + " Solr documents ";
+            logger.fine("Indexed " + filesToReindexAsBatch.size() + " files across " + docs.size() + " Solr documents");
         } catch (SolrServerException | IOException ex) {
-            return " tried to reindex " + filesToReindexAsBatch.size() + " files indexed across " + docs.size() + " Solr documents but caught exception: " + ex;
+            logger.log(Level.WARNING, "Failed to reindex " + filesToReindexAsBatch.size() +
+                    " files across " + docs.size() + " Solr documents", ex);
         }
     }
 

--- a/src/main/java/edu/harvard/iq/dataverse/search/SolrIndexServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/search/SolrIndexServiceBean.java
@@ -28,6 +28,8 @@ import java.util.stream.Stream;
 
 import jakarta.ejb.EJB;
 import jakarta.ejb.Stateless;
+import jakarta.ejb.TransactionAttribute;
+import jakarta.ejb.TransactionAttributeType;
 import jakarta.inject.Named;
 import jakarta.json.Json;
 import jakarta.json.JsonObjectBuilder;
@@ -43,6 +45,9 @@ public class SolrIndexServiceBean {
 
     private static final Logger logger = Logger.getLogger(SolrIndexServiceBean.class.getCanonicalName());
 
+    @EJB
+    private SolrIndexServiceBean self; // Self-injection to allow calling methods in new transactions (from other methods in this bean)
+    
     @EJB
     DvObjectServiceBean dvObjectService;
     @EJB
@@ -317,7 +322,7 @@ public class SolrIndexServiceBean {
 
     /**
      * We use the database to determine direct children since there is no
-     * inheritance
+     * inheritance. This implementation uses smaller transactions to avoid memory issues.
      */
     public IndexResponse indexPermissionsOnSelfAndChildren(DvObject definitionPoint) {
 
@@ -325,114 +330,129 @@ public class SolrIndexServiceBean {
             logger.log(Level.WARNING, "Cannot perform indexPermissionsOnSelfAndChildren with a definitionPoint null");
             return null;
         }
-        int fileQueryMin= JvmSettings.MIN_FILES_TO_USE_PROXY.lookupOptional(Integer.class).orElse(Integer.MAX_VALUE);
-        List<DataFileProxy> filesToReindexAsBatch = new ArrayList<>();
-        /**
-         * @todo Re-indexing the definition point itself seems to be necessary
-         * for revoke but not necessarily grant.
-         */
-
-        // We don't create a Solr "primary/content" doc for the root dataverse
-        // so don't create a Solr "permission" doc either.
-        final int[] counter = {0};
+        int fileQueryMin = JvmSettings.MIN_FILES_TO_USE_PROXY.lookupOptional(Integer.class).orElse(Integer.MAX_VALUE);
+        final int[] counter = { 0 };
         int numObjects = 0;
         long globalStartTime = System.currentTimeMillis();
-        if (definitionPoint.isInstanceofDataverse()) {
-            Dataverse selfDataverse = (Dataverse) definitionPoint;
-            if (!selfDataverse.equals(dataverseService.findRootDataverse())) {
+
+        // Handle the definition point itself in its own transaction
+        if (definitionPoint instanceof Dataverse dataverse) {
+            // We don't create a Solr "primary/content" doc for the root dataverse
+            // so don't create a Solr "permission" doc either.
+            if (!dataverse.equals(dataverseService.findRootDataverse())) {
                 indexPermissionsForOneDvObject(definitionPoint);
                 numObjects++;
             }
-            List<Dataset> directChildDatasetsOfDvDefPoint = datasetService.findByOwnerId(selfDataverse.getId());
-            for (Dataset dataset : directChildDatasetsOfDvDefPoint) {
-                indexPermissionsForOneDvObject(dataset);
-                numObjects++;
 
-                Map<DatasetVersion.VersionState, Boolean> desiredCards = searchPermissionsService.getDesiredCards(dataset);
-                long startTime = System.currentTimeMillis();
-                for (DatasetVersion version : versionsToReIndexPermissionsFor(dataset)) {
-                    if (desiredCards.get(version.getVersionState())) {
-                        List<String> cachedPerms = searchPermissionsService.findDatasetVersionPerms(version);
-                        String solrIdEnd = getDatasetOrDataFileSolrEnding(version.getVersionState());
-                        Long versionId = version.getId();
-                        for (FileMetadata fmd : version.getFileMetadatas()) {
-                            DataFileProxy fileProxy = new DataFileProxy(fmd);
-                            // Since reindexFilesInBatches() re-indexes a file in all versions needed, we should not send a file already in the released version twice
-                            filesToReindexAsBatch.add(fileProxy);
-                            counter[0]++;
-                            if (counter[0] % 100 == 0) {
-                                reindexFilesInBatches(filesToReindexAsBatch, cachedPerms, versionId, solrIdEnd);
-                                filesToReindexAsBatch.clear();
-                            }
-                            if (counter[0] % 1000 == 0) {
-                                logger.fine("Progress: " + counter[0] + "files permissions reindexed");
-                            }
-                        }
+            // Process datasets in batches
+            List<Long> datasetIds = datasetService.findIdsByOwnerId(dataverse.getId());
+            int batchSize = 10; // Process 10 datasets per transaction
 
-                        // Re-index any remaining files in the datasetversion (so that verionId, etc. remain constants for all files in the batch)
-                        reindexFilesInBatches(filesToReindexAsBatch, cachedPerms, versionId, solrIdEnd);
-                        logger.info("Progress : dataset " + dataset.getId() + " permissions reindexed in " + (System.currentTimeMillis() - startTime) + " ms");
-                    }
-                }
+            for (int i = 0; i < datasetIds.size(); i += batchSize) {
+                int endIndex = Math.min(i + batchSize, datasetIds.size());
+                List<Long> batchIds = datasetIds.subList(i, endIndex);
+
+                // Process this batch of datasets in a new transaction
+                self.indexDatasetBatchInNewTransaction(batchIds, counter, fileQueryMin);
+                numObjects += batchIds.size();
+
+                logger.info("Processed batch " + (i / batchSize + 1) + " of " +
+                        (int) Math.ceil(datasetIds.size() / (double) batchSize) +
+                        " dataset batches for dataverse " + dataverse.getId());
             }
-        } else if (definitionPoint.isInstanceofDataset()) {
+        } else if (definitionPoint instanceof Dataset dataset) {
+            // For a single dataset, process it in its own transaction
             indexPermissionsForOneDvObject(definitionPoint);
             numObjects++;
-            // index files
-            Dataset dataset = (Dataset) definitionPoint;
-            Map<DatasetVersion.VersionState, Boolean> desiredCards = searchPermissionsService.getDesiredCards(dataset);
-            for (DatasetVersion version : versionsToReIndexPermissionsFor(dataset)) {
-                if (desiredCards.get(version.getVersionState())) {
-                    List<String> cachedPerms = searchPermissionsService.findDatasetVersionPerms(version);
-                    String solrIdEnd = getDatasetOrDataFileSolrEnding(version.getVersionState());
-                    Long versionId = version.getId();
-                    if (version.getFileMetadatas().size() > fileQueryMin) {
-                        // For large datasets, use a more efficient SQL query instead of loading all file metadata objects
-                        getDataFileInfoForPermissionIndexing(version.getId()).forEach(fileInfo -> {
-                            filesToReindexAsBatch.add(fileInfo);
-                            counter[0]++;
 
-                            if (counter[0] % 100 == 0) {
-                                long startTime = System.currentTimeMillis();
-                                reindexFilesInBatches(filesToReindexAsBatch, cachedPerms, versionId, solrIdEnd);
-                                filesToReindexAsBatch.clear();
-                                logger.fine("Progress: 100 file permissions at " + counter[0] + " files reindexed in " + (System.currentTimeMillis() - startTime) + " ms");
-                            }
-                        });
-                    } else {
-                        version.getFileMetadatas().stream()
-                                .forEach(fmd -> {
-                                    DataFileProxy fileProxy = new DataFileProxy(fmd);
-                                    filesToReindexAsBatch.add(fileProxy);
-                                    counter[0]++;
-                                    if (counter[0] % 100 == 0) {
-                                        long startTime = System.currentTimeMillis();
-                                        reindexFilesInBatches(filesToReindexAsBatch, cachedPerms, versionId, solrIdEnd);
-                                        filesToReindexAsBatch.clear();
-                                        logger.fine("Progress: 100 file permissions at  " + counter[0] + "files reindexed in " + (System.currentTimeMillis() - startTime) + " ms");
-                                    }
-                                });
-                    }
-                    // Re-index any remaining files in the dataset version (versionId, etc. remain constants for all files in the batch)
-                    reindexFilesInBatches(filesToReindexAsBatch, cachedPerms, versionId, solrIdEnd);
-                    filesToReindexAsBatch.clear();
-                }
-
-            }
+            // Process the dataset's files in a new transaction
+            self.indexDatasetFilesInNewTransaction(dataset.getId(), counter, fileQueryMin);
         } else {
+            // For other types (like files), just index in a new transaction
             indexPermissionsForOneDvObject(definitionPoint);
             numObjects++;
         }
 
-        /**
-         * @todo Error handling? What to do with response?
-         *
-         * @todo Should update timestamps, probably, even thought these are files, see
-         *       https://github.com/IQSS/dataverse/issues/2421
-         */
-        logger.fine("Reindexed permissions for " + counter[0] + " files and " + numObjects + "datasets/collections in " + (System.currentTimeMillis() - globalStartTime) + " ms");
-        return new IndexResponse("Number of dvObject permissions indexed for " + definitionPoint
-                + ": " + numObjects);
+        logger.info("Reindexed permissions for " + counter[0] + " files and " + numObjects +
+                " datasets/collections in " + (System.currentTimeMillis() - globalStartTime) + " ms");
+
+        return new IndexResponse("Number of dvObject permissions indexed for " + definitionPoint + ": " + numObjects);
+    }
+
+    @TransactionAttribute(TransactionAttributeType.REQUIRES_NEW)
+    public void indexDatasetBatchInNewTransaction(List<Long> datasetIds, final int[] fileCounter, int fileQueryMin) {
+        for (Long datasetId : datasetIds) {
+            Dataset dataset = datasetService.find(datasetId);
+            if (dataset != null) {
+                indexPermissionsForOneDvObject(dataset);
+
+                // Process files for this dataset
+                Map<DatasetVersion.VersionState, Boolean> desiredCards = searchPermissionsService.getDesiredCards(dataset);
+
+                for (DatasetVersion version : versionsToReIndexPermissionsFor(dataset)) {
+                    if (desiredCards.get(version.getVersionState())) {
+                        processDatasetVersionFiles(version, fileCounter, fileQueryMin);
+                    }
+                }
+            }
+        }
+    }
+
+    @TransactionAttribute(TransactionAttributeType.REQUIRES_NEW)
+    public void indexDatasetFilesInNewTransaction(Long datasetId, final int[] fileCounter, int fileQueryMin) {
+        Dataset dataset = datasetService.find(datasetId);
+        if (dataset != null) {
+            Map<DatasetVersion.VersionState, Boolean> desiredCards = searchPermissionsService.getDesiredCards(dataset);
+            for (DatasetVersion version : versionsToReIndexPermissionsFor(dataset)) {
+                if (desiredCards.get(version.getVersionState())) {
+                    processDatasetVersionFiles(version, fileCounter, fileQueryMin);
+                }
+            }
+        }
+    }
+
+    private void processDatasetVersionFiles(DatasetVersion version,
+            final int[] fileCounter, int fileQueryMin) {
+        List<String> cachedPerms = searchPermissionsService.findDatasetVersionPerms(version);
+        String solrIdEnd = getDatasetOrDataFileSolrEnding(version.getVersionState());
+        Long versionId = version.getId();
+        List<DataFileProxy> filesToReindexAsBatch = new ArrayList<>();
+
+        // Process files in batches of 100
+        int batchSize = 100;
+
+        if (version.getFileMetadatas().size() > fileQueryMin) {
+            // For large datasets, use a more efficient SQL query
+            Stream<DataFileProxy> fileStream = getDataFileInfoForPermissionIndexing(version.getId());
+
+            // Process files in batches to avoid memory issues
+            fileStream.forEach(fileInfo -> {
+                filesToReindexAsBatch.add(fileInfo);
+                fileCounter[0]++;
+
+                if (filesToReindexAsBatch.size() >= batchSize) {
+                    reindexFilesInBatches(filesToReindexAsBatch, cachedPerms, versionId, solrIdEnd);
+                    filesToReindexAsBatch.clear();
+                }
+            });
+        } else {
+            // For smaller datasets, process files directly
+            for (FileMetadata fmd : version.getFileMetadatas()) {
+                DataFileProxy fileProxy = new DataFileProxy(fmd);
+                filesToReindexAsBatch.add(fileProxy);
+                fileCounter[0]++;
+
+                if (filesToReindexAsBatch.size() >= batchSize) {
+                    reindexFilesInBatches(filesToReindexAsBatch, cachedPerms, versionId, solrIdEnd);
+                    filesToReindexAsBatch.clear();
+                }
+            }
+        }
+
+        // Process any remaining files
+        if (!filesToReindexAsBatch.isEmpty()) {
+            reindexFilesInBatches(filesToReindexAsBatch, cachedPerms, versionId, solrIdEnd);
+        }
     }
 
     private String reindexFilesInBatches(List<DataFileProxy> filesToReindexAsBatch, List<String> cachedPerms, Long versionId, String solrIdEnd) {


### PR DESCRIPTION
**What this PR does / why we need it**: When a user is given a role on the root collection (or has that role removed), we reindex all the datasets and files within it. Prior to this PR, that was all done in one transaction. This PR breaks the operation into multiple batches in separate transactions. This reduces the time and memory needed for reindex the permissions.

At QDR, on a ~low-memory test machine, reindexing after a role assignment on root was taking ~5-6 minutes. After the PR, reindexing takes ~30-35 seconds.  (We have also seen the server slow to a crawl doing this permission reindex (at least 10 times slower) when (presumably) other issues have caused very low memory conditions. We're hopeful that batching the work here will also lower overall memory requirements for reindexing perms on root and help to avoid it contributing to/ be less affected by very low memory).

**Which issue(s) this PR closes**:

I thought there was an open issue, but I've only found #10697, #10698. 

- Closes #

**Special notes for your reviewer**: By default, marking a method as requiring a new transaction does nothing if the method is being called from within the same bean. However, by "self-injecting" the bean into itself and then calling the method on the injected copy it works. I've used this technique here (suggested by AI). The alternative is to break the bean into parts and make calls between them. 

**Suggestions on how to test this**: 
Run the /api/admin/index/status command to confirm there are no indexing issues to start. (Runthe /api/admin/index/clear-orphans command if needed to remove perm docs in solr that aren't in the db).

Go to the root dataverse and assign/revoke a role with fine logging on this class. Check the logs for the run time. Then do the same thing after the PR and confirm it's significantly faster. 

Verify that there are no / no new issues reported by /api/admin/index/status .

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
