### PR TITLE
Y2.025K - test hardcoded to 2025

### DIFF
--- a/src/test/java/edu/harvard/iq/dataverse/api/DatasetsIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/DatasetsIT.java
@@ -5042,7 +5042,7 @@ createDataset = UtilIT.createRandomDatasetViaNativeApi(dataverse1Alias, apiToken
                 .body("resource.dates.date[0]", CoreMatchers.equalTo("1999-12-31"))
                 .body("resource.dates.date[1].@dateType", CoreMatchers.equalTo("Updated"))
                 .body("resource.dates.date[1]", CoreMatchers.equalTo(today))
-                .body("resource.publicationYear", CoreMatchers.equalTo("2025"));
+                .body("resource.publicationYear", CoreMatchers.equalTo(currentYear));
 
         Response exportDatasetOaiDc = UtilIT.exportDataset(datasetPid, "oai_dc", apiToken, true);
         exportDatasetOaiDc.prettyPrint();


### PR DESCRIPTION
**What this PR does / why we need it**: This PR updates a test that was hardcoded to assume the current year is 2025
edu.harvard.iq.dataverse.api.DatasetsIT.testCitationDate which failed on #12067.
**Which issue(s) this PR closes**:

- Closes #

**Special notes for your reviewer**:

**Suggestions on how to test this**: Confirm the test listed above passes.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
