### PR TITLE
Add css to Mime type properties.

### DIFF
--- a/src/main/java/propertyFiles/MimeTypeDetectionByFileExtension.properties
+++ b/src/main/java/propertyFiles/MimeTypeDetectionByFileExtension.properties
@@ -1,5 +1,6 @@
 7z=application/x-7z-compressed
 ado=application/x-stata-ado
+css=text/css
 dbf=application/dbf
 dcm=application/dicom
 docx=application/vnd.openxmlformats-officedocument.wordprocessingml.document


### PR DESCRIPTION
**What this PR does / why we need it**:
The PR avoids flooding the payara logs with [INFO] messages of the form: 

_css is a filename/extension Dataverse doesn't know about. Consider adding it to the MimeTypeDetectionByFileExtension.properties file.|#]_

**Which issue(s) this PR closes**:

- Closes #12074

**Special notes for your reviewer**:
Can't tell if the payara messages are due to specifics of our installation but they occur on all systems we deployed Dataverse on (development, staging, production).

**Suggestions on how to test this**:
Check payara logs for above message before and after applying the patch

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
No

**Is there a release notes update needed for this change?**:
No

**Additional documentation**:
