### PR TITLE
Fix typo in demo.rst: change "collection" to "collections" in User Guide reference

### DIFF
--- a/doc/sphinx-guides/source/container/running/demo.rst
+++ b/doc/sphinx-guides/source/container/running/demo.rst
@@ -261,7 +261,7 @@ You should be able to see the new fields from the metadata block you added in th
 
 ``curl http://localhost:8983/solr/collection1/schema/fields``
 
-At this point you can proceed with testing the metadata block in the Dataverse UI. First you'll need to enable it for a collection (see :ref:`general-information` in the User Guide section about collection). Afterwards, create a new dataset, save it, and then edit the metadata for that dataset. Your metadata block should appear.
+At this point you can proceed with testing the metadata block in the Dataverse UI. First you'll need to enable it for a collection (see :ref:`general-information` in the User Guide section about collections). Afterwards, create a new dataset, save it, and then edit the metadata for that dataset. Your metadata block should appear.
 
 Next Steps
 ----------


### PR DESCRIPTION
**What this PR does / why we need it**: 
This PR fixes a minor typo in the Dataverse documentation. In demo.rst, the text currently says "see :ref:general-information in the User Guide section about collection."
It should say "collections" to accurately reflect the content. This improves clarity for readers following the guide.

**Which issue(s) this PR closes**:
- Closes #11858

**Special notes for your reviewer**:
This is a simple documentation change with no functional impact.

**Suggestions on how to test this**:
- Open the demo.rst file in the Sphinx documentation preview to ensure the reference displays correctly.
- Confirm the build runs without errors.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
No UI changes.

**Is there a release notes update needed for this change?**:
No release notes required for documentation typos.

**Additional documentation**:
None.