### PR TITLE
Switching to the DataCite REST API for retrieving registration metadata 

### DIFF
--- a/doc/release-notes/12070-datacite-getmetadata.md
+++ b/doc/release-notes/12070-datacite-getmetadata.md
@@ -1,4 +1,4 @@
-Incremental improvements have been made to the process of registering dataset metadata with DataCite. If your instance is using DataCite, please make sure you have the DataCite REST API url configured, since it is now required.
+Incremental improvements have been made to the process of registering dataset metadata with DataCite. If your instance is using DataCite, please make sure you have a valid DataCite REST API url configured, since it is now required.
 
 The JVM option(s) in question are `dataverse.pid.*.datacite.rest-api-url` if the recommended, new-style pid configuration is used, or `doi.dataciterestapiurlstring` if the legacy settings are in place. In the latter case however, this may be a good occasion to switch to the new configuration setup.
 

--- a/doc/release-notes/12070-datacite-getmetadata.md
+++ b/doc/release-notes/12070-datacite-getmetadata.md
@@ -1,0 +1,11 @@
+Incremental improvements have been made to the process of registering dataset metadata with DataCite. If your instance is using DataCite, please make sure you have the DataCite REST API url configured, since it is now required.
+
+The JVM option(s) in question are `dataverse.pid.*.datacite.rest-api-url` if the recommended, new-style pid configuration is used, or `doi.dataciterestapiurlstring` if the legacy settings are in place. In the latter case however, this may be a good occasion to switch to the new configuration setup.
+
+For instances using registered DataCite authorities in production the url should be:
+
+```<jvm-options>-Ddataverse.pid.<providername>.datacite.rest-api-url=https://api.datacite.org</jvm-options>```
+
+Or, for test and development instances:
+
+```<jvm-options>-Ddataverse.pid.<providername>.datacite.rest-api-url=https://api.test.datacite.org</jvm-options>```

--- a/src/main/java/edu/harvard/iq/dataverse/pidproviders/doi/datacite/DOIDataCiteRegisterService.java
+++ b/src/main/java/edu/harvard/iq/dataverse/pidproviders/doi/datacite/DOIDataCiteRegisterService.java
@@ -87,7 +87,7 @@ public class DOIDataCiteRegisterService {
         String currentMetadata = null;
         boolean hasDifferences = false;
         try {
-            currentMetadata = client.getMetadataViaRestApi(bareIdentifier);
+            currentMetadata = client.getMetadata(bareIdentifier);
             Diff myDiff = DiffBuilder.compare(xmlMetadata).withTest(currentMetadata).ignoreWhitespace().checkForSimilar()
                     .build();
             hasDifferences = myDiff.hasDifferences();

--- a/src/main/java/edu/harvard/iq/dataverse/pidproviders/doi/datacite/DOIDataCiteRegisterService.java
+++ b/src/main/java/edu/harvard/iq/dataverse/pidproviders/doi/datacite/DOIDataCiteRegisterService.java
@@ -42,10 +42,6 @@ public class DOIDataCiteRegisterService {
     //A singleton since it, and the httpClient in it can be reused.
     private DataCiteRESTfullClient client=null;
 
-    public DOIDataCiteRegisterService(String url, String username, String password) {
-            client = new DataCiteRESTfullClient(url, username, password);
-    }
-
     public DOIDataCiteRegisterService(String url, String restApiUrl, String username, String password) {
             client = new DataCiteRESTfullClient(url, restApiUrl, username, password);
     }

--- a/src/main/java/edu/harvard/iq/dataverse/pidproviders/doi/datacite/DOIDataCiteRegisterService.java
+++ b/src/main/java/edu/harvard/iq/dataverse/pidproviders/doi/datacite/DOIDataCiteRegisterService.java
@@ -46,6 +46,10 @@ public class DOIDataCiteRegisterService {
             client = new DataCiteRESTfullClient(url, username, password);
     }
 
+    public DOIDataCiteRegisterService(String url, String restApiUrl, String username, String password) {
+            client = new DataCiteRESTfullClient(url, restApiUrl, username, password);
+    }
+
     /**
      * This "reserveIdentifier" method is heavily based on the
      * "registerIdentifier" method below but doesn't, this one doesn't doesn't
@@ -80,13 +84,14 @@ public class DOIDataCiteRegisterService {
     
     public String reRegisterIdentifier(String identifier, Map<String, String> metadata, DvObject dvObject) throws IOException {
         String retString = "";
-        String numericIdentifier = identifier.substring(identifier.indexOf(":") + 1);
+        // "bare identifier" is the canonical pid with the "doi:" prefix stripped
+        String bareIdentifier = identifier.substring(identifier.indexOf(":") + 1);
         String xmlMetadata = getMetadataFromDvObject(identifier, metadata, dvObject);
         String target = metadata.get("_target");
         String currentMetadata = null;
         boolean hasDifferences = false;
         try {
-            currentMetadata = client.getMetadata(numericIdentifier);
+            currentMetadata = client.getMetadataViaRestApi(bareIdentifier);
             Diff myDiff = DiffBuilder.compare(xmlMetadata).withTest(currentMetadata).ignoreWhitespace().checkForSimilar()
                     .build();
             hasDifferences = myDiff.hasDifferences();
@@ -96,7 +101,7 @@ public class DOIDataCiteRegisterService {
                 }
             }
         } catch (RuntimeException e) {
-            logger.log(Level.INFO, "DOI " + numericIdentifier + " not registered with DataCite, registering now.");
+            logger.log(Level.INFO, "DOI " + bareIdentifier + " not registered with DataCite, registering now.");
             hasDifferences = true;
         }
 
@@ -106,13 +111,13 @@ public class DOIDataCiteRegisterService {
         String currentUrl = null;
         try {
             //May get a 204 if the DOI is still draft
-            currentUrl = client.getUrl(numericIdentifier);
+            currentUrl = client.getUrl(bareIdentifier);
         } catch (RuntimeException ex) {
-            logger.fine("Error getting Url for " + numericIdentifier + ": " + ex.getMessage());
+            logger.fine("Error getting Url for " + bareIdentifier + ": " + ex.getMessage());
         }
         if (!target.equals(currentUrl)) {
             logger.info("Updating target URL to " +  target);
-            client.postUrl(numericIdentifier, target);
+            client.postUrl(bareIdentifier, target);
             retString = retString + "url:\\r" + target;
 
         }

--- a/src/main/java/edu/harvard/iq/dataverse/pidproviders/doi/datacite/DataCiteDOIProvider.java
+++ b/src/main/java/edu/harvard/iq/dataverse/pidproviders/doi/datacite/DataCiteDOIProvider.java
@@ -59,7 +59,7 @@ public class DataCiteDOIProvider extends AbstractDOIProvider {
         this.apiUrl = apiUrl;
         this.username = username;
         this.password = password;
-        doiDataCiteRegisterService = new DOIDataCiteRegisterService(mdsUrl, username, password);
+        doiDataCiteRegisterService = new DOIDataCiteRegisterService(mdsUrl, apiUrl, username, password);
     }
 
     @Override
@@ -349,7 +349,7 @@ public class DataCiteDOIProvider extends AbstractDOIProvider {
                 logger.info(identifier + "updated: " + updated );
                 return true;
             } else {
-                logger.info("No updated needed for " + identifier);
+                logger.info("No update needed for " + identifier);
                 return false; //No update needed
             }
         } catch (Exception e) {

--- a/src/main/java/edu/harvard/iq/dataverse/pidproviders/doi/datacite/DataCiteRESTfullClient.java
+++ b/src/main/java/edu/harvard/iq/dataverse/pidproviders/doi/datacite/DataCiteRESTfullClient.java
@@ -220,7 +220,7 @@ public class DataCiteRESTfullClient implements Closeable {
     
     /**
      * getMetadataViaRestApi
-     * obtains registration metdata utilizing REST API instead of MDS. 
+     * obtains registration metadata utilizing REST API instead of MDS. 
      * This solves some known issues, see #12070 for details. 
      *
      * @param doi

--- a/src/main/java/edu/harvard/iq/dataverse/pidproviders/doi/datacite/DataCiteRESTfullClient.java
+++ b/src/main/java/edu/harvard/iq/dataverse/pidproviders/doi/datacite/DataCiteRESTfullClient.java
@@ -194,6 +194,13 @@ public class DataCiteRESTfullClient implements Closeable {
      * @return
      */
     public String getMetadata(String doi) {
+        // Try obtaining the metadata using the new, REST API:
+        try {
+            return getMetadataViaRestApi(doi);
+        } catch (RuntimeException rex) {
+            logger.warning("Failed to getMetadata via REST API for doi " + doi +", falling back to MDS");
+        }
+        
         HttpGet httpGet = new HttpGet(this.url + "/metadata/" + doi);
         httpGet.setHeader("Accept", "application/xml");
         try {

--- a/src/main/java/edu/harvard/iq/dataverse/pidproviders/doi/datacite/DataCiteRESTfullClient.java
+++ b/src/main/java/edu/harvard/iq/dataverse/pidproviders/doi/datacite/DataCiteRESTfullClient.java
@@ -220,7 +220,8 @@ public class DataCiteRESTfullClient implements Closeable {
     
     /**
      * getMetadataViaRestApi
-     * a temporary/dev. version of the method utilizing REST API instead of MDS
+     * obtains registration metdata utilizing REST API instead of MDS. 
+     * This solves some known issues, see #12070 for details. 
      *
      * @param doi
      * @return

--- a/src/main/java/edu/harvard/iq/dataverse/pidproviders/doi/datacite/DataCiteRESTfullClient.java
+++ b/src/main/java/edu/harvard/iq/dataverse/pidproviders/doi/datacite/DataCiteRESTfullClient.java
@@ -324,11 +324,11 @@ public class DataCiteRESTfullClient implements Closeable {
     }
 
     /**
-     * The main() method can be used to test the functionality on the command 
-     * line outside of Dataverse. 
-     * Un-comment out and modify the code below as needed. 
+     * The main() method can be used to test the functionality on the command
+     * line outside of Dataverse.
+     * Un-comment out and modify the code below as needed.
      * @param args
-     * @throws Exception 
+     * @throws Exception
      */
     public static void main(String[] args) throws Exception {
         String doi = "10.5072/DVN/274533";

--- a/src/main/java/edu/harvard/iq/dataverse/pidproviders/doi/datacite/DataCiteRESTfullClient.java
+++ b/src/main/java/edu/harvard/iq/dataverse/pidproviders/doi/datacite/DataCiteRESTfullClient.java
@@ -46,24 +46,14 @@ public class DataCiteRESTfullClient implements Closeable {
     private static final long RETRY_DELAY_MS = 10000; // 10 seconds
     
     private String url;
-    private String restApiUrl; 
+    private String restApiUrl;
     private CloseableHttpClient httpClient;
     private HttpClientContext context;
     private String encoding = "utf-8";
-    
-    public DataCiteRESTfullClient(String url, String username, String password) {
-        this.url = url;
-        context = HttpClientContext.create();
-        CredentialsProvider credsProvider = new BasicCredentialsProvider();
-        credsProvider.setCredentials(new AuthScope(null, -1), new UsernamePasswordCredentials(username, password));
-        context.setCredentialsProvider(credsProvider);
 
-        httpClient = HttpClients.createDefault();
-    }
-    
     public DataCiteRESTfullClient(String url, String restApiUrl, String username, String password) {
         this.url = url;
-        this.restApiUrl = restApiUrl; 
+        this.restApiUrl = restApiUrl;
         context = HttpClientContext.create();
         CredentialsProvider credsProvider = new BasicCredentialsProvider();
         credsProvider.setCredentials(new AuthScope(null, -1), new UsernamePasswordCredentials(username, password));
@@ -333,9 +323,16 @@ public class DataCiteRESTfullClient implements Closeable {
         }
     }
 
+    /**
+     * The main() method can be used to test the functionality on the command 
+     * line outside of Dataverse. 
+     * Un-comment out and modify the code below as needed. 
+     * @param args
+     * @throws Exception 
+     */
     public static void main(String[] args) throws Exception {
         String doi = "10.5072/DVN/274533";
-        DataCiteRESTfullClient client = new DataCiteRESTfullClient("https://mds.test.datacite.org", "DATACITE_TEST_USERNAME", "DATACITE_TEST_PASSWORD");
+        DataCiteRESTfullClient client = new DataCiteRESTfullClient("https://mds.test.datacite.org", "https://api.test.datacite.org", "DATACITE_TEST_USERNAME", "DATACITE_TEST_PASSWORD");
 //		System.out.println(client.getUrl(doi));
 //		System.out.println(client.getMetadata(doi));
 //        System.out.println(client.postMetadata(readAndClose("C:/Users/luopc/Desktop/datacite.xml", "utf-8")));

--- a/src/main/java/edu/harvard/iq/dataverse/pidproviders/doi/datacite/DataCiteRESTfullClient.java
+++ b/src/main/java/edu/harvard/iq/dataverse/pidproviders/doi/datacite/DataCiteRESTfullClient.java
@@ -8,6 +8,7 @@ package edu.harvard.iq.dataverse.pidproviders.doi.datacite;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.Base64;
 
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -26,10 +27,9 @@ import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
-
-
-
 import org.apache.http.util.EntityUtils;
+import edu.harvard.iq.dataverse.util.json.JsonUtil;
+import jakarta.json.JsonObject;
 
 /**
  * DataCiteRESTfullClient
@@ -46,12 +46,24 @@ public class DataCiteRESTfullClient implements Closeable {
     private static final long RETRY_DELAY_MS = 10000; // 10 seconds
     
     private String url;
+    private String restApiUrl; 
     private CloseableHttpClient httpClient;
     private HttpClientContext context;
     private String encoding = "utf-8";
     
     public DataCiteRESTfullClient(String url, String username, String password) {
         this.url = url;
+        context = HttpClientContext.create();
+        CredentialsProvider credsProvider = new BasicCredentialsProvider();
+        credsProvider.setCredentials(new AuthScope(null, -1), new UsernamePasswordCredentials(username, password));
+        context.setCredentialsProvider(credsProvider);
+
+        httpClient = HttpClients.createDefault();
+    }
+    
+    public DataCiteRESTfullClient(String url, String restApiUrl, String username, String password) {
+        this.url = url;
+        this.restApiUrl = restApiUrl; 
         context = HttpClientContext.create();
         CredentialsProvider credsProvider = new BasicCredentialsProvider();
         credsProvider.setCredentials(new AuthScope(null, -1), new UsernamePasswordCredentials(username, password));
@@ -206,6 +218,57 @@ public class DataCiteRESTfullClient implements Closeable {
         } catch (IOException ioe) {
             logger.log(Level.SEVERE, "IOException when get metadata", ioe);
             throw new RuntimeException("IOException when get metadata", ioe);
+        }
+    }
+    
+    /**
+     * getMetadataViaRestApi
+     * a temporary/dev. version of the method utilizing REST API instead of MDS
+     *
+     * @param doi
+     * @return
+     */
+    public String getMetadataViaRestApi(String doi) {
+        HttpGet httpGet = new HttpGet(this.restApiUrl + "/dois/" + doi);
+
+        try {
+            HttpResponse response = executeWithRetry(httpGet, "getMetadataViaRestApi");
+            String restApiRawData = EntityUtils.toString(response.getEntity(), encoding);
+            
+            logger.fine("REST API raw data: " + restApiRawData);
+            
+            if (response.getStatusLine().getStatusCode() != 200) {
+                String errMsg = "getMetadataViaRestApi, Response: " + response.getStatusLine().getStatusCode() + ", " + restApiRawData;
+                logger.log(Level.SEVERE, errMsg);
+                throw new RuntimeException(errMsg);
+            }
+
+            JsonObject restApiJson = JsonUtil.getJsonObject(restApiRawData);
+            String xmlEncoded = null; 
+            
+            JsonObject restApiJsonData = restApiJson.getJsonObject("data");
+            if (restApiJsonData != null) {
+                JsonObject restApiJsonAttributes = restApiJsonData.getJsonObject("attributes");
+                if (restApiJsonAttributes != null) {
+                    xmlEncoded = restApiJsonAttributes.getString("xml");
+                }
+            }
+            logger.fine("encoded XML entry: " + xmlEncoded);
+            
+            String metadata = null; // what we want to return, registration metadata in the XML format
+
+            if (xmlEncoded != null) {
+                // Stripping any newlines below may be unnecessary - it is likely
+                // always returned as a continuous string; but shouldn't hurt 
+                // either. 
+                metadata = new String(Base64.getDecoder().decode(xmlEncoded.replaceAll("[\\r\\n]", "")), encoding);
+            }
+            
+            logger.fine("decoded XML metadata: " + metadata);
+            return metadata;
+        } catch (IOException ioe) {
+            logger.log(Level.SEVERE, "IOException in getMetadataViaRestApi", ioe);
+            throw new RuntimeException("IOException in getMetadataViaRestAPi", ioe);
         }
     }
     


### PR DESCRIPTION
**What this PR does / why we need it**:

This is to address an issue with UTF8 characters when relying on the traditionally used MDS API, which results in unnecessary registration updates. See #12070. 

This is a very minimal, proof of concept implementation. It appears to be working for its intended purpose. 

**Which issue(s) this PR closes**:

- Closes #12070

**Special notes for your reviewer**:

As discussed during review, a release note has been added telling instances that having a valid REST API url configured is now a requirement. As an extra fail-safe `getMetadata()` will fall back to MDS if it cannot obtain the metadata via REST API. 

We do not have any tests covering DataCiteRESTfullClient and none are added in this PR. The only practical/useful way of testing this functionality I can think of is to make the RestAssured tests rely on a "real" (non-"fake") DataCite authority and test registering real DOIs. I am hesitant however to introduce another dependency on an external service in that suite. 

**Suggestions on how to test this**:

Can be easily tested on any dev. instance. But a _real_ test DataCite authority must be used ("fake" will not do, in other words), as in: 
```
        <jvm-options>-Ddataverse.pid.testdatacite.label=DataCite</jvm-options>
        <jvm-options>-Ddataverse.pid.testdatacite.type=datacite</jvm-options>
        <jvm-options>-Ddataverse.pid.testdatacite.authority=10.70122</jvm-options>
        <jvm-options>-Ddataverse.pid.testdatacite.shoulder=FK2/</jvm-options>
        <jvm-options>-Ddataverse.pid.testdatacite.datacite.mds-api-url=https://mds.test.datacite.org</jvm-options>
        <jvm-options>-Ddataverse.pid.testdatacite.datacite.rest-api-url=https://api.test.datacite.org</jvm-options>
        <jvm-options>-Ddataverse.pid.testdatacite.datacite.username=[REDACTED]</jvm-options>
        <jvm-options>-Ddataverse.pid.testdatacite.datacite.password=[REDACTED]</jvm-options>
```
reach out directly on slack if you don't have the username/password. 

Create a dataset; put something/anything in the description that has UTF8 characters in it. Like the `Universidade de Brasília` etc. in the issue description. 
Publish the dataset. Check on https://doi.test.datacite.org/repositories/gdcc.harvard-test and confirm that the DataCite registration has worked. (Keep in mind that these test DOIs do not redirect using the normal DOI resolver shown on the dataset page)

Enable FINE logging on 
```edu.harvard.iq.dataverse.pidproviders.doi.datacite.level=FINE```
Set ```<jvm-options>-Ddataverse.feature.only-update-datacite-when-needed=true</jvm-options>```, if not present, restart payara. 

Testing the "before" case, i.e. the develop branch or 6.10: 

run the `/modifyRegistrationMetadata` api on the dataset. 
You will see messages in the log indicating that the metadata needed to be updated (not true!) and that the DOI has been re-registered. There should be messages in the log indicating that the differences between the local metadata and (what it thinks) is registered w/ DataCite are due to the UTF8 characters in the fields. 

Testing "after", w/ this PR deployed: 

run `/modifyRegistrationMetadata`
You will see a confirmation in the log that the metadata registered with DataCite is already up-to-date, so there was no need to re-registger. 


**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
