### PR TITLE
Customize the "Publishing" disclaimer message. Add support for multi line and links

### DIFF
--- a/src/main/webapp/dataset.xhtml
+++ b/src/main/webapp/dataset.xhtml
@@ -2034,7 +2034,7 @@
                         <ui:fragment rendered="#{valid and settingsWrapper.isHasPublishDatasetDisclaimerText()}">
                             <div class="form-group">
                                 <p:selectBooleanCheckbox class="text-danger" id="publishDisclaimer"
-                                                         itemLabel="#{settingsWrapper.getPublishDatasetDisclaimerText()}"
+                                                         itemLabel="#{MarkupChecker:sanitizeBasicHTML(settingsWrapper.getPublishDatasetDisclaimerText())}"
                                                          escape="false"
                                                          value="#{DatasetPage.publishDisclaimerAcknowledged}">
                                     <p:ajax event="change" update="releaseDatasetButton"/>

--- a/src/main/webapp/dataset.xhtml
+++ b/src/main/webapp/dataset.xhtml
@@ -2034,7 +2034,7 @@
                         <ui:fragment rendered="#{valid and settingsWrapper.isHasPublishDatasetDisclaimerText()}">
                             <div class="form-group">
                                 <p:selectBooleanCheckbox class="text-danger" id="publishDisclaimer"
-                                                         itemLabel="#{MarkupChecker:sanitizeBasicHTML(settingsWrapper.getPublishDatasetDisclaimerText())}"
+                                                         itemLabel="#{settingsWrapper.getPublishDatasetDisclaimerText()}"
                                                          escape="false"
                                                          value="#{DatasetPage.publishDisclaimerAcknowledged}">
                                     <p:ajax event="change" update="releaseDatasetButton"/>

--- a/src/main/webapp/dataset.xhtml
+++ b/src/main/webapp/dataset.xhtml
@@ -2034,7 +2034,7 @@
                         <ui:fragment rendered="#{valid and settingsWrapper.isHasPublishDatasetDisclaimerText()}">
                             <div class="form-group">
                                 <p:selectBooleanCheckbox class="text-danger" id="publishDisclaimer"
-                                                         itemLabel="#{settingsWrapper.getPublishDatasetDisclaimerText()}"
+                                                         itemLabel="#{MarkupChecker:sanitizeAdvancedHTML(settingsWrapper.getPublishDatasetDisclaimerText())}"
                                                          escape="false"
                                                          value="#{DatasetPage.publishDisclaimerAcknowledged}">
                                     <p:ajax event="change" update="releaseDatasetButton"/>

--- a/src/main/webapp/dataset.xhtml
+++ b/src/main/webapp/dataset.xhtml
@@ -2035,6 +2035,7 @@
                             <div class="form-group">
                                 <p:selectBooleanCheckbox class="text-danger" id="publishDisclaimer"
                                                          itemLabel="#{settingsWrapper.getPublishDatasetDisclaimerText()}"
+                                                         escape="false"
                                                          value="#{DatasetPage.publishDisclaimerAcknowledged}">
                                     <p:ajax event="change" update="releaseDatasetButton"/>
                                 </p:selectBooleanCheckbox>


### PR DESCRIPTION
**What this PR does / why we need it**: Need to allow the setting :PublishDatasetDisclaimerText to be displayed with line feeds and embedded links

**Which issue(s) this PR closes**: https://github.com/IQSS/dataverse-pm/issues/521

- Closes #

**Special notes for your reviewer**:

**Suggestions on how to test this**: use <br/> for line feeds and <a href= for links. Maybe check for attacks/ embedded js code.  This is an admin call so it shouldn't be an issue.

Example:
 curl -sS -X PUT -d 'I agree to the following:<br/>1. My submission has been fully anonymized (required for all humab subject'\''s datasets).<br/>2. My submission does not violate any known copyright laws.<br/>3. I understand that I am liable for any and all violations of the Harvard Repository<a href=\"https://support.dataverse.harvard.edu/harvard-dataverse-general-terms-use">Terms of Use.</a>' "http://localhost:8080/api/admin/settings/:PublishDatasetDisclaimerText"


**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
<img width="1002" height="457" alt="image" src="https://github.com/user-attachments/assets/a8e00d84-7dc0-492d-b566-66db2152ab9e" />



**Is there a release notes update needed for this change?**:

**Additional documentation**:
