### PR TITLE
Experimental: ignore non-explicit groups (IP groups, specifically) when making solr queries 

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/search/SolrSearchServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/search/SolrSearchServiceBean.java
@@ -1048,7 +1048,14 @@ public class SolrSearchServiceBean implements SearchService {
         for (Group group : groups) {
             String groupAlias = group.getAlias();
             if (groupAlias != null && !groupAlias.isEmpty() && (!avoidJoin || !groupAlias.startsWith("builtIn"))) {
-                groupList.add(IndexServiceBean.getGroupPrefix() + groupAlias);
+                boolean skipThisGroup = false;
+                if (FeatureFlags.SKIP_NONEXPLICIT_GROUPS.enabled() && group.getGroupProvider() != null && !"explicit".equals(group.getGroupProvider().getGroupProviderAlias())) {
+                    skipThisGroup = true;
+                    logger.info("Skipping non-explicit group " + groupAlias);
+                }
+                if (!skipThisGroup) {
+                    groupList.add(IndexServiceBean.getGroupPrefix() + groupAlias);
+                }
             }
         }
 

--- a/src/main/java/edu/harvard/iq/dataverse/settings/FeatureFlags.java
+++ b/src/main/java/edu/harvard/iq/dataverse/settings/FeatureFlags.java
@@ -120,6 +120,7 @@ public enum FeatureFlags {
      * @since Dataverse 6.3
      */
     ADD_PUBLICOBJECT_SOLR_FIELD("add-publicobject-solr-field"),
+    SKIP_NONEXPLICIT_GROUPS("skip-nonexplicit-groups"),
     /**
      * With this flag set, Dataverse will index the actual origin of harvested
      * metadata records, instead of the "Harvested" string in all cases. 


### PR DESCRIPTION
**What this PR does / why we need it**:

This was a quick prod. experiment: We have IP groups defined that make a fairly large numbers of otherwise guest/unprivileged users members of at least one group. As of right now however there doesn't seem to be any cases where this group membership results in any extra rights as far as indexing and searching is concerned. So, dropping these allows to build simplified Solr queries without a single JOIN (in combo with the "avoid expensive join" flag). 
I do not have any quantitative data showing that this resulted in any real savings. Just an experiment/was something that was rubbing me the wrong way. 
No intent to merge this into main develop.
Making a draft PR to have these commits in one place for convenient cherry-picking into future prod. patches.
I will delete it if/when I think of a cleaner way to maintain these custom mods. (A prodpatch fork is probably the way to go).


**Which issue(s) this PR closes**:

- Closes #

**Special notes for your reviewer**:

**Suggestions on how to test this**:

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
