### PR TITLE
add release note about Croissant restricted file fix

### DIFF
--- a/doc/release-notes/11752-croissant-restricted.md
+++ b/doc/release-notes/11752-croissant-restricted.md
@@ -8,6 +8,6 @@ If you have enabled the Croissant dataset metadata exporter, you should upgrade 
 
 - Stop Payara.
 - Delete the old Croissant exporter jar file. It will be located in the directory defined by the `dataverse.spi.exporters.directory` setting.
-- Download the updated Croissant jar from https://repo1.maven.org/maven2/io/gdcc/export/croissant/ and place it the same directory.
+- Download the updated Croissant jar from https://repo1.maven.org/maven2/io/gdcc/export/croissant/ and place it in the same directory.
 - Restart Payara.
 - Run reExportAll.


### PR DESCRIPTION
**What this PR does / why we need it**:

People who use Croissant should know about the updated version that fixes the linked issue below. This PR adds a release note snippet.

**Which issue(s) this PR closes**:

- Closes #11752

**Special notes for your reviewer**:

As of this writing Croissant 0.1.6 is not yet on Maven Central. Here are some suggested steps:

- Publish the jar to Maven Central: https://repo1.maven.org/maven2/io/gdcc/export/croissant/
- Validate the new jar by putting it on a test server and going through the upgrade instructions in this PR.
- Merge this PR.