### PR TITLE
Improved db connection

### DIFF
--- a/doc/release-notes/12241-simple db connector.md
+++ b/doc/release-notes/12241-simple db connector.md
@@ -1,0 +1,1 @@
+This version of Dataverse changes the class used for connecting with Postgres. This should help avoid problems seen under high load and potentially improve performance. See #12241 for details.

--- a/doc/sphinx-guides/source/installation/config.rst
+++ b/doc/sphinx-guides/source/installation/config.rst
@@ -949,6 +949,9 @@ Connection Validation
    * - dataverse.db.validate-atmost-once-period-in-seconds
      - Specifies the time interval in seconds between successive requests to validate a connection at most once.
      - ``0`` (disabled)
+   * - dataverse.db.fail-all-connections
+     - When true, refreshes all connections when one fails, speeding recover vs. detecting and refreshing connections individually.
+     - ``true`` (enabled)
 
 Connection & Statement Leaks
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/main/java/edu/harvard/iq/dataverse/util/DataSourceProducer.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/DataSourceProducer.java
@@ -46,6 +46,7 @@ import javax.sql.DataSource;
             "fish.payara.validation-table-name=${MPCONFIG=dataverse.db.validation-table-name:}",
             "fish.payara.validation-classname=${MPCONFIG=dataverse.db.validation-classname:}",
             "fish.payara.validate-atmost-once-period-in-seconds=${MPCONFIG=dataverse.db.validate-atmost-once-period-in-seconds:0}",
+            "fish.payara.fail-all-connections=${MPCONFIG=dataverse.db.fail-all-connections:true}",
             // LEAK DETECTION
             "fish.payara.connection-leak-timeout-in-seconds=${MPCONFIG=dataverse.db.connection-leak-timeout-in-seconds:0}",
             "fish.payara.connection-leak-reclaim=${MPCONFIG=dataverse.db.connection-leak-reclaim:false}",
@@ -54,9 +55,8 @@ import javax.sql.DataSource;
             // LOGGING, SLOWNESS, PERFORMANCE
             "fish.payara.statement-timeout-in-seconds=${MPCONFIG=dataverse.db.statement-timeout-in-seconds:-1}",
             "fish.payara.slow-query-threshold-in-seconds=${MPCONFIG=dataverse.db.slow-query-threshold-in-seconds:-1}",
-            "fish.payara.log-jdbc-calls=${MPCONFIG=dataverse.db.log-jdbc-calls:false}",
-            // OTHER OPTIONS
-            "fish.payara.fail-all-connections=${MPCONFIG=dataverse.db.fail-all-connections:true}"
+            "fish.payara.log-jdbc-calls=${MPCONFIG=dataverse.db.log-jdbc-calls:false}"
+
         })
 public class DataSourceProducer {
 

--- a/src/main/java/edu/harvard/iq/dataverse/util/DataSourceProducer.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/DataSourceProducer.java
@@ -12,10 +12,8 @@ import javax.sql.DataSource;
         name = "java:app/jdbc/dataverse",
         // The app server (Payara) deploys a managed pool for this data source for us.
         // We don't need to deal with this on our own.
-        //
-        // HINT: PGSimpleDataSource would work too, but as we use a connection pool, go with a javax.sql.ConnectionPoolDataSource
-        // HINT: PGXADataSource is unnecessary (no distributed transactions used) and breaks ingest.
-        className = "org.postgresql.ds.PGConnectionPoolDataSource",
+
+        className = "org.postgresql.ds.PGSimpleDataSource",
         
         // BEWARE: as this resource is created before defaults are read from META-INF/microprofile-config.properties,
         // defaults must be provided in this Payara-proprietary manner.
@@ -56,7 +54,9 @@ import javax.sql.DataSource;
             // LOGGING, SLOWNESS, PERFORMANCE
             "fish.payara.statement-timeout-in-seconds=${MPCONFIG=dataverse.db.statement-timeout-in-seconds:-1}",
             "fish.payara.slow-query-threshold-in-seconds=${MPCONFIG=dataverse.db.slow-query-threshold-in-seconds:-1}",
-            "fish.payara.log-jdbc-calls=${MPCONFIG=dataverse.db.log-jdbc-calls:false}"
+            "fish.payara.log-jdbc-calls=${MPCONFIG=dataverse.db.log-jdbc-calls:false}",
+            // OTHER OPTIONS
+            "fish.payara.fail-all-connections=${MPCONFIG=dataverse.db.fail-all-connections:true}"
         })
 public class DataSourceProducer {
 


### PR DESCRIPTION
**What this PR does / why we need it**: At QDR, we've recently see Dataverse stop responding without any out of memory or high load issues. 

The one thing I've seen in the log that is potentially related are errors related to the postgres connection:
- Exception DTX5007:Exception StackTrace javax.transaction.xa.XAException: jakarta.resource.ResourceException: This Managed Connection is not valid as the physical connection is not usable
-  RAR5031:System Exception
- org.eclipse.persistence.exceptions.DatabaseException\nInternal Exception: org.postgre       sql.util.PSQLException: Connection has been closed automatically because a new connection was opened for the same PooledConnection or the PooledConnection has been closed.\nError Code: 0\nCal       l: SELECT ID, CONTENT, LANG, NAME FROM SETTING WHERE ((NAME = ?) AND (LANG = ?))\n\tbind => [2 parameters bound]\nQuery: ReadAllQuery(name=\"Setting.findByName\" referenceClass=Setting sql=\"       SELECT ID, CONTENT, LANG, NAME FROM SETTING WHERE ((NAME = ?) AND (LANG = ?))\")"

Showing AI how the DataSource was configured, it pointed to an issue where we are specifying a pooling connector while Payara is also setting up a pool, causing duplication and potential issues under high load.

This PR switches to the recommended "Simple" connector and adds a new "fish.payara.fail-all-connections=${MPCONFIG=dataverse.db.fail-all-connections:true}" option that seems useful for recovering more quickly when connections are going bad.

While the relevant Dataverse code hasn't changed lately, it's possible that the update to Payara 7/new Eclipselink has changed something that is making the problem more visible.

Even if this is not related to the problem we're seeing at QDR, it seems like a useful update.

**Which issue(s) this PR closes**:

- Closes #

**Special notes for your reviewer**:

AI also recommended several settings that we don't have by default, which ~match Payara's documentation on advanced db settings. I don't know if changing the defaults in our code, or adding these to the recommended settings when upgrading/the docker default config would be useful:
-Ddataverse.db.is-connection-validation-required=true
-Ddataverse.db.validate-atmost-once-period-in-seconds=30
-Ddataverse.db.connection-validation-method=custom-validation
-Ddataverse.db.validation-classname=org.glassfish.api.jdbc.validation.PostgresConnectionValidation
-Ddataverse.db.fail-all-connections=true
-Ddataverse.db.connection-leak-timeout-in-seconds=300



**Suggestions on how to test this**:
Nominally make sure Dataverse works after the change, probably perf test and assure performance doesn't drop and performance under load is as/more stable than before.

FWIW: All of these changes are on QDR test machines - we'll be monitoring performance and hopefully pushing them to production where we've seen outages.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
