### PR TITLE
Add dataset type ID to JSON output in JsonPrinter

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
@@ -356,6 +356,7 @@ public class JsonPrinter {
             JsonArrayBuilder jab = Json.createArrayBuilder();
             for (DatasetType datasetType : allowedDatasetTypes) {
                 NullSafeJsonBuilder json = NullSafeJsonBuilder.jsonObjectBuilder()
+                    .add("id", datasetType.getId())
                     .add("name", datasetType.getName())
                     .add("displayName", datasetType.getDisplayName())
                     .add("description", datasetType.getDescription());


### PR DESCRIPTION
**What this PR does / why we need it**:

The Id on the type is required for mapping on JS Dataverse
