### PR TITLE
update base image version for post-6.8 release

### DIFF
--- a/modules/dataverse-parent/pom.xml
+++ b/modules/dataverse-parent/pom.xml
@@ -454,8 +454,8 @@
                     Once the release has been made (tag created), change this back to "${parsedVersion.majorVersion}.${parsedVersion.nextMinorVersion}"
                     (These properties are provided by the build-helper plugin below.)
                 -->
-                <!-- <base.image.version>${parsedVersion.majorVersion}.${parsedVersion.nextMinorVersion}</base.image.version> -->
-                <base.image.version>${revision}</base.image.version>
+                <base.image.version>${parsedVersion.majorVersion}.${parsedVersion.nextMinorVersion}</base.image.version>
+                <!-- <base.image.version>${revision}</base.image.version> -->
                 <!-- This is used by the maintenance CI jobs, no need to adapt during releases. -->
                 <app.image.version>${base.image.version}</app.image.version>
             </properties>


### PR DESCRIPTION
**What this PR does / why we need it**:

We have to manually change this post release for containers. See https://dataverse-guide--11791.org.readthedocs.build/en/11791/developers/making-releases.html#update-the-container-base-image-version-property

**Which issue(s) this PR closes**:

- Closes #11680

**Special notes for your reviewer**:

**Suggestions on how to test this**:

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
