### PR TITLE
Fix Publish and Submit for Review when no files are present in Dataset

### DIFF
--- a/doc/release-notes/12258-publish-submit-contains-files.md
+++ b/doc/release-notes/12258-publish-submit-contains-files.md
@@ -1,0 +1,2 @@
+## Bug: Publish and Submit for review must contain files
+When `requireFilesToPublishDataset` is set on a Dataverse a Dataset must contain files to be published or submitted for review. This fix make sure the dataset version contains files, and not just the dataset. It also adds this check to the `Submit for Review` functionality.

--- a/doc/sphinx-guides/source/api/changelog.rst
+++ b/doc/sphinx-guides/source/api/changelog.rst
@@ -7,6 +7,13 @@ This API changelog is experimental and we would love feedback on its usefulness.
     :local:
     :depth: 1
 
+v6.11
+-----
+
+- The following API will now return ``403`` if the ``requireFilesToPublishDataset`` flag is set and the dataset version contains 0 files.
+
+  - **/api/datasets/{Id}/submitForReview**
+
 v6.10
 -----
 - The following GET APIs will now return ``400`` if a required Guestbook Response is not supplied. A Guestbook Response can be passed to these APIs in the JSON body using a POST call. See the notes under :ref:`basic-file-access` and :ref:`download-by-dataset-by-version` for details.

--- a/doc/sphinx-guides/source/api/native-api.rst
+++ b/doc/sphinx-guides/source/api/native-api.rst
@@ -1278,7 +1278,7 @@ The following attributes are supported:
 * ``description`` Description
 * ``affiliation`` Affiliation
 * ``filePIDsEnabled`` ("true" or "false") Restricted to use by superusers and only when the :ref:`:AllowEnablingFilePIDsPerCollection <:AllowEnablingFilePIDsPerCollection>` setting is true. Enables or disables registration of file-level PIDs in datasets within the collection (overriding the instance-wide setting).
-* ``requireFilesToPublishDataset`` ("true" or "false") Restricted to use by superusers. Defines if Dataset needs files in order to be published.  If not set the determination will be made through inheritance by checking the owners of this collection. Publishing by a superusers will not be blocked.
+* ``requireFilesToPublishDataset`` ("true" or "false") Restricted to use by superusers. Defines if Dataset version needs files in order to be published or submitted for review.  If not set the determination will be made through inheritance by checking the owners of this collection. Publishing by a superusers will not be blocked.
 * ``allowedDatasetTypes`` Restricted to use by superusers. By default "dataset" is implied. Pass a comma-separated list of dataset types (e.g. "dataset,software"). You cannot unset this attribute so if you want to delete a dataset type, set ``allowedDatasetTypes`` to a dataset type you won't be deleting. See also :ref:`dataset-types`.
 
 See also :ref:`update-dataverse-api`.

--- a/src/main/java/edu/harvard/iq/dataverse/DatasetServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetServiceBean.java
@@ -835,6 +835,18 @@ public class DatasetServiceBean implements java.io.Serializable {
 
         String reminderString;
 
+        if (dataset.getOwner().getEffectiveRequiresFilesToPublishDataset()) {
+            List<FileMetadata> files = dataset.getLatestVersion().getFileMetadatas();
+            if (files.size() < 1) {
+                if (canPublishDataset) {
+                    reminderString = BundleUtil.getStringFromBundle("dataset.mayNotPublish.FilesRequired");
+                } else {
+                    reminderString = BundleUtil.getStringFromBundle("dataset.mayNotSubmitForReview.FilesRequired");
+                }
+                return reminderString;
+            }
+        }
+
         if (canPublishDataset) {
             reminderString = BundleUtil.getStringFromBundle("dataset.message.publish.warning");
         } else {

--- a/src/main/java/edu/harvard/iq/dataverse/PermissionsWrapper.java
+++ b/src/main/java/edu/harvard/iq/dataverse/PermissionsWrapper.java
@@ -12,6 +12,7 @@ import edu.harvard.iq.dataverse.engine.command.Command;
 import edu.harvard.iq.dataverse.engine.command.DataverseRequest;
 import edu.harvard.iq.dataverse.engine.command.impl.*;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
 import jakarta.ejb.EJB;
@@ -253,9 +254,34 @@ public class PermissionsWrapper implements java.io.Serializable {
     
     // PUBLISH DATASET
     public boolean canIssuePublishDatasetCommand(DvObject dvo){
+        // Return false if dataset has 0 files and user want to 'publish' or 'submit for review' and 'publish dataset requires files' flag is set
+        if (dvo.isInstanceofDataset()) {
+            Dataverse dv =((Dataset)dvo).getOwner();
+            if (dv != null) {
+                List<FileMetadata> metadataList = ((Dataset) dvo).getLatestVersion().getFileMetadatas();
+                if (metadataList.size() == 0 && dv.getEffectiveRequiresFilesToPublishDataset()) {
+                    return false;
+                }
+            }
+        }
         return canIssueCommand(dvo, PublishDatasetCommand.class);
     }
-    
+
+    // SUBMIT DATASET FOR REVIEW
+    public boolean canIssueSubmitDatasetForReviewCommand(DvObject dvo){
+        // Return false if dataset has 0 files and user want to 'publish' or 'submit for review' and 'publish dataset requires files' flag is set
+        if (dvo.isInstanceofDataset()) {
+            Dataverse dv =((Dataset)dvo).getOwner();
+            if (dv != null) {
+                List<FileMetadata> metadataList = ((Dataset) dvo).getLatestVersion().getFileMetadatas();
+                if (metadataList.size() == 0 && dv.getEffectiveRequiresFilesToPublishDataset()) {
+                    return false;
+                }
+            }
+        }
+        return canIssueCommand(dvo, SubmitDatasetForReviewCommand.class);
+    }
+
     // For the dataverse_header fragment (and therefore, most of the pages),
     // we need to know if authenticated users can add dataverses and datasets to the
     // root collection. For the "Add Data" menu further in the search include fragment

--- a/src/main/java/edu/harvard/iq/dataverse/PermissionsWrapper.java
+++ b/src/main/java/edu/harvard/iq/dataverse/PermissionsWrapper.java
@@ -254,6 +254,10 @@ public class PermissionsWrapper implements java.io.Serializable {
     
     // PUBLISH DATASET
     public boolean canIssuePublishDatasetCommand(DvObject dvo){
+        User u = session.getUser();
+        if (u != null && u.isSuperuser()) {
+            return true;
+        }
         // Return false if dataset has 0 files and user want to 'publish' or 'submit for review' and 'publish dataset requires files' flag is set
         if (dvo.isInstanceofDataset()) {
             Dataverse dv =((Dataset)dvo).getOwner();

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/AbstractDatasetCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/AbstractDatasetCommand.java
@@ -315,4 +315,14 @@ public abstract class AbstractDatasetCommand<T> extends AbstractCommand<T> {
             }
         }
     }
+
+    // To block Publishing dataset or Submitting dataset for review
+    protected boolean getEffectiveRequiresFilesToPublishDataset() {
+        if (getUser().isSuperuser()) {
+            return false;
+        } else {
+            Dataverse dv = getDataset().getOwner();
+            return dv != null &&  dv.getEffectiveRequiresFilesToPublishDataset();
+        }
+    }
 }

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/PublishDatasetCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/PublishDatasetCommand.java
@@ -1,8 +1,6 @@
 package edu.harvard.iq.dataverse.engine.command.impl;
 
-import edu.harvard.iq.dataverse.Dataset;
-import edu.harvard.iq.dataverse.DatasetLock;
-import edu.harvard.iq.dataverse.Dataverse;
+import edu.harvard.iq.dataverse.*;
 import edu.harvard.iq.dataverse.authorization.Permission;
 import edu.harvard.iq.dataverse.authorization.users.AuthenticatedUser;
 import edu.harvard.iq.dataverse.engine.command.CommandContext;
@@ -17,6 +15,7 @@ import edu.harvard.iq.dataverse.workflow.WorkflowContext.TriggerType;
 
 import jakarta.persistence.OptimisticLockException;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -233,17 +232,10 @@ public class PublishDatasetCommand extends AbstractPublishDatasetCommand<Publish
                 throw new IllegalCommandException("Cannot release as minor version. Re-try as major release.", this);
             }
 
-            if (getDataset().getFiles().isEmpty() && getEffectiveRequiresFilesToPublishDataset()) {
+            List<FileMetadata> files = getDataset().getLatestVersion().getFileMetadatas();
+            if ((files == null || files.isEmpty()) && getEffectiveRequiresFilesToPublishDataset()) {
                 throw new IllegalCommandException(BundleUtil.getStringFromBundle("dataset.mayNotPublish.FilesRequired"), this);
             }
-        }
-    }
-    private boolean getEffectiveRequiresFilesToPublishDataset() {
-        if (getUser().isSuperuser()) {
-            return false;
-        } else {
-            Dataverse dv = getDataset().getOwner();
-            return dv != null &&  dv.getEffectiveRequiresFilesToPublishDataset();
         }
     }
     

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/SubmitDatasetForReviewCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/SubmitDatasetForReviewCommand.java
@@ -1,25 +1,17 @@
 package edu.harvard.iq.dataverse.engine.command.impl;
 
-import edu.harvard.iq.dataverse.Dataset;
-import edu.harvard.iq.dataverse.DatasetLock;
-import edu.harvard.iq.dataverse.DatasetVersionUser;
-import edu.harvard.iq.dataverse.UserNotification;
+import edu.harvard.iq.dataverse.*;
 import edu.harvard.iq.dataverse.authorization.Permission;
 import edu.harvard.iq.dataverse.authorization.users.AuthenticatedUser;
-import edu.harvard.iq.dataverse.batch.util.LoggingUtil;
-import edu.harvard.iq.dataverse.engine.command.AbstractCommand;
 import edu.harvard.iq.dataverse.engine.command.CommandContext;
 import edu.harvard.iq.dataverse.engine.command.DataverseRequest;
 import edu.harvard.iq.dataverse.engine.command.RequiredPermissions;
 import edu.harvard.iq.dataverse.engine.command.exception.CommandException;
 import edu.harvard.iq.dataverse.engine.command.exception.IllegalCommandException;
 import edu.harvard.iq.dataverse.util.BundleUtil;
-import java.io.IOException;
 import java.sql.Timestamp;
 import java.util.Date;
 import java.util.List;
-import java.util.concurrent.Future;
-import org.apache.solr.client.solrj.SolrServerException;
 
 @RequiredPermissions(Permission.EditDataset)
 public class SubmitDatasetForReviewCommand extends AbstractDatasetCommand<Dataset> {
@@ -39,6 +31,11 @@ public class SubmitDatasetForReviewCommand extends AbstractDatasetCommand<Datase
 
         if (getDataset().getLatestVersion().isInReview()) {
             throw new IllegalCommandException(BundleUtil.getStringFromBundle("dataset.submit.failure.inReview"), this);
+        }
+
+        List<FileMetadata> files = getDataset().getLatestVersion().getFileMetadatas();
+        if ((files == null || files.isEmpty()) && getEffectiveRequiresFilesToPublishDataset()) {
+            throw new IllegalCommandException(BundleUtil.getStringFromBundle("dataset.mayNotSubmitForReview.FilesRequired"), this);
         }
 
         //SEK 9-1 Add Lock before saving dataset

--- a/src/main/java/propertyFiles/Bundle.properties
+++ b/src/main/java/propertyFiles/Bundle.properties
@@ -1636,6 +1636,7 @@ dataset.mayNotPublish.both= This dataset cannot be published until {0} is publis
 dataset.mayNotPublish.twoGenerations= This dataset cannot be published until {0} and {1}  are published.
 dataset.mayNotBePublished.both.button=Yes, Publish Both
 dataset.mayNotPublish.FilesRequired=Published datasets should contain at least one data file.
+dataset.mayNotSubmitForReview.FilesRequired=The dataset must contain at least one data file in order to be submitted for review.
 dataset.viewVersion.unpublished=View Unpublished Version
 dataset.viewVersion.published=View Published Version
 dataset.link.title=Link Dataset

--- a/src/main/webapp/dataset.xhtml
+++ b/src/main/webapp/dataset.xhtml
@@ -27,7 +27,8 @@
             <ui:param name="canUpdateDataset" value="#{DatasetPage.canUpdateDataset()}"/>
             <ui:param name="canDownloadFiles" value="#{DatasetPage.canDownloadFiles()}"/>
             <ui:param name="canIssuePublishDatasetCommand" value="#{permissionsWrapper.canIssuePublishDatasetCommand(DatasetPage.dataset)}"/>
-            <ui:param name="showPublishLink" value="#{version == DatasetPage.dataset.latestVersion 
+            <ui:param name="canIssueSubmitDatasetForReviewCommand" value="#{permissionsWrapper.canIssueSubmitDatasetForReviewCommand(DatasetPage.dataset)}"/>
+            <ui:param name="showPublishLink" value="#{version == DatasetPage.dataset.latestVersion
                                                       and DatasetPage.dataset.latestVersion.versionState=='DRAFT'
                                                       and canIssuePublishDatasetCommand}"/>
             <ui:param name="versionHasTabular" value="#{DatasetPage.versionHasTabular}"/>
@@ -56,7 +57,8 @@
                                                               and !DatasetPage.datasetLockedInWorkflow
                                                               and DatasetPage.dataset.latestVersion.versionState=='DRAFT'
                                                               and canUpdateDataset
-                                                              and !canIssuePublishDatasetCommand}"/>
+                                                              and !canIssuePublishDatasetCommand
+                                                              and canIssueSubmitDatasetForReviewCommand}"/>
             <ui:param name="showReturnToAuthorLink" value="#{DatasetPage.dataset.latestVersion.versionState=='DRAFT' and latestVersionInReview
                                                              and canIssuePublishDatasetCommand}"/>
             <ui:param name="showAccessDatasetButtonGroup" value="#{(canDownloadFiles or versionHasGlobus)
@@ -358,7 +360,7 @@
                                             <!-- END: DOWNLOAD/ACCESS DATASET -->
 
                                             <!-- PUBLISH DATASET -->
-                                            <div class="btn-group btn-group-justified" jsf:rendered="#{showPublishLink or showSubmitForReviewLink}">
+                                            <div class="btn-group btn-group-justified" jsf:rendered="#{showSubmitForReviewLink or showReturnToAuthorLink or showPublishLink or latestVersionInReview}">
                                                 <div class="btn-group">
                                                     <!-- Publish BTN -->
                                                     <h:outputLink value="#" disabled="#{DatasetPage.lockedFromPublishing or !DatasetPage.hasValidTermsOfAccess or !valid}">
@@ -372,7 +374,7 @@
                                                             <f:passThroughAttribute name="aria-haspopup" value="true"/>
                                                             <f:passThroughAttribute name="aria-expanded" value="false"/>
                                                         </c:if>
-                                                        #{showPublishLink ? bundle['dataset.publishBtn'] : (latestVersionInReview ? bundle['dataset.disabledSubmittedBtn'] : bundle['dataset.submitBtn'])} <span jsf:rendered="#{(showSubmitForReviewLink or showReturnToAuthorLink) and showPublishLink}" class="caret"></span>
+                                                        #{showPublishLink ? bundle['dataset.publishBtn'] : (latestVersionInReview ? bundle['dataset.disabledSubmittedBtn'] : bundle['dataset.submitBtn'])} <span jsf:rendered="#{(showSubmitForReviewLink or showReturnToAuthorLink or showPublishLink or latestVersionInReview)}" class="caret"></span>
                                                     </h:outputLink>
                                                     <!-- Publish BTN DROPDOWN-MENU OPTIONS -->
                                                     <ul class="dropdown-menu pull-right text-left">

--- a/src/test/java/edu/harvard/iq/dataverse/api/DatasetsIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/DatasetsIT.java
@@ -6868,10 +6868,22 @@ createDataset = UtilIT.createRandomDatasetViaNativeApi(dataverse1Alias, apiToken
         String pathToFile = "src/main/webapp/resources/images/dataverseproject.png";
         Response uploadResponse = UtilIT.uploadFileViaNative(String.valueOf(id), pathToFile, apiToken);
         uploadResponse.then().assertThat().statusCode(OK.getStatusCode());
+        Integer fileId = UtilIT.getDataFileIdFromResponse(uploadResponse);
 
         publishDatasetResponse = UtilIT.publishDatasetViaNativeApi(String.valueOf(id), "major", apiToken);
         publishDatasetResponse.prettyPrint();
         publishDatasetResponse.then().assertThat().statusCode(OK.getStatusCode());
+
+        // Remove the file and try to publish again. Dataset still has a file but the new version has none
+        Response deleteResponse = UtilIT.deleteFileInDataset(fileId, apiToken);
+        deleteResponse.prettyPrint();
+        deleteResponse.then().assertThat().statusCode(OK.getStatusCode());
+
+        publishDatasetResponse = UtilIT.publishDatasetViaNativeApi(String.valueOf(id), "major", apiToken);
+        publishDatasetResponse.prettyPrint();
+        publishDatasetResponse.then().assertThat()
+                .statusCode(FORBIDDEN.getStatusCode())
+                .body("message", containsString( BundleUtil.getStringFromBundle("dataset.mayNotPublish.FilesRequired")));
     }
     
     @Test

--- a/src/test/java/edu/harvard/iq/dataverse/api/InReviewWorkflowIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/InReviewWorkflowIT.java
@@ -1,12 +1,12 @@
 package edu.harvard.iq.dataverse.api;
 
+import edu.harvard.iq.dataverse.util.BundleUtil;
 import io.restassured.RestAssured;
 import io.restassured.path.json.JsonPath;
 import io.restassured.path.xml.XmlPath;
 import io.restassured.response.Response;
 import edu.harvard.iq.dataverse.authorization.DataverseRole;
 import jakarta.json.Json;
-import jakarta.json.JsonArray;
 import jakarta.json.JsonObjectBuilder;
 
 import static edu.harvard.iq.dataverse.UserNotification.Type.*;
@@ -478,4 +478,60 @@ public class InReviewWorkflowIT {
 
     }
 
+    @Test
+    public void testRequireFilesToSubmitDatasetForReview() {
+        // create dataverse owner and dataset creator
+        Response superUser = UtilIT.createRandomUser();
+        superUser.prettyPrint();
+        superUser.then().assertThat()
+                .statusCode(OK.getStatusCode());
+        String username = UtilIT.getUsernameFromResponse(superUser);
+        String superUserApiToken = UtilIT.getApiTokenFromResponse(superUser);
+        Response makeSuperUserResponse = UtilIT.setSuperuserStatus(username, true);
+        makeSuperUserResponse.then().assertThat()
+                .statusCode(OK.getStatusCode());
+
+        Response createCurator = UtilIT.createRandomUser();
+        createCurator.prettyPrint();
+        createCurator.then().assertThat()
+                .statusCode(OK.getStatusCode());
+        String authorUsername = UtilIT.getUsernameFromResponse(createCurator);
+        String apiToken = UtilIT.getApiTokenFromResponse(createCurator);
+
+        // Create the dataverse and set it to require files to publish and submit for review
+        Response createDataverseResponse = UtilIT.createRandomDataverse(superUserApiToken);
+        createDataverseResponse.prettyPrint();
+        createDataverseResponse.then().assertThat()
+                .statusCode(CREATED.getStatusCode());
+
+        String dataverseAlias = UtilIT.getAliasFromResponse(createDataverseResponse);
+
+        Response setDataverseAttributeResponse = UtilIT.setCollectionAttribute(dataverseAlias, "requireFilesToPublishDataset", "true", superUserApiToken);
+        setDataverseAttributeResponse.prettyPrint();
+        setDataverseAttributeResponse.then().assertThat()
+                .statusCode(OK.getStatusCode());
+
+        // grant role to dataset creator to be able to create a dataset in the dataverse
+        Response grantAuthorAddDataset = UtilIT.grantRoleOnDataverse(dataverseAlias, DataverseRole.DS_CONTRIBUTOR.toString(), "@" + authorUsername, superUserApiToken);
+        grantAuthorAddDataset.prettyPrint();
+        grantAuthorAddDataset.then().assertThat()
+                .body("data.assignee", equalTo("@" + authorUsername))
+                .body("data._roleAlias", equalTo("dsContributor"))
+                .statusCode(OK.getStatusCode());
+
+        // Create a dataset with no files
+        Response createDataset = UtilIT.createRandomDatasetViaNativeApi(dataverseAlias, apiToken);
+        createDataset.prettyPrint();
+        createDataset.then().assertThat()
+                .statusCode(CREATED.getStatusCode());
+
+        String datasetPersistentId = UtilIT.getDatasetPersistentIdFromResponse(createDataset);
+
+        // Submit for review with no data files
+        Response submitForReview = UtilIT.submitDatasetForReview(datasetPersistentId, apiToken);
+        submitForReview.prettyPrint();
+        submitForReview.then().assertThat()
+                .statusCode(FORBIDDEN.getStatusCode())
+                .body("message", equalTo(BundleUtil.getStringFromBundle("dataset.mayNotSubmitForReview.FilesRequired")));
+    }
 }


### PR DESCRIPTION

**What this PR does / why we need it**:
Per https://github.com/IQSS/dataverse/issues/10981 a dataset should not be publishable if it contains no files. This issue should check the number of files in the Dataset version and not the total number of files in the dataset.
This is only an issue when the attribute 'requireFilesToPublishDataset' is set

**Which issue(s) this PR closes**:https://github.com/IQSS/dataverse/issues/12258

- Closes #12258

**Special notes for your reviewer**:

**Suggestions on how to test this**:

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
Submit for review button on JSF UI Dataset Page will be hidden if no files are contained in the Dataset Version

requireFilesToPublishDataset set to true
<img width="1160" height="560" alt="image" src="https://github.com/user-attachments/assets/f06f48e0-276a-4d79-ba16-e6518a5dad0a" />

requireFilesToPublishDataset set to false
<img width="1163" height="555" alt="image" src="https://github.com/user-attachments/assets/78a8999f-c8b2-4a04-bb88-658751d29e6c" />



**Is there a release notes update needed for this change?**: Included

**Additional documentation**: changelog
