### PR TITLE
explain :DatasetPublishPopupCustomText vs :PublishDatasetDisclaimerText

### DIFF
--- a/doc/sphinx-guides/source/installation/config.rst
+++ b/doc/sphinx-guides/source/installation/config.rst
@@ -4796,6 +4796,9 @@ If you have a long text string, you can upload it as a file as in the example be
 
 ``curl -X PUT --upload-file /tmp/long.txt http://localhost:8080/api/admin/settings/:DatasetPublishPopupCustomText``
 
+There is a related setting called :ref:`:PublishDatasetDisclaimerText` that also makes text appear on the popup when publishing, but it requires a checkbox to be clicked.
+
+
 :DatasetPublishPopupCustomTextOnAllVersions
 +++++++++++++++++++++++++++++++++++++++++++
 
@@ -5325,6 +5328,8 @@ See :ref:`Workflow Admin section <workflow_admin>` for more details and context.
 The text displayed to the user that must be acknowledged prior to publishing a Dataset. When not set the acknowledgment is not required nor displayed.
 
 ``curl -X PUT -d "By publishing this dataset, I fully accept all legal responsibility for ensuring that the deposited content is: anonymized, free of copyright violations, and contains data that is computationally reusable. I understand and agree that any violation of these conditions may result in the immediate removal of the dataset by the repository without prior notice." http://localhost:8080/api/admin/settings/:PublishDatasetDisclaimerText``
+
+There is a similar setting called :ref:`:DatasetPublishPopupCustomText` that also makes text appear on the popup when publishing, but it is only informational. There is no checkbox to click.
 
 .. _:BagItHandlerEnabled:
 


### PR DESCRIPTION
**What this PR does / why we need it**:

In the following PR we introduced a new setting called :PublishDatasetDisclaimerText

- #12051

This new setting is strikingly similar to an older setting called :DatasetPublishPopupCustomText

Here's how they look in JSF when you enable both:

<img width="1408" height="1088" alt="Screenshot 2026-03-11 at 1 29 19 PM" src="https://github.com/user-attachments/assets/d995cd31-7ab7-4b3f-8936-69b0a0a3214a" />

In this pull request, I'm crosslinking the two settings in the guides so that people who are customizing the publishing popup can more easily learn about the presence of both settings.

Preview the crosslinking here:

- https://dataverse-guide--12206.org.readthedocs.build/en/12206/installation/config.html#datasetpublishpopupcustomtext
- https://dataverse-guide--12206.org.readthedocs.build/en/12206/installation/config.html#publishdatasetdisclaimertext

p.s. Here's the pull request on the SPA with a similar screenshot:

- https://github.com/IQSS/dataverse-frontend/pull/924