### PR TITLE
Adding DCAT and Schema.org repository description to the Dataverse homepage (#12022)

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DataversePage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DataversePage.java
@@ -4,6 +4,7 @@ import edu.harvard.iq.dataverse.UserNotification.Type;
 import edu.harvard.iq.dataverse.authorization.Permission;
 import edu.harvard.iq.dataverse.authorization.users.AuthenticatedUser;
 import edu.harvard.iq.dataverse.authorization.users.User;
+import edu.harvard.iq.dataverse.branding.BrandingUtil;
 import edu.harvard.iq.dataverse.dataaccess.DataAccess;
 import edu.harvard.iq.dataverse.dataset.DatasetUtil;
 import edu.harvard.iq.dataverse.dataverse.DataverseUtil;
@@ -56,6 +57,12 @@ import org.primefaces.model.DualListModel;
 import jakarta.ejb.EJBException;
 import jakarta.faces.event.ValueChangeEvent;
 import jakarta.faces.model.SelectItem;
+import jakarta.json.JsonObject;
+import jakarta.json.Json;
+import jakarta.json.JsonObjectBuilder;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
 import org.apache.commons.text.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.primefaces.PrimeFaces;
@@ -278,6 +285,458 @@ public class DataversePage implements java.io.Serializable {
         linkingDataverseId = (Long) event.getNewValue();
     }
 
+    public String getSchemaOrgDcatJson () {
+        String repositoryURL    = SystemConfig.getDataverseSiteUrlStatic();
+        String repositoryName   = BrandingUtil.getInstallationBrandName();
+        String repositoryContact= settingsWrapper.getSupportTeamEmail();
+        String description      = settingsWrapper.get(":dcat_repositoryDescription");
+        String language         = settingsWrapper.get(":dcat_repository_language");
+        String country          = settingsWrapper.get(":dcat_repository_country");
+        String reserarchArea    = settingsWrapper.get(":dcat_repository_research_area");
+        String prev_policy      = settingsWrapper.get(":dcat_repository_prev_policy");
+        String terms            = settingsWrapper.get(":dcat_repository_terms");
+        String license          = settingsWrapper.get(":dcat_repository_license");
+        String orgName          = settingsWrapper.get(":dcat_repository_org_name");
+        String access_terms     = settingsWrapper.get(":dcat_repository_access_terms"); 
+        String certification    = settingsWrapper.get(":dcat_repository_certification");
+        JsonObject oaiSchJson       = JsonObject.EMPTY_JSON_OBJECT;
+        JsonObject siteMapSchJson   = JsonObject.EMPTY_JSON_OBJECT;
+        JsonObject oaiDcatJson      = JsonObject.EMPTY_JSON_OBJECT;
+        JsonObject licenseDcatJson  = JsonObject.EMPTY_JSON_OBJECT;
+        JsonObject termsDcatJson    = JsonObject.EMPTY_JSON_OBJECT;
+        JsonObject preservDcatJson  = JsonObject.EMPTY_JSON_OBJECT;
+        JsonObject siteMapDcatJson  = JsonObject.EMPTY_JSON_OBJECT;
+        
+
+        if (systemConfig.isOAIServerEnabled ()) {
+            JsonObjectBuilder oaiBuilder= Json.createObjectBuilder()
+                        .add("@type", "schema:Offer")
+                        .add("schema:itemOffered", Json.createObjectBuilder()
+                            .add("@type", "schema:WebAPI")
+                            .add("schema:url", repositoryURL + "/oai")
+                            .add("schema:documentation", "https://www.openarchives.org/OAI/2.0/guidelines-static-repository.htm"));
+            oaiSchJson= oaiBuilder.build();
+        }
+        try {
+            URL url = new URL(repositoryURL + "/sitemap/sitemap.xml");
+            HttpURLConnection huc = (HttpURLConnection) url.openConnection();
+            int responseCode = huc.getResponseCode();
+            if (responseCode== 200) {
+                JsonObjectBuilder siteMapBuilder= Json.createObjectBuilder()
+                        .add("@type", "schema:Offer")
+                        .add("schema:itemOffered", Json.createObjectBuilder()
+                            .add("@type", "schema:WebAPI")
+                            .add("schema:url", repositoryURL + "/sitemap.xml")
+                            .add("schema:documentation", "https://www.sitemaps.org/protocol.html"));
+                siteMapSchJson= siteMapBuilder.build();
+            }
+        } catch (IOException iOException) {
+            // Nothing to do 
+        }
+
+        JsonObjectBuilder builder = Json.createObjectBuilder()
+                .add("@context", Json.createObjectBuilder()
+                    .add("dcat", "http://www.w3.org/ns/dcat#")
+                    .add("dct", "http://purl.org/dc/terms/")
+                    .add("foaf", "http://xmlns.com/foaf/0.1/")
+                    .add("rdf", "http://www.w3.org/1999/02/22-rdf-syntax-ns#")
+                    .add("rdfs", "http://www.w3.org/2000/01/rdf-schema#")
+                    .add("schema", "http://schema.org/")
+                    .add("vcard", "http://www.w3.org/2006/vcard/ns#")
+                    .add("xsd", "http://www.w3.org/2001/XMLSchema#")
+                    .add("dqv", "http://www.w3.org/ns/dqv#")
+                    .add("oa", "http://www.w3.org/ns/oa#")
+                    .add("premis", "http://www.loc.gov/premis/rdf/v3/"))
+                .add("@type", Json.createArrayBuilder()
+                    .add("dcat:Catalog")
+                    .add("foaf:Project")
+                    .add("schema:DataCatalog")
+                    .add("schema:Project"));
+        if (!StringUtils.isEmpty(repositoryURL)) {
+            builder= builder
+                .add("@id",repositoryURL)
+                .add("foaf:homepage", repositoryURL)
+                .add("dct:identifier", repositoryURL)    
+                .add("schema:url",repositoryURL);
+        }
+        if (!StringUtils.isEmpty(repositoryName)) {
+            builder= builder
+                .add("foaf:name", repositoryName)
+                .add("dct:title", repositoryName);
+        }
+        if (!StringUtils.isEmpty(description)) {
+            builder= builder
+                .add("dct:description", description);
+        }
+        if (!StringUtils.isEmpty(repositoryContact)) {
+            builder= builder
+                .add("dcat:contactPoint", repositoryContact);
+        }
+        if (!StringUtils.isEmpty(reserarchArea)) {
+            builder= builder
+                .add("dcat:theme", Json.createArrayBuilder()
+                .add(reserarchArea));
+        }
+        if (!StringUtils.isEmpty(access_terms)) {
+            builder= builder
+                .add("dct:accessRights", access_terms);
+        }
+        if (!StringUtils.isEmpty(license)) {
+            builder= builder
+                .add("dct:license", license);
+            JsonObjectBuilder licBuilder= Json.createObjectBuilder()
+                        .add("@type", "dct:Policy")
+                        .add("@id", license);
+            licenseDcatJson= licBuilder.build();
+        }
+        if (!StringUtils.isEmpty(certification) && !StringUtils.isEmpty(repositoryURL) ) {
+            String [] certificationParts= certification.split("\\|");
+            if (certificationParts[0].equals("CoreTrustSeal")) {
+                builder= builder
+                .add("dqv:hasQualityAnnotation", Json.createObjectBuilder()
+                    .add("@type", "dqv:QualityCertificate")
+                    .add("oa:hasTarget", repositoryURL)
+                    .add("oa:hasBody", "https://amt.coretrustseal.org/certificates")
+                    .add("oa:motivatedBy", "dqv:qualityAssessment")
+                    .add("dct:creator", "CoreTrustSeal"));
+            }
+        }
+        if (systemConfig.isOAIServerEnabled ()) {
+            JsonObjectBuilder oaiBuilder= Json.createObjectBuilder()
+                        .add("@type", "dcat:DataService")
+                        .add("dcat:endpointURL", repositoryURL + "oai")
+                        .add("dct:conformsTo", "https://www.openarchives.org/OAI/2.0/guidelines-static-repository.htm");
+            oaiDcatJson= oaiBuilder.build();
+        }
+        if (!StringUtils.isEmpty(terms)) {
+            JsonObjectBuilder termsBuilder= Json.createObjectBuilder()
+                        .add("@type", "dct:accrualPolicy")
+                        .add("@id", terms);
+            termsDcatJson= termsBuilder.build();
+        }
+        if (!StringUtils.isEmpty(prev_policy)) {
+            JsonObjectBuilder preservBuilder= Json.createObjectBuilder()
+                        .add("@type", "premis:PreservationPolicy")
+                        .add("@id", prev_policy)
+                        .add("rdfs:seeAlso", "https://w3id.org/fair/fip/latest/Metadata-preservation-policy");
+            preservDcatJson= preservBuilder.build();
+        }
+        if (!StringUtils.isEmpty(repositoryName)) {
+            builder= builder
+                .add("schema:name",repositoryName);
+        }
+        if (!StringUtils.isEmpty(description)) {
+            builder= builder
+                .add("schema:description",description);
+        }
+        if (!StringUtils.isEmpty(repositoryContact)) {
+            builder= builder
+                .add("schema:contactPoint",repositoryContact);
+        }
+        if (!StringUtils.isEmpty(reserarchArea)) {
+            builder= builder
+                .add("schema:keywords", Json.createArrayBuilder()
+                    .add(reserarchArea));
+        }
+        if (!StringUtils.isEmpty(access_terms)) {
+            builder= builder
+                .add("schema:conditionsOfAccess", access_terms);
+        }
+        if (!StringUtils.isEmpty(license)) {
+            builder= builder
+                .add("schema:license", license);
+        }
+        if (!StringUtils.isEmpty(certification)) {
+            String [] certificationParts= certification.split("\\|");
+            if (certificationParts.length== 3 && certificationParts[0].equals("CoreTrustSeal"))
+                builder= builder
+                .add("schema:hasCertification", Json.createObjectBuilder()
+                    .add("@type", "schema:Certification")
+                    .add("schema:url", "https://amt.coretrustseal.org/certificates")
+                    .add("schema:certificationStatus", "schema:CertificationActive")
+                    .add("schema:issuedBy", Json.createObjectBuilder()
+                        .add("@type", "schema:Organization")
+                        .add("schema:name", "CoreTrustSeal")
+                        .add("schema:url", "https://www.coretrustseal.org"))
+                    .add("schema:auditDate", "2023-04-18")
+                    .add("schema:expires", "2026-04-17"));
+        }
+        if (!StringUtils.isEmpty(terms) && !StringUtils.isEmpty(prev_policy)) {
+            builder=builder
+                .add("schema:publishingPrinciples", Json.createArrayBuilder()
+                    .add(Json.createObjectBuilder()
+                        .add("@type", "schema:CreativeWork")
+                        .add("schema:url", terms)
+                        .add("schema:additionalType", "dct:Policy"))
+                    .add(Json.createObjectBuilder()
+                        .add("@type", "schema:CreativeWork")
+                        .add("schema:url", prev_policy)
+                        .add("schema:additionalType", "premis:PreservationPolicy")));
+        } else if (!StringUtils.isEmpty(terms)) {
+            builder=builder
+                        .add("schema:publishingPrinciples", Json.createArrayBuilder()
+                    .add(Json.createObjectBuilder()
+                        .add("@type", "schema:CreativeWork")
+                        .add("schema:url", terms)
+                        .add("schema:additionalType", "dct:Policy")));            
+        } else if (!StringUtils.isEmpty(prev_policy)) {
+            builder=builder
+                .add("schema:publishingPrinciples", Json.createArrayBuilder()
+                    .add(Json.createObjectBuilder()
+                        .add("@type", "schema:CreativeWork")
+                        .add("schema:url", prev_policy)
+                        .add("schema:additionalType", "premis:PreservationPolicy")));
+        }
+        if (!StringUtils.isEmpty(orgName) && !StringUtils.isEmpty(country)) {
+            builder= builder
+                .add("schema:publisher", Json.createObjectBuilder()
+                    .add("@type", "schema:Organization")
+                    .add("schema:name", orgName)
+                    .add("schema:address", Json.createObjectBuilder()
+                        .add("@type", "schema:PostalAddress")
+                        .add("schema:addressCountry", country)));
+        }
+        if (!StringUtils.isEmpty(language)) {
+            builder= builder
+                .add("schema:inLanguage", language);
+        }
+        builder= builder
+                .add("dct:conformsTo", Json.createArrayBuilder()
+                    .add(termsDcatJson)
+                    .add(licenseDcatJson)
+                    .add(preservDcatJson)
+                    .add(Json.createObjectBuilder()
+                        .add("@type", "dct:Standard")
+                        .add("@id", "http://www.dcc.ac.uk/resources/metadata-standards/dcat-data-catalog-vocabulary")
+                        .add("rdfs:seeAlso", "https://w3id.org/fair/fip/latest/Metadata-schema"))
+                    .add(Json.createObjectBuilder()
+                        .add("@type", "dct:Standard")
+                        .add("@id", "https://www.dcc.ac.uk/resources/metadata-standards/oai-ore-open-archives-initiative-object-reuse-and-exchange")
+                        .add("rdfs:seeAlso", "https://w3id.org/fair/fip/latest/Metadata-schema"))
+                    .add(Json.createObjectBuilder()
+                        .add("@type", "dct:Standard")
+                        .add("@id", "https://www.dcc.ac.uk/resources/metadata-standards/datacite-metadata-schema")
+                        .add("rdfs:seeAlso", "https://w3id.org/fair/fip/latest/Metadata-schema"))
+                    .add(Json.createObjectBuilder()
+                        .add("@type", "dct:Standard")
+                        .add("@id", "https://guidelines.openaire.eu/en/latest/data/use_of_datacite.html")
+                        .add("rdfs:seeAlso", "https://w3id.org/fair/fip/latest/Metadata-schema"))
+                    .add(Json.createObjectBuilder()
+                        .add("@type", "dct:Standard")
+                        .add("@id", "https://json-ld.org")
+                        .add("rdfs:seeAlso", "https://w3id.org/fair/fip/latest/Metadata-schema"))
+                    .add(Json.createObjectBuilder()
+                        .add("@type", "dct:Standard")
+                        .add("@id", "https://www.dcc.ac.uk/resources/metadata-standards/ddi-data-documentation-initiative")
+                        .add("rdfs:seeAlso", "https://w3id.org/fair/fip/latest/Metadata-schema"))
+                    .add(Json.createObjectBuilder()
+                        .add("@type", "dct:Standard")
+                        .add("@id", "https://www.dublincore.org/specifications/dublin-core/dcmi-terms")
+                        .add("rdfs:seeAlso", "https://w3id.org/fair/fip/latest/Metadata-schema"))
+                    .add(Json.createObjectBuilder()
+                        .add("@type", "dct:Standard")
+                        .add("@id", "https://ddialliance.org/Specification/DDI-Codebook/2.5/")
+                        .add("rdfs:seeAlso", "https://w3id.org/fair/fip/latest/Metadata-schema"))
+                    .add(Json.createObjectBuilder()
+                        .add("@type", "dct:Standard")
+                        .add("@id", "https://www.json.org")
+                        .add("rdfs:seeAlso", "https://w3id.org/fair/fip/latest/Metadata-schema"))
+                    .add(Json.createObjectBuilder()
+                        .add("@type", "dct:Standard")
+                        .add("@id", "https://doi.datacite.org")
+                        .add("rdfs:seeAlso", "https://w3id.org/fair/fip/latest/Identifier-service")));
+        if (!StringUtils.isEmpty(orgName) && !StringUtils.isEmpty(country)) {
+            builder= builder
+                .add("dct:publisher", Json.createObjectBuilder()
+                    .add("@type", Json.createArrayBuilder()
+                        .add("foaf:Agent")
+                        .add("vcard:Kind"))
+                    .add("foaf:name", orgName)
+                    .add("vcard:fn", orgName)
+                    .add("vcard:country-name", country));
+        }
+        if (!StringUtils.isEmpty(language)) {
+            builder= builder
+                .add("dct:language", language);
+        }
+        builder= builder
+                .add("dcat:service", Json.createArrayBuilder()
+                    .add(Json.createObjectBuilder()
+                        .add("@type", "dcat:DataService")
+                        .add("dcat:endpointURL", repositoryURL + "/resources/json/.well-known/api-catalog")
+                        .add("dct:conformsTo", "https://signposting.org/FAIRiCat"))
+                    .add(Json.createObjectBuilder()
+                        .add("@type", "dcat:DataService")
+                        .add("dcat:endpointURL", repositoryURL + "/api")
+                                .add("dct:conformsTo", "https://guides.dataverse.org/en/latest/api/search.html"))
+                    .add(Json.createObjectBuilder()
+                        .add("@type", "dcat:DataService")
+                        .add("dcat:endpointURL", repositoryURL + "/api")
+                                .add("dct:conformsTo", "https://guides.dataverse.org/en/latest/api/dataaccess.html"))
+                    .add(Json.createObjectBuilder()
+                        .add("@type", "dcat:DataService")
+                        .add("dcat:endpointURL", repositoryURL + "/api")
+                                .add("dct:conformsTo", "https://guides.dataverse.org/en/latest/api/native-api.html"))
+                    .add(Json.createObjectBuilder()
+                        .add("@type", "dcat:DataService")
+                        .add("dcat:endpointURL", repositoryURL + "/api")
+                                .add("dct:conformsTo", "https://guides.dataverse.org/en/latest/developers/dataset-semantic-metadata-api.html"))
+                    .add(Json.createObjectBuilder()
+                        .add("@type", "dcat:DataService")
+                        .add("dcat:endpointURL", repositoryURL + "/api")
+                                .add("dct:conformsTo", "https://guides.dataverse.org/en/latest/developers/s3-direct-upload-api.html"))
+                    .add(Json.createObjectBuilder()
+                        .add("@type", "dcat:DataService")
+                        .add("dcat:endpointURL", repositoryURL + "/api")
+                                .add("dct:conformsTo", "https://guides.dataverse.org/en/latest/developers/globus-api.html"))
+                    .add(Json.createObjectBuilder()
+                        .add("@type", "dcat:DataService")
+                        .add("dcat:endpointURL", repositoryURL + "/api")
+                                .add("dct:conformsTo", "https://guides.dataverse.org/en/latest/api/metrics.html"))
+                    .add(Json.createObjectBuilder()
+                        .add("@type", "dcat:DataService")
+                        .add("dcat:endpointURL", repositoryURL + "/api")
+                                .add("dct:conformsTo", "http://swordapp.org/"))
+                    .add(oaiDcatJson)
+                    .add(siteMapDcatJson));
+        builder= builder
+                .add("schema:offers", Json.createArrayBuilder()   
+                    .add(Json.createObjectBuilder()
+                        .add("@type", "schema:Offer")
+                        .add("schema:itemOffered", Json.createObjectBuilder()
+                            .add("@type", "schema:WebAPI")
+                            .add("schema:url", repositoryURL + "/resources/json/.well-known/api-catalog")
+                            .add("schema:documentation", "https://signposting.org/FAIRiCat")))
+                    .add(Json.createObjectBuilder()
+                        .add("@type", "schema:Offer")
+                        .add("schema:itemOffered", Json.createObjectBuilder()
+                            .add("@type", "schema:WebAPI")
+                            .add("schema:url", repositoryURL + "/api")
+                            .add("schema:documentation", "https://guides.dataverse.org/en/latest/api/search.html")))
+                    .add(Json.createObjectBuilder()
+                        .add("@type", "schema:Offer")
+                        .add("schema:itemOffered", Json.createObjectBuilder()
+                            .add("@type", "schema:WebAPI")
+                            .add("schema:url", repositoryURL + "/api")
+                            .add("schema:documentation", "https://guides.dataverse.org/en/latest/api/dataaccess.html")))
+                    .add(Json.createObjectBuilder()
+                        .add("@type", "schema:Offer")
+                        .add("schema:itemOffered", Json.createObjectBuilder()
+                            .add("@type", "schema:WebAPI")
+                            .add("schema:url", repositoryURL + "/api")
+                            .add("schema:documentation", "https://guides.dataverse.org/en/latest/api/native-api.html")))
+                    .add(Json.createObjectBuilder()
+                        .add("@type", "schema:Offer")
+                        .add("schema:itemOffered", Json.createObjectBuilder()
+                            .add("@type", "schema:WebAPI")
+                            .add("schema:url", repositoryURL + "/api")
+                            .add("schema:documentation", "https://guides.dataverse.org/en/latest/developers/dataset-semantic-metadata-api.html")))
+                    .add(Json.createObjectBuilder()
+                        .add("@type", "schema:Offer")
+                        .add("schema:itemOffered", Json.createObjectBuilder()
+                            .add("@type", "schema:WebAPI")
+                            .add("schema:url", repositoryURL + "/api")
+                            .add("schema:documentation", "https://guides.dataverse.org/en/latest/developers/dataset-migration-api.html")))
+                    .add(Json.createObjectBuilder()
+                        .add("@type", "schema:Offer")
+                        .add("schema:itemOffered", Json.createObjectBuilder()
+                            .add("@type", "schema:WebAPI")
+                            .add("schema:url", repositoryURL + "/api")
+                            .add("schema:documentation", "https://guides.dataverse.org/en/latest/developers/s3-direct-upload-api.html")))
+                    .add(Json.createObjectBuilder()
+                        .add("@type", "schema:Offer")
+                        .add("schema:itemOffered", Json.createObjectBuilder()
+                            .add("@type", "schema:WebAPI")
+                            .add("schema:url", repositoryURL + "/api")
+                            .add("schema:documentation", "https://guides.dataverse.org/en/latest/developers/globus-api.html")))
+                    .add(Json.createObjectBuilder()
+                        .add("@type", "schema:Offer")
+                        .add("schema:itemOffered", Json.createObjectBuilder()
+                            .add("@type", "schema:WebAPI")
+                            .add("schema:url", repositoryURL + "/api")
+                            .add("schema:documentation", "https://guides.dataverse.org/en/latest/api/metrics.html")))
+                    .add(Json.createObjectBuilder()
+                        .add("@type", "schema:Offer")
+                        .add("schema:itemOffered", Json.createObjectBuilder()
+                            .add("@type", "schema:WebAPI")
+                            .add("schema:url", repositoryURL + "/api")
+                            .add("schema:documentation", "http://swordapp.org/")))
+                    .add(oaiSchJson)
+                    .add(siteMapSchJson)
+                    .add(Json.createObjectBuilder()
+                        .add("@type", "schema:Offer")
+                        .add("schema:itemOffered", Json.createObjectBuilder()
+                            .add("@type", "schema:Service")
+                            .add("schema:serviceOutput", Json.createObjectBuilder()
+                                .add("schema:identifier", "https://doi.datacite.org"))
+                            .add("schema:serviceType", "https://w3id.org/fair/fip/latest/Identifier-service")))
+                    .add(Json.createObjectBuilder()
+                        .add("@type", "schema:Offer")
+                        .add("schema:itemOffered", Json.createObjectBuilder()
+                            .add("@type", "schema:Service")
+                            .add("schema:serviceOutput", Json.createObjectBuilder()
+                                .add("schema:identifier", "http://www.dcc.ac.uk/resources/metadata-standards/dcat-data-catalog-vocabulary"))
+                            .add("schema:serviceType", "https://w3id.org/fair/fip/latest/Metadata-schema")))
+                    .add(Json.createObjectBuilder()
+                        .add("@type", "schema:Offer")
+                        .add("schema:itemOffered", Json.createObjectBuilder()
+                            .add("@type", "schema:Service")
+                            .add("schema:serviceOutput", Json.createObjectBuilder()
+                                .add("schema:identifier", "https://www.dcc.ac.uk/resources/metadata-standards/oai-ore-open-archives-initiative-object-reuse-and-exchange"))
+                            .add("schema:serviceType", "https://w3id.org/fair/fip/latest/Metadata-schema")))
+                    .add(Json.createObjectBuilder()
+                        .add("@type", "schema:Offer")
+                        .add("schema:itemOffered", Json.createObjectBuilder()
+                            .add("@type", "schema:Service")
+                            .add("schema:serviceOutput", Json.createObjectBuilder()
+                                .add("schema:identifier", "https://www.dcc.ac.uk/resources/metadata-standards/datacite-metadata-schema"))
+                            .add("schema:serviceType", "https://w3id.org/fair/fip/latest/Metadata-schema")))
+                    .add(Json.createObjectBuilder()
+                        .add("@type", "schema:Offer")
+                        .add("schema:itemOffered", Json.createObjectBuilder()
+                            .add("@type", "schema:Service")
+                            .add("schema:serviceOutput", Json.createObjectBuilder()
+                                .add("schema:identifier", "https://guidelines.openaire.eu/en/latest/data/use_of_datacite.html"))
+                            .add("schema:serviceType", "https://w3id.org/fair/fip/latest/Metadata-schema")))
+                    .add(Json.createObjectBuilder()
+                        .add("@type", "schema:Offer")
+                        .add("schema:itemOffered", Json.createObjectBuilder()
+                            .add("@type", "schema:Service")
+                            .add("schema:serviceOutput", Json.createObjectBuilder()
+                                .add("schema:identifier", "https://json-ld.org"))
+                            .add("schema:serviceType", "https://w3id.org/fair/fip/latest/Metadata-schema")))
+                    .add(Json.createObjectBuilder()
+                        .add("@type", "schema:Offer")
+                        .add("schema:itemOffered", Json.createObjectBuilder()
+                            .add("@type", "schema:Service")
+                            .add("schema:serviceOutput", Json.createObjectBuilder()
+                                .add("schema:identifier", "https://www.dcc.ac.uk/resources/metadata-standards/ddi-data-documentation-initiative"))
+                            .add("schema:serviceType", "https://w3id.org/fair/fip/latest/Metadata-schema")))
+                    .add(Json.createObjectBuilder()
+                        .add("@type", "schema:Offer")
+                        .add("schema:itemOffered", Json.createObjectBuilder()
+                            .add("@type", "schema:Service")
+                            .add("schema:serviceOutput", Json.createObjectBuilder()
+                                .add("schema:identifier", "https://www.dublincore.org/specifications/dublin-core/dcmi-terms"))
+                            .add("schema:serviceType", "https://w3id.org/fair/fip/latest/Metadata-schema")))
+                    .add(Json.createObjectBuilder()
+                        .add("@type", "schema:Offer")
+                        .add("schema:itemOffered", Json.createObjectBuilder()
+                            .add("@type", "schema:Service")
+                            .add("schema:serviceOutput", Json.createObjectBuilder()
+                                .add("schema:identifier", "https://ddialliance.org/Specification/DDI-Codebook/2.5/"))
+                            .add("schema:serviceType", "https://w3id.org/fair/fip/latest/Metadata-schema")))
+                    .add(Json.createObjectBuilder()
+                        .add("@type", "schema:Offer")
+                        .add("schema:itemOffered", Json.createObjectBuilder()
+                            .add("@type", "schema:Service")
+                            .add("schema:serviceOutput", Json.createObjectBuilder()
+                                .add("schema:identifier", "https://www.json.org"))
+                            .add("schema:serviceType", "https://w3id.org/fair/fip/latest/Metadata-schema"))));
+        
+        return builder.build().toString();
+    }
+    
     public Dataverse getDataverse() {
         return dataverse;
     }

--- a/src/main/java/edu/harvard/iq/dataverse/settings/SettingsServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/settings/SettingsServiceBean.java
@@ -757,7 +757,7 @@ public class SettingsServiceBean {
         // JSON specification of the targets to send announcements to
         COARNotifyRelationshipAnnouncementTargets,
 
-        // DCAT an json repository description entries
+        // DCAT and Schema.org repository description entries
         // The country in which the repository operates
         dcat_repository_country,
         // The native language of the user interface of the repository.

--- a/src/main/java/edu/harvard/iq/dataverse/settings/SettingsServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/settings/SettingsServiceBean.java
@@ -756,8 +756,30 @@ public class SettingsServiceBean {
         COARNotifyRelationshipAnnouncementTriggerFields,
         // JSON specification of the targets to send announcements to
         COARNotifyRelationshipAnnouncementTargets,
-        ;
 
+        // DCAT an json repository description entries
+        // The country in which the repository operates
+        dcat_repository_country,
+        // The native language of the user interface of the repository.
+        dcat_repository_language,
+        // The subject classification of datasets in a repository. If none, it could be generic 
+        dcat_repository_research_area,
+        //  Policies that explain the repository’s commitment and processes that ensure the long-term preservation, fitness, and availability of datasets.
+        dcat_repository_prev_policy,
+        // Policies that explain what datasets the repository will accept for deposit, from whom, and under what conditions, including costs.
+        dcat_repository_terms,
+        // The terms of reuse of datasets that are provided by a repository
+        dcat_repository_license,
+        // Evidence that a repository meets a formal standard and adheres to a set of best, professional practices. Format. Certification|Start date|End date
+        dcat_repository_certification,
+        // The organization responsible for the data repository
+        dcat_repository_org_name,
+        // Policies for who can view and access a dataset and under what conditions.
+        dcat_repository_access_terms,
+        // A general description of the data repository
+        dcat_repositoryDescription      
+        ;
+        
         @Override
         public String toString() {
             return ":" + name();

--- a/src/main/webapp/dataverse.xhtml
+++ b/src/main/webapp/dataverse.xhtml
@@ -49,6 +49,14 @@
                     <f:viewAction action="#{SearchIncludeFragment.search()}" />
                 </f:metadata>
             </ui:define>
+            <ui:define name="jsonld_header">
+                <ui:fragment rendered="#{DataversePage.isRootDataverse()}">
+                    <link rel="api-catalog" type="application/linkset+json" href="#{systemConfig.dataverseSiteUrl}/resources/json/.well-known/api-catalog"/>
+                    <script rel="describedby" type="application/ld+json">
+                        #{DataversePage.getSchemaOrgDcatJson ()}
+                    </script>
+                </ui:fragment>
+            </ui:define>
             <ui:define name="body">
                 <f:loadBundle basename="ValidationMessages" var="valMsg"/>
                 <h:form id="dataverseForm">

--- a/src/main/webapp/resources/json/.well-known/api-catalog
+++ b/src/main/webapp/resources/json/.well-known/api-catalog
@@ -1,0 +1,120 @@
+{
+  "linkset": [
+    {
+      "anchor": "https://edatos.consorciomadrono.es/oai",
+      "service-doc": [
+        {
+          "href": "https://www.openarchives.org/OAI/2.0/guidelines-static-repository.htm",
+          "type": "text/html",
+          "title": "Specification for an OAI Static Repository and an OAI Static Repository Gateway"
+        }
+      ],
+      "service-meta": [
+        {
+          "href": "https://edatos.consorciomadrono.es/oai",
+          "type": "application/xml"
+        }
+      ]
+    },
+    {
+      "anchor": "https://edatos.consorciomadrono.es/api",
+      "service-doc": [
+        {
+          "href": "https://guides.dataverse.org/en/latest/api/search.html",
+          "type": "application/html"
+          "title": "API Rest"
+        }
+      ]
+    },
+    {
+      "anchor": "https://edatos.consorciomadrono.es/api",
+      "service-doc": [
+        {
+          "href": "https://guides.dataverse.org/en/latest/api/dataaccess.html",
+          "type": "application/html"
+          "title": "API Rest"
+        }
+      ]
+    },
+    {
+      "anchor": "https://edatos.consorciomadrono.es/api",
+      "service-doc": [
+        {
+          "href": "https://guides.dataverse.org/en/latest/api/native-api.html",
+          "type": "application/html"
+          "title": "API Rest"
+        }
+      ]
+    },
+    {
+      "anchor": "https://edatos.consorciomadrono.es/api",
+      "service-doc": [
+        {
+          "href": "https://guides.dataverse.org/en/latest/developers/dataset-semantic-metadata-api.html",
+          "type": "application/html"
+          "title": "API Rest"
+        }
+      ]
+    },
+    {
+      "anchor": "https://edatos.consorciomadrono.es/api",
+      "service-doc": [
+        {
+          "href": "https://guides.dataverse.org/en/latest/developers/dataset-migration-api.html",
+          "type": "application/html"
+          "title": "API Rest"
+        }
+      ]
+    },
+    {
+      "anchor": "https://edatos.consorciomadrono.es/api",
+      "service-doc": [
+        {
+          "href": "https://guides.dataverse.org/en/latest/developers/s3-direct-upload-api.html",
+          "type": "application/html"
+          "title": "API Rest"
+        }
+      ]
+    },
+    {
+      "anchor": "https://edatos.consorciomadrono.es/api",
+      "service-doc": [
+        {
+          "href": "https://guides.dataverse.org/en/latest/developers/globus-api.html",
+          "type": "application/html"
+          "title": "API Rest"
+        }
+      ]
+    },
+    {
+      "anchor": "https://edatos.consorciomadrono.es/api",
+      "service-doc": [
+        {
+          "href": "https://guides.dataverse.org/en/latest/api/metrics.html",
+          "type": "application/html"
+          "title": "API Rest"
+        }
+      ]
+    },
+    {
+      "anchor": "https://edatos.consorciomadrono.es/api",
+      "service-doc": [
+        {
+          "href": "http://swordapp.org/",
+          "type": "application/html"
+          "title": "API Rest"
+        }
+      ]
+    },
+    {
+      "anchor": "https://edatos.consorciomadrono.es/sitemap.xml",
+      "service-doc": [
+        {
+          "href": "https://www.sitemaps.org/protocol.html",
+          "type": "text/html",
+          "title": "sitemaps.org - Protocol"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

- closes #12022

This PR is created to add Schema.org and DCAT information in JSON-LD format to the repository homepage in order to improve the visibility and trustworthiness of the repository. This could include:

**Special notes for your reviewer**:
It is a possible solution, obtaining the data from the setting table in the database. The json-ld data will be created into the html code:
```
[...]<meta http-equiv="X-UA-Compatible" content="IE=edge" />
<meta name="description" content="Repositorio de Datos del Consorcio Madroño" />
<link rel="api-catalog" type="application/linkset+json" href="[http://bib6162invi6106:8080/resources/json/.well-known/api-catalog](view-source:http://bib6162invi6106:8080/resources/json/.well-known/api-catalog)" />
<script rel="describedby" type="application/ld+json">
{"@context":{"dcat":"http://www.w3.org/ns/dcat#","dct":"http://purl.org/dc/terms/","foaf":"http://xmlns.com/foaf/0.1/","rdf":"http://www.w3.org/1999/02/22-rdf-syntax-ns#"," ...................
</script><link type="text/css" rel="stylesheet" href="[/jakarta.faces.resource/ ............................
<link rel="apple-touch-icon" sizes="180x180" .............
[...]
```
**Suggestions on how to test this**:
Check the homepage to see that the json-ld code is into the html. It shouldn't be into other dataset or dataverse pages.

**Additional documentation**:
If this PR is approved, Dataverse api guide should be update too. 

