### PR TITLE
chore(ci): update Trivy engine to a newer, but safe version #12242

### DIFF
--- a/.github/workflows/container_maintenance.yml
+++ b/.github/workflows/container_maintenance.yml
@@ -175,7 +175,7 @@ jobs:
       - name: Setup Trivy binary for vulnerability scanning
         uses: aquasecurity/setup-trivy@v0.2.6
         with:
-          version: v0.63.0
+          version: v0.69.3
 
       # Execute matrix build for the discovered branches
       - name: Execute build matrix script


### PR DESCRIPTION
**What this PR does / why we need it**:

Update the Trivy Scanning Engine as well in addition to the action, see also #12235 

In addition, the secrets have been rotated.

**Which issue(s) this PR closes**:

- Closes #12242

**Special notes for your reviewer**:
None

**Suggestions on how to test this**:
None

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
Nope

**Is there a release notes update needed for this change?**:
Nope

**Additional documentation**:
None
