### PR TITLE
Enable S3 multipart upload (in non-direct upload)

### DIFF
--- a/doc/release-notes/12358-enable-s3-multipart-upload.md
+++ b/doc/release-notes/12358-enable-s3-multipart-upload.md
@@ -1,0 +1,1 @@
+Fixed a defect that caused upload of files larger than 1G to fail silently for S3 storage, unless direct upload was used. 

--- a/src/main/java/edu/harvard/iq/dataverse/dataaccess/S3AccessIO.java
+++ b/src/main/java/edu/harvard/iq/dataverse/dataaccess/S3AccessIO.java
@@ -1208,6 +1208,9 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
             // Create a builder for the S3AsyncClient
             S3AsyncClientBuilder s3CB = S3AsyncClient.builder().requestChecksumCalculation(RequestChecksumCalculation.WHEN_REQUIRED);
 
+            // Always enable multipart upload. It is only used when necessary
+            s3CB.multipartEnabled(true);
+
             // Create a custom HTTP client with the desired pool size
             Integer poolSize = Integer.getInteger("dataverse.files." + driverId + ".connection-pool-size", 256);
             Builder httpClientBuilder = NettyNioAsyncHttpClient.builder().maxConcurrency(poolSize);


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR re-enables multipart upload for non-direct uploads for S3-compatible storage. At some point between 6.7.1 and 6.9 the default changed from enabled to disabled. This PR explicitly enables it when creating the `S3AsyncClient`. It will only be used when necessary anyway.

Without this change, an upload of a file larger than 1G  using a storage driver that does not support direct upload, the upload fails silently when clicking Save on the confirmation screen. So the file is uploaded to the Dataverse server, but then uploading it from there to the object store fails, without any error message to the user.

**Which issue(s) this PR closes**:
N/a

**Special notes for your reviewer**:
N/a

**Suggestions on how to test this**:
Perform an upload of a file larger than 1G, which will require the client to use multipart upload.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
No

**Is there a release notes update needed for this change?**:
See: doc/release-notes/12358-enable-s3-multipart-upload.md

**Additional documentation**:
No
