### PR TITLE
User Guide: restricted and embargoed files can be downloaded from preview URL

### DIFF
--- a/doc/sphinx-guides/source/user/dataset-management.rst
+++ b/doc/sphinx-guides/source/user/dataset-management.rst
@@ -704,7 +704,7 @@ If you have a Contributor role (can edit metadata, upload files, and edit files,
 Preview URL to Review Unpublished Dataset
 =========================================
 
-Creating a Preview URL for a draft version of your dataset allows you to share your dataset (for viewing and downloading of files, including :ref:`restricted <restricted-files>` and :ref:`embargoed <embargoes>` files) before it is published to a wide group of individuals who may not have a user account on the Dataverse installation. Anyone you send the Preview URL to will not have to log into the Dataverse installation to view the unpublished dataset. Once a dataset has been published you may create new General Preview URLs for subsequent draft versions, but the Anonymous Preview URL will no longer be available.
+Creating a Preview URL for a draft version of your dataset allows you to share your dataset (for viewing and downloading files, including :ref:`restricted <restricted-files>` and :ref:`embargoed <embargoes>` files) before it is published to a wide group of people who might not have a user account on the Dataverse installation. Anyone you send the Preview URL to will not have to log in to the Dataverse installation to view the unpublished dataset. Once a dataset has been published, you may create new General Preview URLs for subsequent draft versions, but the Anonymous Preview URL will no longer be available.
 
 **Note:** To create a Preview URL, you must have the *ManageDatasetPermissions* permission for your draft dataset, usually given by the :ref:`roles <permissions>` *Curator* or *Administrator*.
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The expected behavior is not clear. Here's a recent question: https://groups.google.com/g/dataverse-community/c/PUPbss6fV-I/m/KGqAYo7NBAAJ

**Which issue(s) this PR closes**:

None

**Special notes for your reviewer**:

Preview at https://dataverse-guide--11897.org.readthedocs.build/en/11897/user/dataset-management.html#preview-url-to-review-unpublished-dataset