### PR TITLE
Add release note snippet about Dataverse Uploader GitHub Action fix

### DIFF
--- a/doc/release-notes/dataverse-uploader-github-action-fixed.md
+++ b/doc/release-notes/dataverse-uploader-github-action-fixed.md
@@ -1,0 +1,1 @@
+It came to our attention that the [Dataverse Uploader GitHub Action](https://guides.dataverse.org/en/6.10/admin/integrations.html#github) was [failing](https://github.com/IQSS/dataverse-uploader/issues/28) with an "unhashable type" error. This has been fixed in a new release, [v1.7](https://github.com/IQSS/dataverse-uploader/releases/tag/v1.7).


### PR DESCRIPTION
**What this PR does / why we need it**:

Dataverse Uploader GitHub Action v1.6 was not working so I released v1.7.

This is just a heads up for the 6.10 release notes in case people have seen failures with the old version. If so, hopefully, they'll try again.

I also posted something here: https://groups.google.com/g/dataverse-community/c/Aox_31C6VBM/m/ar_4OOMJBgAJ

**Which issue(s) this PR closes**:

- None

**Special notes for your reviewer**:

See details here:

- https://github.com/IQSS/dataverse-uploader/issues/28

**Suggestions on how to test this**:

Nothing to test. Just a public service announcement. You could try the action itself if you want!

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No.