### PR TITLE
Add usage and response counts to get guestbooks list

### DIFF
--- a/doc/release-notes/12260-get-guestbook-with-usage-and-response-counts.md
+++ b/doc/release-notes/12260-get-guestbook-with-usage-and-response-counts.md
@@ -1,3 +1,2 @@
 ## API Enhancement
-API call to `/api/guestbooks/{dataverseAlias}/list` will now include `"usageCount":#` and `"responseCount":#` in the response.
-By adding the query param "ignoreStats=true" these values can be excluded for faster response.
+API call to `/api/guestbooks/{dataverseAlias}/list` can now include `"usageCount":#` and `"responseCount":#` in the response by adding the query param "includeStats=true".

--- a/doc/release-notes/12260-get-guestbook-with-usage-and-response-counts.md
+++ b/doc/release-notes/12260-get-guestbook-with-usage-and-response-counts.md
@@ -1,0 +1,3 @@
+## API Enhancement
+API call to `/api/guestbooks/{dataverseAlias}/list` will now include `"usageCount":#` and `"responseCount":#` in the response.
+By adding the query param "ignoreStats=true" these values can be excluded for faster response.

--- a/doc/sphinx-guides/source/api/native-api.rst
+++ b/doc/sphinx-guides/source/api/native-api.rst
@@ -1239,6 +1239,8 @@ The fully expanded example above (without environment variables) looks like this
 
   curl -H "X-Dataverse-key:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" "https://demo.dataverse.org/api/guestbooks/root/list"
 
+.. note:: By adding the query param "ignoreStats=true" `usageCount` and `responseCount` values can be excluded for faster response.
+
 Get a Guestbook for a Dataverse Collection
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/doc/sphinx-guides/source/api/native-api.rst
+++ b/doc/sphinx-guides/source/api/native-api.rst
@@ -1239,7 +1239,7 @@ The fully expanded example above (without environment variables) looks like this
 
   curl -H "X-Dataverse-key:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" "https://demo.dataverse.org/api/guestbooks/root/list"
 
-.. note:: By adding the query param "ignoreStats=true" `usageCount` and `responseCount` values can be excluded for faster response.
+.. note:: By adding the query param "includeStats=true" `usageCount` and `responseCount` values can be added to the response.
 
 Get a Guestbook for a Dataverse Collection
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/main/java/edu/harvard/iq/dataverse/api/Guestbooks.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Guestbooks.java
@@ -60,7 +60,7 @@ public class Guestbooks extends AbstractApiBean {
     @GET
     @AuthRequired
     @Path("{identifier}/list")
-    public Response getGuestbooks(@Context ContainerRequestContext crc, @PathParam("identifier") String identifier, @QueryParam("ignoreStats") boolean ignoreStats) {
+    public Response getGuestbooks(@Context ContainerRequestContext crc, @PathParam("identifier") String identifier, @QueryParam("includeStats") boolean includeStats) {
         return response( req -> {
             Dataverse dataverse = findDataverseOrDie(identifier);
             final Long dataverseId = dataverse.getId();
@@ -71,8 +71,7 @@ public class Guestbooks extends AbstractApiBean {
             JsonArrayBuilder guestbookArray = Json.createArrayBuilder();
             JsonPrinter jsonPrinter = new JsonPrinter();
             for (Guestbook gb : guestbooks) {
-                // default is to include the stats. Ignore the stats for a faster reply if they are not needed
-                if (!ignoreStats) {
+                if (includeStats) {
                     gb.setUsageCount(guestbookService.findCountUsages(gb.getId(), dataverseId));
                     gb.setResponseCount(guestbookResponseService.findCountByGuestbookId(gb.getId(), dataverseId));
                 }

--- a/src/main/java/edu/harvard/iq/dataverse/api/Guestbooks.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Guestbooks.java
@@ -2,6 +2,7 @@ package edu.harvard.iq.dataverse.api;
 
 import edu.harvard.iq.dataverse.Dataverse;
 import edu.harvard.iq.dataverse.Guestbook;
+import edu.harvard.iq.dataverse.GuestbookResponseServiceBean;
 import edu.harvard.iq.dataverse.GuestbookServiceBean;
 import edu.harvard.iq.dataverse.api.auth.AuthRequired;
 import edu.harvard.iq.dataverse.authorization.Permission;
@@ -38,6 +39,8 @@ public class Guestbooks extends AbstractApiBean {
 
     @EJB
     GuestbookServiceBean guestbookService;
+    @EJB
+    GuestbookResponseServiceBean guestbookResponseService;
 
     @GET
     @AuthRequired
@@ -57,9 +60,10 @@ public class Guestbooks extends AbstractApiBean {
     @GET
     @AuthRequired
     @Path("{identifier}/list")
-    public Response getGuestbooks(@Context ContainerRequestContext crc, @PathParam("identifier") String identifier) {
+    public Response getGuestbooks(@Context ContainerRequestContext crc, @PathParam("identifier") String identifier, @QueryParam("ignoreStats") boolean ignoreStats) {
         return response( req -> {
             Dataverse dataverse = findDataverseOrDie(identifier);
+            final Long dataverseId = dataverse.getId();
             if (!permissionSvc.request(req).on(dataverse).has(Permission.EditDataverse)) {
                 return error(Response.Status.FORBIDDEN, "Not authorized");
             }
@@ -67,6 +71,11 @@ public class Guestbooks extends AbstractApiBean {
             JsonArrayBuilder guestbookArray = Json.createArrayBuilder();
             JsonPrinter jsonPrinter = new JsonPrinter();
             for (Guestbook gb : guestbooks) {
+                // default is to include the stats. Ignore the stats for a faster reply if they are not needed
+                if (!ignoreStats) {
+                    gb.setUsageCount(guestbookService.findCountUsages(gb.getId(), dataverseId));
+                    gb.setResponseCount(guestbookResponseService.findCountByGuestbookId(gb.getId(), dataverseId));
+                }
                 guestbookArray.add(jsonPrinter.json(gb));
             }
             return ok(guestbookArray);

--- a/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
@@ -423,6 +423,12 @@ public class JsonPrinter {
             guestbookObject.add("nameRequired", guestbook.isNameRequired());
             guestbookObject.add("institutionRequired", guestbook.isInstitutionRequired());
             guestbookObject.add("positionRequired", guestbook.isPositionRequired());
+            if (guestbook.getUsageCount() != null) {
+                guestbookObject.add("usageCount", guestbook.getUsageCount());
+            }
+            if (guestbook.getResponseCount() != null) {
+                guestbookObject.add("responseCount", guestbook.getResponseCount());
+            }
             JsonArrayBuilder customQuestions = Json.createArrayBuilder();
             if (guestbook.getCustomQuestions() != null) {
                 for (CustomQuestion cq : guestbook.getCustomQuestions()) {

--- a/src/test/java/edu/harvard/iq/dataverse/api/FilesIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/FilesIT.java
@@ -4062,7 +4062,7 @@ public class FilesIT {
         assertEquals(OK.getStatusCode(), signedUrlResponse.getStatusCode());
 
         // Verify that the guestbook has proper stats
-        Response guestbookListResponse = UtilIT.getGuestbooks(dataverseAlias, ownerApiToken);
+        Response guestbookListResponse = UtilIT.getGuestbooks(dataverseAlias, ownerApiToken, true);
         guestbookListResponse.prettyPrint();
         guestbookListResponse.then().assertThat()
                 .statusCode(OK.getStatusCode())

--- a/src/test/java/edu/harvard/iq/dataverse/api/FilesIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/FilesIT.java
@@ -3983,6 +3983,7 @@ public class FilesIT {
                 .statusCode(BAD_REQUEST.getStatusCode());
         String guestbookResponseForGuest = guestbookResponse.replace("\"guestbookResponse\": {",
                 "\"guestbookResponse\": { \"name\":\"My Name\", \"email\":\"myemail@example.com\", \"position\":\"My Position\", \"institution\":\"My Institution\",");
+
         // With GuestbookResponse. Guest user doesn't have the required Name, etc. So we will add those to the Guestbook Response
         downloadResponse = UtilIT.postDownloadFile(fileId4, guestbookResponseForGuest);
         downloadResponse.prettyPrint();
@@ -4007,6 +4008,12 @@ public class FilesIT {
         downloadResponse.then().assertThat()
                 .statusCode(OK.getStatusCode());
         signedUrl = UtilIT.getSignedUrlFromResponse(downloadResponse);
+
+        // Verify that the Guestbook Response is persisted
+        Response guestbookResponseResponse = UtilIT.getGuestbookResponses(dataverseAlias, guestbook.getId(), ownerApiToken);
+        guestbookResponseResponse.then().assertThat()
+                .statusCode(OK.getStatusCode());
+        assertTrue(guestbookResponseResponse.prettyPrint().contains("What color car do you drive,Yellow"));
 
         // Download the file using the signed url
         signedUrlResponse = get(signedUrl);
@@ -4053,6 +4060,14 @@ public class FilesIT {
         signedUrl = UtilIT.getSignedUrlFromResponse(downloadResponse);
         signedUrlResponse = get(signedUrl);
         assertEquals(OK.getStatusCode(), signedUrlResponse.getStatusCode());
+
+        // Verify that the guestbook has proper stats
+        Response guestbookListResponse = UtilIT.getGuestbooks(dataverseAlias, ownerApiToken);
+        guestbookListResponse.prettyPrint();
+        guestbookListResponse.then().assertThat()
+                .statusCode(OK.getStatusCode())
+                .body("data[0].usageCount", is(1))
+                .body("data[0].responseCount", is(16));
     }
 
     @Test

--- a/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
@@ -612,9 +612,13 @@ public class UtilIT {
     }
 
     static Response getGuestbooks(String dataverseAlias, String apiToken) {
+        return getGuestbooks(dataverseAlias, apiToken, false);
+    }
+    static Response getGuestbooks(String dataverseAlias, String apiToken, boolean includeStats) {
+        String params = "?includeStats=" + includeStats;
         RequestSpecification requestSpec = given()
                 .header(API_TOKEN_HTTP_HEADER, apiToken);
-        return requestSpec.get("/api/guestbooks/" + dataverseAlias + "/list" );
+        return requestSpec.get("/api/guestbooks/" + dataverseAlias + "/list" + params );
     }
 
     static Response enableGuestbook(String dataverseAlias, Long guestbookId, String apiToken, String enable) {

--- a/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
@@ -1267,7 +1267,9 @@ public class UtilIT {
 
     static Response getDownloadFileUrlWithGuestbookResponse(Integer fileId, String apiToken, String body) {
         RequestSpecification requestSpecification = given();
-        requestSpecification.header(API_TOKEN_HTTP_HEADER, apiToken);
+        if (apiToken != null) {
+            requestSpecification.header(API_TOKEN_HTTP_HEADER, apiToken);
+        }
         if (body != null) {
             requestSpecification.body(body);
         }


### PR DESCRIPTION
**What this PR does / why we need it**:Currently, the GET Guestbook API returns metadata about guestbooks (e.g., name, required fields, custom questions), but it does not include usage and responses, needed for Manage Guestbooks table

**Which issue(s) this PR closes**:https://github.com/IQSS/dataverse/issues/12260

- Closes #12260

**Special notes for your reviewer**:

**Suggestions on how to test this**:

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**: Included

**Additional documentation**:
