### PR TITLE
add release date script

### DIFF
--- a/scripts/dev/release-dates/AGENTS.md
+++ b/scripts/dev/release-dates/AGENTS.md
@@ -1,0 +1,16 @@
+- Write the script in pure Python with no dependencies.
+- Work backward from the provided Release Date, which we prefer to be on a Wednesday.
+- Curation Team Review starts on the Monday prior. After the date, put "(allocate 5 full days)".
+- Code Freeze starts on the Thursday prior.
+- Core PR Last Call starts on the Thursday prior.
+- Community PR Last Call starts on the Thursday prior.
+- Start starts three months before the Release Date, on a Thursday. It's ok to put "??" for the sprint number.
+
+Here's some example output:
+
+- Start: Sprint ??, 2026-03-26
+- Community PR Last Call: 2026-05-21
+- Core PR Last Call: 2026-05-28
+- Code Freeze: 2026-06-04
+- Curation Team Review: 2026-06-08 (allocate 5 full days)
+- Release Date: 2026-06-17

--- a/scripts/dev/release-dates/generate_release_dates.py
+++ b/scripts/dev/release-dates/generate_release_dates.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+
+"""Generate release milestone dates from a release date."""
+
+from __future__ import annotations
+
+import sys
+from datetime import date, timedelta
+
+
+USAGE = "Usage: generate_release_dates.py YYYY-MM-DD"
+
+
+def parse_release_date(value: str) -> date:
+    try:
+        return date.fromisoformat(value)
+    except ValueError as exc:
+        raise SystemExit(f"Invalid date '{value}'. Expected YYYY-MM-DD.") from exc
+
+
+def previous_thursday(reference: date) -> date:
+    days_since_thursday = (reference.weekday() - 3) % 7
+    return reference - timedelta(days=days_since_thursday or 7)
+
+
+def build_schedule(release_date: date) -> list[tuple[str, str]]:
+    code_freeze = previous_thursday(release_date - timedelta(days=7))
+    core_pr_last_call = code_freeze - timedelta(days=7)
+    community_pr_last_call = core_pr_last_call - timedelta(days=7)
+    curation_team_review = code_freeze + timedelta(days=4)
+    start = community_pr_last_call - timedelta(days=56)
+
+    return [
+        ("Start", f"Sprint ??, {start.isoformat()}"),
+        ("Community PR Last Call", community_pr_last_call.isoformat()),
+        ("Core PR Last Call", core_pr_last_call.isoformat()),
+        ("Code Freeze", code_freeze.isoformat()),
+        (
+            "Curation Team Review",
+            f"{curation_team_review.isoformat()} (allocate 5 full days)",
+        ),
+        ("Release Date", release_date.isoformat()),
+    ]
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2 or argv[1] in {"-h", "--help"}:
+        print(USAGE, file=sys.stderr if len(argv) != 2 else sys.stdout)
+        return 1 if len(argv) != 2 else 0
+
+    release_date = parse_release_date(argv[1])
+
+    if release_date.weekday() != 2:
+        print(
+            "Warning: Release Date is usually expected to be a Wednesday.",
+            file=sys.stderr,
+        )
+
+    for label, value in build_schedule(release_date):
+        print(f"- {label}: {value}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))


### PR DESCRIPTION
**What this PR does / why we need it**:

We'd like a script to suggest dates tied to our release such as code freeze. We could have used it today here:

- https://github.com/IQSS/dataverse-pm/issues/537

**Special notes for your reviewer**:

I didn't ask Codex to consider US holidays, but we could. We would edit the rules in AGENTS.md and have it try again.

This is the prompt I used:

<img width="780" height="472" alt="Screenshot 2026-04-06 at 2 18 05 PM" src="https://github.com/user-attachments/assets/689db347-c3f1-4f45-af5e-394bcc786210" />

**Suggestions on how to test this**:

- Run the script without arguments
- Run it with various arguments.