### PR TITLE
Remove Purl from COAR context

### DIFF
--- a/src/test/java/edu/harvard/iq/dataverse/api/LDNInboxTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/LDNInboxTest.java
@@ -251,7 +251,7 @@ public class LDNInboxTest {
 
     static String createRelationshipAnnouncementMessage(String sourceId, String targetId, String relationship) {
         JsonArray context = Json.createArrayBuilder().add("https://www.w3.org/ns/activitystreams")
-                .add("https://purl.org/coar/notify").build();
+                .add("https://coar-notify.net").build();
 
         JsonArray type = Json.createArrayBuilder().add("Announce").add("coar-notify:RelationshipAction").build();
 


### PR DESCRIPTION
**What this PR does / why we need it**: COAR originally used a purl URL in it's examples for the COAR notify context used in it's JSON-LD messages. With purl down today, I noticed because the tests slow down by minutes as they wait for purl.org to timeout. (As there has been some flakiness before, the main code has a fallback if retrieving the context fail, but it still waits).

This PR updates the test messages we create to use the more direct https://coar-notify.net URL COAR now shows in it's online examples.

**Which issue(s) this PR closes**:

- Closes #

**Special notes for your reviewer**:

**Suggestions on how to test this**: Verify tests still work. If purl.org is down when testing, you may see the test run slow before and fast after the PR. I did see this at QDR while purl.org was down: 
<img width="507" height="287" alt="image" src="https://github.com/user-attachments/assets/3e4c8087-c7e7-4bcb-8a59-d4a8b21cff45" />


**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
