### PR TITLE
Fix for Cache Test

### DIFF
--- a/src/test/java/edu/harvard/iq/dataverse/util/cache/CacheFactoryBeanTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/util/cache/CacheFactoryBeanTest.java
@@ -173,7 +173,9 @@ public class CacheFactoryBeanTest {
             }
         }
         long endTime = System.currentTimeMillis();
-        long durationMinutes = (endTime - startTime) / 60000L;
+        System.out.println("Test loop took " + (endTime - startTime) + " ms");
+        //Add a few seconds to account for time outside loop
+        long durationMinutes = (6000 + endTime - startTime) / 60000L;
         // 120 calls/hr = 2 calls/min. Add any tokens that may have been added during the test run
         long expectedMax = 120 + (durationMinutes * 2);
 


### PR DESCRIPTION
**What this PR does / why we need it**:
We occasionally see test failures for this rate limiting test, most recently in https://jenkins.dataverse.org/blue/organizations/jenkins/IQSS-Dataverse-Develop-PR/detail/PR-12167/11/tests . 

This PR includes two potential fixes - one is clearing the rate cache between tests and the other is checking the time the test takes so that, if it takes more than a minute, we account for the extra tokens added. (The fact that the test runs to 122 counts instead of 120 suggests two tokens are being added.)

**Which issue(s) this PR closes**:

- Closes #

**Special notes for your reviewer**:

**Suggestions on how to test this**: Not sure how to QA aside from watching for new test failures.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
