### PR TITLE
Revert "BugFix: controlled vocab values validation"

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DatasetFieldValidator.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetFieldValidator.java
@@ -59,24 +59,8 @@ public class DatasetFieldValidator implements ConstraintValidator<ValidateDatase
         }
 
         // if value is not primitive or not empty
-        // For controlled vocabulary fields, check that actual CV values are selected,
-        // not just that datasetFieldValues contains something (which might be an invalid N/A placeholder)
-        // See https://github.com/IQSS/dataverse/issues/11900
-        if (!dsfType.isPrimitive()) {
+        if (!dsfType.isPrimitive() || !StringUtils.isBlank(value.getValue())) {
             return true;
-        }
-        
-        if (dsfType.isControlledVocabulary()) {
-            // For CV fields, check if there are actual controlled vocabulary values selected
-            if (value.getControlledVocabularyValues() != null && !value.getControlledVocabularyValues().isEmpty()) {
-                return true;
-            }
-            // If no CV values, fall through to required field check below
-        } else {
-            // For non-CV primitive fields, check if value is not blank
-            if (!StringUtils.isBlank(value.getValue())) {
-                return true;
-            }
         }
        
         if (value.isRequired()) { 

--- a/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
@@ -4039,8 +4039,8 @@ public class DatasetPage implements java.io.Serializable {
             dataset.setOwner(ownerId != null ? dataverseService.find(ownerId) : null);
         }
         // Validate
-        workingVersion.validate(); // add validation messages to dataset fields
-        if (!workingVersion.isValid()) {
+        Set<ConstraintViolation> constraintViolations = workingVersion.validate();
+        if (!constraintViolations.isEmpty()) {
             FacesContext.getCurrentInstance().validationFailed();
             return "";
         }

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/AbstractDatasetCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/AbstractDatasetCommand.java
@@ -110,14 +110,10 @@ public abstract class AbstractDatasetCommand<T> extends AbstractCommand<T> {
         Set<ConstraintViolation> constraintViolations = dsv.validate();
         if (!constraintViolations.isEmpty()) {
             if (lenient) {
-                // populate invalid primitive fields with N/A
-                // Note: controlled vocabulary fields should NOT get N/A values in datasetfieldvalue,
-                // as this creates an inconsistent state where the CV field appears valid but is empty.
-                // See https://github.com/IQSS/dataverse/issues/11900
+                // populate invalid fields with N/A
                 constraintViolations.stream()
                     .filter(cv -> cv.getRootBean() instanceof DatasetField)
                     .map(cv -> ((DatasetField) cv.getRootBean()))
-                    .filter(f -> !f.getDatasetFieldType().isControlledVocabulary())
                     .forEach(f -> f.setSingleValue(DatasetField.NA_VALUE));
 
             } else {


### PR DESCRIPTION
Reverts IQSS/dataverse#11950

We have to revert the PR, since it broke OAI harvesting when using oai_dc format (which happens to be the most popular OAI format). 
It also broke the following 5 tests: 
```
edu.harvard.iq.dataverse.api.HarvestingClientsIT.testHarvestingClientRun_AllowHarvestingMissingCVV_True_WithSourceName
edu.harvard.iq.dataverse.api.HarvestingClientsIT.testHarvestingClientRun_AllowHarvestingMissingCVV_True
edu.harvard.iq.dataverse.api.HarvestingClientsIT.testHarvestingFromDatacite
edu.harvard.iq.dataverse.api.HarvestingClientsIT.testHarvestingClientRun_AllowHarvestingMissingCVV_False
edu.harvard.iq.dataverse.api.SearchIT.testDataverseDatasetCounts
```

... however, for some strange reason Jenkins tests were not run on this PR since https://jenkins.dataverse.org/job/IQSS-Dataverse-Develop-PR/view/change-requests/job/PR-11950/9/ (i.e., since November, where it passed), and that must be the reason why this was not detected before the PR was merged. 

[edit: _and that must be the reason why this was not detected before the PR was merged_ - actually, I'm not 100% about this; vs some scenario where there were in fact more Jenkins runs, but they somehow got deleted - ? Doesn't matter at this point, really]