### PR TITLE
Edit Metadata Form fix for CVoc fields

### DIFF
--- a/src/main/webapp/datasetFieldForEditFragment.xhtml
+++ b/src/main/webapp/datasetFieldForEditFragment.xhtml
@@ -38,7 +38,8 @@
                              or dsfv.datasetField.datasetFieldType.fieldType == 'FLOAT'
                              or dsfv.datasetField.datasetFieldType.fieldType == 'URL'
                              or dsfv.datasetField.datasetFieldType.fieldType == 'DATE'
-                             or dsfv.datasetField.datasetFieldType.fieldType == 'EMAIL')}">
+                             or dsfv.datasetField.datasetFieldType.fieldType == 'EMAIL')}"
+                     onkeypress="return event.keyCode !== 13;">
             <c:if test="#{dsfvIndex!=0}">
                 <f:passThroughAttribute name="aria-label" value="#{bundle['dataset.additionalEntry']}" />
             </c:if>
@@ -63,7 +64,8 @@
                              or dsfv.datasetField.datasetFieldType.fieldType == 'FLOAT'
                              or dsfv.datasetField.datasetFieldType.fieldType == 'URL'
                              or dsfv.datasetField.datasetFieldType.fieldType == 'DATE'
-                             or dsfv.datasetField.datasetFieldType.fieldType == 'EMAIL')}">
+                             or dsfv.datasetField.datasetFieldType.fieldType == 'EMAIL')}"
+                     onkeypress="return event.keyCode !== 13;">
             <c:if test="#{dsfvIndex!=0}">
                 <f:passThroughAttribute name="aria-label" value="#{bundle['dataset.additionalEntry']}" />
             </c:if>


### PR DESCRIPTION
**What this PR does / why we need it**: #8500 fixed #7895 for normal fields but didn't apply the same fix to fields using CVoc. This PR does that. This stops cases such as when the user selects aa plain text author when using an ORCID CVoc script and then tries to manually enter some other type of ID. Without this fix, hitting return in the Identifier field tries to save the metadata form immediately.

**Which issue(s) this PR closes**:

- Closes #

**Special notes for your reviewer**: Basically cut/paste of the earlier solution to suppress the normal processing of hitting the enter key.

**Suggestions on how to test this**: As above, configure the people.js script (or others) on the author field and try adding a text name and then a random Identifier, hit enter.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**: no one has reported the issue...

**Additional documentation**:
