### PR TITLE
Required controlledVocabulary metadata marked as valid while empty

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DatasetFieldValidator.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetFieldValidator.java
@@ -59,10 +59,26 @@ public class DatasetFieldValidator implements ConstraintValidator<ValidateDatase
         }
 
         // if value is not primitive or not empty
-        if (!dsfType.isPrimitive() || !StringUtils.isBlank(value.getValue())) {
+        // For controlled vocabulary fields, check that actual CV values are selected,
+        // not just that datasetFieldValues contains something (which might be an invalid N/A placeholder)
+        // See https://github.com/IQSS/dataverse/issues/11900
+        if (!dsfType.isPrimitive()) {
             return true;
         }
-       
+
+        if (dsfType.isControlledVocabulary()) {
+            // For CV fields, check if there are actual controlled vocabulary values selected
+            if (value.getControlledVocabularyValues() != null && !value.getControlledVocabularyValues().isEmpty()) {
+                return true;
+            }
+            // If no CV values, fall through to required field check below
+        } else {
+            // For non-CV primitive fields, check if value is not blank
+            if (!StringUtils.isBlank(value.getValue())) {
+                return true;
+            }
+        }
+
         if (value.isRequired()) { 
             String errorMessage = null;
             DatasetFieldCompoundValue parent = value.getParentDatasetFieldCompoundValue();

--- a/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
@@ -111,7 +111,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.primefaces.event.FileUploadEvent;
 import org.primefaces.model.file.UploadedFile;
 
-import jakarta.validation.ConstraintViolation;
 import java.util.Arrays;
 import java.util.HashSet;
 import jakarta.faces.model.SelectItem;

--- a/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
@@ -4039,8 +4039,8 @@ public class DatasetPage implements java.io.Serializable {
             dataset.setOwner(ownerId != null ? dataverseService.find(ownerId) : null);
         }
         // Validate
-        Set<ConstraintViolation> constraintViolations = workingVersion.validate();
-        if (!constraintViolations.isEmpty()) {
+        workingVersion.validate(); // add validation messages to dataset fields
+        if (!workingVersion.isValid()) {
             FacesContext.getCurrentInstance().validationFailed();
             return "";
         }

--- a/src/main/java/edu/harvard/iq/dataverse/api/imports/ImportServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/imports/ImportServiceBean.java
@@ -760,13 +760,17 @@ public class ImportServiceBean {
                     msg += "Missing required field: " + f.getDatasetFieldType().getDisplayName() + ";";
                     if (sanitize) {
                         if (f.getDatasetFieldType().isControlledVocabulary()) {
-                            ControlledVocabularyValue ccv = new ControlledVocabularyValue(null, DatasetField.NA_VALUE, f.getDatasetFieldType());
-                            f.setControlledVocabularyValues(List.of(ccv));
+                            ControlledVocabularyValue naValue = datasetfieldService.findNAControlledVocabularyValue();
+                            if (naValue != null) {
+                                f.setControlledVocabularyValues(List.of(naValue));
+                                msg += " populated with '" + DatasetField.NA_VALUE + "'";
+                                fixed = true;
+                            }
                         } else {
                             f.setSingleValue(DatasetField.NA_VALUE);
+                            msg += " populated with '" + DatasetField.NA_VALUE + "'";
+                            fixed = true;
                         }
-                        msg += " populated with '" + DatasetField.NA_VALUE + "'";
-                        fixed = true;
                     }
                 } else if (invalid instanceof DatasetFieldValue) {
                     DatasetFieldValue fv = (DatasetFieldValue) invalid;

--- a/src/main/java/edu/harvard/iq/dataverse/api/imports/ImportServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/imports/ImportServiceBean.java
@@ -749,7 +749,6 @@ public class ImportServiceBean {
      */
     private boolean validateVersionMetadata(DatasetVersion version, boolean sanitize, PrintWriter cleanupLog) throws ImportException {
         boolean fixed = false;
-        boolean allowHarvestingMissingCVV =  version.getDataset().getHarvestedFrom() != null ? version.getDataset().getHarvestedFrom().getAllowHarvestingMissingCVV() : false;
         Set<ConstraintViolation> invalidViolations = version.validate();
         if (!invalidViolations.isEmpty()) {
             for (ConstraintViolation v : invalidViolations) {
@@ -760,12 +759,13 @@ public class ImportServiceBean {
 
                     msg += "Missing required field: " + f.getDatasetFieldType().getDisplayName() + ";";
                     if (sanitize) {
-                        if (allowHarvestingMissingCVV && f.getDatasetFieldType().isControlledVocabulary()) {
+                        if (f.getDatasetFieldType().isControlledVocabulary()) {
                             ControlledVocabularyValue ccv = new ControlledVocabularyValue(null, DatasetField.NA_VALUE, f.getDatasetFieldType());
                             f.setControlledVocabularyValues(List.of(ccv));
+                        } else {
+                            f.setSingleValue(DatasetField.NA_VALUE);
                         }
                         msg += " populated with '" + DatasetField.NA_VALUE + "'";
-                        f.setSingleValue(DatasetField.NA_VALUE);
                         fixed = true;
                     }
                 } else if (invalid instanceof DatasetFieldValue) {

--- a/src/main/java/edu/harvard/iq/dataverse/api/imports/ImportServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/imports/ImportServiceBean.java
@@ -7,20 +7,7 @@ package edu.harvard.iq.dataverse.api.imports;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import edu.harvard.iq.dataverse.Dataset;
-import edu.harvard.iq.dataverse.DatasetField;
-import edu.harvard.iq.dataverse.DatasetFieldConstant;
-import edu.harvard.iq.dataverse.DatasetFieldServiceBean;
-import edu.harvard.iq.dataverse.DatasetFieldType;
-import edu.harvard.iq.dataverse.DatasetFieldValue;
-import edu.harvard.iq.dataverse.DatasetServiceBean;
-import edu.harvard.iq.dataverse.DatasetVersion;
-import edu.harvard.iq.dataverse.Dataverse;
-import edu.harvard.iq.dataverse.DataverseContact;
-import edu.harvard.iq.dataverse.DataverseServiceBean;
-import edu.harvard.iq.dataverse.EjbDataverseEngine;
-import edu.harvard.iq.dataverse.GlobalId;
-import edu.harvard.iq.dataverse.MetadataBlockServiceBean;
+import edu.harvard.iq.dataverse.*;
 import edu.harvard.iq.dataverse.api.dto.DatasetDTO;
 import edu.harvard.iq.dataverse.api.imports.ImportUtil.ImportType;
 import edu.harvard.iq.dataverse.dataset.DatasetTypeServiceBean;
@@ -762,16 +749,21 @@ public class ImportServiceBean {
      */
     private boolean validateVersionMetadata(DatasetVersion version, boolean sanitize, PrintWriter cleanupLog) throws ImportException {
         boolean fixed = false;
+        boolean allowHarvestingMissingCVV =  version.getDataset().getHarvestedFrom() != null ? version.getDataset().getHarvestedFrom().getAllowHarvestingMissingCVV() : false;
         Set<ConstraintViolation> invalidViolations = version.validate();
         if (!invalidViolations.isEmpty()) {
             for (ConstraintViolation v : invalidViolations) {
                 Object invalid = v.getRootBean();
                 String msg = "";
                 if (invalid instanceof DatasetField) {
-                    DatasetField f = (DatasetField) invalid; 
-                    
-                    msg += "Missing required field: " + f.getDatasetFieldType().getDisplayName() + ";";                  
+                    DatasetField f = (DatasetField) invalid;
+
+                    msg += "Missing required field: " + f.getDatasetFieldType().getDisplayName() + ";";
                     if (sanitize) {
+                        if (allowHarvestingMissingCVV && f.getDatasetFieldType().isControlledVocabulary()) {
+                            ControlledVocabularyValue ccv = new ControlledVocabularyValue(null, DatasetField.NA_VALUE, f.getDatasetFieldType());
+                            f.setControlledVocabularyValues(List.of(ccv));
+                        }
                         msg += " populated with '" + DatasetField.NA_VALUE + "'";
                         f.setSingleValue(DatasetField.NA_VALUE);
                         fixed = true;

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/AbstractDatasetCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/AbstractDatasetCommand.java
@@ -110,10 +110,14 @@ public abstract class AbstractDatasetCommand<T> extends AbstractCommand<T> {
         Set<ConstraintViolation> constraintViolations = dsv.validate();
         if (!constraintViolations.isEmpty()) {
             if (lenient) {
-                // populate invalid fields with N/A
+                // populate invalid primitive fields with N/A
+                // Note: controlled vocabulary fields should NOT get N/A values in datasetfieldvalue,
+                // as this creates an inconsistent state where the CV field appears valid but is empty.
+                // See https://github.com/IQSS/dataverse/issues/11900
                 constraintViolations.stream()
                     .filter(cv -> cv.getRootBean() instanceof DatasetField)
                     .map(cv -> ((DatasetField) cv.getRootBean()))
+                    .filter(f -> !f.getDatasetFieldType().isControlledVocabulary())
                     .forEach(f -> f.setSingleValue(DatasetField.NA_VALUE));
 
             } else {


### PR DESCRIPTION
**What this PR does / why we need it**: Previous PR caused post merge test failures in Jenkins. This PR includes the code from the previous PR plus the fixes needed to pass the tests

**Which issue(s) this PR closes**:https://github.com/IQSS/dataverse/issues/11900

- Closes #11900

**Special notes for your reviewer**: Original PR https://github.com/IQSS/dataverse/pull/11950

**Suggestions on how to test this**:

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
