### PR TITLE
Replace deprecated glassfish files with payara-* files in WEB-INF

### DIFF
--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -30,7 +30,7 @@ FROM $BASE_IMAGE
 ENV MP_CONFIG_PROFILE=ct
 
 # Workaround to configure upload directories by default to useful place until we can have variable lookups in
-# defaults for glassfish-web.xml and other places.
+# defaults for payara-web.xml and other places.
 ENV DATAVERSE_FILES_UPLOADS="${STORAGE_DIR}/uploads"
 ENV DATAVERSE_FILES_DOCROOT="${STORAGE_DIR}/docroot"
 

--- a/src/main/resources/META-INF/microprofile-config.properties
+++ b/src/main/resources/META-INF/microprofile-config.properties
@@ -10,9 +10,9 @@ dataverse.build=
 
 # FILES
 # NOTE: The following uses STORAGE_DIR for both containers and classic installations. When defaulting to
-#       "com.sun.aas.instanceRoot" if not present, it equals the hardcoded default "." in glassfish-web.xml
+#       "com.sun.aas.instanceRoot" if not present, it equals the hardcoded default "." in payara-web.xml
 #       (which is relative to the domain root folder).
-#       Also, be aware that this props file cannot provide any value for lookups in glassfish-web.xml during servlet
+#       Also, be aware that this props file cannot provide any value for lookups in payara-web.xml during servlet
 #       initialization, as this file will not have been read yet! The names and their values are in sync here and over
 #       there to ensure the config checker is able to check for the directories (exist + writeable).
 dataverse.files.directory=${STORAGE_DIR:/tmp/dataverse}

--- a/src/main/webapp/WEB-INF/payara-resources.xml
+++ b/src/main/webapp/WEB-INF/payara-resources.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE resources PUBLIC "-//Payara.fish//DTD Payara Server {page-version} Resource Definitions//EN" "{payaraResourcesDtd}">
+<!DOCTYPE resources PUBLIC "-//Payara.fish//DTD Payara Server 4 Resource Definitions//EN" "https://github.com/payara/Payara-Documentation/raw/refs/heads/main-6/docs/modules/ROOT/pages/Appendix/Schemas/payara-resources_1_8.dtd">
 <resources>
     <!-- This executor is used in edu.harvard.iq.dataverse.dataaccess.S3AccessIO to support asynchronous operations -->
     <custom-resource res-type="javax.enterprise.concurrent.ManagedExecutorService" 

--- a/src/main/webapp/WEB-INF/payara-resources.xml
+++ b/src/main/webapp/WEB-INF/payara-resources.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE resources PUBLIC "-//Payara.fish//DTD Payara Server 4 Resource Definitions//EN" "https://github.com/payara/Payara-Documentation/raw/refs/heads/main-6/docs/modules/ROOT/pages/Appendix/Schemas/payara-resources_1_8.dtd">
+<!DOCTYPE resources PUBLIC "-//Payara.fish//DTD Payara Server 7 Resource Definitions//EN" "https://raw.githubusercontent.com/payara/Payara-Documentation/main-7/docs/modules/ROOT/pages/Appendix/Schemas/payara-resources_1_8.dtd">
 <resources>
     <!-- This executor is used in edu.harvard.iq.dataverse.dataaccess.S3AccessIO to support asynchronous operations -->
-    <custom-resource res-type="javax.enterprise.concurrent.ManagedExecutorService" 
+    <custom-resource res-type="jakarta.enterprise.concurrent.ManagedExecutorService" 
                      jndi-name="java:app/env/concurrent/s3UploadExecutor" 
                      factory-class="org.glassfish.resources.custom.factory.ManagedExecutorServiceFactory">
         <property name="threadPriority" value="5"/>
@@ -12,7 +12,7 @@
         <property name="threadLifeTime" value="3600"/>
     </custom-resource>
     <!-- Managed Executor Service for Citation Updates -->
-    <custom-resource res-type="javax.enterprise.concurrent.ManagedExecutorService" 
+    <custom-resource res-type="jakarta.enterprise.concurrent.ManagedExecutorService" 
                      jndi-name="java:app/env/concurrent/CitationUpdateExecutor" 
                      factory-class="org.glassfish.resources.custom.factory.ManagedExecutorServiceFactory">
         <property name="corePoolSize" value="1"/>

--- a/src/main/webapp/WEB-INF/payara-resources.xml
+++ b/src/main/webapp/WEB-INF/payara-resources.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE resources PUBLIC "-//GlassFish.org//DTD GlassFish Application Server 3.1 Resource Definitions//EN" "http://glassfish.org/dtds/glassfish-resources_1_5.dtd">
+<!DOCTYPE resources PUBLIC "-//Payara.fish//DTD Payara Server {page-version} Resource Definitions//EN" "{payaraResourcesDtd}">
 <resources>
     <!-- This executor is used in edu.harvard.iq.dataverse.dataaccess.S3AccessIO to support asynchronous operations -->
     <custom-resource res-type="javax.enterprise.concurrent.ManagedExecutorService" 

--- a/src/main/webapp/WEB-INF/payara-web.xml
+++ b/src/main/webapp/WEB-INF/payara-web.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE payara-web-app PUBLIC "-//Payara.fish//DTD Payara Server 6.36.0//EN" "https://raw.githubusercontent.com/payara/Payara-Documentation/main-6/docs/modules/ROOT/pages/Appendix/Schemas/payara-web-app_4.dtd">
+<!DOCTYPE payara-web-app PUBLIC "-//Payara.fish//DTD Payara Server 7.2026.2//EN" "https://raw.githubusercontent.com/payara/Payara-Documentation/main-7/docs/modules/ROOT/pages/Appendix/Schemas/payara-web-app_6_1-0.dtd">
 <payara-web-app error-url="">
   <context-root>/</context-root>
   <class-loader delegate="true"/>

--- a/src/main/webapp/WEB-INF/payara-web.xml
+++ b/src/main/webapp/WEB-INF/payara-web.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE glassfish-web-app PUBLIC "-//GlassFish.org//DTD GlassFish Application Server 3.1 Servlet 3.0//EN" "http://glassfish.org/dtds/glassfish-web-app_3_0-1.dtd">
-<glassfish-web-app error-url="">
+<!DOCTYPE payara-web-app PUBLIC "-//Payara.fish//DTD Payara Server 6.36.0//EN" "https://raw.githubusercontent.com/payara/Payara-Documentation/main-6/docs/modules/ROOT/pages/Appendix/Schemas/payara-web-app_4.dtd">
+<payara-web-app error-url="">
   <context-root>/</context-root>
   <class-loader delegate="true"/>
   <jsp-config>
@@ -24,4 +24,4 @@
   <!-- NOTE: As we cannot use variables in defaults of ${MPCONFIG}, there is a workaround for containers necessary;
              see src/main/docker/Dockerfile. Once Payara upstream fixes this, we can use STORAGE_DIR here. -->
   <property name="tempdir" value="${MPCONFIG=dataverse.files.uploads:./uploads}"/>
-</glassfish-web-app>
+</payara-web-app>


### PR DESCRIPTION
**What this PR does / why we need it**: Per Payara at https://docs.payara.fish/community/docs/Technical%20Documentation/Payara%20Server%20Documentation/Application%20Deployment/Deployment%20Descriptor%20Files.html , the glassfish-web.xml and glassfish-resources,xml file formats we use are deprecated "and support will be removed in a future release". This PR updates to the newer payara* formats - basically a matter of updating the DOCTYPE lines and changing names.

**Which issue(s) this PR closes**:

- Closes #

**Special notes for your reviewer**:

**Suggestions on how to test this**: Make sure Dataverse deploy and runs after the update.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
