### PR TITLE
Add missing mimetype mapping

### DIFF
--- a/src/main/java/propertyFiles/MimeTypeDetectionByFileExtension.properties
+++ b/src/main/java/propertyFiles/MimeTypeDetectionByFileExtension.properties
@@ -44,3 +44,4 @@ Rmd=text/x-r-notebook
 rb=text/x-ruby-script
 dag=text/x-dagman
 glb=model/gltf-binary
+css=text/css


### PR DESCRIPTION
**What this PR does / why we need it**:

Add css=text/css to `MimeTypeDetectionByFileExtension`. This prevents a lot of logging lines like this:
```
css is a filename/extension Dataverse doesn't know about. Consider adding it to the MimeTypeDetectionByFileExtension.properties file.|#]
```

**Which issue(s) this PR closes**:

N/a

**Special notes for your reviewer**:

N/a

**Suggestions on how to test this**:

Requesting any page with customization would trigger above logging.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No

**Is there a release notes update needed for this change?**:

No

**Additional documentation**:

N/a
