### PR TITLE
A quick fix for the missing org attribute in ShibServiceBean

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/authorization/providers/shib/ShibServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/authorization/providers/shib/ShibServiceBean.java
@@ -52,7 +52,7 @@ public class ShibServiceBean {
     private static final String INCOMMON_MDQ_API_BASE = "https://mdq.incommon.org";
     private static final String INCOMMON_MDQ_API_ENTITIES_URL = INCOMMON_MDQ_API_BASE + "/entities/";
     private static final String INCOMMON_WAYFINDER_URL = "https://wayfinder.incommon.org";
-    
+    private static final String INCOMMON_ORGANIZATION_ATTRIBUTE = "OrganizationDisplayName";
     /**
      * "Production" means "don't mess with the HTTP request".
      */
@@ -233,7 +233,7 @@ public class ShibServiceBean {
                 if (event == XMLStreamConstants.START_ELEMENT) {
                     String currentElement = xmlr.getLocalName();
                     
-                    if ("".equals(currentElement)) {
+                    if (INCOMMON_ORGANIZATION_ATTRIBUTE.equals(currentElement)) {
                         int eventType = xmlr.next();
                         if (eventType == XMLStreamConstants.CHARACTERS) {
                             String affiliation = xmlr.getText();


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a trivial fix for a bug that was introduced right before the shib/mdq PR got merged; possibly as a botched copy-and-paste. The issue was only manifesting itself w/ brand new accounts; and was relatively minor and easy to miss. 

Kudos to @donsizemore for spotting the issue. 

**Which issue(s) this PR closes**:

- Closes #11907

**Special notes for your reviewer**:

**Suggestions on how to test this**:

The only 2 instances where the bug and the fix can be tested are demo.dataverse.org and dataverse6.rdmc.unc.edu. (the fix is already deployed on demo). 
The actual test is to set the `affiliation` in the `authenticateduser` table to null for your harvardKey or a similar institutional account, then log in. With the fix in place it will be properly populated with "Harvard University" or whatever institutional equivalent after a successful login. 


**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
