### PR TITLE
Fix destroy dataset response for persistent IDs

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/api/Datasets.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Datasets.java
@@ -372,8 +372,15 @@ public class Datasets extends AbstractApiBean {
                 fileService.finalizeFileDeletes(deleteStorageLocations);
             }
 
-            return ok("Dataset " + id + " destroyed");
+            return ok(getDatasetDestroyedMessage(id, doomed));
         }, u);
+    }
+
+    static String getDatasetDestroyedMessage(String id, Dataset dataset) {
+        String datasetIdentifier = PERSISTENT_ID_KEY.equals(id)
+                ? dataset.getGlobalId().asString()
+                : id;
+        return "Dataset " + datasetIdentifier + " destroyed";
     }
 
     @DELETE

--- a/src/test/java/edu/harvard/iq/dataverse/api/DatasetsTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/DatasetsTest.java
@@ -1,5 +1,8 @@
 package edu.harvard.iq.dataverse.api;
 
+import edu.harvard.iq.dataverse.Dataset;
+import edu.harvard.iq.dataverse.GlobalId;
+import edu.harvard.iq.dataverse.pidproviders.doi.AbstractDOIProvider;
 import org.junit.jupiter.api.Test;
 import java.util.HashSet;
 import java.util.Set;
@@ -54,5 +57,20 @@ public class DatasetsTest {
         assertTrue(deleted.contains("18383198c49-aeda08ccffff"));
         assertTrue(deleted.contains("1837fda17ce-d7b9987fc6e9_suffix"));
         assertTrue(deleted.contains("1837fda17ce-d7b9987fc6e9.aux"));
+    }
+
+    @Test
+    public void testGetDatasetDestroyedMessageWithId() {
+        assertEquals("Dataset 42 destroyed", Datasets.getDatasetDestroyedMessage("42", new Dataset()));
+    }
+
+    @Test
+    public void testGetDatasetDestroyedMessageWithPersistentId() {
+        Dataset dataset = new Dataset();
+        dataset.setGlobalId(new GlobalId(AbstractDOIProvider.DOI_PROTOCOL, "10.5072", "FK2/ABCDEF", "/",
+                AbstractDOIProvider.DOI_RESOLVER_URL, null));
+
+        assertEquals("Dataset doi:10.5072/FK2/ABCDEF destroyed",
+                Datasets.getDatasetDestroyedMessage(AbstractApiBean.PERSISTENT_ID_KEY, dataset));
     }
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the destroy dataset success message for `:persistentId` requests so it reports the actual dataset persistent ID instead of the literal `:persistentId` path token. Adds unit coverage for numeric IDs and persistent IDs.

**Which issue(s) this PR closes**:

- Closes #8412

**Special notes for your reviewer**:

None.

**Suggestions on how to test this**:

- `mvn -Dtest=DatasetsTest test`

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No.

**Is there a release notes update needed for this change?**:

No.

**Additional documentation**:

None.