### PR TITLE
Add display order compound fields

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DatasetField.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetField.java
@@ -172,6 +172,7 @@ public class DatasetField implements Serializable {
     }
 
     @OneToMany(mappedBy = "parentDatasetField", orphanRemoval = true, cascade = {CascadeType.REMOVE, CascadeType.MERGE, CascadeType.PERSIST})
+    @OrderBy("displayOrder ASC")
     private List<DatasetFieldCompoundValue> datasetFieldCompoundValues = new ArrayList<>();
 
     public List<DatasetFieldCompoundValue> getDatasetFieldCompoundValues() {


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds ordering to the getter for compound values
**Which issue(s) this PR closes**:

- Closes #12027

**Special notes for your reviewer**:
one line fix

**Suggestions on how to test this**:
if you can create a datset where the ordering is wrong before testing; then apply fix and confirm ordering is fixed


**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
no (besides a fix to the order)

**Is there a release notes update needed for this change?**:
no

**Additional documentation**:
