### PR TITLE
Handle duplicate role assignments with 409 Conflict instead of 403 Forbidden

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/api/AbstractApiBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/AbstractApiBean.java
@@ -892,6 +892,8 @@ public abstract class AbstractApiBean {
             throw new WrappedResponse(ex, badRequest(ex.getMessage(), ex.getFieldErrors()));
         } catch (InvalidCommandArgumentsException ex) {
             throw new WrappedResponse(ex, error(Status.BAD_REQUEST, ex.getMessage()));
+        } catch (ConflictException ex) {
+            throw new WrappedResponse(ex, conflict(ex.getMessage()));
         } catch (CommandException ex) {
             Logger.getLogger(AbstractApiBean.class.getName()).log(Level.SEVERE, "Error while executing command " + cmd, ex);
             throw new WrappedResponse(ex, error(Status.INTERNAL_SERVER_ERROR, ex.getMessage()));

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/exception/ConflictException.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/exception/ConflictException.java
@@ -1,0 +1,14 @@
+package edu.harvard.iq.dataverse.engine.command.exception;
+
+import edu.harvard.iq.dataverse.engine.command.Command;
+
+/**
+ * An exception raised when a command cannot be executed because it clashes with the current state, e.g. when trying to
+ * create a resource that already exists.
+ */
+public class ConflictException extends CommandException {
+
+    public ConflictException(String message, Command aCommand) {
+        super(message, aCommand);
+    }
+}

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/AssignRoleCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/AssignRoleCommand.java
@@ -16,6 +16,7 @@ import edu.harvard.iq.dataverse.engine.command.AbstractCommand;
 import edu.harvard.iq.dataverse.engine.command.CommandContext;
 import edu.harvard.iq.dataverse.engine.command.DataverseRequest;
 import edu.harvard.iq.dataverse.engine.command.exception.CommandException;
+import edu.harvard.iq.dataverse.engine.command.exception.ConflictException;
 import edu.harvard.iq.dataverse.engine.command.exception.IllegalCommandException;
 import edu.harvard.iq.dataverse.util.BundleUtil;
 
@@ -73,7 +74,7 @@ public RoleAssignment execute(CommandContext ctxt) throws CommandException {
         }
     }
     if(isExistingRole(ctxt)){
-        throw new IllegalCommandException(BundleUtil.getStringFromBundle("datasets.api.grant.role.assignee.has.role.error"), this);
+        throw new ConflictException(BundleUtil.getStringFromBundle("datasets.api.grant.role.assignee.has.role.error"), this);
     }
     // TODO make sure the role is defined on the dataverse.
     RoleAssignment roleAssignment = new RoleAssignment(role, grantee, defPoint, privateUrlToken, anonymizedAccess);

--- a/src/test/java/edu/harvard/iq/dataverse/api/DataversesIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/DataversesIT.java
@@ -2890,10 +2890,10 @@ public class DataversesIT {
         grantRoleResponse.prettyPrint();
         grantRoleResponse.then().assertThat().statusCode(OK.getStatusCode());
 
-        // Let the first user assign the same role to the same user again
+        // Let the first user assign the same role to the same user again -> 409 Conflict
         Response grantRoleTwiceResponse = UtilIT.grantRoleOnDataverse(dataverseAlias, DataverseRole.DS_CONTRIBUTOR, "@" + secondUsername, apiToken);
         grantRoleTwiceResponse.prettyPrint();
-        grantRoleTwiceResponse.then().assertThat().statusCode(OK.getStatusCode());
+        grantRoleTwiceResponse.then().assertThat().statusCode(CONFLICT.getStatusCode());
 
         // Clean up
         Response deleteDataverse = UtilIT.deleteDataverse(dataverseAlias, apiToken);


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR changes the return code when trying to create a duplicate role assignment from 403 Forbidden to 409 Conflict, which seems to make more sense.

**Which issue(s) this PR closes**:

- Closes #12113

**Special notes for your reviewer**:

/

**Suggestions on how to test this**:

I've added a test: `mvn test -Dtest="DataversesIT#testAssignRoleOnDataverse"`

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

/

**Is there a release notes update needed for this change?**:

Not sure

**Additional documentation**:

/
