### PR TITLE
DataCite reRegister: fix handling when DOI doesn't exist at DataCite

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/pidproviders/doi/datacite/DOIDataCiteRegisterService.java
+++ b/src/main/java/edu/harvard/iq/dataverse/pidproviders/doi/datacite/DOIDataCiteRegisterService.java
@@ -83,16 +83,24 @@ public class DOIDataCiteRegisterService {
         String numericIdentifier = identifier.substring(identifier.indexOf(":") + 1);
         String xmlMetadata = getMetadataFromDvObject(identifier, metadata, dvObject);
         String target = metadata.get("_target");
-        String currentMetadata = client.getMetadata(numericIdentifier);
-        Diff myDiff = DiffBuilder.compare(xmlMetadata)
-                .withTest(currentMetadata).ignoreWhitespace().checkForSimilar()
-                .build();
-
-        if (myDiff.hasDifferences()) {
-            for(Difference d : myDiff.getDifferences()) {
-            
-              logger.fine(d.toString());
+        String currentMetadata = null;
+        boolean hasDifferences = false;
+        try {
+            currentMetadata = client.getMetadata(numericIdentifier);
+            Diff myDiff = DiffBuilder.compare(xmlMetadata).withTest(currentMetadata).ignoreWhitespace().checkForSimilar()
+                    .build();
+            hasDifferences = myDiff.hasDifferences();
+            if (hasDifferences) {
+                for (Difference d : myDiff.getDifferences()) {
+                    logger.fine(d.toString());
+                }
             }
+        } catch (RuntimeException e) {
+            logger.log(Level.INFO, "DOI " + numericIdentifier + " not registered with DataCite, registering now.");
+            hasDifferences = true;
+        }
+
+        if (hasDifferences) {
             retString = "metadata:\\r" + client.postMetadata(xmlMetadata) + "\\r";
         }
         String currentUrl = null;


### PR DESCRIPTION
**What this PR does / why we need it**: As recently seen at Harvard, the reRegisterMethod, which checks with DataCite to see if a DOI's metadata/url need to be updated and only making the update calls if needed, isn't handling the case when the DOI doesn't exist/hasn't been registered. This PR adds the appropriate try/catch logic to handle the case when a non 200 response is received, which allows the reRegister call to just register the DOI in this case.

**Which issue(s) this PR closes**:

- Closes #

**Special notes for your reviewer**:

**Suggestions on how to test this**:

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
