### PR TITLE
Publish SPI package to Maven Central (post defunct OSSRH)

### DIFF
--- a/modules/dataverse-spi/pom.xml
+++ b/modules/dataverse-spi/pom.xml
@@ -67,12 +67,6 @@
             <id>central</id>
             <url>https://central.sonatype.com/repository/maven-snapshots/</url>
         </snapshotRepository>
-        <repository>
-            <!--TODO: change this from ossrh to central?-->
-            <id>ossrh</id>
-            <!--TODO: change this url?-->
-            <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
     </distributionManagement>
     
     <properties>
@@ -80,6 +74,7 @@
         <project.version.suffix></project.version.suffix>
         <javadoc.lint>none</javadoc.lint>
         <skipDeploy>false</skipDeploy>
+        <skipRelease>false</skipRelease>
     </properties>
     
     <dependencies>
@@ -108,15 +103,14 @@
             
             <!-- RELEASING -->
             <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
                 <extensions>true</extensions>
                 <configuration>
-                    <!--TODO: change this from ossrh to central?-->
-                    <serverId>ossrh</serverId>
-                    <!--TODO: change this URL?-->
-                    <nexusUrl>https://s01.oss.sonatype.org</nexusUrl>
-                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                    <publishingServerId>central</publishingServerId>
+                    <autoPublish>true</autoPublish>
+                    <deploymentName>${project.name}</deploymentName>
+                    <skipPublishing>${skipRelease}</skipPublishing>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
**What this PR does / why we need it**:

As explained in this issue...

- #11512

... we need to update all packages that publish to Maven Central to get away from the old OSSRH method.

**Which issue(s) this PR closes**:

None. Relates to:

- #11766
- #11767

**Special notes for your reviewer**:

I hope this does it. Merge it and see? 🤷 

Here's the commit message:

remove defunct ossrh and use central instead

At https://github.com/IQSS/dataverse/issues/11512 we are tracking the changes we're making get publishing to Maven Central working again now that OSSRH is not supported.

We already switched our maven parent package from old to new so I compared these versions to come up with the change in this commit:

old (OSSRH): https://github.com/gdcc/maven-parent/blob/ae7b5904d7332259825409faa77545cdff6b84b9/pom.xml
new: https://github.com/gdcc/maven-parent/blob/6af0bf07d2134dd4c3f38c58b55479d82922509f/pom.xml

See also these docs:
https://central.sonatype.org/publish/publish-portal-maven/#automatic-publishing

**Suggestions on how to test this**:

It's really hard to test GitHub Actions. If we get a failure after merging, I suppose we can try again.

**Addendum**

p.s. We have multiple patterns for making library releases to Maven Central and I'm much more familiar with the one I wrote about at https://guides.dataverse.org/en/6.8/developers/making-library-releases.html

If you remove the details, releasing to Maven Central boils down to two commands:

```
mvn release:clean
mvn release:prepare
```

This pattern is used for the exporters, xoai, probably sword, etc. Here's the xoai GitHub Action: https://github.com/gdcc/xoai/blob/76201f0f5eb8f12a5d0a95d797bf43a3431bbbd6/.github/workflows/maven-release.yml

The SPI library uses a different pattern because it's in the main repo. So we don't add a tag to the main repo, for example, when we make an SPI release. Here's the SPI GitHub Action: https://github.com/IQSS/dataverse/blob/bf08caf8edf7457c118312e04c26a853da5de781/.github/workflows/spi_release.yml

Once we understand this "library in the main repo" pattern better, we should add it to the docs above!