### PR TITLE
bump to 6.10.1

### DIFF
--- a/doc/release-notes/12252-fix-download-with-guestbook.md
+++ b/doc/release-notes/12252-fix-download-with-guestbook.md
@@ -1,4 +1,0 @@
-## Bug fix for JSF download file
-This fixes the issue where the action to download a single file in JSF UI silently fails
-
-See:12251

--- a/doc/release-notes/6.10.1-release-notes.md
+++ b/doc/release-notes/6.10.1-release-notes.md
@@ -1,0 +1,53 @@
+# Dataverse 6.10.1
+
+This is a bug fix release for Dataverse 6.10 that fixes download bug #12251 that was fixed in pull request #12251. The bug caused single-file downloads (as opposed to multi-file zip download) to silently fail from the web interface (the API was unaffected).
+
+## Complete List of Changes
+
+For the complete list of code changes in this release, see the [6.10.1 milestone](https://github.com/IQSS/dataverse/issues?q=milestone%3A6.10.1+is%3Aclosed) in GitHub.
+
+## Getting Help
+
+For help with upgrading, installing, or general questions please see [getting help](https://guides.dataverse.org/en/latest/installation/intro.html#getting-help) in the Installation Guide.
+
+## Installation
+
+If this is a new installation, please follow our [Installation Guide](https://guides.dataverse.org/en/latest/installation/). Please don't be shy about [asking for help](https://guides.dataverse.org/en/latest/installation/intro.html#getting-help) if you need it!
+
+Once you are in production, we would be delighted to update our [map of Dataverse installations around the world](https://dataverse.org/installations) to include yours! Please [create an issue](https://github.com/IQSS/dataverse-installations/issues) or email us at support@dataverse.org to join the club!
+
+You are also very welcome to join the [Global Dataverse Community Consortium](https://www.gdcc.io/) (GDCC).
+
+## Upgrade Instructions
+
+Upgrading requires a maintenance window and downtime. Please plan accordingly, create backups of your database, etc.
+
+Note: These instructions assume that you are upgrading from the immediate previous version. That is to say, you've already upgraded through all the 6.x releases and are now running Dataverse 6.10. See [tags on GitHub](https://github.com/IQSS/dataverse/tags) for a list of versions. If you are running an earlier version, the only supported way to upgrade is to progress through the upgrades to all the releases in between before attempting the upgrade to this version.
+
+If you are running Payara as a non-root user (and you should be!), **remember not to execute the commands below as root**. By default, Payara runs as the `dataverse` user. In the commands below, we use sudo to run the commands as a non-root user.
+
+Also, we assume that Payara is installed in `/usr/local/payara7`. If not, adjust as needed.
+
+1. Undeploy Dataverse, if deployed, using the unprivileged service account ("dataverse", by default).
+
+   `sudo -u dataverse /usr/local/payara7/bin/asadmin list-applications`
+
+   `sudo -u dataverse /usr/local/payara7/bin/asadmin undeploy dataverse-6.10`
+
+1. Deploy the Dataverse 6.10.1 war file.
+
+   `wget https://github.com/IQSS/dataverse/releases/download/v6.10.1/dataverse-6.10.1.war`
+
+   `sudo -u dataverse /usr/local/payara7/bin/asadmin deploy dataverse-6.10.1.war`
+
+1. Check that you get a version number from Dataverse.
+
+   This is just a sanity check that Dataverse has been deployed properly.
+
+   `curl http://localhost:8080/api/info/version`
+
+1. For installations with internationalization or text customizations:
+
+   Please remember to update translations via [Dataverse language packs](https://github.com/GlobalDataverseCommunityConsortium/dataverse-language-packs).
+
+   If you have text customizations you can get the latest English files from <https://github.com/IQSS/dataverse/tree/v6.10/src/main/java/propertyFiles>.

--- a/doc/release-notes/6.10.1-release-notes.md
+++ b/doc/release-notes/6.10.1-release-notes.md
@@ -1,6 +1,6 @@
 # Dataverse 6.10.1
 
-This is a bug fix release for Dataverse 6.10 that fixes download bug #12251 that was fixed in pull request #12251. The bug caused single-file downloads (as opposed to multi-file zip download) to silently fail from the web interface (the API was unaffected).
+This is a bug fix release for Dataverse 6.10 that fixes download bug #12251 that was fixed in pull request #12252. The bug caused single-file downloads (as opposed to multi-file zip download) to silently fail from the web interface (the API was unaffected).
 
 ## Complete List of Changes
 

--- a/doc/sphinx-guides/source/conf.py
+++ b/doc/sphinx-guides/source/conf.py
@@ -70,7 +70,7 @@ copyright = u'%d, The President & Fellows of Harvard College' % datetime.now().y
 # built documents.
 #
 # The short X.Y version.
-version = '6.10'
+version = '6.10.1'
 # The full version, including alpha/beta/rc tags.
 release = version
 

--- a/doc/sphinx-guides/source/versions.rst
+++ b/doc/sphinx-guides/source/versions.rst
@@ -8,6 +8,7 @@ This list provides a way to refer to the documentation for previous and future v
 
 - pre-release `HTML (not final!) <http://preview.guides.gdcc.io/en/develop/>`__ and `PDF (experimental!) <http://preview.guides.gdcc.io/_/downloads/en/develop/pdf/>`__ built from the :doc:`develop </developers/version-control>` branch :doc:`(how to contribute!) </contributor/documentation>`
 - |version|
+- `6.10 </en/6.10/>`__
 - `6.9 </en/6.9/>`__
 - `6.8 </en/6.8/>`__
 - `6.7.1 </en/6.7.1/>`__

--- a/modules/dataverse-parent/pom.xml
+++ b/modules/dataverse-parent/pom.xml
@@ -132,7 +132,7 @@
  
     <properties>
         <!-- This is a special Maven property name, do not change! -->
-        <revision>6.10</revision>
+        <revision>6.10.1</revision>
     
         <target.java.version>21</target.java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -461,8 +461,8 @@
                     Once the release has been made (tag created), change this back to "${parsedVersion.majorVersion}.${parsedVersion.nextMinorVersion}"
                     (These properties are provided by the build-helper plugin below.)
                 -->
-                <base.image.version>${parsedVersion.majorVersion}.${parsedVersion.nextMinorVersion}</base.image.version>
-                <!-- <base.image.version>${revision}</base.image.version> -->
+                <!-- <base.image.version>${parsedVersion.majorVersion}.${parsedVersion.nextMinorVersion}</base.image.version> -->
+                <base.image.version>${revision}</base.image.version>
                 <!-- This is used by the maintenance CI jobs, no need to adapt during releases. -->
                 <app.image.version>${base.image.version}</app.image.version>
             </properties>


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a bug fix release for Dataverse 6.10 that fixes download bug #12251 that was fixed in pull request #12252. The bug caused single-file downloads (as opposed to multi-file zip download) to silently fail from the web interface (the API was unaffected).