### PR TITLE
fixing broken tests when dup role assingment changed to return 409

### DIFF
--- a/src/test/java/edu/harvard/iq/dataverse/api/DatasetsIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/DatasetsIT.java
@@ -299,7 +299,7 @@ public class DatasetsIT {
         grantRole.prettyPrint();
         grantRole.then().assertThat()
                 .body("message", containsString(BundleUtil.getStringFromBundle("datasets.api.grant.role.assignee.has.role.error")))
-                .statusCode(FORBIDDEN.getStatusCode());
+                .statusCode(CONFLICT.getStatusCode());
 
         // Create another random user: 
         
@@ -2354,7 +2354,7 @@ public class DatasetsIT {
         failedGrantPermission.prettyPrint();
         failedGrantPermission.then().assertThat()
                 .body("message", containsString(BundleUtil.getStringFromBundle("datasets.api.grant.role.assignee.has.role.error")))
-                .statusCode(FORBIDDEN.getStatusCode());
+                .statusCode(CONFLICT.getStatusCode());
     }
 
     @Test


### PR DESCRIPTION
**What this PR does / why we need it**: https://github.com/IQSS/dataverse/pull/12134 breaks tests that expect 403. now getting 409

**Which issue(s) this PR closes**:

- Closes #

**Special notes for your reviewer**:

**Suggestions on how to test this**:

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
