### PR TITLE
Added support for HTML in JSF UI for file description

### DIFF
--- a/doc/release-notes/11397-support-html-in-file-level-description.md
+++ b/doc/release-notes/11397-support-html-in-file-level-description.md
@@ -1,0 +1,2 @@
+## Feature Request
+File metadata description will now support html in JSF UI. Is already supported in SPA.

--- a/src/main/webapp/editFilesFragment.xhtml
+++ b/src/main/webapp/editFilesFragment.xhtml
@@ -459,7 +459,7 @@
                                             <label class="control-label" for="fileDescription" style="margin-right:1em; margin-top:.5em; vertical-align:top;">
                                                 #{bundle.description}
                                             </label>
-                                            <p:inputTextarea id="fileDescription" rows="2" cols="40" value="#{fileMetadata.description}" style="width:60%; margin-top:.5em;"/> 
+                                            <p:inputTextarea id="fileDescription" rows="2" cols="40" value="#{MarkupChecker:sanitizeBasicHTML(fileMetadata.description)}" escape="false" style="width:60%; margin-top:.5em;"/>
                                             <p:watermark for="fileDescription" value="#{bundle['file.addDescription']}"/>
                                             <p:message for="fileDescription"/>
                                         </div>

--- a/src/main/webapp/editFilesFragment.xhtml
+++ b/src/main/webapp/editFilesFragment.xhtml
@@ -459,7 +459,7 @@
                                             <label class="control-label" for="fileDescription" style="margin-right:1em; margin-top:.5em; vertical-align:top;">
                                                 #{bundle.description}
                                             </label>
-                                            <p:inputTextarea id="fileDescription" rows="2" cols="40" value="#{MarkupChecker:sanitizeBasicHTML(fileMetadata.description)}" escape="false" style="width:60%; margin-top:.5em;"/>
+                                            <p:inputTextarea id="fileDescription" rows="2" cols="40" value="#{fileMetadata.description}" escape="false" style="width:60%; margin-top:.5em;"/>
                                             <p:watermark for="fileDescription" value="#{bundle['file.addDescription']}"/>
                                             <p:message for="fileDescription"/>
                                         </div>

--- a/src/main/webapp/file-info-fragment.xhtml
+++ b/src/main/webapp/file-info-fragment.xhtml
@@ -122,7 +122,7 @@
                 </div>
             </div>
             <div class="fileDescription small" jsf:rendered="#{hasDescription}">
-                <h:outputText id="fileDescNonEmpty" value="#{fileMetadata.description}"/>
+                <h:outputText id="fileDescNonEmpty" value="#{MarkupChecker:sanitizeBasicHTML(fileMetadata.description)}" escape="false"/>
             </div>
             <div class="file-tags-block" jsf:rendered="#{hasCategories or hasTags}">
                 <ui:repeat value="#{fileMetadata.categories}" var="cat">

--- a/src/main/webapp/file.xhtml
+++ b/src/main/webapp/file.xhtml
@@ -625,7 +625,7 @@
                                                         <th scope="row">
                                                             #{bundle['file.metadataTab.fileMetadata.description.label']}
                                                         </th>
-                                                        <td><h:outputFormat value="#{MarkupChecker:sanitizeAdvancedHTML(FilePage.fileMetadata.description)}" escape="false"></h:outputFormat></td>
+                                                        <td><h:outputFormat value="#{MarkupChecker:sanitizeBasicHTML(FilePage.fileMetadata.description)}" escape="false"></h:outputFormat></td>
                                                     </tr>
                                                 </tbody>
                                             </table>

--- a/src/main/webapp/file.xhtml
+++ b/src/main/webapp/file.xhtml
@@ -625,7 +625,7 @@
                                                         <th scope="row">
                                                             #{bundle['file.metadataTab.fileMetadata.description.label']}
                                                         </th>
-                                                        <td>#{FilePage.fileMetadata.description}</td>
+                                                        <td><h:outputFormat value="#{MarkupChecker:sanitizeAdvancedHTML(FilePage.fileMetadata.description)}" escape="false"></h:outputFormat></td>
                                                     </tr>
                                                 </tbody>
                                             </table>

--- a/src/main/webapp/search-include-fragment.xhtml
+++ b/src/main/webapp/search-include-fragment.xhtml
@@ -6,7 +6,8 @@
                 xmlns:p="http://primefaces.org/ui"
                 xmlns:o="http://omnifaces.org/ui"
                 xmlns:of="http://omnifaces.org/functions"
-                xmlns:jsf="http://xmlns.jcp.org/jsf" xmlns:Strings="http://omnifaces.org/functions">
+                xmlns:jsf="http://xmlns.jcp.org/jsf"
+                xmlns:Strings="http://omnifaces.org/functions">
 
     <c:set var="page" value="/dataverse/#{DataversePage.dataverse.alias}"/>
     <c:set var="cvocConf" value="#{settingsWrapper.getCVocConf(true)}"/>
@@ -539,7 +540,7 @@
 
                         <hr style="margin:.5em;border:0;"/>
 
-                        <h:outputText value="#{Strings:abbreviate(MarkupChecker:sanitizeBasicHTML(result.descriptionNoSnippet), descriptionAbbreviationThreshold)}" escape="false" rendered="#{result.descriptionSnippets.size() eq 0}"/>
+                        <h:outputText value="#{Strings:abbreviate(MarkupChecker:stripAllTags(result.descriptionNoSnippet), descriptionAbbreviationThreshold)}" escape="false" rendered="#{result.descriptionSnippets.size() eq 0}"/>
 
                         <ui:repeat value="#{result.descriptionSnippets}" var="snippet" varStatus="varStatus"
                                    rendered="#{result.descriptionSnippets.size() gt 0}">
@@ -607,7 +608,7 @@
                             <h:outputText value="#{result.citationHtml != null ? result.citationHtml : result.citation}" escape="false"/>
                         </div>
                         
-                        <h:outputText value="#{Strings:abbreviate(MarkupChecker:sanitizeBasicHTML(result.descriptionNoSnippet), descriptionAbbreviationThreshold)}" escape="false" rendered="#{result.descriptionSnippets.size() eq 0}"/>
+                        <h:outputText value="#{Strings:abbreviate(MarkupChecker:stripAllTags(result.descriptionNoSnippet), descriptionAbbreviationThreshold)}" escape="false" rendered="#{result.descriptionSnippets.size() eq 0}"/>
 
                         <ui:repeat value="#{result.descriptionSnippets}" var="snippet" varStatus="varStatus"
                                    rendered="#{result.descriptionSnippets.size() gt 0}">
@@ -721,7 +722,7 @@
                             </ui:repeat>
                         </div>
 
-                        <h:outputText value="#{Strings:abbreviate(MarkupChecker:sanitizeBasicHTML(result.descriptionNoSnippet), descriptionAbbreviationThreshold)}" escape="false" rendered="#{result.descriptionSnippets.size() eq 0}"/>
+                        <h:outputText value="#{Strings:abbreviate(MarkupChecker:stripAllTags(result.descriptionNoSnippet), descriptionAbbreviationThreshold)}" escape="false" rendered="#{result.descriptionSnippets.size() eq 0}"/>
 
                         <ui:repeat value="#{result.descriptionSnippets}" var="snippet" varStatus="varStatus"
                                    rendered="#{result.descriptionSnippets.size() gt 0}">

--- a/src/main/webapp/search-include-fragment.xhtml
+++ b/src/main/webapp/search-include-fragment.xhtml
@@ -1,12 +1,12 @@
 <ui:composition xmlns="http://www.w3.org/1999/xhtml"
-     xmlns:h="http://java.sun.com/jsf/html"
-     xmlns:f="http://java.sun.com/jsf/core"
-     xmlns:ui="http://java.sun.com/jsf/facelets"
-     xmlns:c="http://java.sun.com/jsp/jstl/core"
-     xmlns:p="http://primefaces.org/ui"
-     xmlns:o="http://omnifaces.org/ui"
-     xmlns:of="http://omnifaces.org/functions"
-     xmlns:jsf="http://xmlns.jcp.org/jsf">
+                xmlns:h="http://java.sun.com/jsf/html"
+                xmlns:f="http://java.sun.com/jsf/core"
+                xmlns:ui="http://java.sun.com/jsf/facelets"
+                xmlns:c="http://java.sun.com/jsp/jstl/core"
+                xmlns:p="http://primefaces.org/ui"
+                xmlns:o="http://omnifaces.org/ui"
+                xmlns:of="http://omnifaces.org/functions"
+                xmlns:jsf="http://xmlns.jcp.org/jsf" xmlns:Strings="http://omnifaces.org/functions">
 
     <c:set var="page" value="/dataverse/#{DataversePage.dataverse.alias}"/>
     <c:set var="cvocConf" value="#{settingsWrapper.getCVocConf(true)}"/>
@@ -539,7 +539,7 @@
 
                         <hr style="margin:.5em;border:0;"/>
 
-                        <h:outputText value="#{Strings:abbreviate(result.descriptionNoSnippet, descriptionAbbreviationThreshold)}" rendered="#{result.descriptionSnippets.size() eq 0}"/>
+                        <h:outputText value="#{Strings:abbreviate(MarkupChecker:sanitizeBasicHTML(result.descriptionNoSnippet), descriptionAbbreviationThreshold)}" escape="false" rendered="#{result.descriptionSnippets.size() eq 0}"/>
 
                         <ui:repeat value="#{result.descriptionSnippets}" var="snippet" varStatus="varStatus"
                                    rendered="#{result.descriptionSnippets.size() gt 0}">
@@ -607,7 +607,7 @@
                             <h:outputText value="#{result.citationHtml != null ? result.citationHtml : result.citation}" escape="false"/>
                         </div>
                         
-                        <h:outputText value="#{Strings:abbreviate(result.descriptionNoSnippet, descriptionAbbreviationThreshold)}" rendered="#{result.descriptionSnippets.size() eq 0}"/>
+                        <h:outputText value="#{Strings:abbreviate(MarkupChecker:sanitizeBasicHTML(result.descriptionNoSnippet), descriptionAbbreviationThreshold)}" escape="false" rendered="#{result.descriptionSnippets.size() eq 0}"/>
 
                         <ui:repeat value="#{result.descriptionSnippets}" var="snippet" varStatus="varStatus"
                                    rendered="#{result.descriptionSnippets.size() gt 0}">
@@ -721,7 +721,7 @@
                             </ui:repeat>
                         </div>
 
-                        <h:outputText value="#{Strings:abbreviate(result.descriptionNoSnippet, descriptionAbbreviationThreshold)}" rendered="#{result.descriptionSnippets.size() eq 0}"/>
+                        <h:outputText value="#{Strings:abbreviate(MarkupChecker:sanitizeBasicHTML(result.descriptionNoSnippet), descriptionAbbreviationThreshold)}" escape="false" rendered="#{result.descriptionSnippets.size() eq 0}"/>
 
                         <ui:repeat value="#{result.descriptionSnippets}" var="snippet" varStatus="varStatus"
                                    rendered="#{result.descriptionSnippets.size() gt 0}">


### PR DESCRIPTION
**What this PR does / why we need it**: SPA already supports html in file description field. JSF UI also needs this functionality.

**Which issue(s) this PR closes**: https://github.com/IQSS/dataverse/issues/11397

- Closes #11397

**Special notes for your reviewer**:

**Suggestions on how to test this**:

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

Before:

<img width="718" height="203" alt="image" src="https://github.com/user-attachments/assets/7d14e661-d173-4f56-b9ae-8b54f50b5b79" />

After:
<img width="762" height="318" alt="image" src="https://github.com/user-attachments/assets/7be07632-0918-4be0-8955-f6c27e438a54" />


**Is there a release notes update needed for this change?**: included

**Additional documentation**:
