### PR TITLE
Update Docker Maven Plugin for Docker v29+ compatibility

### DIFF
--- a/modules/dataverse-parent/pom.xml
+++ b/modules/dataverse-parent/pom.xml
@@ -200,7 +200,7 @@
         <pomchecker-maven-plugin.version>1.7.0</pomchecker-maven-plugin.version>
         
         <!-- Container related -->
-        <fabric8-dmp.version>0.46.0</fabric8-dmp.version>
+        <fabric8-dmp.version>0.48.0</fabric8-dmp.version>
     </properties>
     
     <pluginRepositories>


### PR DESCRIPTION
**What this PR does / why we need it**:

To ensure compatibility with Docker v29+, we need to upgrade the plugin.

Multiple folks were starting to see this error message when trying to build or run images via Maven:
`[ERROR] Failed to execute goal io.fabric8:docker-maven-plugin:0.46.0:run (default-cli) on project dataverse: Execution default-cli of goal io.fabric8:docker-maven-plugin:0.46.0:run failed: Cannot invoke "com.google.gson.JsonElement.isJsonNull()" because the return value of "com.google.gson.JsonObject.get(String)" is null -> [Help 1]`

This is fixed as of release 0.48.0: https://github.com/fabric8io/docker-maven-plugin/releases/tag/v0.48.0
Using `-Dfabric8-dmp.version=0.48.0` has shown the issue is mitigated and builds went smoothly, thus making this permanent with this PR.
