### PR TITLE
bump Payara major/minor versions in installUtils.py

### DIFF
--- a/scripts/installer/installUtils.py
+++ b/scripts/installer/installUtils.py
@@ -57,7 +57,7 @@ def test_appserver_directory(directory):
 
         #print("version: major: "+str(major_version)+", minor: "+str(minor_version))
 
-        if major_version != 6 or minor_version < 2023:
+        if major_version != 7 or minor_version < 2026:
             return False
         return True
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Hard-coded major/minor version checks fail when installer is run manually.

**Which issue(s) this PR closes**:

- Closes #12321

**Special notes for your reviewer**:

just a version bump

**Suggestions on how to test this**:

run installer manually

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

no

**Is there a release notes update needed for this change?**:

no

**Additional documentation**:

none