### PR TITLE
More crosslinks for :DatasetPublishPopupCustomText vs :PublishDatasetDisclaimerText

### DIFF
--- a/doc/sphinx-guides/source/api/native-api.rst
+++ b/doc/sphinx-guides/source/api/native-api.rst
@@ -6424,7 +6424,7 @@ The fully expanded example above (without environment variables) looks like this
 Show Disclaimer for Publishing Datasets
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The setting "PublishDatasetDisclaimerText", when set, will prevent a draft dataset from being published through the UI without the user acknowledging the disclaimer.
+The setting :ref:`:PublishDatasetDisclaimerText`, when set, will prevent a draft dataset from being published through the UI without the user acknowledging the disclaimer.
 
 .. note:: See :ref:`show-custom-popup-for-publishing-datasets` if the user acknowledgment is not required but you want the message to be displayed in the UI.
 .. note:: See :ref:`curl-examples-and-environment-variables` if you are unfamiliar with the use of export below.

--- a/doc/sphinx-guides/source/installation/config.rst
+++ b/doc/sphinx-guides/source/installation/config.rst
@@ -4798,6 +4798,7 @@ If you have a long text string, you can upload it as a file as in the example be
 
 There is a related setting called :ref:`:PublishDatasetDisclaimerText` that also makes text appear on the popup when publishing, but it requires a checkbox to be clicked.
 
+See also :ref:`show-custom-popup-for-publishing-datasets` in the API Guide.
 
 :DatasetPublishPopupCustomTextOnAllVersions
 +++++++++++++++++++++++++++++++++++++++++++
@@ -5330,6 +5331,8 @@ The text displayed to the user that must be acknowledged prior to publishing a D
 ``curl -X PUT -d "By publishing this dataset, I fully accept all legal responsibility for ensuring that the deposited content is: anonymized, free of copyright violations, and contains data that is computationally reusable. I understand and agree that any violation of these conditions may result in the immediate removal of the dataset by the repository without prior notice." http://localhost:8080/api/admin/settings/:PublishDatasetDisclaimerText``
 
 There is a similar setting called :ref:`:DatasetPublishPopupCustomText` that also makes text appear on the popup when publishing, but it is only informational. There is no checkbox to click.
+
+See also :ref:`show-disclaimer-for-publishing-datasets` in the API Guide.
 
 .. _:BagItHandlerEnabled:
 


### PR DESCRIPTION
Just a quick follow up to this:

- #12206

There are a few more links I'd like to add.