### PR TITLE
Fix GET /settings/name 500 error

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/api/Admin.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Admin.java
@@ -271,8 +271,8 @@ public class Admin extends AbstractApiBean {
             
             String content = settingsSvc.get(name);
             return (content != null) ? ok(content) : notFound("Setting " + name + " not found.");
-        } catch (IllegalArgumentException iae) {
-            return error(Response.Status.BAD_REQUEST, iae.getMessage());
+        } catch (SettingsValidationException sve) {
+            return error(Response.Status.BAD_REQUEST, sve.getMessage());
         }
     }
     


### PR DESCRIPTION
**What this PR does / why we need it**: It doesn't look like the /api/admin/settings/{name} call was updated correctly when validation was added. This PR catches the correct exception type to return a 400 {"status":"ERROR","message":"The name of the setting is invalid."} response instead of a 500 and a stack trace in the log for a bad setting name.

**Which issue(s) this PR closes**:

- Closes #12077

**Special notes for your reviewer**: 
#12077 suggests a larger refactor, but it would be good to have some fix.

**Suggestions on how to test this**: Call http://localhost:8080/api/admin/settings/badsetting before and after the PR. Note the error fix

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
