### PR TITLE
add a GitHub Workflow to add bugs to the project board

### DIFF
--- a/.github/workflows/add_bugs_to_project.yml
+++ b/.github/workflows/add_bugs_to_project.yml
@@ -1,0 +1,18 @@
+name: Add bugs to project board
+
+on:
+  issues:
+    types:
+      - opened
+      - labeled
+
+jobs:
+  add-to-project:
+    name: Add bug to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v1.0.2
+        with:
+          project-url: https://github.com/orgs/IQSS/projects/34
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          labeled: "Type: Bug"


### PR DESCRIPTION
**What this PR does / why we need it**:

We'd like all new issues that are labeled as bugs to be automatically added to project 34. They will show up (among other places) in the "Open Bugs" view at https://github.com/orgs/IQSS/projects/34/views/46

**Special notes for your reviewer**:

Here are the docs: https://github.com/actions/add-to-project

I added a secret called ADD_TO_PROJECT_PAT for @dataversebot to the "dataverse" repo. See "Creating a PAT and adding it to your repository" in the docs above. I made a classic token with "project" scope, as required. PAT stands for Personal Access Token ~~and it's currently tied to my account (@pdurbin)~~.

I also gave @dataversebot write access to project 34 here: https://github.com/orgs/IQSS/projects/34/settings/access

**Suggestions on how to test this**:

Merge this. Create a new issue with `label:"Type: Bug"`. Check if it was added to the project. Find an existing issue that doesn't have `label:"Type: Bug"`. Add that label. See if it was added to the project. Try creating a issue without that label. It shouldn't be added.

Also, you can test over at https://github.com/IQSS/dataverse-installations because I set it up there first. (I added the same ADD_TO_PROJECT_PAT there too.)

Here's how it looks:

<img width="659" height="68" alt="Screenshot 2026-03-19 at 12 26 29 PM" src="https://github.com/user-attachments/assets/8b1d037f-2744-49ad-8dc8-59ef99787a86" />

