### PR TITLE
IQSS/11909-Update netcdf library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <jhove.version>1.20.1</jhove.version>
         <poi.version>5.4.0</poi.version>
         <tika.version>3.2.2</tika.version>
-        <netcdf.version>5.5.3</netcdf.version>
+        <netcdf.version>5.9.1</netcdf.version>
         
         <openapi.infoTitle>Dataverse API</openapi.infoTitle>
         <openapi.infoVersion>${project.version}</openapi.infoVersion>

--- a/src/main/java/edu/harvard/iq/dataverse/pidproviders/AbstractPidProvider.java
+++ b/src/main/java/edu/harvard/iq/dataverse/pidproviders/AbstractPidProvider.java
@@ -17,7 +17,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.apache.commons.lang3.RandomStringUtils;
-import com.beust.jcommander.Strings;
 
 public abstract class AbstractPidProvider implements PidProvider {
 
@@ -577,8 +576,8 @@ public abstract class AbstractPidProvider implements PidProvider {
         providerSpecification.add("shoulder", shoulder);
         providerSpecification.add("identifierGenerationStyle", identifierGenerationStyle);
         providerSpecification.add("datafilePidFormat", datafilePidFormat);
-        providerSpecification.add("managedSet", Strings.join(",", managedSet.toArray()));
-        providerSpecification.add("excludedSet", Strings.join(",", excludedSet.toArray()));
+        providerSpecification.add("managedSet", String.join(",", managedSet));
+        providerSpecification.add("excludedSet", String.join(",", excludedSet));
         return providerSpecification.build();
     }
     


### PR DESCRIPTION
**What this PR does / why we need it**: This PR updates the library needed for the netcdf ingest functionality. The old copy of the library has become unavailable causing build errors. We have also seen warnings about bouncycastle being unavailable (it is now bouncy) - not clear if this update will fix that.

**Which issue(s) this PR closes**:

- Closes #

**Special notes for your reviewer**: The change to the AbstractPidProvider is switching from a Strings class that was evidently coming from one of the libraries previously used in the 

**Suggestions on how to test this**: If we can now build, the PR serves its purpose. Testing the netcdf ingest process (regression testing) should also be done.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
