### PR TITLE
IQSS/12244 - fix org citations

### DIFF
--- a/doc/release-notes/12244-fix-citations.md
+++ b/doc/release-notes/12244-fix-citations.md
@@ -1,0 +1,1 @@
+This release fixes a bug causing Author names of Organizations to be incorrect in styled citations (the software attempted to interpret the organization's name as a first name/last name pair).

--- a/src/main/java/edu/harvard/iq/dataverse/DataCitation.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DataCitation.java
@@ -880,7 +880,7 @@ public class DataCitation {
                         cslAuthors.add(new CSLNameBuilder().given(givenName).family(familyName).isInstitution(false).build());
                     } else {
                         cslAuthors.add(
-                                new CSLNameBuilder().literal(formatString(authorJson.getString("fullName"), true)).isInstitution(false).build());
+                                new CSLNameBuilder().literal(formatString(authorJson.getString("fullName"), true)).isInstitution(true).build());
                     }
                 }
             }


### PR DESCRIPTION
**What this PR does / why we need it**: The code had logic to test when a name is for an organization but, due to a typo/cut-paste issue, the CSL Json used to create citations was still marking the entry as not being an organization. This PR fixes the issue.

**Which issue(s) this PR closes**:

- Closes #12244

**Special notes for your reviewer**:

**Suggestions on how to test this**: Add a multiword org name as an author, check the chicago style or other styles citations available in the UI/API. (See issue for example).

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**: inc.

**Additional documentation**:
