### PR TITLE
fix(docker): increase jetty request header size

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -141,6 +141,8 @@ services:
     restart: on-failure
     ports:
       - "8983:8983"
+    environment:
+      - SOLR_OPTS=-Dsolr.jetty.request.header.size=102400
     networks:
       - dataverse
     command:

--- a/docker/compose/demo/compose.yml
+++ b/docker/compose/demo/compose.yml
@@ -141,6 +141,8 @@ services:
     restart: on-failure
     ports:
       - "8983:8983"
+    environment:
+      - SOLR_OPTS=-Dsolr.jetty.request.header.size=102400
     networks:
       - dataverse
     command:


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR sets an environment variable for the Solr docker container, increasing jetty response header size from the default value of `8192` to `102400` as recommended in the [installation guide](https://guides.dataverse.org/en/latest/installation/prerequisites.html#installing-solr). This prevents errors when importing larger metadata blocks.

**Which issue(s) this PR closes**:

- Closes #12047

**Special notes for your reviewer**:

**Suggestions on how to test this**:

1. Deploy Dataverse using docker using compose files from current `develop` branch or `6.8`
2. Import a large metadata block
3. Observe error as described in #12047 
4. Recreate containers with the environment variable set/this PR applied
5. No error should be thrown.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

no

**Is there a release notes update needed for this change?**:

**Additional documentation**:
