### PR TITLE
QDR-DataCite Scaling

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/pidproviders/doi/datacite/DOIDataCiteRegisterService.java
+++ b/src/main/java/edu/harvard/iq/dataverse/pidproviders/doi/datacite/DOIDataCiteRegisterService.java
@@ -95,7 +95,14 @@ public class DOIDataCiteRegisterService {
             }
             retString = "metadata:\\r" + client.postMetadata(xmlMetadata) + "\\r";
         }
-        if (!target.equals(client.getUrl(numericIdentifier))) {
+        String currentUrl = null;
+        try {
+            //May get a 204 if the DOI is still draft
+            currentUrl = client.getUrl(numericIdentifier);
+        } catch (RuntimeException ex) {
+            logger.fine("Error getting Url for " + numericIdentifier + ": " + ex.getMessage());
+        }
+        if (!target.equals(currentUrl)) {
             logger.info("Updating target URL to " +  target);
             client.postUrl(numericIdentifier, target);
             retString = retString + "url:\\r" + target;

--- a/src/main/java/edu/harvard/iq/dataverse/pidproviders/doi/datacite/DataCiteDOIProvider.java
+++ b/src/main/java/edu/harvard/iq/dataverse/pidproviders/doi/datacite/DataCiteDOIProvider.java
@@ -15,6 +15,7 @@ import edu.harvard.iq.dataverse.DvObject;
 import edu.harvard.iq.dataverse.FileMetadata;
 import edu.harvard.iq.dataverse.GlobalId;
 import edu.harvard.iq.dataverse.pidproviders.doi.AbstractDOIProvider;
+import edu.harvard.iq.dataverse.settings.FeatureFlags;
 import edu.harvard.iq.dataverse.util.json.JsonUtil;
 import jakarta.json.JsonObject;
 
@@ -217,7 +218,11 @@ public class DataCiteDOIProvider extends AbstractDOIProvider {
         metadata.put("datacite.publicationyear", generateYear(dvObject));
         metadata.put("_target", getTargetUrl(dvObject));
         try {
-            doiDataCiteRegisterService.registerIdentifier(identifier, metadata, dvObject);
+            if (FeatureFlags.ONLY_UPDATE_DATACITE_WHEN_NEEDED.enabled()) {
+                doiDataCiteRegisterService.reRegisterIdentifier(identifier, metadata, dvObject);
+            } else {
+                doiDataCiteRegisterService.registerIdentifier(identifier, metadata, dvObject);
+            }
             return true;
         } catch (Exception e) {
             logger.log(Level.WARNING, "modifyMetadata failed: " + e.getMessage(), e);

--- a/src/main/java/edu/harvard/iq/dataverse/pidproviders/doi/datacite/DataCiteRESTfullClient.java
+++ b/src/main/java/edu/harvard/iq/dataverse/pidproviders/doi/datacite/DataCiteRESTfullClient.java
@@ -41,6 +41,10 @@ public class DataCiteRESTfullClient implements Closeable {
     
     private static final Logger logger = Logger.getLogger(DataCiteRESTfullClient.class.getCanonicalName());
 
+    // Constants for retry mechanism
+    private static final int MAX_RETRIES = 5;
+    private static final long RETRY_DELAY_MS = 10000; // 10 seconds
+    
     private String url;
     private CloseableHttpClient httpClient;
     private HttpClientContext context;
@@ -59,11 +63,78 @@ public class DataCiteRESTfullClient implements Closeable {
     public void close() {
         if (this.httpClient != null) {
             try {
-           httpClient.close();
+                httpClient.close();
             } catch (IOException io) {
-               logger.warning("IOException closing hhtpClient: " + io.getMessage());
-           }
+                logger.warning("IOException closing httpClient: " + io.getMessage());
+            }
         }
+    }
+    
+    /**
+     * Execute HTTP request with retry mechanism for specific status codes
+     * 
+     * @param request The HTTP request to execute
+     * @param operationName Name of the operation for logging
+     * @return HttpResponse The response from the server
+     * @throws IOException If an error occurs during the request
+     */
+    private HttpResponse executeWithRetry(org.apache.http.client.methods.HttpRequestBase request, String operationName) throws IOException {
+        int attempts = 0;
+        IOException lastException = null;
+        
+        while (attempts < MAX_RETRIES) {
+            try {
+                HttpResponse response = httpClient.execute(request, context);
+                int statusCode = response.getStatusLine().getStatusCode();
+                
+                // If we get a retry status code, try again after delay
+                if (statusCode == 429 || statusCode == 503 || statusCode == 504) {
+                    EntityUtils.consumeQuietly(response.getEntity());
+                    attempts++;
+                    
+                    if (attempts < MAX_RETRIES) {
+                        logger.warning("DataCite API returned status " + statusCode + 
+                                       " for " + operationName + ". Retrying in " + 
+                                       (RETRY_DELAY_MS / 1000) + " seconds (attempt " + attempts + " of " + MAX_RETRIES + ")");
+                        try {
+                            Thread.sleep(RETRY_DELAY_MS);
+                        } catch (InterruptedException ie) {
+                            Thread.currentThread().interrupt();
+                            throw new IOException("Retry interrupted", ie);
+                        }
+                    } else {
+                        logger.severe("DataCite API failed with status " + statusCode + 
+                                      " for " + operationName + " after " + MAX_RETRIES + " attempts");
+                        return response; // Return the last failed response
+                    }
+                } else {
+                    // Success or non-retry error code
+                    return response;
+                }
+            } catch (IOException ioe) {
+                lastException = ioe;
+                attempts++;
+                
+                if (attempts < MAX_RETRIES) {
+                    logger.warning("IOException during " + operationName + ": " + ioe.getMessage() + 
+                                   ". Retrying in " + (RETRY_DELAY_MS / 1000) + " seconds (attempt " + 
+                                   attempts + " of " + MAX_RETRIES + ")");
+                    try {
+                        Thread.sleep(RETRY_DELAY_MS);
+                    } catch (InterruptedException ie) {
+                        Thread.currentThread().interrupt();
+                        throw new IOException("Retry interrupted", ie);
+                    }
+                } else {
+                    logger.severe("DataCite API failed for " + operationName + " after " + 
+                                  MAX_RETRIES + " attempts due to: " + ioe.getMessage());
+                    throw lastException;
+                }
+            }
+        }
+        
+        // This should never happen, but just in case
+        throw new IOException("Failed to execute request after " + MAX_RETRIES + " attempts");
     }
 
     /**
@@ -75,7 +146,7 @@ public class DataCiteRESTfullClient implements Closeable {
     public String getUrl(String doi) {
         HttpGet httpGet = new HttpGet(this.url + "/doi/" + doi);
         try {
-            HttpResponse response = httpClient.execute(httpGet,context);
+            HttpResponse response = executeWithRetry(httpGet, "getUrl");
             HttpEntity entity = response.getEntity();
             String data = null;
 
@@ -104,7 +175,7 @@ public class DataCiteRESTfullClient implements Closeable {
         httpPost.setHeader("Content-Type", "text/plain;charset=UTF-8");
         httpPost.setEntity(new StringEntity("doi=" + doi + "\nurl=" + url, "utf-8"));
 
-        HttpResponse response = httpClient.execute(httpPost, context);
+        HttpResponse response = executeWithRetry(httpPost, "postUrl");
         String data = EntityUtils.toString(response.getEntity(), encoding);
         if (response.getStatusLine().getStatusCode() != 201) {
             String errMsg = "Response from postUrl: " + response.getStatusLine().getStatusCode() + ", " + data;
@@ -124,7 +195,7 @@ public class DataCiteRESTfullClient implements Closeable {
         HttpGet httpGet = new HttpGet(this.url + "/metadata/" + doi);
         httpGet.setHeader("Accept", "application/xml");
         try {
-            HttpResponse response = httpClient.execute(httpGet,context);
+            HttpResponse response = executeWithRetry(httpGet, "getMetadata");
             String data = EntityUtils.toString(response.getEntity(), encoding);
             if (response.getStatusLine().getStatusCode() != 200) {
                 String errMsg = "Response from getMetadata: " + response.getStatusLine().getStatusCode() + ", " + data;
@@ -133,7 +204,7 @@ public class DataCiteRESTfullClient implements Closeable {
             }
             return data;
         } catch (IOException ioe) {
-            logger.log(Level.SEVERE, "IOException when get metadata");
+            logger.log(Level.SEVERE, "IOException when get metadata", ioe);
             throw new RuntimeException("IOException when get metadata", ioe);
         }
     }
@@ -147,7 +218,7 @@ public class DataCiteRESTfullClient implements Closeable {
     public boolean testDOIExists(String doi) throws IOException {
         HttpGet httpGet = new HttpGet(this.url + "/metadata/" + doi);
         httpGet.setHeader("Accept", "application/xml");
-        HttpResponse response = httpClient.execute(httpGet, context);
+        HttpResponse response = executeWithRetry(httpGet, "testDOIExists");
         if (response.getStatusLine().getStatusCode() != 200) {
             EntityUtils.consumeQuietly(response.getEntity());
             return false;
@@ -166,7 +237,7 @@ public class DataCiteRESTfullClient implements Closeable {
         HttpPost httpPost = new HttpPost(this.url + "/metadata");
         httpPost.setHeader("Content-Type", "application/xml;charset=UTF-8");
         httpPost.setEntity(new StringEntity(metadata, "utf-8"));
-        HttpResponse response = httpClient.execute(httpPost, context);
+        HttpResponse response = executeWithRetry(httpPost, "postMetadata");
         String data = EntityUtils.toString(response.getEntity(), encoding);
         if (response.getStatusLine().getStatusCode() != 201) {
             String errMsg = "Response from postMetadata: " + response.getStatusLine().getStatusCode() + ", " + data;
@@ -185,7 +256,7 @@ public class DataCiteRESTfullClient implements Closeable {
     public String inactiveDataset(String doi) {
         HttpDelete httpDelete = new HttpDelete(this.url + "/metadata/" + doi);
         try {
-            HttpResponse response = httpClient.execute(httpDelete,context);
+            HttpResponse response = executeWithRetry(httpDelete, "inactiveDataset");
             String data = EntityUtils.toString(response.getEntity(), encoding);
             if (response.getStatusLine().getStatusCode() != 200) {
                 String errMsg = "Response code: " + response.getStatusLine().getStatusCode() + ", " + data;
@@ -194,7 +265,7 @@ public class DataCiteRESTfullClient implements Closeable {
             }
             return data;
         } catch (IOException ioe) {
-            logger.log(Level.SEVERE, "IOException when inactive dataset");
+            logger.log(Level.SEVERE, "IOException when inactive dataset", ioe);
             throw new RuntimeException("IOException when inactive dataset", ioe);
         }
     }

--- a/src/main/java/edu/harvard/iq/dataverse/settings/FeatureFlags.java
+++ b/src/main/java/edu/harvard/iq/dataverse/settings/FeatureFlags.java
@@ -229,7 +229,12 @@ public enum FeatureFlags {
      * @since Dataverse 6.8
      */
     ENABLE_PID_FAILURE_LOG("enable-pid-failure-log"),
-    
+
+    /**
+     * Only update a DataCite DOI when needed (for efficiency, lighter load on DataCite).
+     */
+    ONLY_UPDATE_DATACITE_WHEN_NEEDED("only-update-datacite-when-needed"),
+
     ;
     
     final String flag;


### PR DESCRIPTION
**What this PR does / why we need it**: This PR improves scaling of requests to DataCite in two ways:

- adds retries with a delay if/when DataCite responds with error codes that indicate requests are being throttled (429) or their server is temporarily not responding (503, 504)
- optionally checks with DataCite to see if updates are needed before sending updates

The former is fairly straight forward - rather than failing immediately, Dataverse will wait/temporarily slow requests to see if DataCite recovers/Dataverse can drop below the rate limit. If things recover, Dataverse's operations will succeed. If not, there could be a delay of ~ 1minute before a final error occurs and the operation fails.

The latter is perhaps more controversial (there was discussion several years ago about whether this is useful): instead of always sending an update, causing DataCite to write info, this optional change causes Dataverse to first query DataCite (a read) and only send an update if the local info is different than what DataCite has. In cases such as file DOIs where changes are infrequent, this results in many reads and few writes instead of many writes and DataCite (and growing records as they track all writes of new metadata) which appears to be faster. It may be generally useful, but installations not using file DOIs may not want to try it.

**Which issue(s) this PR closes**:

- Closes #

**Special notes for your reviewer**: QDR had trouble publishing a dataset with >10K files before this change and succeeded after.

**Suggestions on how to test this**: Minimally regression test (w/ and w/o flag). 

Could also attempt to create/publish a dataset with file DOIs and many files using the DataCite test server and see if the changes increase the success rate/largest size that succeeds and/or improves performance (i.e. with the flag on.) I'm not sure this is worth it given the testing/deployment at QDR.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
