### PR TITLE
Replace MinIO with LocalStack as an S3 storage option 

### DIFF
--- a/conf/keycloak/docker-compose-dev.yml
+++ b/conf/keycloak/docker-compose-dev.yml
@@ -53,16 +53,6 @@ services:
         -Ddataverse.files.localstack1.download-redirect=true
         -Ddataverse.files.localstack1.access-key=default
         -Ddataverse.files.localstack1.secret-key=default
-        -Ddataverse.files.minio1.type=s3
-        -Ddataverse.files.minio1.label=MinIO
-        -Ddataverse.files.minio1.custom-endpoint-url=http://minio:9000
-        -Ddataverse.files.minio1.custom-endpoint-region=us-east-1
-        -Ddataverse.files.minio1.bucket-name=mybucket
-        -Ddataverse.files.minio1.path-style-access=true
-        -Ddataverse.files.minio1.upload-redirect=false
-        -Ddataverse.files.minio1.download-redirect=false
-        -Ddataverse.files.minio1.access-key=4cc355_k3y
-        -Ddataverse.files.minio1.secret-key=s3cr3t_4cc355_k3y
         -Ddataverse.pid.providers=fake
         -Ddataverse.pid.default-provider=fake
         -Ddataverse.pid.fake.type=FAKE
@@ -259,23 +249,6 @@ services:
       - ../localstack:/etc/localstack/init/ready.d
     tmpfs:
       - /localstack:mode=770,size=128M,uid=1000,gid=1000
-
-  dev_minio:
-    container_name: "dev_minio"
-    hostname: "minio"
-    image: minio/minio
-    restart: on-failure
-    ports:
-      - "9000:9000"
-      - "9001:9001"
-    networks:
-      - dataverse
-    volumes:
-      - ./docker-dev-volumes/minio_storage:/data
-    environment:
-      MINIO_ROOT_USER: 4cc355_k3y
-      MINIO_ROOT_PASSWORD: s3cr3t_4cc355_k3y
-    command: server /data
 
   previewers-provider:
     container_name: previewers-provider

--- a/conf/keycloak/docker-compose-dev.yml
+++ b/conf/keycloak/docker-compose-dev.yml
@@ -57,7 +57,7 @@ services:
         -Ddataverse.files.localstack_noredirect.label=LocalStackNoRedirect
         -Ddataverse.files.localstack_noredirect.custom-endpoint-url=http://localstack:4566
         -Ddataverse.files.localstack_noredirect.custom-endpoint-region=us-east-2
-        -Ddataverse.files.localstack_noredirect.bucket-name=mybucket
+        -Ddataverse.files.localstack_noredirect.bucket-name=mybucket-noredirect
         -Ddataverse.files.localstack_noredirect.path-style-access=true
         -Ddataverse.files.localstack_noredirect.upload-redirect=false
         -Ddataverse.files.localstack_noredirect.download-redirect=false

--- a/conf/keycloak/docker-compose-dev.yml
+++ b/conf/keycloak/docker-compose-dev.yml
@@ -53,6 +53,16 @@ services:
         -Ddataverse.files.localstack1.download-redirect=true
         -Ddataverse.files.localstack1.access-key=default
         -Ddataverse.files.localstack1.secret-key=default
+        -Ddataverse.files.localstack_noredirect.type=s3
+        -Ddataverse.files.localstack_noredirect.label=LocalStackNoRedirect
+        -Ddataverse.files.localstack_noredirect.custom-endpoint-url=http://localstack:4566
+        -Ddataverse.files.localstack_noredirect.custom-endpoint-region=us-east-2
+        -Ddataverse.files.localstack_noredirect.bucket-name=mybucket
+        -Ddataverse.files.localstack_noredirect.path-style-access=true
+        -Ddataverse.files.localstack_noredirect.upload-redirect=false
+        -Ddataverse.files.localstack_noredirect.download-redirect=false
+        -Ddataverse.files.localstack_noredirect.access-key=default
+        -Ddataverse.files.localstack_noredirect.secret-key=default
         -Ddataverse.pid.providers=fake
         -Ddataverse.pid.default-provider=fake
         -Ddataverse.pid.fake.type=FAKE

--- a/conf/localstack/buckets.sh
+++ b/conf/localstack/buckets.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 # https://stackoverflow.com/questions/53619901/auto-create-s3-buckets-on-localstack
 awslocal s3 mb s3://mybucket
+awslocal s3 mb s3://mybucket-noredirect

--- a/doc/sphinx-guides/source/installation/big-data-support.rst
+++ b/doc/sphinx-guides/source/installation/big-data-support.rst
@@ -68,7 +68,6 @@ If the bucket allows the wildcard ``*`` but the Dataverse application only allow
 Detailed information for the most common S3 admin tools around CORS:
 
 - `AWS <https://docs.aws.amazon.com/AmazonS3/latest/userguide/enabling-cors-examples.html>`_
-- `Minio mc <https://docs.min.io/enterprise/aistor-object-store/reference/cli/mc-cors>`_
 - `s3cmd <https://servicedesk.surf.nl/wiki/spaces/WIKI/pages/215253125/Object+Store+S3+CORS+Policies>`_
 
 Get Current CORS Policy on Bucket
@@ -79,9 +78,6 @@ If you'd like to check the CORS configuration on your bucket before making chang
 .. tabs::
    .. group-tab:: AWS CLI
       :code:`aws s3api get-bucket-cors --bucket <BUCKET_NAME>`
-
-   .. group-tab:: Minio Client (mc)
-      :code:`mc cors get <STORE_NAME>/<BUCKET_NAME>`
 
 Set CORS Policy on Bucket
 +++++++++++++++++++++++++
@@ -107,9 +103,6 @@ Both JSON and XML format are explained in detail in `AWS Docs <https://docs.aws.
 
     Alternatively, you can enable CORS using the AWS S3 web interface, using json-encoded rules as in the example above.
 
-  .. group-tab:: Minio Client (mc)
-    Create a file :download:`cors.xml </_static/installation/cors/cors.xml>` as follows:
-
     .. literalinclude:: /_static/installation/cors/cors.xml
         :name: xml-cors
         :language: xml
@@ -124,7 +117,7 @@ Both JSON and XML format are explained in detail in `AWS Docs <https://docs.aws.
 S3 Tags and Direct Upload
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Since the direct upload mechanism creates the final file rather than an intermediate temporary file, user actions, such as neither saving or canceling an upload session before closing the browser page, can leave an abandoned file in the store. The direct upload mechanism attempts to use S3 tags to aid in identifying/removing such files. Upon upload, files are given a "dv-state":"temp" tag which is removed when the dataset changes are saved and new files are added in the Dataverse installation. Note that not all S3 implementations support tags. Minio, for example, does not. With such stores, direct upload may not work and you might need to disable tagging. For details, see :ref:`s3-tagging` in the Installation Guide.
+Since the direct upload mechanism creates the final file rather than an intermediate temporary file, user actions, such as neither saving or canceling an upload session before closing the browser page, can leave an abandoned file in the store. The direct upload mechanism attempts to use S3 tags to aid in identifying/removing such files. Upon upload, files are given a "dv-state":"temp" tag which is removed when the dataset changes are saved and new files are added in the Dataverse installation. Note that not all S3 implementations support tags. With such stores, direct upload may not work and you might need to disable tagging. For details, see :ref:`s3-tagging` in the Installation Guide.
 
 Trusted Remote Storage with the ``remote`` Store Type
 -----------------------------------------------------

--- a/doc/sphinx-guides/source/installation/config.rst
+++ b/doc/sphinx-guides/source/installation/config.rst
@@ -1218,7 +1218,7 @@ You can configure this redirect properly in your cloud environment to generate a
 Amazon S3 Storage (or Compatible)
 +++++++++++++++++++++++++++++++++
 
-The Dataverse Software supports Amazon S3 storage as well as other S3-compatible stores (like Minio, Ceph RADOS S3 Gateway and many more) for files uploaded to your Dataverse installation.
+The Dataverse Software supports Amazon S3 storage as well as other S3-compatible stores (like Ceph RADOS S3 Gateway and many more) for files uploaded to your Dataverse installation.
 
 The Dataverse Software S3 driver supports multi-part upload for large files (over 1 GB by default - see the min-part-size option in the table below to change this).
 
@@ -1264,7 +1264,7 @@ Please make note of the following details:
 
 - **Endpoint URL** - consult the documentation of your service on how to find it.
 
-  * Example: https://play.minio.io:9000
+  * Example: http://localhost.localstack.cloud:4566
 
 - **Region:** Optional, but some services might use it. Consult your service documentation.
 
@@ -1460,11 +1460,6 @@ You may provide the values for these via any `supported MicroProfile Config API 
 
 Reported Working S3-Compatible Storage
 ######################################
-
-`Minio v2018-09-12 <https://minio.io>`_
-  Set ``dataverse.files.<id>.path-style-access=true``, as Minio works path-based. Works pretty smooth, easy to setup.
-  **Can be used for quick testing, too:** just use the example values above. Uses the public (read: unsecure and
-  possibly slow) https://play.minio.io:9000 service.
 
 `StorJ Object Store <https://www.storj.io>`_
  StorJ is a distributed object store that can be configured with an S3 gateway. Per the S3 Storage instructions above, you'll first set up the StorJ S3 store by defining the id, type, and label. After following the general installation, set the following configuration to use a StorJ object store: ``dataverse.files.<id>.chunked-encoding=false``. For step-by-step instructions see https://docs.storj.io/dcs/how-tos/dataverse-integration-guide/

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -44,16 +44,6 @@ services:
         -Ddataverse.files.localstack1.download-redirect=true
         -Ddataverse.files.localstack1.access-key=default
         -Ddataverse.files.localstack1.secret-key=default
-        -Ddataverse.files.minio1.type=s3
-        -Ddataverse.files.minio1.label=MinIO
-        -Ddataverse.files.minio1.custom-endpoint-url=http://minio:9000
-        -Ddataverse.files.minio1.custom-endpoint-region=us-east-1
-        -Ddataverse.files.minio1.bucket-name=mybucket
-        -Ddataverse.files.minio1.path-style-access=true
-        -Ddataverse.files.minio1.upload-redirect=false
-        -Ddataverse.files.minio1.download-redirect=false
-        -Ddataverse.files.minio1.access-key=4cc355_k3y
-        -Ddataverse.files.minio1.secret-key=s3cr3t_4cc355_k3y
         -Ddataverse.pid.providers=fake
         -Ddataverse.pid.default-provider=fake
         -Ddataverse.pid.fake.type=FAKE
@@ -251,23 +241,6 @@ services:
       - ./conf/localstack:/etc/localstack/init/ready.d
     tmpfs:
       - /localstack:mode=770,size=128M,uid=1000,gid=1000
-
-  dev_minio:
-    container_name: "dev_minio"
-    hostname: "minio"
-    image: minio/minio
-    restart: on-failure
-    ports:
-      - "9000:9000"
-      - "9001:9001"
-    networks:
-      - dataverse
-    volumes:
-      - ./docker-dev-volumes/minio_storage:/data
-    environment:
-      MINIO_ROOT_USER: 4cc355_k3y
-      MINIO_ROOT_PASSWORD: s3cr3t_4cc355_k3y
-    command: server /data
 
   previewers-provider:
     container_name: previewers-provider

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -44,6 +44,16 @@ services:
         -Ddataverse.files.localstack1.download-redirect=true
         -Ddataverse.files.localstack1.access-key=default
         -Ddataverse.files.localstack1.secret-key=default
+        -Ddataverse.files.localstack_noredirect.type=s3
+        -Ddataverse.files.localstack_noredirect.label=LocalStackNoRedirect
+        -Ddataverse.files.localstack_noredirect.custom-endpoint-url=http://localstack:4566
+        -Ddataverse.files.localstack_noredirect.custom-endpoint-region=us-east-2
+        -Ddataverse.files.localstack_noredirect.bucket-name=mybucket
+        -Ddataverse.files.localstack_noredirect.path-style-access=true
+        -Ddataverse.files.localstack_noredirect.upload-redirect=false
+        -Ddataverse.files.localstack_noredirect.download-redirect=false
+        -Ddataverse.files.localstack_noredirect.access-key=default
+        -Ddataverse.files.localstack_noredirect.secret-key=default
         -Ddataverse.pid.providers=fake
         -Ddataverse.pid.default-provider=fake
         -Ddataverse.pid.fake.type=FAKE

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -48,7 +48,7 @@ services:
         -Ddataverse.files.localstack_noredirect.label=LocalStackNoRedirect
         -Ddataverse.files.localstack_noredirect.custom-endpoint-url=http://localstack:4566
         -Ddataverse.files.localstack_noredirect.custom-endpoint-region=us-east-2
-        -Ddataverse.files.localstack_noredirect.bucket-name=mybucket
+        -Ddataverse.files.localstack_noredirect.bucket-name=mybucket-noredirect
         -Ddataverse.files.localstack_noredirect.path-style-access=true
         -Ddataverse.files.localstack_noredirect.upload-redirect=false
         -Ddataverse.files.localstack_noredirect.download-redirect=false

--- a/scripts/dev/dev-start-frd.sh
+++ b/scripts/dev/dev-start-frd.sh
@@ -28,7 +28,6 @@ mkdir -p docker-dev-volumes/app/secrets
 mkdir -p docker-dev-volumes/postgresql/data
 mkdir -p docker-dev-volumes/solr/data
 mkdir -p docker-dev-volumes/solr/conf
-mkdir -p docker-dev-volumes/minio_storage
 
 # Only disable DDL generation if database is already initialized
 # (on first run, we need create-tables to bootstrap the schema)

--- a/src/main/java/edu/harvard/iq/dataverse/dataaccess/S3AccessIO.java
+++ b/src/main/java/edu/harvard/iq/dataverse/dataaccess/S3AccessIO.java
@@ -210,7 +210,7 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
                                 + ") is not associated with a bucket.");
                     }
                 } // else we're OK (assumes bucket name in storageidentifier matches the driver's
-                  // bucketname)
+                // bucketname)
             } else {
                 if (!storageIdentifier.contains(":")) {
                     // No driver id or bucket
@@ -307,8 +307,8 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
             try {
                 responseInputStream = s3.getObject(GetObjectRequest.builder().bucket(bucketName).key(key).build(),
                         AsyncResponseTransformer.toBlockingInputStream()).get(); // Since s3 is an S3AsyncClient, we
-                                                                                 // need to call .get() to wait for the
-                                                                                 // result
+                // need to call .get() to wait for the
+                // result
                 setInputStream(responseInputStream);
             } catch (InterruptedException | ExecutionException e) {
                 // TODO Auto-generated catch block
@@ -443,7 +443,7 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
         try {
             DeleteObjectRequest deleteObjRequest = DeleteObjectRequest.builder().bucket(bucketName).key(key).build();
             s3.deleteObject(deleteObjRequest).get(); // Since s3 is an S3AsyncClient, we need to call .get() to wait for
-                                                     // the result
+            // the result
         } catch (InterruptedException | ExecutionException e) {
             logger.warning("Caught an exception in S3AccessIO.delete(): " + e.getMessage());
             throw new IOException("Failed to delete storage location " + getStorageLocation(), e);
@@ -480,7 +480,7 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
                     .build();
 
             s3.headObject(headObjectRequest).get(); // Since s3 is an S3AsyncClient, we need to call .get() to wait for
-                                                    // the result
+            // the result
             return true;
         } catch (InterruptedException | ExecutionException e) {
             if (e.getCause() instanceof NoSuchKeyException) {
@@ -499,20 +499,20 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
         try {
             HeadObjectResponse headObjectResponse = s3
                     .headObject(HeadObjectRequest.builder().bucket(bucketName).key(destinationKey).build()).get(); // Since
-                                                                                                                   // s3
-                                                                                                                   // is
-                                                                                                                   // an
-                                                                                                                   // S3AsyncClient,
-                                                                                                                   // we
-                                                                                                                   // need
-                                                                                                                   // to
-                                                                                                                   // call
-                                                                                                                   // .get()
-                                                                                                                   // to
-                                                                                                                   // wait
-                                                                                                                   // for
-                                                                                                                   // the
-                                                                                                                   // result
+            // s3
+            // is
+            // an
+            // S3AsyncClient,
+            // we
+            // need
+            // to
+            // call
+            // .get()
+            // to
+            // wait
+            // for
+            // the
+            // result
             return headObjectResponse.contentLength();
         } catch (InterruptedException | ExecutionException e) {
             if (e.getCause() instanceof NoSuchKeyException) {
@@ -539,7 +539,7 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
                     .destinationBucket(bucketName).destinationKey(destinationKey).build();
 
             s3.copyObject(copyObjectRequest).get(); // Since s3 is an S3AsyncClient, we need to call .get() to wait for
-                                                    // the result
+            // the result
         } catch (InterruptedException | ExecutionException e) {
             logger.warning("Caught an exception in S3AccessIO.backupAsAux: " + e.getMessage());
             throw new IOException("S3AccessIO: Unable to backup original auxiliary object", e);
@@ -554,7 +554,7 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
                     .sourceKey(destinationKey).destinationBucket(bucketName).destinationKey(key).build();
 
             s3.copyObject(copyObjectRequest).get(); // Since s3 is an S3AsyncClient, we need to call .get() to wait for
-                                                    // the result
+            // the result
             deleteAuxObject(auxItemTag);
         } catch (InterruptedException | ExecutionException e) {
             logger.warning("Caught an exception in S3AccessIO.revertBackupAsAux: " + e.getMessage());
@@ -573,7 +573,7 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
                     .build();
             AsyncRequestBody asyncRequestBody = AsyncRequestBody.fromFile(fileSystemPath);
             s3.putObject(putObjectRequest, asyncRequestBody).get(); // Since s3 is an S3AsyncClient, we need to call
-                                                                    // .get() to wait for the result
+            // .get() to wait for the result
         } catch (InterruptedException | ExecutionException e) {
             logger.warning("Caught an exception in S3AccessIO.savePathAsAux(): " + e.getMessage());
             throw new IOException("S3AccessIO: Failed to save path as an auxiliary object.", e);
@@ -597,7 +597,7 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
                         executorService);
 
                 s3.putObject(putObjectRequest, asyncRequestBody).get(); // Since s3 is an S3AsyncClient, we need to call
-                                                                        // .get() to wait for the result
+                // .get() to wait for the result
             } catch (InterruptedException | ExecutionException e) {
                 String failureMsg = e.getMessage();
 
@@ -610,21 +610,22 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
     }
 
     /**
-     * Implements the StorageIO saveInputStreamAsAux() method. This implementation
-     * is problematic, because S3 cannot save an object of an unknown length. This
-     * effectively nullifies any benefits of streaming; as we cannot start saving
-     * until we have read the entire stream. One way of solving this would be to
-     * buffer the entire stream as byte[], in memory, then save it... Which of
-     * course would be limited by the amount of memory available, and thus would not
-     * work for streams larger than that. So we have eventually decided to save save
-     * the stream to a temp file, then save to S3. This is slower, but guaranteed to
-     * work on any size stream. An alternative we may want to consider is to not
-     * implement this method in the S3 driver, and make it throw the
-     * UnsupportedDataAccessOperationException, similarly to how we handle attempts
-     * to open OutputStreams, in this and the Swift driver.
-     * 
+     * Implements the StorageIO saveInputStreamAsAux() method. This
+     * implementation is problematic, because S3 cannot save an object of an
+     * unknown length. This effectively nullifies any benefits of streaming; as
+     * we cannot start saving until we have read the entire stream. One way of
+     * solving this would be to buffer the entire stream as byte[], in memory,
+     * then save it... Which of course would be limited by the amount of memory
+     * available, and thus would not work for streams larger than that. So we
+     * have eventually decided to save save the stream to a temp file, then save
+     * to S3. This is slower, but guaranteed to work on any size stream. An
+     * alternative we may want to consider is to not implement this method in
+     * the S3 driver, and make it throw the
+     * UnsupportedDataAccessOperationException, similarly to how we handle
+     * attempts to open OutputStreams, in this and the Swift driver.
+     *
      * @param inputStream InputStream we want to save
-     * @param auxItemTag  String representing this Auxiliary type ("extension")
+     * @param auxItemTag String representing this Auxiliary type ("extension")
      * @throws IOException if anything goes wrong.
      */
     @Override
@@ -759,7 +760,7 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
                     .key(destinationKey).build();
 
             s3.deleteObject(deleteObjectRequest).get(); // Since s3 is an S3AsyncClient, we need to call .get() to wait
-                                                        // for the result
+            // for the result
         } catch (InterruptedException | ExecutionException e) {
             logger.warning("S3AccessIO: Unable to delete object: " + e.getMessage());
             throw new IOException("Failed to delete auxiliary object", e);
@@ -910,13 +911,13 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
     }
 
     /**
-     * TODO: this function is not side effect free (sets instance variables key and
-     * bucketName). Is this good or bad? Need to ask @landreev
+     * TODO: this function is not side effect free (sets instance variables key
+     * and bucketName). Is this good or bad? Need to ask @landreev
      *
      * Extract the file key from a file stored on S3. Follows template: "owner
-     * authority name"/"owner identifier"/"storage identifier without bucketname and
-     * protocol"
-     * 
+     * authority name"/"owner identifier"/"storage identifier without bucketname
+     * and protocol"
+     *
      * @return Main File Key
      * @throws IOException
      */
@@ -979,12 +980,12 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
     /**
      * Generates a temporary URL for a direct S3 download; either for the main
      * physical file, or (optionally) for an auxiliary.
-     * 
-     * @param auxiliaryTag      (optional)
-     * @param auxiliaryType     (optional) - aux. mime type, if different from the
-     *                          main type
-     * @param auxiliaryFileName (optional) - file name, if different from the main
-     *                          file label.
+     *
+     * @param auxiliaryTag (optional)
+     * @param auxiliaryType (optional) - aux. mime type, if different from the
+     * main type
+     * @param auxiliaryFileName (optional) - file name, if different from the
+     * main file label.
      * @return redirect url
      * @throws IOException.
      */
@@ -1003,9 +1004,9 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
             GetObjectPresignRequest presignRequest = GetObjectPresignRequest.builder()
                     .signatureDuration(expirationDuration)
                     .getObjectRequest(req -> req.bucket(bucketName).key(key)
-                            .responseContentDisposition("attachment; filename*=UTF-8''"
-                                    + URLEncoder.encode(fileName, StandardCharsets.UTF_8).replaceAll("\\+", "%20"))
-                            .responseContentType(contentType))
+                    .responseContentDisposition("attachment; filename*=UTF-8''"
+                            + URLEncoder.encode(fileName, StandardCharsets.UTF_8).replaceAll("\\+", "%20"))
+                    .responseContentType(contentType))
                     .build();
 
             PresignedGetObjectRequest presignedRequest;
@@ -1270,7 +1271,7 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
         }
 
     }
-    
+
     private static AwsCredentialsProvider getCredentialsProvider(String driverId) {
         if (driverCredentialsProviderMap.containsKey(driverId)) {
             return driverCredentialsProviderMap.get(driverId);
@@ -1331,8 +1332,8 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
             if (e.getCause() instanceof S3Exception) {
                 S3Exception s3e = (S3Exception) e.getCause();
                 if (s3e.statusCode() == 501) {
-                    // In this case, it's likely that tags are not implemented at all (e.g. by
-                    // Minio) so no tag was set either and it's just something to be aware of
+                    // In this case, it's likely that tags are not implemented at all,
+                    // so no tag was set either and it's just something to be aware of
                     logger.warning("Temp tag not deleted: Object tags not supported by storage: " + driverId);
                 } else {
                     // In this case, the assumption is that adding tags has worked, so not removing
@@ -1521,12 +1522,12 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
             throw new IOException("Failed to delete file", e);
         }
     }
-    
+
     @Override
     public void closeInputStream() {
         try {
             ResponseInputStream<GetObjectResponse> responseInputStream = (ResponseInputStream<GetObjectResponse>) getInputStream();
-            if(responseInputStream!= null && responseInputStream.available()>0) {
+            if (responseInputStream != null && responseInputStream.available() > 0) {
                 responseInputStream.abort();
             }
         } catch (IOException e) {

--- a/src/main/java/edu/harvard/iq/dataverse/dataaccess/S3AccessIO.java
+++ b/src/main/java/edu/harvard/iq/dataverse/dataaccess/S3AccessIO.java
@@ -210,7 +210,7 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
                                 + ") is not associated with a bucket.");
                     }
                 } // else we're OK (assumes bucket name in storageidentifier matches the driver's
-                // bucketname)
+                  // bucketname)
             } else {
                 if (!storageIdentifier.contains(":")) {
                     // No driver id or bucket
@@ -307,8 +307,8 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
             try {
                 responseInputStream = s3.getObject(GetObjectRequest.builder().bucket(bucketName).key(key).build(),
                         AsyncResponseTransformer.toBlockingInputStream()).get(); // Since s3 is an S3AsyncClient, we
-                // need to call .get() to wait for the
-                // result
+                                                                                 // need to call .get() to wait for the
+                                                                                 // result
                 setInputStream(responseInputStream);
             } catch (InterruptedException | ExecutionException e) {
                 // TODO Auto-generated catch block
@@ -443,7 +443,7 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
         try {
             DeleteObjectRequest deleteObjRequest = DeleteObjectRequest.builder().bucket(bucketName).key(key).build();
             s3.deleteObject(deleteObjRequest).get(); // Since s3 is an S3AsyncClient, we need to call .get() to wait for
-            // the result
+                                                     // the result
         } catch (InterruptedException | ExecutionException e) {
             logger.warning("Caught an exception in S3AccessIO.delete(): " + e.getMessage());
             throw new IOException("Failed to delete storage location " + getStorageLocation(), e);
@@ -480,7 +480,7 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
                     .build();
 
             s3.headObject(headObjectRequest).get(); // Since s3 is an S3AsyncClient, we need to call .get() to wait for
-            // the result
+                                                    // the result
             return true;
         } catch (InterruptedException | ExecutionException e) {
             if (e.getCause() instanceof NoSuchKeyException) {
@@ -499,20 +499,20 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
         try {
             HeadObjectResponse headObjectResponse = s3
                     .headObject(HeadObjectRequest.builder().bucket(bucketName).key(destinationKey).build()).get(); // Since
-            // s3
-            // is
-            // an
-            // S3AsyncClient,
-            // we
-            // need
-            // to
-            // call
-            // .get()
-            // to
-            // wait
-            // for
-            // the
-            // result
+                                                                                                                   // s3
+                                                                                                                   // is
+                                                                                                                   // an
+                                                                                                                   // S3AsyncClient,
+                                                                                                                   // we
+                                                                                                                   // need
+                                                                                                                   // to
+                                                                                                                   // call
+                                                                                                                   // .get()
+                                                                                                                   // to
+                                                                                                                   // wait
+                                                                                                                   // for
+                                                                                                                   // the
+                                                                                                                   // result
             return headObjectResponse.contentLength();
         } catch (InterruptedException | ExecutionException e) {
             if (e.getCause() instanceof NoSuchKeyException) {
@@ -539,7 +539,7 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
                     .destinationBucket(bucketName).destinationKey(destinationKey).build();
 
             s3.copyObject(copyObjectRequest).get(); // Since s3 is an S3AsyncClient, we need to call .get() to wait for
-            // the result
+                                                    // the result
         } catch (InterruptedException | ExecutionException e) {
             logger.warning("Caught an exception in S3AccessIO.backupAsAux: " + e.getMessage());
             throw new IOException("S3AccessIO: Unable to backup original auxiliary object", e);
@@ -554,7 +554,7 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
                     .sourceKey(destinationKey).destinationBucket(bucketName).destinationKey(key).build();
 
             s3.copyObject(copyObjectRequest).get(); // Since s3 is an S3AsyncClient, we need to call .get() to wait for
-            // the result
+                                                    // the result
             deleteAuxObject(auxItemTag);
         } catch (InterruptedException | ExecutionException e) {
             logger.warning("Caught an exception in S3AccessIO.revertBackupAsAux: " + e.getMessage());
@@ -573,7 +573,7 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
                     .build();
             AsyncRequestBody asyncRequestBody = AsyncRequestBody.fromFile(fileSystemPath);
             s3.putObject(putObjectRequest, asyncRequestBody).get(); // Since s3 is an S3AsyncClient, we need to call
-            // .get() to wait for the result
+                                                                    // .get() to wait for the result
         } catch (InterruptedException | ExecutionException e) {
             logger.warning("Caught an exception in S3AccessIO.savePathAsAux(): " + e.getMessage());
             throw new IOException("S3AccessIO: Failed to save path as an auxiliary object.", e);
@@ -597,7 +597,7 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
                         executorService);
 
                 s3.putObject(putObjectRequest, asyncRequestBody).get(); // Since s3 is an S3AsyncClient, we need to call
-                // .get() to wait for the result
+                                                                        // .get() to wait for the result
             } catch (InterruptedException | ExecutionException e) {
                 String failureMsg = e.getMessage();
 
@@ -610,22 +610,21 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
     }
 
     /**
-     * Implements the StorageIO saveInputStreamAsAux() method. This
-     * implementation is problematic, because S3 cannot save an object of an
-     * unknown length. This effectively nullifies any benefits of streaming; as
-     * we cannot start saving until we have read the entire stream. One way of
-     * solving this would be to buffer the entire stream as byte[], in memory,
-     * then save it... Which of course would be limited by the amount of memory
-     * available, and thus would not work for streams larger than that. So we
-     * have eventually decided to save save the stream to a temp file, then save
-     * to S3. This is slower, but guaranteed to work on any size stream. An
-     * alternative we may want to consider is to not implement this method in
-     * the S3 driver, and make it throw the
-     * UnsupportedDataAccessOperationException, similarly to how we handle
-     * attempts to open OutputStreams, in this and the Swift driver.
-     *
+     * Implements the StorageIO saveInputStreamAsAux() method. This implementation
+     * is problematic, because S3 cannot save an object of an unknown length. This
+     * effectively nullifies any benefits of streaming; as we cannot start saving
+     * until we have read the entire stream. One way of solving this would be to
+     * buffer the entire stream as byte[], in memory, then save it... Which of
+     * course would be limited by the amount of memory available, and thus would not
+     * work for streams larger than that. So we have eventually decided to save save
+     * the stream to a temp file, then save to S3. This is slower, but guaranteed to
+     * work on any size stream. An alternative we may want to consider is to not
+     * implement this method in the S3 driver, and make it throw the
+     * UnsupportedDataAccessOperationException, similarly to how we handle attempts
+     * to open OutputStreams, in this and the Swift driver.
+     * 
      * @param inputStream InputStream we want to save
-     * @param auxItemTag String representing this Auxiliary type ("extension")
+     * @param auxItemTag  String representing this Auxiliary type ("extension")
      * @throws IOException if anything goes wrong.
      */
     @Override
@@ -760,7 +759,7 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
                     .key(destinationKey).build();
 
             s3.deleteObject(deleteObjectRequest).get(); // Since s3 is an S3AsyncClient, we need to call .get() to wait
-            // for the result
+                                                        // for the result
         } catch (InterruptedException | ExecutionException e) {
             logger.warning("S3AccessIO: Unable to delete object: " + e.getMessage());
             throw new IOException("Failed to delete auxiliary object", e);
@@ -911,13 +910,13 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
     }
 
     /**
-     * TODO: this function is not side effect free (sets instance variables key
-     * and bucketName). Is this good or bad? Need to ask @landreev
+     * TODO: this function is not side effect free (sets instance variables key and
+     * bucketName). Is this good or bad? Need to ask @landreev
      *
      * Extract the file key from a file stored on S3. Follows template: "owner
-     * authority name"/"owner identifier"/"storage identifier without bucketname
-     * and protocol"
-     *
+     * authority name"/"owner identifier"/"storage identifier without bucketname and
+     * protocol"
+     * 
      * @return Main File Key
      * @throws IOException
      */
@@ -980,12 +979,12 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
     /**
      * Generates a temporary URL for a direct S3 download; either for the main
      * physical file, or (optionally) for an auxiliary.
-     *
-     * @param auxiliaryTag (optional)
-     * @param auxiliaryType (optional) - aux. mime type, if different from the
-     * main type
-     * @param auxiliaryFileName (optional) - file name, if different from the
-     * main file label.
+     * 
+     * @param auxiliaryTag      (optional)
+     * @param auxiliaryType     (optional) - aux. mime type, if different from the
+     *                          main type
+     * @param auxiliaryFileName (optional) - file name, if different from the main
+     *                          file label.
      * @return redirect url
      * @throws IOException.
      */
@@ -1004,9 +1003,9 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
             GetObjectPresignRequest presignRequest = GetObjectPresignRequest.builder()
                     .signatureDuration(expirationDuration)
                     .getObjectRequest(req -> req.bucket(bucketName).key(key)
-                    .responseContentDisposition("attachment; filename*=UTF-8''"
-                            + URLEncoder.encode(fileName, StandardCharsets.UTF_8).replaceAll("\\+", "%20"))
-                    .responseContentType(contentType))
+                            .responseContentDisposition("attachment; filename*=UTF-8''"
+                                    + URLEncoder.encode(fileName, StandardCharsets.UTF_8).replaceAll("\\+", "%20"))
+                            .responseContentType(contentType))
                     .build();
 
             PresignedGetObjectRequest presignedRequest;
@@ -1271,7 +1270,7 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
         }
 
     }
-
+    
     private static AwsCredentialsProvider getCredentialsProvider(String driverId) {
         if (driverCredentialsProviderMap.containsKey(driverId)) {
             return driverCredentialsProviderMap.get(driverId);
@@ -1332,8 +1331,8 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
             if (e.getCause() instanceof S3Exception) {
                 S3Exception s3e = (S3Exception) e.getCause();
                 if (s3e.statusCode() == 501) {
-                    // In this case, it's likely that tags are not implemented at all,
-                    // so no tag was set either and it's just something to be aware of
+                    // In this case, it's likely that tags are not implemented at all (e.g. by
+                    // Minio) so no tag was set either and it's just something to be aware of
                     logger.warning("Temp tag not deleted: Object tags not supported by storage: " + driverId);
                 } else {
                     // In this case, the assumption is that adding tags has worked, so not removing
@@ -1522,12 +1521,12 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
             throw new IOException("Failed to delete file", e);
         }
     }
-
+    
     @Override
     public void closeInputStream() {
         try {
             ResponseInputStream<GetObjectResponse> responseInputStream = (ResponseInputStream<GetObjectResponse>) getInputStream();
-            if (responseInputStream != null && responseInputStream.available() > 0) {
+            if(responseInputStream!= null && responseInputStream.available()>0) {
                 responseInputStream.abort();
             }
         } catch (IOException e) {

--- a/src/main/java/edu/harvard/iq/dataverse/dataaccess/S3AccessIO.java
+++ b/src/main/java/edu/harvard/iq/dataverse/dataaccess/S3AccessIO.java
@@ -1331,8 +1331,8 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
             if (e.getCause() instanceof S3Exception) {
                 S3Exception s3e = (S3Exception) e.getCause();
                 if (s3e.statusCode() == 501) {
-                    // In this case, it's likely that tags are not implemented at all (e.g. by
-                    // Minio) so no tag was set either and it's just something to be aware of
+                    // In this case, it's likely that tags are not implemented at all
+                    // so no tag was set either and it's just something to be aware of
                     logger.warning("Temp tag not deleted: Object tags not supported by storage: " + driverId);
                 } else {
                     // In this case, the assumption is that adding tags has worked, so not removing

--- a/src/main/java/edu/harvard/iq/dataverse/dataaccess/S3AccessIO.java
+++ b/src/main/java/edu/harvard/iq/dataverse/dataaccess/S3AccessIO.java
@@ -210,7 +210,7 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
                                 + ") is not associated with a bucket.");
                     }
                 } // else we're OK (assumes bucket name in storageidentifier matches the driver's
-                  // bucketname)
+                // bucketname)
             } else {
                 if (!storageIdentifier.contains(":")) {
                     // No driver id or bucket
@@ -307,8 +307,8 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
             try {
                 responseInputStream = s3.getObject(GetObjectRequest.builder().bucket(bucketName).key(key).build(),
                         AsyncResponseTransformer.toBlockingInputStream()).get(); // Since s3 is an S3AsyncClient, we
-                                                                                 // need to call .get() to wait for the
-                                                                                 // result
+                // need to call .get() to wait for the
+                // result
                 setInputStream(responseInputStream);
             } catch (InterruptedException | ExecutionException e) {
                 // TODO Auto-generated catch block
@@ -443,7 +443,7 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
         try {
             DeleteObjectRequest deleteObjRequest = DeleteObjectRequest.builder().bucket(bucketName).key(key).build();
             s3.deleteObject(deleteObjRequest).get(); // Since s3 is an S3AsyncClient, we need to call .get() to wait for
-                                                     // the result
+            // the result
         } catch (InterruptedException | ExecutionException e) {
             logger.warning("Caught an exception in S3AccessIO.delete(): " + e.getMessage());
             throw new IOException("Failed to delete storage location " + getStorageLocation(), e);
@@ -480,7 +480,7 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
                     .build();
 
             s3.headObject(headObjectRequest).get(); // Since s3 is an S3AsyncClient, we need to call .get() to wait for
-                                                    // the result
+            // the result
             return true;
         } catch (InterruptedException | ExecutionException e) {
             if (e.getCause() instanceof NoSuchKeyException) {
@@ -499,20 +499,20 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
         try {
             HeadObjectResponse headObjectResponse = s3
                     .headObject(HeadObjectRequest.builder().bucket(bucketName).key(destinationKey).build()).get(); // Since
-                                                                                                                   // s3
-                                                                                                                   // is
-                                                                                                                   // an
-                                                                                                                   // S3AsyncClient,
-                                                                                                                   // we
-                                                                                                                   // need
-                                                                                                                   // to
-                                                                                                                   // call
-                                                                                                                   // .get()
-                                                                                                                   // to
-                                                                                                                   // wait
-                                                                                                                   // for
-                                                                                                                   // the
-                                                                                                                   // result
+            // s3
+            // is
+            // an
+            // S3AsyncClient,
+            // we
+            // need
+            // to
+            // call
+            // .get()
+            // to
+            // wait
+            // for
+            // the
+            // result
             return headObjectResponse.contentLength();
         } catch (InterruptedException | ExecutionException e) {
             if (e.getCause() instanceof NoSuchKeyException) {
@@ -539,7 +539,7 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
                     .destinationBucket(bucketName).destinationKey(destinationKey).build();
 
             s3.copyObject(copyObjectRequest).get(); // Since s3 is an S3AsyncClient, we need to call .get() to wait for
-                                                    // the result
+            // the result
         } catch (InterruptedException | ExecutionException e) {
             logger.warning("Caught an exception in S3AccessIO.backupAsAux: " + e.getMessage());
             throw new IOException("S3AccessIO: Unable to backup original auxiliary object", e);
@@ -554,7 +554,7 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
                     .sourceKey(destinationKey).destinationBucket(bucketName).destinationKey(key).build();
 
             s3.copyObject(copyObjectRequest).get(); // Since s3 is an S3AsyncClient, we need to call .get() to wait for
-                                                    // the result
+            // the result
             deleteAuxObject(auxItemTag);
         } catch (InterruptedException | ExecutionException e) {
             logger.warning("Caught an exception in S3AccessIO.revertBackupAsAux: " + e.getMessage());
@@ -573,7 +573,7 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
                     .build();
             AsyncRequestBody asyncRequestBody = AsyncRequestBody.fromFile(fileSystemPath);
             s3.putObject(putObjectRequest, asyncRequestBody).get(); // Since s3 is an S3AsyncClient, we need to call
-                                                                    // .get() to wait for the result
+            // .get() to wait for the result
         } catch (InterruptedException | ExecutionException e) {
             logger.warning("Caught an exception in S3AccessIO.savePathAsAux(): " + e.getMessage());
             throw new IOException("S3AccessIO: Failed to save path as an auxiliary object.", e);
@@ -597,7 +597,7 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
                         executorService);
 
                 s3.putObject(putObjectRequest, asyncRequestBody).get(); // Since s3 is an S3AsyncClient, we need to call
-                                                                        // .get() to wait for the result
+                // .get() to wait for the result
             } catch (InterruptedException | ExecutionException e) {
                 String failureMsg = e.getMessage();
 
@@ -610,21 +610,22 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
     }
 
     /**
-     * Implements the StorageIO saveInputStreamAsAux() method. This implementation
-     * is problematic, because S3 cannot save an object of an unknown length. This
-     * effectively nullifies any benefits of streaming; as we cannot start saving
-     * until we have read the entire stream. One way of solving this would be to
-     * buffer the entire stream as byte[], in memory, then save it... Which of
-     * course would be limited by the amount of memory available, and thus would not
-     * work for streams larger than that. So we have eventually decided to save save
-     * the stream to a temp file, then save to S3. This is slower, but guaranteed to
-     * work on any size stream. An alternative we may want to consider is to not
-     * implement this method in the S3 driver, and make it throw the
-     * UnsupportedDataAccessOperationException, similarly to how we handle attempts
-     * to open OutputStreams, in this and the Swift driver.
-     * 
+     * Implements the StorageIO saveInputStreamAsAux() method. This
+     * implementation is problematic, because S3 cannot save an object of an
+     * unknown length. This effectively nullifies any benefits of streaming; as
+     * we cannot start saving until we have read the entire stream. One way of
+     * solving this would be to buffer the entire stream as byte[], in memory,
+     * then save it... Which of course would be limited by the amount of memory
+     * available, and thus would not work for streams larger than that. So we
+     * have eventually decided to save save the stream to a temp file, then save
+     * to S3. This is slower, but guaranteed to work on any size stream. An
+     * alternative we may want to consider is to not implement this method in
+     * the S3 driver, and make it throw the
+     * UnsupportedDataAccessOperationException, similarly to how we handle
+     * attempts to open OutputStreams, in this and the Swift driver.
+     *
      * @param inputStream InputStream we want to save
-     * @param auxItemTag  String representing this Auxiliary type ("extension")
+     * @param auxItemTag String representing this Auxiliary type ("extension")
      * @throws IOException if anything goes wrong.
      */
     @Override
@@ -759,7 +760,7 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
                     .key(destinationKey).build();
 
             s3.deleteObject(deleteObjectRequest).get(); // Since s3 is an S3AsyncClient, we need to call .get() to wait
-                                                        // for the result
+            // for the result
         } catch (InterruptedException | ExecutionException e) {
             logger.warning("S3AccessIO: Unable to delete object: " + e.getMessage());
             throw new IOException("Failed to delete auxiliary object", e);
@@ -910,13 +911,13 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
     }
 
     /**
-     * TODO: this function is not side effect free (sets instance variables key and
-     * bucketName). Is this good or bad? Need to ask @landreev
+     * TODO: this function is not side effect free (sets instance variables key
+     * and bucketName). Is this good or bad? Need to ask @landreev
      *
      * Extract the file key from a file stored on S3. Follows template: "owner
-     * authority name"/"owner identifier"/"storage identifier without bucketname and
-     * protocol"
-     * 
+     * authority name"/"owner identifier"/"storage identifier without bucketname
+     * and protocol"
+     *
      * @return Main File Key
      * @throws IOException
      */
@@ -979,12 +980,12 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
     /**
      * Generates a temporary URL for a direct S3 download; either for the main
      * physical file, or (optionally) for an auxiliary.
-     * 
-     * @param auxiliaryTag      (optional)
-     * @param auxiliaryType     (optional) - aux. mime type, if different from the
-     *                          main type
-     * @param auxiliaryFileName (optional) - file name, if different from the main
-     *                          file label.
+     *
+     * @param auxiliaryTag (optional)
+     * @param auxiliaryType (optional) - aux. mime type, if different from the
+     * main type
+     * @param auxiliaryFileName (optional) - file name, if different from the
+     * main file label.
      * @return redirect url
      * @throws IOException.
      */
@@ -1003,9 +1004,9 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
             GetObjectPresignRequest presignRequest = GetObjectPresignRequest.builder()
                     .signatureDuration(expirationDuration)
                     .getObjectRequest(req -> req.bucket(bucketName).key(key)
-                            .responseContentDisposition("attachment; filename*=UTF-8''"
-                                    + URLEncoder.encode(fileName, StandardCharsets.UTF_8).replaceAll("\\+", "%20"))
-                            .responseContentType(contentType))
+                    .responseContentDisposition("attachment; filename*=UTF-8''"
+                            + URLEncoder.encode(fileName, StandardCharsets.UTF_8).replaceAll("\\+", "%20"))
+                    .responseContentType(contentType))
                     .build();
 
             PresignedGetObjectRequest presignedRequest;
@@ -1270,7 +1271,7 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
         }
 
     }
-    
+
     private static AwsCredentialsProvider getCredentialsProvider(String driverId) {
         if (driverCredentialsProviderMap.containsKey(driverId)) {
             return driverCredentialsProviderMap.get(driverId);
@@ -1331,8 +1332,8 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
             if (e.getCause() instanceof S3Exception) {
                 S3Exception s3e = (S3Exception) e.getCause();
                 if (s3e.statusCode() == 501) {
-                    // In this case, it's likely that tags are not implemented at all (e.g. by
-                    // Minio) so no tag was set either and it's just something to be aware of
+                    // In this case, it's likely that tags are not implemented at all
+                    // so no tag was set either and it's just something to be aware of
                     logger.warning("Temp tag not deleted: Object tags not supported by storage: " + driverId);
                 } else {
                     // In this case, the assumption is that adding tags has worked, so not removing
@@ -1521,12 +1522,12 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
             throw new IOException("Failed to delete file", e);
         }
     }
-    
+
     @Override
     public void closeInputStream() {
         try {
             ResponseInputStream<GetObjectResponse> responseInputStream = (ResponseInputStream<GetObjectResponse>) getInputStream();
-            if(responseInputStream!= null && responseInputStream.available()>0) {
+            if (responseInputStream != null && responseInputStream.available() > 0) {
                 responseInputStream.abort();
             }
         } catch (IOException e) {

--- a/src/main/java/edu/harvard/iq/dataverse/dataaccess/S3AccessIO.java
+++ b/src/main/java/edu/harvard/iq/dataverse/dataaccess/S3AccessIO.java
@@ -210,7 +210,7 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
                                 + ") is not associated with a bucket.");
                     }
                 } // else we're OK (assumes bucket name in storageidentifier matches the driver's
-                // bucketname)
+                  // bucketname)
             } else {
                 if (!storageIdentifier.contains(":")) {
                     // No driver id or bucket
@@ -307,8 +307,8 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
             try {
                 responseInputStream = s3.getObject(GetObjectRequest.builder().bucket(bucketName).key(key).build(),
                         AsyncResponseTransformer.toBlockingInputStream()).get(); // Since s3 is an S3AsyncClient, we
-                // need to call .get() to wait for the
-                // result
+                                                                                 // need to call .get() to wait for the
+                                                                                 // result
                 setInputStream(responseInputStream);
             } catch (InterruptedException | ExecutionException e) {
                 // TODO Auto-generated catch block
@@ -443,7 +443,7 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
         try {
             DeleteObjectRequest deleteObjRequest = DeleteObjectRequest.builder().bucket(bucketName).key(key).build();
             s3.deleteObject(deleteObjRequest).get(); // Since s3 is an S3AsyncClient, we need to call .get() to wait for
-            // the result
+                                                     // the result
         } catch (InterruptedException | ExecutionException e) {
             logger.warning("Caught an exception in S3AccessIO.delete(): " + e.getMessage());
             throw new IOException("Failed to delete storage location " + getStorageLocation(), e);
@@ -480,7 +480,7 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
                     .build();
 
             s3.headObject(headObjectRequest).get(); // Since s3 is an S3AsyncClient, we need to call .get() to wait for
-            // the result
+                                                    // the result
             return true;
         } catch (InterruptedException | ExecutionException e) {
             if (e.getCause() instanceof NoSuchKeyException) {
@@ -499,20 +499,20 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
         try {
             HeadObjectResponse headObjectResponse = s3
                     .headObject(HeadObjectRequest.builder().bucket(bucketName).key(destinationKey).build()).get(); // Since
-            // s3
-            // is
-            // an
-            // S3AsyncClient,
-            // we
-            // need
-            // to
-            // call
-            // .get()
-            // to
-            // wait
-            // for
-            // the
-            // result
+                                                                                                                   // s3
+                                                                                                                   // is
+                                                                                                                   // an
+                                                                                                                   // S3AsyncClient,
+                                                                                                                   // we
+                                                                                                                   // need
+                                                                                                                   // to
+                                                                                                                   // call
+                                                                                                                   // .get()
+                                                                                                                   // to
+                                                                                                                   // wait
+                                                                                                                   // for
+                                                                                                                   // the
+                                                                                                                   // result
             return headObjectResponse.contentLength();
         } catch (InterruptedException | ExecutionException e) {
             if (e.getCause() instanceof NoSuchKeyException) {
@@ -539,7 +539,7 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
                     .destinationBucket(bucketName).destinationKey(destinationKey).build();
 
             s3.copyObject(copyObjectRequest).get(); // Since s3 is an S3AsyncClient, we need to call .get() to wait for
-            // the result
+                                                    // the result
         } catch (InterruptedException | ExecutionException e) {
             logger.warning("Caught an exception in S3AccessIO.backupAsAux: " + e.getMessage());
             throw new IOException("S3AccessIO: Unable to backup original auxiliary object", e);
@@ -554,7 +554,7 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
                     .sourceKey(destinationKey).destinationBucket(bucketName).destinationKey(key).build();
 
             s3.copyObject(copyObjectRequest).get(); // Since s3 is an S3AsyncClient, we need to call .get() to wait for
-            // the result
+                                                    // the result
             deleteAuxObject(auxItemTag);
         } catch (InterruptedException | ExecutionException e) {
             logger.warning("Caught an exception in S3AccessIO.revertBackupAsAux: " + e.getMessage());
@@ -573,7 +573,7 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
                     .build();
             AsyncRequestBody asyncRequestBody = AsyncRequestBody.fromFile(fileSystemPath);
             s3.putObject(putObjectRequest, asyncRequestBody).get(); // Since s3 is an S3AsyncClient, we need to call
-            // .get() to wait for the result
+                                                                    // .get() to wait for the result
         } catch (InterruptedException | ExecutionException e) {
             logger.warning("Caught an exception in S3AccessIO.savePathAsAux(): " + e.getMessage());
             throw new IOException("S3AccessIO: Failed to save path as an auxiliary object.", e);
@@ -597,7 +597,7 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
                         executorService);
 
                 s3.putObject(putObjectRequest, asyncRequestBody).get(); // Since s3 is an S3AsyncClient, we need to call
-                // .get() to wait for the result
+                                                                        // .get() to wait for the result
             } catch (InterruptedException | ExecutionException e) {
                 String failureMsg = e.getMessage();
 
@@ -610,22 +610,21 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
     }
 
     /**
-     * Implements the StorageIO saveInputStreamAsAux() method. This
-     * implementation is problematic, because S3 cannot save an object of an
-     * unknown length. This effectively nullifies any benefits of streaming; as
-     * we cannot start saving until we have read the entire stream. One way of
-     * solving this would be to buffer the entire stream as byte[], in memory,
-     * then save it... Which of course would be limited by the amount of memory
-     * available, and thus would not work for streams larger than that. So we
-     * have eventually decided to save save the stream to a temp file, then save
-     * to S3. This is slower, but guaranteed to work on any size stream. An
-     * alternative we may want to consider is to not implement this method in
-     * the S3 driver, and make it throw the
-     * UnsupportedDataAccessOperationException, similarly to how we handle
-     * attempts to open OutputStreams, in this and the Swift driver.
-     *
+     * Implements the StorageIO saveInputStreamAsAux() method. This implementation
+     * is problematic, because S3 cannot save an object of an unknown length. This
+     * effectively nullifies any benefits of streaming; as we cannot start saving
+     * until we have read the entire stream. One way of solving this would be to
+     * buffer the entire stream as byte[], in memory, then save it... Which of
+     * course would be limited by the amount of memory available, and thus would not
+     * work for streams larger than that. So we have eventually decided to save save
+     * the stream to a temp file, then save to S3. This is slower, but guaranteed to
+     * work on any size stream. An alternative we may want to consider is to not
+     * implement this method in the S3 driver, and make it throw the
+     * UnsupportedDataAccessOperationException, similarly to how we handle attempts
+     * to open OutputStreams, in this and the Swift driver.
+     * 
      * @param inputStream InputStream we want to save
-     * @param auxItemTag String representing this Auxiliary type ("extension")
+     * @param auxItemTag  String representing this Auxiliary type ("extension")
      * @throws IOException if anything goes wrong.
      */
     @Override
@@ -760,7 +759,7 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
                     .key(destinationKey).build();
 
             s3.deleteObject(deleteObjectRequest).get(); // Since s3 is an S3AsyncClient, we need to call .get() to wait
-            // for the result
+                                                        // for the result
         } catch (InterruptedException | ExecutionException e) {
             logger.warning("S3AccessIO: Unable to delete object: " + e.getMessage());
             throw new IOException("Failed to delete auxiliary object", e);
@@ -911,13 +910,13 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
     }
 
     /**
-     * TODO: this function is not side effect free (sets instance variables key
-     * and bucketName). Is this good or bad? Need to ask @landreev
+     * TODO: this function is not side effect free (sets instance variables key and
+     * bucketName). Is this good or bad? Need to ask @landreev
      *
      * Extract the file key from a file stored on S3. Follows template: "owner
-     * authority name"/"owner identifier"/"storage identifier without bucketname
-     * and protocol"
-     *
+     * authority name"/"owner identifier"/"storage identifier without bucketname and
+     * protocol"
+     * 
      * @return Main File Key
      * @throws IOException
      */
@@ -980,12 +979,12 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
     /**
      * Generates a temporary URL for a direct S3 download; either for the main
      * physical file, or (optionally) for an auxiliary.
-     *
-     * @param auxiliaryTag (optional)
-     * @param auxiliaryType (optional) - aux. mime type, if different from the
-     * main type
-     * @param auxiliaryFileName (optional) - file name, if different from the
-     * main file label.
+     * 
+     * @param auxiliaryTag      (optional)
+     * @param auxiliaryType     (optional) - aux. mime type, if different from the
+     *                          main type
+     * @param auxiliaryFileName (optional) - file name, if different from the main
+     *                          file label.
      * @return redirect url
      * @throws IOException.
      */
@@ -1004,9 +1003,9 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
             GetObjectPresignRequest presignRequest = GetObjectPresignRequest.builder()
                     .signatureDuration(expirationDuration)
                     .getObjectRequest(req -> req.bucket(bucketName).key(key)
-                    .responseContentDisposition("attachment; filename*=UTF-8''"
-                            + URLEncoder.encode(fileName, StandardCharsets.UTF_8).replaceAll("\\+", "%20"))
-                    .responseContentType(contentType))
+                            .responseContentDisposition("attachment; filename*=UTF-8''"
+                                    + URLEncoder.encode(fileName, StandardCharsets.UTF_8).replaceAll("\\+", "%20"))
+                            .responseContentType(contentType))
                     .build();
 
             PresignedGetObjectRequest presignedRequest;
@@ -1271,7 +1270,7 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
         }
 
     }
-
+    
     private static AwsCredentialsProvider getCredentialsProvider(String driverId) {
         if (driverCredentialsProviderMap.containsKey(driverId)) {
             return driverCredentialsProviderMap.get(driverId);
@@ -1332,8 +1331,8 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
             if (e.getCause() instanceof S3Exception) {
                 S3Exception s3e = (S3Exception) e.getCause();
                 if (s3e.statusCode() == 501) {
-                    // In this case, it's likely that tags are not implemented at all
-                    // so no tag was set either and it's just something to be aware of
+                    // In this case, it's likely that tags are not implemented at all (e.g. by
+                    // Minio) so no tag was set either and it's just something to be aware of
                     logger.warning("Temp tag not deleted: Object tags not supported by storage: " + driverId);
                 } else {
                     // In this case, the assumption is that adding tags has worked, so not removing
@@ -1522,12 +1521,12 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
             throw new IOException("Failed to delete file", e);
         }
     }
-
+    
     @Override
     public void closeInputStream() {
         try {
             ResponseInputStream<GetObjectResponse> responseInputStream = (ResponseInputStream<GetObjectResponse>) getInputStream();
-            if (responseInputStream != null && responseInputStream.available() > 0) {
+            if(responseInputStream!= null && responseInputStream.available()>0) {
                 responseInputStream.abort();
             }
         } catch (IOException e) {

--- a/src/test/java/edu/harvard/iq/dataverse/api/S3AccessIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/S3AccessIT.java
@@ -46,7 +46,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 /**
- * This test requires LocalStack and Minio to be running. Developers can use our
+ * This test requires LocalStack to be running. Developers can use our
  * docker-compose file, which has all the necessary configuration.
  */
 public class S3AccessIT {
@@ -55,7 +55,6 @@ public class S3AccessIT {
 
     static final String BUCKET_NAME = "mybucket";
     static S3Client s3localstack = null;
-    static S3Client s3minio = null;
 
     @BeforeAll
     public static void setUp() {
@@ -71,45 +70,21 @@ public class S3AccessIT {
                 .region(Region.US_EAST_2)
                 .build();
 
-        String accessKeyMinio = "4cc355_k3y";
-        String secretKeyMinio = "s3cr3t_4cc355_k3y";
-        s3minio = S3Client.builder()
-                .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKeyMinio, secretKeyMinio)))
-                .endpointOverride(URI.create("http://localhost:9000"))
-                .region(Region.US_EAST_1)
-                .forcePathStyle(true)
-                .build();
-
         // create bucket if it doesn't exist
         try {
             s3localstack.headBucket(HeadBucketRequest.builder().bucket(BUCKET_NAME).build());
         } catch (NoSuchBucketException ex) {
             s3localstack.createBucket(CreateBucketRequest.builder().bucket(BUCKET_NAME).build());
         }
-
-        try {
-            s3minio.headBucket(HeadBucketRequest.builder().bucket(BUCKET_NAME).build());
-        } catch (NoSuchBucketException ex) {
-            try {
-                CreateBucketResponse createBucketResponse = s3minio.createBucket(CreateBucketRequest.builder().bucket(BUCKET_NAME).build());
-                if (createBucketResponse.sdkHttpResponse().isSuccessful()) {
-                    System.out.println("Bucket created successfully");
-                } else {
-                    System.err.println("Failed to create bucket: " + createBucketResponse.sdkHttpResponse().statusCode());
-                }
-            } catch (S3Exception e) {
-                System.err.println("Error creating bucket: " + e.getMessage());
-            }
-        }
     }
 
     /**
-     * We're using MinIO for testing non-direct upload.
+     * We're using Localstack for testing non-direct upload.
      */
     @Test
     public void testNonDirectUpload() {
-        String driverId = "minio1";
-        String driverLabel = "MinIO";
+        String driverId = "localstack1";
+        String driverLabel = "LocalStack";
 
         Response createSuperuser = UtilIT.createRandomUser();
         createSuperuser.then().assertThat().statusCode(200);
@@ -124,7 +99,6 @@ public class S3AccessIT {
     "status": "OK",
     "data": {
         "LocalStack": "localstack1",
-        "MinIO": "minio1",
         "Local": "local",
         "Filesystem": "file1"
     }
@@ -191,7 +165,7 @@ public class S3AccessIT {
         String keyInS3 = datasetStorageIdentifier + "/" + keyInDataverse;
         String s3Object = null;
         try {
-            ResponseInputStream<GetObjectResponse> s3ObjectResponse = s3minio.getObject(GetObjectRequest.builder()
+            ResponseInputStream<GetObjectResponse> s3ObjectResponse = s3localstack.getObject(GetObjectRequest.builder()
                     .bucket(BUCKET_NAME)
                     .key(keyInS3)
                     .build());
@@ -220,7 +194,7 @@ public class S3AccessIT {
 
         S3Exception expectedException = null;
         try {
-            ResponseInputStream<GetObjectResponse> s3ObjectResponse = s3minio.getObject(GetObjectRequest.builder()
+            ResponseInputStream<GetObjectResponse> s3ObjectResponse = s3localstack.getObject(GetObjectRequest.builder()
                     .bucket(BUCKET_NAME)
                     .key(keyInS3)
                     .build());
@@ -258,7 +232,6 @@ public class S3AccessIT {
     "status": "OK",
     "data": {
         "LocalStack": "localstack1",
-        "MinIO": "minio1",
         "Local": "local",
         "Filesystem": "file1"
     }
@@ -441,7 +414,7 @@ public class S3AccessIT {
 
         S3Exception expectedException = null;
         try {
-            ResponseInputStream<GetObjectResponse> s3ObjectResponse = s3minio.getObject(GetObjectRequest.builder()
+            ResponseInputStream<GetObjectResponse> s3ObjectResponse = s3localstack.getObject(GetObjectRequest.builder()
                     .bucket(BUCKET_NAME)
                     .key(keyInS3)
                     .build());
@@ -476,7 +449,6 @@ public class S3AccessIT {
     "status": "OK",
     "data": {
         "LocalStack": "localstack1",
-        "MinIO": "minio1",
         "Local": "local",
         "Filesystem": "file1"
     }
@@ -663,7 +635,6 @@ public class S3AccessIT {
     "status": "OK",
     "data": {
         "LocalStack": "localstack1",
-        "MinIO": "minio1",
         "Local": "local",
         "Filesystem": "file1"
     }

--- a/src/test/java/edu/harvard/iq/dataverse/api/S3AccessIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/S3AccessIT.java
@@ -240,6 +240,7 @@ public class S3AccessIT {
     "status": "OK",
     "data": {
         "LocalStack": "localstack1",
+        "LocalStackNoRedirect": "localstack_noredirect",
         "Local": "local",
         "Filesystem": "file1"
     }
@@ -457,6 +458,7 @@ public class S3AccessIT {
     "status": "OK",
     "data": {
         "LocalStack": "localstack1",
+        "LocalStackNoRedirect": "localstack_noredirect",
         "Local": "local",
         "Filesystem": "file1"
     }
@@ -643,6 +645,7 @@ public class S3AccessIT {
     "status": "OK",
     "data": {
         "LocalStack": "localstack1",
+        "LocalStackNoRedirect": "localstack_noredirect",
         "Local": "local",
         "Filesystem": "file1"
     }

--- a/src/test/java/edu/harvard/iq/dataverse/api/S3AccessIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/S3AccessIT.java
@@ -54,6 +54,7 @@ public class S3AccessIT {
     private static final Logger logger = Logger.getLogger(S3AccessIT.class.getCanonicalName());
 
     static final String BUCKET_NAME = "mybucket";
+    static final String BUCKET_NAME_NOREDIRECT = "mybucket-noredirect";
     static S3Client s3localstack = null;
 
     @BeforeAll
@@ -165,13 +166,13 @@ public class S3AccessIT {
 
         String storageIdentifier = JsonPath.from(addFileResponse.body().asString()).getString("data.files[0].dataFile.storageIdentifier");
         String keyInDataverse = storageIdentifier.split(":")[2];
-        Assertions.assertEquals(driverId + "://" + BUCKET_NAME + ":" + keyInDataverse, storageIdentifier);
+        Assertions.assertEquals(driverId + "://" + BUCKET_NAME_NOREDIRECT + ":" + keyInDataverse, storageIdentifier);
 
         String keyInS3 = datasetStorageIdentifier + "/" + keyInDataverse;
         String s3Object = null;
         try {
             ResponseInputStream<GetObjectResponse> s3ObjectResponse = s3localstack.getObject(GetObjectRequest.builder()
-                    .bucket(BUCKET_NAME)
+                    .bucket(BUCKET_NAME_NOREDIRECT)
                     .key(keyInS3)
                     .build());
             // Read the content of the object into a string
@@ -203,7 +204,7 @@ public class S3AccessIT {
         S3Exception expectedException = null;
         try {
             ResponseInputStream<GetObjectResponse> s3ObjectResponse = s3localstack.getObject(GetObjectRequest.builder()
-                    .bucket(BUCKET_NAME)
+                    .bucket(BUCKET_NAME_NOREDIRECT)
                     .key(keyInS3)
                     .build());
             // Read the content of the object into a string

--- a/src/test/java/edu/harvard/iq/dataverse/api/S3AccessIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/S3AccessIT.java
@@ -79,7 +79,8 @@ public class S3AccessIT {
         try {
             s3localstack.headBucket(HeadBucketRequest.builder().bucket(bucketName).build());
         } catch (S3Exception ex) {
-            if (ex.statusCode() == 404 || "NoSuchBucket".equals(ex.awsErrorDetails().errorCode())) {
+            String errorCode = ex.awsErrorDetails() == null ? null : ex.awsErrorDetails().errorCode();
+            if (ex.statusCode() == 404 || "NoSuchBucket".equals(errorCode)) {
                 s3localstack.createBucket(CreateBucketRequest.builder().bucket(bucketName).build());
             } else {
                 throw ex;

--- a/src/test/java/edu/harvard/iq/dataverse/api/S3AccessIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/S3AccessIT.java
@@ -79,12 +79,16 @@ public class S3AccessIT {
     }
 
     /**
-     * We're using Localstack for testing non-direct upload.
+     * We're using LocalStack (with redirects disabled) for testing non-direct
+     * upload. Using localstack_noredirect ensures the non-redirect
+     * (proxy-through-Dataverse) code path is actually exercised. If localstack1
+     * (redirect-enabled) were used, RestAssured would silently follow the 303
+     * redirect and the proxy path would never be tested.
      */
     @Test
     public void testNonDirectUpload() {
-        String driverId = "localstack1";
-        String driverLabel = "LocalStack";
+        String driverId = "localstack_noredirect";
+        String driverLabel = "LocalStackNoRedirect";
 
         Response createSuperuser = UtilIT.createRandomUser();
         createSuperuser.then().assertThat().statusCode(200);
@@ -99,6 +103,7 @@ public class S3AccessIT {
     "status": "OK",
     "data": {
         "LocalStack": "localstack1",
+        "LocalStackNoRedirect": "localstack_noredirect",
         "Local": "local",
         "Filesystem": "file1"
     }
@@ -181,8 +186,11 @@ public class S3AccessIT {
             fail("Failed to read S3 object content: " + ex.getMessage());
         }
 
+        // Use downloadFileNoRedirect to verify Dataverse serves the content directly
+        // (status 200). If the driver were misconfigured with download-redirect=true,
+        // this would return 303 instead, causing the test to fail explicitly.
         System.out.println("non-direct download...");
-        Response downloadFile = UtilIT.downloadFile(Integer.valueOf(fileId), apiToken);
+        Response downloadFile = UtilIT.downloadFileNoRedirect(Integer.valueOf(fileId), apiToken);
         downloadFile.then().assertThat().statusCode(200);
 
         String contentsOfDownloadedFile = downloadFile.getBody().asString();

--- a/src/test/java/edu/harvard/iq/dataverse/api/S3AccessIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/S3AccessIT.java
@@ -319,18 +319,6 @@ public class S3AccessIT {
         InputStream inputStream = new ByteArrayInputStream(contentsOfFile.getBytes(StandardCharsets.UTF_8));
         Response uploadFileDirect = UtilIT.uploadFileDirect(localhostUrl, inputStream);
         uploadFileDirect.prettyPrint();
-        /*
-        Direct upload to MinIO is failing with errors like this:
-        <Error>
-          <Code>SignatureDoesNotMatch</Code>
-          <Message>The request signature we calculated does not match the signature you provided. Check your key and signing method.</Message>
-          <Key>10.5072/FK2/KGFCEJ/18b8c06688c-21b8320a3ee5</Key>
-          <BucketName>mybucket</BucketName>
-          <Resource>/mybucket/10.5072/FK2/KGFCEJ/18b8c06688c-21b8320a3ee5</Resource>
-          <RequestId>1793915CCC5BC95C</RequestId>
-          <HostId>dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8</HostId>
-        </Error>
-         */
         uploadFileDirect.then().assertThat().statusCode(200);
 
         // TODO: Use MD5 or whatever Dataverse is configured for and
@@ -533,18 +521,6 @@ public class S3AccessIT {
         }
         Response uploadFileDirect = UtilIT.uploadFileDirect(localhostUrl, inputStream);
         uploadFileDirect.prettyPrint();
-        /*
-        Direct upload to MinIO is failing with errors like this:
-        <Error>
-          <Code>SignatureDoesNotMatch</Code>
-          <Message>The request signature we calculated does not match the signature you provided. Check your key and signing method.</Message>
-          <Key>10.5072/FK2/KGFCEJ/18b8c06688c-21b8320a3ee5</Key>
-          <BucketName>mybucket</BucketName>
-          <Resource>/mybucket/10.5072/FK2/KGFCEJ/18b8c06688c-21b8320a3ee5</Resource>
-          <RequestId>1793915CCC5BC95C</RequestId>
-          <HostId>dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8</HostId>
-        </Error>
-         */
         uploadFileDirect.then().assertThat().statusCode(200);
 
         // TODO: Use MD5 or whatever Dataverse is configured for and

--- a/src/test/java/edu/harvard/iq/dataverse/api/S3AccessIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/S3AccessIT.java
@@ -78,10 +78,8 @@ public class S3AccessIT {
     private static void ensureBucketExists(String bucketName) {
         try {
             s3localstack.headBucket(HeadBucketRequest.builder().bucket(bucketName).build());
-        } catch (NoSuchBucketException ex) {
-            s3localstack.createBucket(CreateBucketRequest.builder().bucket(bucketName).build());
         } catch (S3Exception ex) {
-            if (ex.statusCode() == 404) {
+            if (ex.statusCode() == 404 || "NoSuchBucket".equals(ex.awsErrorDetails().errorCode())) {
                 s3localstack.createBucket(CreateBucketRequest.builder().bucket(bucketName).build());
             } else {
                 throw ex;

--- a/src/test/java/edu/harvard/iq/dataverse/api/S3AccessIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/S3AccessIT.java
@@ -71,11 +71,21 @@ public class S3AccessIT {
                 .region(Region.US_EAST_2)
                 .build();
 
-        // create bucket if it doesn't exist
+        ensureBucketExists(BUCKET_NAME);
+        ensureBucketExists(BUCKET_NAME_NOREDIRECT);
+    }
+
+    private static void ensureBucketExists(String bucketName) {
         try {
-            s3localstack.headBucket(HeadBucketRequest.builder().bucket(BUCKET_NAME).build());
+            s3localstack.headBucket(HeadBucketRequest.builder().bucket(bucketName).build());
         } catch (NoSuchBucketException ex) {
-            s3localstack.createBucket(CreateBucketRequest.builder().bucket(BUCKET_NAME).build());
+            s3localstack.createBucket(CreateBucketRequest.builder().bucket(bucketName).build());
+        } catch (S3Exception ex) {
+            if (ex.statusCode() == 404) {
+                s3localstack.createBucket(CreateBucketRequest.builder().bucket(bucketName).build());
+            } else {
+                throw ex;
+            }
         }
     }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes MinIO and replaces MinIO tests with LocalStack.

Previously since LocalStack did not offer good pre-signed URL capabilities, the Dataverse team was forced to go with MinIO. However, since that decision was made LocalStack has improved significantly in capabilities. So, this PR replaces the previous MinIO instantiation with a localstack_noredirect instantiation which performs the same no redirect downloads with LocalStack instead. Changes were made in dataverse-ansible to make sure localstack_noredirect is present in the testing environment. After this PR is merged, changes have to be made again in dataverse-ansible to remove MinIO and stay true to Dataverse's open-source roots. The dev_minio containers were removed from both the docker-compose-dev.yml files to reflect these changes into containers as well.

**Which issue(s) this PR closes**:

- Closes #12036 

**Special notes for your reviewer**:
Could be a breaking change for people running on containers.

**Suggestions on how to test this**:
1. Containers should be launching and working as usual along with containerized testing working as usual.
2. The S3AccessIT API test needs to be able to pass on Jenkins

If these two are satisfied then, the PR should be good to go. However, Phil, Oliver, and others might have a lot of things to say about the messy way I go about things, so everything they have to add too.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
N/A

**Is there a release notes update needed for this change?**:
Yes. Probably. Oliver would know better than me.

**Additional documentation**:
Absolutely needed. Again, Oliver would know better than me.
