### PR TITLE
Guard against NPE in BagGenerator

### DIFF
--- a/doc/release-notes/12246-guard-npe-bag-generator.md
+++ b/doc/release-notes/12246-guard-npe-bag-generator.md
@@ -1,0 +1,1 @@
+Fixed a problem in the BagPack generator, which caused the export to fail for datasets with multiple Contact Points, of which some had no name while others did.

--- a/src/main/java/edu/harvard/iq/dataverse/util/bagit/BagGenerator.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/bagit/BagGenerator.java
@@ -938,7 +938,7 @@ public class BagGenerator {
                         info.append(CRLF);
 
                     } else {
-                        if (contactNameTerm != null) {
+                        if (contactNameTerm != null && ((JsonObject) person).has(contactNameTerm.getLabel())) {
                             info.append(multilineWrap(CONTACT_NAME + ((JsonObject) person).get(contactNameTerm.getLabel()).getAsString()));
                             info.append(CRLF);
                         }


### PR DESCRIPTION
**What this PR does / why we need it**
When there are more than one contacts, it may occur that one of them does not have a "name" sub-field. In that case `contactNameTerm` is not `null`, but `((JsonObject) person).get(contactNameTerm.getLabel())` does evaluate to `null`, causing an NPE.

**Which issue(s) this PR closes**:
N/a

**Special notes for your reviewer**:
None

**Suggestions on how to test this**:
1. Create a dataset with two contacts:
* One with all subfields filled out.
* One without a "name"
2. Archive the dataset

Before fix, the archiving will fail.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
No

**Is there a release notes update needed for this change?**:
See: https://github.com/IQSS/dataverse/pull/12246/changes#diff-3dd3cb83d7219250c6bfbacb2f7d829b806a67e46020967f63ab039b5e506d3f

**Additional documentation**:
N/a
