### PR TITLE
Added Dataset.getGlobalIdForFileStorage for direct upload URLs that support legacy lowercase DOIs

### DIFF
--- a/doc/release-notes/12268-direct-upload-support-legacy-lowercase-dois.md
+++ b/doc/release-notes/12268-direct-upload-support-legacy-lowercase-dois.md
@@ -1,1 +1,1 @@
-Fixed a problem with S3 direct upload to older datasets which still contain lowercase letters in the database.
+Fixed a problem with S3 direct upload to datasets which using lower- or mixed-case PID authority/identifier in the database and to datasets using an alternative identifier for file storage.

--- a/doc/release-notes/12268-direct-upload-support-legacy-lowercase-dois.md
+++ b/doc/release-notes/12268-direct-upload-support-legacy-lowercase-dois.md
@@ -1,0 +1,1 @@
+Fixed a problem with S3 direct upload to older datasets which still contain lowercase letters in the database.

--- a/src/main/java/edu/harvard/iq/dataverse/Dataset.java
+++ b/src/main/java/edu/harvard/iq/dataverse/Dataset.java
@@ -662,7 +662,7 @@ public class Dataset extends DvObjectContainer {
         return retVal;         
     }
 
-    public String getGlobalIdForFileStorage() {
+    public String getGlobalIdForFileStorageAsString() {
         return getProtocolForFileStorage() + ":" + getAuthorityForFileStorage() + "/" + getIdentifierForFileStorage();
     }
 

--- a/src/main/java/edu/harvard/iq/dataverse/Dataset.java
+++ b/src/main/java/edu/harvard/iq/dataverse/Dataset.java
@@ -662,6 +662,10 @@ public class Dataset extends DvObjectContainer {
         return retVal;         
     }
 
+    public String getGlobalIdForFileStorage() {
+        return getProtocolForFileStorage() + ":" + getAuthorityForFileStorage() + "/" + getIdentifierForFileStorage();
+    }
+
     public String getNextMajorVersionString() {
         // Never need to get the next major version for harvested studies.
         if (isHarvested()) {

--- a/src/main/java/edu/harvard/iq/dataverse/EditDatafilesPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/EditDatafilesPage.java
@@ -1706,7 +1706,7 @@ public class EditDatafilesPage implements java.io.Serializable {
         String storageIdentifier = null;
         try {
             storageIdentifier = FileUtil.getStorageIdentifierFromLocation(s3io.getStorageLocation());
-            urls = s3io.generateTemporaryS3UploadUrls(dataset.getGlobalIdForFileStorage(), storageIdentifier, fileSize);
+            urls = s3io.generateTemporaryS3UploadUrls(dataset.getGlobalIdForFileStorageAsString(), storageIdentifier, fileSize);
 
         } catch (IOException io) {
             logger.warning(io.getMessage());

--- a/src/main/java/edu/harvard/iq/dataverse/EditDatafilesPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/EditDatafilesPage.java
@@ -1706,7 +1706,7 @@ public class EditDatafilesPage implements java.io.Serializable {
         String storageIdentifier = null;
         try {
             storageIdentifier = FileUtil.getStorageIdentifierFromLocation(s3io.getStorageLocation());
-            urls = s3io.generateTemporaryS3UploadUrls(dataset.getGlobalId().asString(), storageIdentifier, fileSize);
+            urls = s3io.generateTemporaryS3UploadUrls(dataset.getGlobalIdForFileStorage(), storageIdentifier, fileSize);
 
         } catch (IOException io) {
             logger.warning(io.getMessage());

--- a/src/main/java/edu/harvard/iq/dataverse/api/Datasets.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Datasets.java
@@ -2798,7 +2798,7 @@ public class Datasets extends AbstractApiBean {
             String storageIdentifier = null;
             try {
                 storageIdentifier = FileUtil.getStorageIdentifierFromLocation(s3io.getStorageLocation());
-                response = s3io.generateTemporaryS3UploadUrls(dataset.getGlobalIdForFileStorage(), storageIdentifier, fileSize);
+                response = s3io.generateTemporaryS3UploadUrls(dataset.getGlobalIdForFileStorageAsString(), storageIdentifier, fileSize);
 
             } catch (IOException io) {
                 logger.warning(io.getMessage());

--- a/src/main/java/edu/harvard/iq/dataverse/api/Datasets.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Datasets.java
@@ -2798,7 +2798,7 @@ public class Datasets extends AbstractApiBean {
             String storageIdentifier = null;
             try {
                 storageIdentifier = FileUtil.getStorageIdentifierFromLocation(s3io.getStorageLocation());
-                response = s3io.generateTemporaryS3UploadUrls(dataset.getGlobalId().asString(), storageIdentifier, fileSize);
+                response = s3io.generateTemporaryS3UploadUrls(dataset.getGlobalIdForFileStorage(), storageIdentifier, fileSize);
 
             } catch (IOException io) {
                 logger.warning(io.getMessage());


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds `Dataset.getGlobalIdForFileStorage()` and uses it in the calls to `s3io.generateTemporaryS3UploadUrls()` instead of `Dataset.getGlobalId().toString()`. When Dataverse contains datasets with DOIs which were added before Dataverse started enforcing uppercase DOIs, the upload URLs didn't match the actually keys in the object store for those datasets, causing direct upload to fail at the "completion" step (with multi-part uploads, not sure if single part uploads failed). This changed fixes the problem.

**Which issue(s) this PR closes**:
N/a

**Special notes for your reviewer**:
I have tested this with new datasets (all uppercase DOIs) and with legacy DOIs from our system, which contain lowercase letters. Both work. I have only been able to test through the API, although the UI-code has also been updated.

**Suggestions on how to test this**:
(Jim:) Minimally, one could edit the db to set a dataset identifier to lower/mixed case. (Not sure if using a lower case shoulder still results in a lowercase entry in the db.) One could also find/configure a dataset with an alternate identifier and configure it for use in file storage. In either case, direct uploads via the UI should work. Same for the API but in that case one could also inspect the results of the /api/datasets/{id}/uploadurls call and verify that the case used in the abort and complete URLs match the URLs for parts w.r.t. case.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
No

**Is there a release notes update needed for this change?**:
See: https://github.com/IQSS/dataverse/pull/12268/changes#diff-3187604c28e828f652f43814550e9271409b81a62db28527c71fdd3c08cf9344

**Additional documentation**:
N/a