### PR TITLE
Featured Items API can now retrieve images for creator

### DIFF
--- a/doc/release-notes/11537-featured-items-retrieve-image-bug.md
+++ b/doc/release-notes/11537-featured-items-retrieve-image-bug.md
@@ -1,0 +1,3 @@
+## BUG
+
+Featured Item creator can now view/download images when a dataverse is not published. ViewUnpublishedDataverse is not required for the featured item creator.

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/GetDataverseFeaturedItemCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/GetDataverseFeaturedItemCommand.java
@@ -30,8 +30,11 @@ public class GetDataverseFeaturedItemCommand extends AbstractCommand<DataverseFe
 
     @Override
     public Map<String, Set<Permission>> getRequiredPermissions() {
-        return Collections.singletonMap("",
-                dataverseFeaturedItem.getDataverse().isReleased() ? Collections.emptySet()
-                        : Collections.singleton(Permission.ViewUnpublishedDataverse));
+        // If the dataverse is not released only a user with ViewUnpublishedDataverse permissions or the creator can access the featured item and its images
+        if (!dataverseFeaturedItem.getDataverse().isReleased() && !getRequest().getUser().equals(dataverseFeaturedItem.getDataverse().getCreator())) {
+            return Collections.singletonMap("", Collections.singleton(Permission.ViewUnpublishedDataverse));
+        } else {
+            return Collections.singletonMap("",Collections.emptySet());
+        }
     }
 }

--- a/src/test/java/edu/harvard/iq/dataverse/api/DataversesIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/DataversesIT.java
@@ -2184,6 +2184,17 @@ public class DataversesIT {
                 .body("data[2].type", equalTo("custom"))
                 .statusCode(OK.getStatusCode());
 
+        // Verify that the unpublished image can be downloaded by its creator and not by a user without ViewUnpublishedDataverse permissions
+        JsonPath path = JsonPath.from(listDataverseFeaturedItemsResponse.body().asString());
+        String imageUrl = path.getString("data[2].imageFileUrl");
+        Response downloadResponse = given().get(imageUrl + "?key=" + apiToken);
+        downloadResponse.then().assertThat().statusCode(OK.getStatusCode());
+
+        Response createUserResponse2 = UtilIT.createRandomUser();
+        String apiToken2 = UtilIT.getApiTokenFromResponse(createUserResponse2);
+        Response downloadResponse2 = given().get(imageUrl + "?key=" + apiToken2);
+        downloadResponse2.then().assertThat().statusCode(NO_CONTENT.getStatusCode());
+
         // Should return not found error when dataverse does not exist
 
         listDataverseFeaturedItemsResponse = UtilIT.listDataverseFeaturedItems("thisDataverseDoesNotExist", apiToken);


### PR DESCRIPTION
**What this PR does / why we need it**: Creator of a featured item of a non published dataverse could not see the images.

**Which issue(s) this PR closes**:https://github.com/IQSS/dataverse/issues/11537

- Closes #11537

**Special notes for your reviewer**:

**Suggestions on how to test this**: See DataversesIT testListFeaturedItems. 

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**: included

**Additional documentation**:
