### PR TITLE
Fix typo in dataset management documentation

### DIFF
--- a/doc/sphinx-guides/source/user/dataset-management.rst
+++ b/doc/sphinx-guides/source/user/dataset-management.rst
@@ -1,4 +1,4 @@
-Dataset + File Management
+fDataset + File Management
 +++++++++++++++++++++++++
 
 A dataset in a Dataverse installation is a container for your data, documentation, code, and the metadata describing this Dataset.
@@ -439,6 +439,7 @@ Go to the dataset you would like to edit, where you will see the listing of file
 - Restrict the selected files
 - Unrestrict the selected files (only if the selected files are restricted)
 - Add tags to the selected files
+- Embargo the selected files
 
 You will not have to leave the dataset page to complete these action, except for editing file metadata, which will bring you to the Edit Files page. There you will have to click the "Save Changes" button to apply your edits and return to the dataset page.
 

--- a/doc/sphinx-guides/source/user/dataset-management.rst
+++ b/doc/sphinx-guides/source/user/dataset-management.rst
@@ -1,4 +1,4 @@
-fDataset + File Management
+Dataset + File Management
 +++++++++++++++++++++++++
 
 A dataset in a Dataverse installation is a container for your data, documentation, code, and the metadata describing this Dataset.


### PR DESCRIPTION
Updates the dataset management guide to include the missing "Embargo" option under the Edit Files menu.

Closes #11739

Preview URL:
https://dataverse-guide--12396.org.readthedocs.build/en/12396/user/dataset-management.html#edit-file-metadata