### PR TITLE
Timezone fix in validateInternalTimestampIsNotOutdated()

### DIFF
--- a/doc/sphinx-guides/source/api/native-api.rst
+++ b/doc/sphinx-guides/source/api/native-api.rst
@@ -2645,7 +2645,7 @@ For these edits your JSON file need only include those dataset fields which you 
 
 This endpoint also allows removing fields, as long as they are not required by the dataset. To remove a field, send an empty value (``""``) for individual fields. For multiple fields, send an empty array (``[]``). A sample JSON file for removing fields may be downloaded here: :download:`dataset-edit-metadata-delete-fields-sample.json <../_static/api/dataset-edit-metadata-delete-fields-sample.json>`
 
-If another user updates the dataset version metadata before you send the update request, metadata inconsistencies may occur. To prevent this, you can use the optional ``sourceLastUpdateTime`` query parameter. This parameter must include the ``lastUpdateTime`` corresponding to the dataset version being updated. The date must be in the format ``yyyy-MM-dd'T'HH:mm:ss'Z'``.
+If another user updates the dataset version metadata before you send the update request, metadata inconsistencies may occur. To prevent this, you can use the optional ``sourceLastUpdateTime`` query parameter. The intended API workflow is for the client to send along the ``lastUpdateTime`` obtained from the last ``GET`` call on the version that is being modified. Dataverse APIs will always report these time stamps in UTC, ISO 8601-formatted (``yyyy-MM-dd'T'HH:mm:ss'Z'``; for example: ``2026-04-22T14:30:00Z``), regardless of the actual time zone used by the server. This is the only format this API will accept. 
 
 If this parameter is provided, the update will proceed only if the ``lastUpdateTime`` remains unchanged (meaning no one has updated the dataset metadata since you retrieved it). Otherwise, the request will fail with an error.
 
@@ -2695,6 +2695,9 @@ Update Dataset Terms of Access
 
 Updates the terms of access for the restricted files of a dataset by applying it to the draft version, or by creating a draft if none exists.
 
+If another user updates an already existing draft version before you send the update request, metadata inconsistencies may occur. To prevent this, you can use the optional ``sourceLastUpdateTime`` query parameter. The intended API workflow is for the client to send along the ``lastUpdateTime`` obtained from the last ``GET`` call on the version that is being modified. Dataverse APIs will always report these time stamps in UTC, ISO 8601-formatted (``yyyy-MM-dd'T'HH:mm:ss'Z'``; for example: ``2026-04-22T14:30:00Z``), regardless of the actual time zone used by the server. This is the only format this API will accept. 
+
+If this parameter is provided, the update will proceed only if the ``lastUpdateTime`` remains unchanged (meaning no one has updated the dataset metadata since you retrieved it). Otherwise, the request will fail with an error.
 
 To define custom terms of access, provide a JSON body with the following properties. All fields within ``customTermsOfAccess`` are optional, except if there are restricted files in your dataset then ``fileAccessRequest`` must be set to true or ``termsOfAccess`` must be provided:
 
@@ -5543,7 +5546,8 @@ Updating File Metadata
 
 Updates the file metadata for an existing file where ``ID`` is the database id of the file to update or ``PERSISTENT_ID`` is the persistent id (DOI or Handle) of the file. Requires a ``jsonString`` expressing the new metadata. No metadata from the previous version of this file will be persisted, so if you want to update a specific field first get the json with the above command and alter the fields you want.
 
-An optional parameter, sourceLastUpdateTime=datetime (in format: ``yyyy-MM-dd'T'HH:mm:ss'Z'``), can be used to verify that the file metadata being edited has not been changed since you last retrieved it, thereby avoiding potential lost metadata updates. The value for sourceLastUpdateTime can be taken from ``lastUpdateTime`` in the response to get $SERVER_URL/api/files/$ID API call.
+An optional parameter, ``sourceLastUpdateTime``, can be used to verify that the file metadata being edited has not been changed since you last retrieved it, thereby avoiding potential inconsistencies. In the intended API workflow this will be the time stamp in ``lastUpdateTime`` from the last ``GET /api/files/<id>`` API call. Dataverse APIs will always report these time stamps in UTC, ISO 8601-formatted (``yyyy-MM-dd'T'HH:mm:ss'Z'``; for example: ``2026-04-22T14:30:00Z``), regardless of the actual time zone used by the server. This is the only format this API will accept. 
+
 
 A curl example using an ``ID``
 

--- a/src/main/java/edu/harvard/iq/dataverse/api/AbstractApiBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/AbstractApiBean.java
@@ -488,7 +488,27 @@ public abstract class AbstractApiBean {
     }
 
     protected void validateInternalTimestampIsNotOutdated(DvObject dvObject, String sourceLastUpdateTime) throws WrappedResponse {
-        Date date = sourceLastUpdateTime != null ? DateUtil.parseDate(sourceLastUpdateTime, "yyyy-MM-dd'T'HH:mm:ss'Z'") : null;
+        // The timestamp string must always be in UTC, ISO 8601-formatted
+        // for example: 2026-04-22T14:30:00Z. This is explicitly specified in the
+        // API guide.
+        //
+        // In the intended workflow, the clients will be reusing the last update
+        // timestamps obtained from the output of other Dataverse APIs, such as
+        // /versions and /files, where they are always in that form, regardless
+        // of the actual time zone the server lives in.
+        //
+        // For consistency, we do not want to accept any other formats or timezones,
+        // and will reject anything that does not match "yyyy-MM-dd'T'HH:mm:ss'Z'".
+        // For that reason there is an explicit check added for .endsWith("Z").
+        // The "X" in the parsing format string will recognize literal 'Z' as "+0000",
+        // but it would also accept other ISO 8601 timezones, such as "+0400" for
+        // EDT, etc. In theory, we could accept all these other notations - in
+        // case the client decided to convert the UTC timestamp they received from
+        // Dataverse into that... but there is really no good reason to encourage
+        // that.
+        Date date = sourceLastUpdateTime != null && sourceLastUpdateTime.endsWith("Z")
+                ? DateUtil.parseDate(sourceLastUpdateTime, "yyyy-MM-dd'T'HH:mm:ssX")
+                : null;
         if (date == null) {
             throw new WrappedResponse(
                     badRequest(BundleUtil.getStringFromBundle("jsonparser.error.parsing.date", Collections.singletonList(sourceLastUpdateTime)))


### PR DESCRIPTION
**What this PR does / why we need it**:

In the intended API workflow the client using the ```sourceLastUpdateTime``` parameter would be reusing the timestamps obtained from the output of other Dataverse APIs, like ```/versions``` and ```/files```, where they are always reported in UTC, ISO 8601-formatted. (with the "Z", for ex.: ```2026-04-22T14:30:00Z```; regardless of where the server lives). 
This format is specified as required in the guides. 

However, the scheme appears to work only if the server happens to live in GMT and save the timestamps in the database that are already UTC. 
That happens to be the case with Jenkins, beta, qa and docker instances (and that's how the bug stayed unnoticed for a year). But it becomes a problem on servers that use different time zones. Such as our "real" servers, demo.dataverse.org and dataverse.harvard.edu that live in US Eastern. (It was confirmed that file metadata could not be updated in the SPA on demo because of this)

**Which issue(s) this PR closes**:

- Closes #12354

**Special notes for your reviewer**:

The simplest, minimalist fix would be 3 characters total: change ```yyyy-MM-dd'T'HH:mm:ss'Z'``` to ```yyyy-MM-dd'T'HH:mm:ssX```. i.e., from "ignore the literal 'Z'" to "parse ISO 8601 time zone", which recognizes "Z" as "+0000". 
But I added some comments and rewrote a few sentences that describe the parameter in the API guide. 

Branch rebased to squash the commits. 

**Suggestions on how to test this**:

Testing is straightforward, you just need a Dataverse instance operating in a non-GMT time zone. If you have a working Payara etc. setup installed locally on your computer, then you are all set. Unless you live in London, etc. 

If you are testing with a Docker environment, you should be able to configure it to run in US Eastern by adding this to your `docker-compose-dev.yml`: 

```
--- docker-compose-dev.yml
+++ docker-compose-dev-us-east.yml
@@ -9,6 +9,7 @@
     restart: on-failure
     user: payara
     environment:
+      TZ: America/New_York
       DATAVERSE_DB_HOST: postgres
       DATAVERSE_DB_PASSWORD: secret
       DATAVERSE_DB_USER: ${DATAVERSE_DB_USER}
@@ -113,6 +114,7 @@
     image: postgres:${POSTGRES_VERSION}
     restart: on-failure
     environment:
+      - TZ=America/New_York
       - POSTGRES_USER=${DATAVERSE_DB_USER}
       - POSTGRES_PASSWORD=secret
     ports:
```
Rebuild your Docker env. completely from scratch. 

I recommend to make sure to reproduce the actual bug in 6.10.1 and current develop; as there were some conflicting reports on how easy that was. 
It should be possible to test the bug, and the fix by simply making the 2 API calls involved directly. The best way however is probably to run one of the RestAssured tests that cover the functionality, for example
```
mvn test -Dtest=FilesIT#testUpdateWithEmptyFieldsAndVersionCheck
```
The failure would look something like this in the output:
```
            "directoryLabel": "data/subdir1",
            "lastUpdateTime": "2026-04-22T19:54:20Z",
            "fileAccessRequest": true
        }
    }
}
{
    "status": "ERROR",
    "message": "Internal version timestamp 2026-04-22T19:54:20Z is outdated"
}
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 13.06 s <<< FAILURE! -- in edu.harvard.iq.dataverse.api.FilesIT
[ERROR] edu.harvard.iq.dataverse.api.FilesIT.testUpdateWithEmptyFieldsAndVersionCheck -- Time elapsed: 10.40 s <<< FAILURE!

```
Note that the time stamp described in the API error as "outdated" appears strikingly identical to the actual `lastUpdateTime` in the output of the GET API right above. 

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
