### PR TITLE
change http back to https to make `mlcroissant validate` happy

### DIFF
--- a/doc/sphinx-guides/source/api/changelog.rst
+++ b/doc/sphinx-guides/source/api/changelog.rst
@@ -10,7 +10,7 @@ This API changelog is experimental and we would love feedback on its usefulness.
 v6.11
 -----
 
-- The Croissant :ref:`metadata export format <metadata-export-formats>` has been updated from version 1.0 to 1.1, which is reflected in the ``conformsTo`` property. ``@vocab`` and ``sc`` properties now use "http" as `recommended <https://github.com/mlcommons/croissant/pull/929#pullrequestreview-3079137662>`_. The unused ``wd`` property has been dropped.
+- The Croissant :ref:`metadata export format <metadata-export-formats>` has been updated from version 1.0 to 1.1, which is reflected in the ``conformsTo`` property. The unused ``wd`` property has been dropped.
 
 v6.10
 -----

--- a/src/main/java/edu/harvard/iq/dataverse/export/croissant/CroissantExportUtil.java
+++ b/src/main/java/edu/harvard/iq/dataverse/export/croissant/CroissantExportUtil.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 import org.apache.commons.text.StringEscapeUtils;
 
+// Validate with src/test/resources/croissant/validate.sh
 public class CroissantExportUtil {
 
     public static void exportDataset(
@@ -31,7 +32,7 @@ public class CroissantExportUtil {
             {
                 "@context": {
                     "@language": "en",
-                    "@vocab": "http://schema.org/",
+                    "@vocab": "https://schema.org/",
                     "citeAs": "cr:citeAs",
                     "column": "cr:column",
                     "conformsTo": "dct:conformsTo",
@@ -70,7 +71,7 @@ public class CroissantExportUtil {
                     "repeated": "cr:repeated",
                     "replace": "cr:replace",
                     "samplingRate": "cr:samplingRate",
-                    "sc": "http://schema.org/",
+                    "sc": "https://schema.org/",
                     "separator": "cr:separator",
                     "source": "cr:source",
                     "subField": "cr:subField",

--- a/src/test/resources/croissant/cars/expected/cars-croissant.json
+++ b/src/test/resources/croissant/cars/expected/cars-croissant.json
@@ -1,7 +1,7 @@
 {
     "@context": {
         "@language": "en",
-        "@vocab": "http://schema.org/",
+        "@vocab": "https://schema.org/",
         "citeAs": "cr:citeAs",
         "column": "cr:column",
         "conformsTo": "dct:conformsTo",
@@ -40,7 +40,7 @@
         "repeated": "cr:repeated",
         "replace": "cr:replace",
         "samplingRate": "cr:samplingRate",
-        "sc": "http://schema.org/",
+        "sc": "https://schema.org/",
         "separator": "cr:separator",
         "source": "cr:source",
         "subField": "cr:subField",

--- a/src/test/resources/croissant/cars/expected/cars-croissantSlim.json
+++ b/src/test/resources/croissant/cars/expected/cars-croissantSlim.json
@@ -1,7 +1,7 @@
 {
     "@context": {
         "@language": "en",
-        "@vocab": "http://schema.org/",
+        "@vocab": "https://schema.org/",
         "citeAs": "cr:citeAs",
         "column": "cr:column",
         "conformsTo": "dct:conformsTo",
@@ -40,7 +40,7 @@
         "repeated": "cr:repeated",
         "replace": "cr:replace",
         "samplingRate": "cr:samplingRate",
-        "sc": "http://schema.org/",
+        "sc": "https://schema.org/",
         "separator": "cr:separator",
         "source": "cr:source",
         "subField": "cr:subField",

--- a/src/test/resources/croissant/draft/expected/draft-croissant.json
+++ b/src/test/resources/croissant/draft/expected/draft-croissant.json
@@ -1,7 +1,7 @@
 {
     "@context": {
         "@language": "en",
-        "@vocab": "http://schema.org/",
+        "@vocab": "https://schema.org/",
         "citeAs": "cr:citeAs",
         "column": "cr:column",
         "conformsTo": "dct:conformsTo",
@@ -40,7 +40,7 @@
         "repeated": "cr:repeated",
         "replace": "cr:replace",
         "samplingRate": "cr:samplingRate",
-        "sc": "http://schema.org/",
+        "sc": "https://schema.org/",
         "separator": "cr:separator",
         "source": "cr:source",
         "subField": "cr:subField",

--- a/src/test/resources/croissant/draft/expected/draft-croissantSlim.json
+++ b/src/test/resources/croissant/draft/expected/draft-croissantSlim.json
@@ -1,7 +1,7 @@
 {
     "@context": {
         "@language": "en",
-        "@vocab": "http://schema.org/",
+        "@vocab": "https://schema.org/",
         "citeAs": "cr:citeAs",
         "column": "cr:column",
         "conformsTo": "dct:conformsTo",
@@ -40,7 +40,7 @@
         "repeated": "cr:repeated",
         "replace": "cr:replace",
         "samplingRate": "cr:samplingRate",
-        "sc": "http://schema.org/",
+        "sc": "https://schema.org/",
         "separator": "cr:separator",
         "source": "cr:source",
         "subField": "cr:subField",

--- a/src/test/resources/croissant/junk/expected/junk-croissant.json
+++ b/src/test/resources/croissant/junk/expected/junk-croissant.json
@@ -1,7 +1,7 @@
 {
     "@context": {
         "@language": "en",
-        "@vocab": "http://schema.org/",
+        "@vocab": "https://schema.org/",
         "citeAs": "cr:citeAs",
         "column": "cr:column",
         "conformsTo": "dct:conformsTo",
@@ -40,7 +40,7 @@
         "repeated": "cr:repeated",
         "replace": "cr:replace",
         "samplingRate": "cr:samplingRate",
-        "sc": "http://schema.org/",
+        "sc": "https://schema.org/",
         "separator": "cr:separator",
         "source": "cr:source",
         "subField": "cr:subField",

--- a/src/test/resources/croissant/max/expected/max-croissant.json
+++ b/src/test/resources/croissant/max/expected/max-croissant.json
@@ -1,7 +1,7 @@
 {
     "@context": {
         "@language": "en",
-        "@vocab": "http://schema.org/",
+        "@vocab": "https://schema.org/",
         "citeAs": "cr:citeAs",
         "column": "cr:column",
         "conformsTo": "dct:conformsTo",
@@ -40,7 +40,7 @@
         "repeated": "cr:repeated",
         "replace": "cr:replace",
         "samplingRate": "cr:samplingRate",
-        "sc": "http://schema.org/",
+        "sc": "https://schema.org/",
         "separator": "cr:separator",
         "source": "cr:source",
         "subField": "cr:subField",

--- a/src/test/resources/croissant/max/expected/max-croissantSlim.json
+++ b/src/test/resources/croissant/max/expected/max-croissantSlim.json
@@ -1,7 +1,7 @@
 {
     "@context": {
         "@language": "en",
-        "@vocab": "http://schema.org/",
+        "@vocab": "https://schema.org/",
         "citeAs": "cr:citeAs",
         "column": "cr:column",
         "conformsTo": "dct:conformsTo",
@@ -40,7 +40,7 @@
         "repeated": "cr:repeated",
         "replace": "cr:replace",
         "samplingRate": "cr:samplingRate",
-        "sc": "http://schema.org/",
+        "sc": "https://schema.org/",
         "separator": "cr:separator",
         "source": "cr:source",
         "subField": "cr:subField",

--- a/src/test/resources/croissant/minimal/expected/minimal-croissant.json
+++ b/src/test/resources/croissant/minimal/expected/minimal-croissant.json
@@ -1,7 +1,7 @@
 {
     "@context": {
         "@language": "en",
-        "@vocab": "http://schema.org/",
+        "@vocab": "https://schema.org/",
         "citeAs": "cr:citeAs",
         "column": "cr:column",
         "conformsTo": "dct:conformsTo",
@@ -40,7 +40,7 @@
         "repeated": "cr:repeated",
         "replace": "cr:replace",
         "samplingRate": "cr:samplingRate",
-        "sc": "http://schema.org/",
+        "sc": "https://schema.org/",
         "separator": "cr:separator",
         "source": "cr:source",
         "subField": "cr:subField",

--- a/src/test/resources/croissant/requirements.txt
+++ b/src/test/resources/croissant/requirements.txt
@@ -1,0 +1,1 @@
+mlcroissant==1.0.22

--- a/src/test/resources/croissant/restricted/expected/restricted-croissant.json
+++ b/src/test/resources/croissant/restricted/expected/restricted-croissant.json
@@ -1,7 +1,7 @@
 {
     "@context": {
         "@language": "en",
-        "@vocab": "http://schema.org/",
+        "@vocab": "https://schema.org/",
         "citeAs": "cr:citeAs",
         "column": "cr:column",
         "conformsTo": "dct:conformsTo",
@@ -40,7 +40,7 @@
         "repeated": "cr:repeated",
         "replace": "cr:replace",
         "samplingRate": "cr:samplingRate",
-        "sc": "http://schema.org/",
+        "sc": "https://schema.org/",
         "separator": "cr:separator",
         "source": "cr:source",
         "subField": "cr:subField",

--- a/src/test/resources/croissant/restricted/expected/restricted-croissantSlim.json
+++ b/src/test/resources/croissant/restricted/expected/restricted-croissantSlim.json
@@ -1,7 +1,7 @@
 {
     "@context": {
         "@language": "en",
-        "@vocab": "http://schema.org/",
+        "@vocab": "https://schema.org/",
         "citeAs": "cr:citeAs",
         "column": "cr:column",
         "conformsTo": "dct:conformsTo",
@@ -40,7 +40,7 @@
         "repeated": "cr:repeated",
         "replace": "cr:replace",
         "samplingRate": "cr:samplingRate",
-        "sc": "http://schema.org/",
+        "sc": "https://schema.org/",
         "separator": "cr:separator",
         "source": "cr:source",
         "subField": "cr:subField",

--- a/src/test/resources/croissant/validate.sh
+++ b/src/test/resources/croissant/validate.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+# Check datasets with this tool as well: https://huggingface.co/spaces/JoaquinVanschoren/croissant-checker
+#
+# Following warnings are expected for drafts.
+# -  [Metadata(Draft Dataset)] Property "https://schema.org/datePublished" is recommended, but does not exist.
+# -  [Metadata(Draft Dataset)] WarningException("Version doesn't follow MAJOR.MINOR.PATCH: DRAFT. For more information refer to: https://semver.org/spec/v2.0.0.html")
+for i in */expected/*.json; do
+  echo testing $i
+  mlcroissant validate --jsonld $i
+done


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit reverts 9e619b6 from #12214. I made that change to mirror a change in the Croissant 1.1 spec but there's a mismatch between the spec change and `mlcroissant validate`. I opened this issue upstream:

- https://github.com/mlcommons/croissant/issues/1018

**Which issue(s) this PR closes**:

- None. This is a follow up to #12214

**Special notes for your reviewer**:

**Suggestions on how to test this**:

Try this before and after this change (`pip install -r requirements.txt` first)

`cd src/test/resources/croissant && ./validate.sh` 

The "before" output should show an error like this for every single Croissant file:

```
E0415 16:02:49.695261 8656855360 validate.py:55] Found the following 1 error(s) during the validation:
  -  The current JSON-LD doesn't extend https://schema.org/Dataset.
...
```

The "after" output should look something like this. That is to say, there are no errors for non-drafts. For drafts, the errors and warnings below are expected and the same as before #12214 for Croissant 1.1 was merged:

```
 % ./validate.sh         
testing cars/expected/cars-croissant.json
I0415 17:58:41.688423 8656855360 validate.py:53] Done.
testing cars/expected/cars-croissantSlim.json
I0415 17:58:42.074821 8656855360 validate.py:53] Done.
testing draft/expected/draft-croissant.json
E0415 17:58:42.470159 8656855360 validate.py:55] Found the following 1 error(s) during the validation:
  -  [Metadata(Draft Dataset)] ValueError({'Dates or DateTimes should follow the [ISO 8601 format](https://en.wikipedia.org/wiki/ISO_8601). Got '})
Found the following 2 warning(s) during the validation:
  -  [Metadata(Draft Dataset)] Property "https://schema.org/datePublished" is recommended, but does not exist.
  -  [Metadata(Draft Dataset)] WarningException("Version doesn't follow MAJOR.MINOR.PATCH: DRAFT. For more information refer to: https://semver.org/spec/v2.0.0.html")
testing draft/expected/draft-croissantSlim.json
E0415 17:58:42.853607 8656855360 validate.py:55] Found the following 1 error(s) during the validation:
  -  [Metadata(Draft Dataset)] ValueError({'Dates or DateTimes should follow the [ISO 8601 format](https://en.wikipedia.org/wiki/ISO_8601). Got '})
Found the following 2 warning(s) during the validation:
  -  [Metadata(Draft Dataset)] Property "https://schema.org/datePublished" is recommended, but does not exist.
  -  [Metadata(Draft Dataset)] WarningException("Version doesn't follow MAJOR.MINOR.PATCH: DRAFT. For more information refer to: https://semver.org/spec/v2.0.0.html")
testing junk/expected/junk-croissant.json
I0415 17:58:43.250323 8656855360 validate.py:53] Done.
...
```

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No.

**Is there a release notes update needed for this change?**:

No. I looked at https://github.com/IQSS/dataverse/blob/12014-valid-croissant/doc/release-notes/12014-croissant-1.1.md from the last PR (#12214) and it's still accurate.

**Additional documentation**:

I updated the API changelog. You can preview the change at https://dataverse-guide--12333.org.readthedocs.build/en/12333/api/changelog.html