### PR TITLE
bump Apache commons-text to v1.15.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -384,7 +384,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-text</artifactId>
-            <version>1.10.0</version>
+            <version>1.15.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
**What this PR does / why we need it**:

updates Apache commons-text to its current version

**Which issue(s) this PR closes**:

- Closes https://github.com/IQSS/dataverse-security/issues/118

**Special notes for your reviewer**:

none

**Suggestions on how to test this**:

unit tests passed, FWTW

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

no

**Is there a release notes update needed for this change?**:

no

**Additional documentation**:

none