### PR TITLE
Auto Create thumbnail so Search API will return image_url when publis…

### DIFF
--- a/doc/release-notes/11588-search-api-doesnt-return-image-url.md
+++ b/doc/release-notes/11588-search-api-doesnt-return-image-url.md
@@ -1,0 +1,4 @@
+## BUG ##
+Search API doesn't return image_url after newly created dataset is published.
+
+The Dataset thumbnail will be created automatically when a Dataset is published under the following conditions: The Dataset has no existing thumbnail; The Dataset has image files that can be converted to a thumbnail; The Feature Flag "disable-dataset-thumbnail-autoselect" is not enabled;

--- a/src/main/java/edu/harvard/iq/dataverse/Dataset.java
+++ b/src/main/java/edu/harvard/iq/dataverse/Dataset.java
@@ -763,6 +763,10 @@ public class Dataset extends DvObjectContainer {
         this.thumbnailFile = thumbnailFile;
     }
 
+    public String getThumbnailUrl() {
+        return thumbnailFile != null ? SystemConfig.getDataverseSiteUrlStatic() + "/api/datasets/" + this.getId() + "/logo" : null;
+    }
+
     public boolean isUseGenericThumbnail() {
         return useGenericThumbnail;
     }

--- a/src/main/java/edu/harvard/iq/dataverse/DatasetVersionServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetVersionServiceBean.java
@@ -35,7 +35,6 @@ import jakarta.json.Json;
 import jakarta.json.JsonObjectBuilder;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.NoResultException;
-import jakarta.persistence.OptimisticLockException;
 import jakarta.persistence.PersistenceContext;
 import jakarta.persistence.Query;
 import jakarta.persistence.TypedQuery;
@@ -892,7 +891,7 @@ public class DatasetVersionServiceBean implements java.io.Serializable {
 
                 if (thumbnailFileId != null) {
                     logger.fine("obtained file id: " + thumbnailFileId);
-                    DataFile thumbnailFile = datafileService.find(thumbnailFileId);
+                    DataFile thumbnailFile = getDataFileById(thumbnailFileId);
                     if (thumbnailFile != null) {
                         if (datafileService.isThumbnailAvailable(thumbnailFile)) {
                             assignDatasetThumbnailByNativeQuery(versionId, thumbnailFileId);
@@ -925,7 +924,7 @@ public class DatasetVersionServiceBean implements java.io.Serializable {
                 }
 
                 if (thumbnailFileId != null) {
-                    DataFile thumbnailFile = datafileService.find(thumbnailFileId);
+                    DataFile thumbnailFile = getDataFileById(thumbnailFileId);
                     if (thumbnailFile != null) {
                         if (datafileService.isThumbnailAvailable(thumbnailFile)) {
                             assignDatasetThumbnailByNativeQuery(versionId, thumbnailFileId);
@@ -937,7 +936,11 @@ public class DatasetVersionServiceBean implements java.io.Serializable {
         }
         return null;
     }
-    
+
+    public DataFile getDataFileById(Long id) {
+        return datafileService.find(id);
+    }
+
     private void assignDatasetThumbnailByNativeQuery(Long versionId, Long dataFileId) {
         try {
             em.createNativeQuery("UPDATE dataset SET thumbnailfile_id=" + dataFileId + " WHERE id in (SELECT dataset_id FROM datasetversion WHERE id=" + versionId + ")").executeUpdate();

--- a/src/main/java/edu/harvard/iq/dataverse/ThumbnailServiceWrapper.java
+++ b/src/main/java/edu/harvard/iq/dataverse/ThumbnailServiceWrapper.java
@@ -208,7 +208,7 @@ public class ThumbnailServiceWrapper implements java.io.Serializable  {
             // If no other logo we attempt to auto-select via the optimized, native
             // query-based method
             // from the DatasetVersionService:
-            if (!hasDatasetLogo && datasetVersionService.getThumbnailByVersionId(versionId) == null) {
+            if (!hasDatasetLogo && (!autoselect || datasetVersionService.getThumbnailByVersionId(versionId) == null)) {
                 return null;
             }
         }

--- a/src/main/java/edu/harvard/iq/dataverse/ThumbnailServiceWrapper.java
+++ b/src/main/java/edu/harvard/iq/dataverse/ThumbnailServiceWrapper.java
@@ -212,7 +212,7 @@ public class ThumbnailServiceWrapper implements java.io.Serializable  {
                 return null;
             }
         }
-        String url = SystemConfig.getDataverseSiteUrlStatic() + "/api/datasets/" + dataset.getId() + "/logo";
+        String url = dataset.getThumbnailUrl();
         logger.fine("getDatasetCardImageAsUrl: " + url);
         this.dvobjectThumbnailsMap.put(datasetId,url);
         return url;

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/FinalizeDatasetPublicationCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/FinalizeDatasetPublicationCommand.java
@@ -1,6 +1,5 @@
 package edu.harvard.iq.dataverse.engine.command.impl;
 
-import com.rometools.utils.Lists;
 import edu.harvard.iq.dataverse.ControlledVocabularyValue;
 import edu.harvard.iq.dataverse.CurationStatus;
 import edu.harvard.iq.dataverse.DataFile;
@@ -18,8 +17,6 @@ import edu.harvard.iq.dataverse.Embargo;
 import edu.harvard.iq.dataverse.UserNotification;
 import edu.harvard.iq.dataverse.authorization.Permission;
 import edu.harvard.iq.dataverse.authorization.users.AuthenticatedUser;
-import edu.harvard.iq.dataverse.dataaccess.ImageThumbConverter;
-import edu.harvard.iq.dataverse.dataset.DatasetThumbnail;
 import edu.harvard.iq.dataverse.dataset.DatasetUtil;
 import edu.harvard.iq.dataverse.engine.command.CommandContext;
 import edu.harvard.iq.dataverse.engine.command.DataverseRequest;
@@ -27,7 +24,6 @@ import edu.harvard.iq.dataverse.engine.command.RequiredPermissions;
 import edu.harvard.iq.dataverse.engine.command.exception.CommandException;
 import edu.harvard.iq.dataverse.pidproviders.PidProvider;
 import edu.harvard.iq.dataverse.privateurl.PrivateUrl;
-import edu.harvard.iq.dataverse.settings.FeatureFlags;
 import edu.harvard.iq.dataverse.util.BundleUtil;
 import edu.harvard.iq.dataverse.workflow.WorkflowContext;
 import edu.harvard.iq.dataverse.workflow.WorkflowContext.TriggerType;
@@ -178,7 +174,9 @@ public class FinalizeDatasetPublicationCommand extends AbstractPublishDatasetCom
 
         // Populate thumbnail if needed and allowed
         if (theDataset.getThumbnailFile() == null && !theDataset.isUseGenericThumbnail()) {
-            ctxt.datasetVersion().getThumbnailByVersionId(version.getId());
+            Long thumbnailFileId = ctxt.datasetVersion().getThumbnailByVersionId(version.getId());
+            theDataset.setThumbnailFile(ctxt.datasetVersion().getDataFileById(thumbnailFileId));
+            logger.info("Setting default thumbnail " + theDataset.getThumbnailUrl());
         }
 
         // 

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/FinalizeDatasetPublicationCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/FinalizeDatasetPublicationCommand.java
@@ -175,8 +175,10 @@ public class FinalizeDatasetPublicationCommand extends AbstractPublishDatasetCom
         // Populate thumbnail if needed and allowed
         if (theDataset.getThumbnailFile() == null && !theDataset.isUseGenericThumbnail()) {
             Long thumbnailFileId = ctxt.datasetVersion().getThumbnailByVersionId(version.getId());
-            theDataset.setThumbnailFile(ctxt.datasetVersion().getDataFileById(thumbnailFileId));
-            logger.info("Setting default thumbnail " + theDataset.getThumbnailUrl());
+            if (thumbnailFileId != null) {
+                theDataset.setThumbnailFile(ctxt.datasetVersion().getDataFileById(thumbnailFileId));
+                logger.info("Setting default thumbnail " + theDataset.getThumbnailUrl());
+            }
         }
 
         // 

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/FinalizeDatasetPublicationCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/FinalizeDatasetPublicationCommand.java
@@ -1,5 +1,6 @@
 package edu.harvard.iq.dataverse.engine.command.impl;
 
+import com.rometools.utils.Lists;
 import edu.harvard.iq.dataverse.ControlledVocabularyValue;
 import edu.harvard.iq.dataverse.CurationStatus;
 import edu.harvard.iq.dataverse.DataFile;
@@ -17,6 +18,8 @@ import edu.harvard.iq.dataverse.Embargo;
 import edu.harvard.iq.dataverse.UserNotification;
 import edu.harvard.iq.dataverse.authorization.Permission;
 import edu.harvard.iq.dataverse.authorization.users.AuthenticatedUser;
+import edu.harvard.iq.dataverse.dataaccess.ImageThumbConverter;
+import edu.harvard.iq.dataverse.dataset.DatasetThumbnail;
 import edu.harvard.iq.dataverse.dataset.DatasetUtil;
 import edu.harvard.iq.dataverse.engine.command.CommandContext;
 import edu.harvard.iq.dataverse.engine.command.DataverseRequest;
@@ -24,6 +27,7 @@ import edu.harvard.iq.dataverse.engine.command.RequiredPermissions;
 import edu.harvard.iq.dataverse.engine.command.exception.CommandException;
 import edu.harvard.iq.dataverse.pidproviders.PidProvider;
 import edu.harvard.iq.dataverse.privateurl.PrivateUrl;
+import edu.harvard.iq.dataverse.settings.FeatureFlags;
 import edu.harvard.iq.dataverse.util.BundleUtil;
 import edu.harvard.iq.dataverse.workflow.WorkflowContext;
 import edu.harvard.iq.dataverse.workflow.WorkflowContext.TriggerType;
@@ -171,7 +175,15 @@ public class FinalizeDatasetPublicationCommand extends AbstractPublishDatasetCom
         
         //Use dataset pub date (which may not be the current date for migrated datasets)
         updateFiles(new Timestamp(version.getReleaseTime().getTime()), ctxt);
-        
+
+        // Populate thumbnail if needed and allowed (Only look for DataFiles)
+        if (theDataset.getThumbnailFile() == null && !theDataset.isUseGenericThumbnail() && !FeatureFlags.DISABLE_DATASET_THUMBNAIL_AUTOSELECT.enabled()) {
+            List<DatasetThumbnail> candidatesList = DatasetUtil.getThumbnailCandidates(theDataset, false, ImageThumbConverter.DEFAULT_CARDIMAGE_SIZE);
+            if (Lists.isNotEmpty(candidatesList)) {
+                theDataset.setThumbnailFile(candidatesList.get(0).getDataFile());
+            }
+        }
+
         // 
         // TODO: Not sure if this .merge() is necessary here - ? 
         // I'm moving a bunch of code from PublishDatasetCommand here; and this .merge()

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/FinalizeDatasetPublicationCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/FinalizeDatasetPublicationCommand.java
@@ -176,12 +176,9 @@ public class FinalizeDatasetPublicationCommand extends AbstractPublishDatasetCom
         //Use dataset pub date (which may not be the current date for migrated datasets)
         updateFiles(new Timestamp(version.getReleaseTime().getTime()), ctxt);
 
-        // Populate thumbnail if needed and allowed (Only look for DataFiles)
-        if (theDataset.getThumbnailFile() == null && !theDataset.isUseGenericThumbnail() && !FeatureFlags.DISABLE_DATASET_THUMBNAIL_AUTOSELECT.enabled()) {
-            List<DatasetThumbnail> candidatesList = DatasetUtil.getThumbnailCandidates(theDataset, false, ImageThumbConverter.DEFAULT_CARDIMAGE_SIZE);
-            if (Lists.isNotEmpty(candidatesList)) {
-                theDataset.setThumbnailFile(candidatesList.get(0).getDataFile());
-            }
+        // Populate thumbnail if needed and allowed
+        if (theDataset.getThumbnailFile() == null && !theDataset.isUseGenericThumbnail()) {
+            ctxt.datasetVersion().getThumbnailByVersionId(version.getId());
         }
 
         // 

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/PublishDatasetCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/PublishDatasetCommand.java
@@ -1,13 +1,18 @@
 package edu.harvard.iq.dataverse.engine.command.impl;
 
+import com.rometools.utils.Lists;
 import edu.harvard.iq.dataverse.*;
 import edu.harvard.iq.dataverse.authorization.Permission;
 import edu.harvard.iq.dataverse.authorization.users.AuthenticatedUser;
+import edu.harvard.iq.dataverse.dataaccess.ImageThumbConverter;
+import edu.harvard.iq.dataverse.dataset.DatasetThumbnail;
+import edu.harvard.iq.dataverse.dataset.DatasetUtil;
 import edu.harvard.iq.dataverse.engine.command.CommandContext;
 import edu.harvard.iq.dataverse.engine.command.DataverseRequest;
 import edu.harvard.iq.dataverse.engine.command.RequiredPermissions;
 import edu.harvard.iq.dataverse.engine.command.exception.CommandException;
 import edu.harvard.iq.dataverse.engine.command.exception.IllegalCommandException;
+import edu.harvard.iq.dataverse.settings.FeatureFlags;
 import edu.harvard.iq.dataverse.util.BundleUtil;
 import edu.harvard.iq.dataverse.workflow.Workflow;
 import edu.harvard.iq.dataverse.workflow.WorkflowContext;
@@ -165,6 +170,15 @@ public class PublishDatasetCommand extends AbstractPublishDatasetCommand<Publish
                 lock.setInfo(info);
                 ctxt.datasets().addDatasetLock(theDataset, lock);
             }
+
+            // Populate thumbnail if needed (Only look for DataFiles)
+            if (theDataset.getThumbnailFile() == null && !FeatureFlags.DISABLE_DATASET_THUMBNAIL_AUTOSELECT.enabled()) {
+                List<DatasetThumbnail> candidatesList = DatasetUtil.getThumbnailCandidates(theDataset, false, ImageThumbConverter.DEFAULT_CARDIMAGE_SIZE);
+                if (Lists.isNotEmpty(candidatesList)) {
+                    theDataset.setThumbnailFile(candidatesList.get(0).getDataFile());
+                }
+            }
+
             try {
                 theDataset = ctxt.em().merge(theDataset);
             } catch (OptimisticLockException e) {

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/PublishDatasetCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/PublishDatasetCommand.java
@@ -1,18 +1,13 @@
 package edu.harvard.iq.dataverse.engine.command.impl;
 
-import com.rometools.utils.Lists;
 import edu.harvard.iq.dataverse.*;
 import edu.harvard.iq.dataverse.authorization.Permission;
 import edu.harvard.iq.dataverse.authorization.users.AuthenticatedUser;
-import edu.harvard.iq.dataverse.dataaccess.ImageThumbConverter;
-import edu.harvard.iq.dataverse.dataset.DatasetThumbnail;
-import edu.harvard.iq.dataverse.dataset.DatasetUtil;
 import edu.harvard.iq.dataverse.engine.command.CommandContext;
 import edu.harvard.iq.dataverse.engine.command.DataverseRequest;
 import edu.harvard.iq.dataverse.engine.command.RequiredPermissions;
 import edu.harvard.iq.dataverse.engine.command.exception.CommandException;
 import edu.harvard.iq.dataverse.engine.command.exception.IllegalCommandException;
-import edu.harvard.iq.dataverse.settings.FeatureFlags;
 import edu.harvard.iq.dataverse.util.BundleUtil;
 import edu.harvard.iq.dataverse.workflow.Workflow;
 import edu.harvard.iq.dataverse.workflow.WorkflowContext;
@@ -170,15 +165,6 @@ public class PublishDatasetCommand extends AbstractPublishDatasetCommand<Publish
                 lock.setInfo(info);
                 ctxt.datasets().addDatasetLock(theDataset, lock);
             }
-
-            // Populate thumbnail if needed (Only look for DataFiles)
-            if (theDataset.getThumbnailFile() == null && !FeatureFlags.DISABLE_DATASET_THUMBNAIL_AUTOSELECT.enabled()) {
-                List<DatasetThumbnail> candidatesList = DatasetUtil.getThumbnailCandidates(theDataset, false, ImageThumbConverter.DEFAULT_CARDIMAGE_SIZE);
-                if (Lists.isNotEmpty(candidatesList)) {
-                    theDataset.setThumbnailFile(candidatesList.get(0).getDataFile());
-                }
-            }
-
             try {
                 theDataset = ctxt.em().merge(theDataset);
             } catch (OptimisticLockException e) {

--- a/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
@@ -551,10 +551,8 @@ public class JsonPrinter {
                 .add("separator", ds.getSeparator())
                 .add("publisher", BrandingUtil.getInstallationBrandName())
                 .add("publicationDate", ds.getPublicationDateFormattedYYYYMMDD())
+                .add("image_url", ds.getThumbnailUrl())
                 .add("storageIdentifier", ds.getStorageIdentifier());
-        if (ds.getThumbnailFile() != null) {
-            bld.add("image_url", ds.getThumbnailUrl());
-        }
         if (ds.getGuestbook() != null) {
             bld.add("guestbookId", ds.getGuestbook().getId());
         }

--- a/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
@@ -552,6 +552,9 @@ public class JsonPrinter {
                 .add("publisher", BrandingUtil.getInstallationBrandName())
                 .add("publicationDate", ds.getPublicationDateFormattedYYYYMMDD())
                 .add("storageIdentifier", ds.getStorageIdentifier());
+        if (ds.getThumbnailFile() != null) {
+            bld.add("image_url", ds.getThumbnailUrl());
+        }
         if (ds.getGuestbook() != null) {
             bld.add("guestbookId", ds.getGuestbook().getId());
         }

--- a/src/test/java/edu/harvard/iq/dataverse/api/DataRetrieverApiIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/DataRetrieverApiIT.java
@@ -21,7 +21,6 @@ import static jakarta.ws.rs.core.Response.Status.*;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.junit.jupiter.api.Assertions.*;
-import org.junit.jupiter.api.Disabled;
 
 public class DataRetrieverApiIT {
 
@@ -78,7 +77,7 @@ public class DataRetrieverApiIT {
         Response createDatasetResponse = UtilIT.createRandomDatasetViaNativeApi(dataverseAlias, normalUserApiToken);
         createDatasetResponse.prettyPrint();
         Integer datasetId = UtilIT.getDatasetIdFromResponse(createDatasetResponse);
-        UtilIT.sleepForReindex(datasetId.toString(), normalUserApiToken, 4);
+        UtilIT.sleepForDatasetIndex(datasetId.toString(), normalUserApiToken);
         Response oneDatasetResponse = UtilIT.retrieveMyDataAsJsonString(normalUserApiToken, "", new ArrayList<>(Arrays.asList(6L)));
         assertEquals(OK.getStatusCode(), oneDatasetResponse.getStatusCode());
         JsonPath jsonPathOneDataset = oneDatasetResponse.getBody().jsonPath();
@@ -277,13 +276,13 @@ public class DataRetrieverApiIT {
         createDatasetOneResponse.prettyPrint();
         Integer datasetOneId = UtilIT.getDatasetIdFromResponse(createDatasetOneResponse);
         String datasetOnePid = UtilIT.getDatasetPersistentIdFromResponse(createDatasetOneResponse);
-        UtilIT.sleepForReindex(datasetOneId.toString(), userApiToken, 4);
+        UtilIT.sleepForDatasetIndex(datasetOneId.toString(), userApiToken);
 
         Response createDatasetTwoResponse = UtilIT.createRandomDatasetViaNativeApi(dataverseAlias, userApiToken);
         createDatasetTwoResponse.prettyPrint();
         Integer datasetTwoId = UtilIT.getDatasetIdFromResponse(createDatasetTwoResponse);
         String datasetTwoPid = UtilIT.getDatasetPersistentIdFromResponse(createDatasetTwoResponse);
-        UtilIT.sleepForReindex(datasetTwoId.toString(), userApiToken, 4);
+        UtilIT.sleepForDatasetIndex(datasetTwoId.toString(), userApiToken);
 
         // Request datasets belonging to user
         Response twoDatasetsInReviewResponse = UtilIT.retrieveMyDataAsJsonString(userApiToken, "", new ArrayList<>(Arrays.asList(6L)));
@@ -301,13 +300,13 @@ public class DataRetrieverApiIT {
         Response publishDatasetOne = UtilIT.publishDatasetViaNativeApi(datasetOneId, "major", superUserApiToken);
         publishDatasetOne.prettyPrint();
         publishDatasetOne.then().assertThat().statusCode(OK.getStatusCode());
-        UtilIT.sleepForReindex(datasetOneId.toString(), userApiToken, 4);
+        UtilIT.sleepForDatasetIndex(datasetOneId.toString(), userApiToken);
 
         // Publish dataset 2
         Response publishDatasetTwo = UtilIT.publishDatasetViaNativeApi(datasetTwoId, "major", superUserApiToken);
         publishDatasetTwo.prettyPrint();
         publishDatasetTwo.then().assertThat().statusCode(OK.getStatusCode());
-        UtilIT.sleepForReindex(datasetTwoId.toString(), userApiToken, 4);
+        UtilIT.sleepForDatasetIndex(datasetTwoId.toString(), userApiToken);
 
         // Request datasets belonging to user
         Response twoPublishedDatasetsResponse = UtilIT.retrieveMyDataAsJsonString(userApiToken, "", new ArrayList<>(Arrays.asList(6L)));
@@ -326,7 +325,7 @@ public class DataRetrieverApiIT {
         Response addDataToPublishedVersion = UtilIT.addDatasetMetadataViaNative(datasetOnePid, pathToJsonFilePostPub, userApiToken);
         addDataToPublishedVersion.prettyPrint();
         addDataToPublishedVersion.then().assertThat().statusCode(OK.getStatusCode());
-        UtilIT.sleepForReindex(datasetOneId.toString(), userApiToken, 4);
+        UtilIT.sleepForDatasetIndex(datasetOneId.toString(), userApiToken);
 
         // Request datasets belonging to user
         Response twoPublishedDatasetsOneDraftResponse = UtilIT.retrieveMyDataAsJsonString(userApiToken, "", new ArrayList<>(Arrays.asList(6L)));
@@ -350,7 +349,7 @@ public class DataRetrieverApiIT {
         Response uploadImage = UtilIT.uploadFileViaNative(datasetTwoId.toString(), pathToFile, userApiToken);
         uploadImage.prettyPrint();
         uploadImage.then().assertThat().statusCode(OK.getStatusCode());
-        UtilIT.sleepForReindex(datasetTwoId.toString(), userApiToken, 4);
+        UtilIT.sleepForDatasetIndex(datasetTwoId.toString(), userApiToken);
 
         // Request datasets belonging to user
         Response twoPublishedDatasetsTwoDraftsResponse = UtilIT.retrieveMyDataAsJsonString(userApiToken, "", new ArrayList<>(Arrays.asList(6L)));
@@ -373,7 +372,7 @@ public class DataRetrieverApiIT {
         Response publishDatasetOneMinor = UtilIT.publishDatasetViaNativeApi(datasetOneId, "minor", superUserApiToken);
         publishDatasetOneMinor.prettyPrint();
         publishDatasetOneMinor.then().assertThat().statusCode(OK.getStatusCode());
-        UtilIT.sleepForReindex(datasetOneId.toString(), userApiToken, 4);
+        UtilIT.sleepForDatasetIndex(datasetOneId.toString(), userApiToken);
 
         // Request datasets belonging to user
         Response oneMinorOneMajorOneDraftDatasetResponse = UtilIT.retrieveMyDataAsJsonString(userApiToken, "", new ArrayList<>(Arrays.asList(6L)));
@@ -429,7 +428,7 @@ public class DataRetrieverApiIT {
         Response createDatasetResponse = UtilIT.createRandomDatasetViaNativeApi(dataverseAlias, apiToken);
         String datasetId = UtilIT.getDatasetIdFromResponse(createDatasetResponse).toString();
         
-        UtilIT.sleepForReindex(datasetId, apiToken, 5);
+        UtilIT.sleepForDatasetIndex(datasetId, apiToken);
         
         Response myDataWithAuthor = UtilIT.retrieveMyDataAsJsonString(apiToken, "", new ArrayList<>(Arrays.asList(6L)), "&metadata_fields=citation:author");
         myDataWithAuthor.prettyPrint();
@@ -482,7 +481,7 @@ public class DataRetrieverApiIT {
 
         UtilIT.publishDatasetViaNativeApi(datasetId, "major", apiToken).then().assertThat().statusCode(OK.getStatusCode());
 
-        UtilIT.sleepForReindex(datasetPid, apiToken, 5);
+        UtilIT.sleepForDatasetIndex(datasetPid, apiToken);
         
         // Test that the Dataverse collection that the dataset was created in is returned
         Response myDataResponse = UtilIT.retrieveMyDataAsJsonString(apiToken, "", new ArrayList<>(Arrays.asList(6L)), "&show_collections=true");
@@ -506,7 +505,7 @@ public class DataRetrieverApiIT {
 
         UtilIT.linkDataset(datasetPid, dataverse2Alias, apiToken).then().assertThat().statusCode(OK.getStatusCode());
 
-        UtilIT.sleepForReindex(String.valueOf(datasetId), apiToken, 5);
+        UtilIT.sleepForDatasetIndex(String.valueOf(datasetId), apiToken);
 
         // Test that the Dataverse collection that the dataset was linked to is also returned
         myDataResponse = UtilIT.retrieveMyDataAsJsonString(apiToken, "", new ArrayList<>(Arrays.asList(6L)), "&show_collections=true");

--- a/src/test/java/edu/harvard/iq/dataverse/api/SearchIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/SearchIT.java
@@ -2426,21 +2426,22 @@ public class SearchIT {
     public void testWithThumbnailAutoSelect() {
         Response createUser = UtilIT.createRandomUser();
         createUser.prettyPrint();
-        String username = UtilIT.getUsernameFromResponse(createUser);
+        createUser.then().assertThat().statusCode(OK.getStatusCode());
         String apiToken = UtilIT.getApiTokenFromResponse(createUser);
 
         Response createDataverseResponse = UtilIT.createRandomDataverse(apiToken);
         createDataverseResponse.prettyPrint();
+        createDataverseResponse.then().assertThat().statusCode(CREATED.getStatusCode());
         String dataverseAlias = UtilIT.getAliasFromResponse(createDataverseResponse);
         UtilIT.publishDataverseViaNativeApi(dataverseAlias, apiToken);
 
         Response createDatasetResponse = UtilIT.createRandomDatasetViaNativeApi(dataverseAlias, apiToken);
         createDatasetResponse.prettyPrint();
+        createDataverseResponse.then().assertThat().statusCode(CREATED.getStatusCode());
         Integer datasetId = UtilIT.getDatasetIdFromResponse(createDatasetResponse);
-        String datasetPersistentId = UtilIT.getDatasetPersistentIdFromResponse(createDatasetResponse);
 
         uploadFile(datasetId, "src/test/resources/tab/test.tab", apiToken);
-        long dataFileId1 = uploadFile(datasetId, "src/main/webapp/resources/images/dataverse-icon-1200.png", apiToken);
+        uploadFile(datasetId, "src/main/webapp/resources/images/dataverse-icon-1200.png", apiToken);
         uploadFile(datasetId, "src/main/webapp/resources/images/dataverseproject.png", apiToken);
         Response publishResponse = UtilIT.publishDatasetViaNativeApi(datasetId, "major", apiToken);
         publishResponse.prettyPrint();
@@ -2452,7 +2453,7 @@ public class SearchIT {
         search1.then().assertThat()
                 .body("data.items[0].name", equalTo("Darwin's Finches"))
                 .body("data.items[0].image_url", notNullValue())
-                .statusCode(200);
+                .statusCode(OK.getStatusCode());
     }
 
     private long uploadFile(Integer datasetId, String pathToFile, String apiToken) {
@@ -2464,7 +2465,7 @@ public class SearchIT {
                 );
         Response addResponse = UtilIT.uploadFileViaNative(datasetId.toString(), pathToFile, json.build(), apiToken);
         addResponse.prettyPrint();
-        addResponse.then().assertThat().statusCode(200);
+        addResponse.then().assertThat().statusCode(OK.getStatusCode());
         assertTrue(UtilIT.sleepForLock(datasetId.longValue(), "Ingest", apiToken, UtilIT.MAXIMUM_INGEST_LOCK_DURATION), "Failed test if Ingest Lock exceeds max duration " + pathToFile);
         return UtilIT.getDataFileIdFromResponse(addResponse);
     }

--- a/src/test/java/edu/harvard/iq/dataverse/api/SearchIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/SearchIT.java
@@ -2437,8 +2437,9 @@ public class SearchIT {
 
         Response createDatasetResponse = UtilIT.createRandomDatasetViaNativeApi(dataverseAlias, apiToken);
         createDatasetResponse.prettyPrint();
-        createDataverseResponse.then().assertThat().statusCode(CREATED.getStatusCode());
+        createDatasetResponse.then().assertThat().statusCode(CREATED.getStatusCode());
         Integer datasetId = UtilIT.getDatasetIdFromResponse(createDatasetResponse);
+        String persistentId = UtilIT.getDatasetPersistentIdFromResponse(createDatasetResponse);
 
         uploadFile(datasetId, "src/test/resources/tab/test.tab", apiToken);
         uploadFile(datasetId, "src/main/webapp/resources/images/dataverse-icon-1200.png", apiToken);
@@ -2453,6 +2454,12 @@ public class SearchIT {
         search1.then().assertThat()
                 .body("data.items[0].name", equalTo("Darwin's Finches"))
                 .body("data.items[0].image_url", notNullValue())
+                .statusCode(OK.getStatusCode());
+
+        Response getDatasetResponse = UtilIT.getDatasetWithOwners(persistentId, apiToken, false);
+        getDatasetResponse.prettyPrint();
+        getDatasetResponse.then().assertThat()
+                .body("data.image_url", notNullValue())
                 .statusCode(OK.getStatusCode());
     }
 

--- a/src/test/java/edu/harvard/iq/dataverse/api/SearchIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/SearchIT.java
@@ -37,8 +37,8 @@ import static jakarta.ws.rs.core.Response.Status.*;
 import static java.lang.Thread.sleep;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
+
+import static org.hamcrest.CoreMatchers.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -2422,4 +2422,50 @@ public class SearchIT {
                 .statusCode(OK.getStatusCode());
     }
 
+    @Test
+    public void testWithThumbnailAutoSelect() {
+        Response createUser = UtilIT.createRandomUser();
+        createUser.prettyPrint();
+        String username = UtilIT.getUsernameFromResponse(createUser);
+        String apiToken = UtilIT.getApiTokenFromResponse(createUser);
+
+        Response createDataverseResponse = UtilIT.createRandomDataverse(apiToken);
+        createDataverseResponse.prettyPrint();
+        String dataverseAlias = UtilIT.getAliasFromResponse(createDataverseResponse);
+        UtilIT.publishDataverseViaNativeApi(dataverseAlias, apiToken);
+
+        Response createDatasetResponse = UtilIT.createRandomDatasetViaNativeApi(dataverseAlias, apiToken);
+        createDatasetResponse.prettyPrint();
+        Integer datasetId = UtilIT.getDatasetIdFromResponse(createDatasetResponse);
+        String datasetPersistentId = UtilIT.getDatasetPersistentIdFromResponse(createDatasetResponse);
+
+        uploadFile(datasetId, "src/test/resources/tab/test.tab", apiToken);
+        long dataFileId1 = uploadFile(datasetId, "src/main/webapp/resources/images/dataverse-icon-1200.png", apiToken);
+        uploadFile(datasetId, "src/main/webapp/resources/images/dataverseproject.png", apiToken);
+        Response publishResponse = UtilIT.publishDatasetViaNativeApi(datasetId, "major", apiToken);
+        publishResponse.prettyPrint();
+        publishResponse.then().assertThat().statusCode(OK.getStatusCode());
+        UtilIT.sleepForReindex(datasetId.toString(), apiToken, 4);
+
+        Response search1 = UtilIT.search("id:dataset_" + datasetId, apiToken);
+        search1.prettyPrint();
+        search1.then().assertThat()
+                .body("data.items[0].name", equalTo("Darwin's Finches"))
+                .body("data.items[0].image_url", notNullValue())
+                .statusCode(200);
+    }
+
+    private long uploadFile(Integer datasetId, String pathToFile, String apiToken) {
+        JsonObjectBuilder json = Json.createObjectBuilder()
+                .add("description", "Test Data")
+                .add("directoryLabel", "data/subdir1")
+                .add("categories", Json.createArrayBuilder()
+                        .add("Data")
+                );
+        Response addResponse = UtilIT.uploadFileViaNative(datasetId.toString(), pathToFile, json.build(), apiToken);
+        addResponse.prettyPrint();
+        addResponse.then().assertThat().statusCode(200);
+        assertTrue(UtilIT.sleepForLock(datasetId.longValue(), "Ingest", apiToken, UtilIT.MAXIMUM_INGEST_LOCK_DURATION), "Failed test if Ingest Lock exceeds max duration " + pathToFile);
+        return UtilIT.getDataFileIdFromResponse(addResponse);
+    }
 }

--- a/src/test/java/edu/harvard/iq/dataverse/api/SearchIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/SearchIT.java
@@ -786,7 +786,7 @@ public class SearchIT {
         System.out.println("identifier: " + identifier);
 
         String searchPart = identifier.replace("FK2/", "");
-        UtilIT.sleepForReindex(String.valueOf(datasetId), apiToken, 5);
+        UtilIT.sleepForDatasetIndex(String.valueOf(datasetId), apiToken);
         Response searchUnpublished = UtilIT.search(searchPart, apiToken);
         searchUnpublished.prettyPrint();
         searchUnpublished.then().assertThat()
@@ -802,7 +802,7 @@ public class SearchIT {
                 .statusCode(OK.getStatusCode());
 
         searchPart = identifier.replace("FK2/", "");
-        UtilIT.sleepForReindex(String.valueOf(datasetId), apiToken, 5);
+        UtilIT.sleepForDatasetIndex(String.valueOf(datasetId), apiToken);
         Response searchTargeted = UtilIT.search("dsPersistentId:" + searchPart, apiToken);
         searchTargeted.prettyPrint();
         searchTargeted.then().assertThat()
@@ -896,7 +896,7 @@ public class SearchIT {
         Response publishDataset = UtilIT.publishDatasetViaNativeApi(datasetPid, "major", apiToken);
         publishDataset.then().assertThat()
                 .statusCode(OK.getStatusCode());
-        UtilIT.sleepForReindex(datasetPid, apiToken, 5);
+        UtilIT.sleepForDatasetIndex(datasetPid, apiToken);
         assertTrue(UtilIT.sleepForSearch(searchPart, apiToken, "&subtree=" + dataverseAlias, 2, UtilIT.GENERAL_LONG_DURATION), "Did not find 2 children");
         assertTrue(UtilIT.sleepForSearch(searchPart, apiToken, "&subtree=" + dataverseAlias2, 1, UtilIT.GENERAL_LONG_DURATION), "Did not find 1 child");
     }
@@ -992,7 +992,7 @@ public class SearchIT {
                 .statusCode(OK.getStatusCode());
         
         // Wait a little while for the index to pick up the datasets, otherwise timing issue with searching for it.
-        UtilIT.sleepForReindex(datasetId2.toString(), apiToken, 3);
+        UtilIT.sleepForDatasetIndex(datasetId2.toString(), apiToken);
 
         String identifier = JsonPath.from(datasetAsJson.getBody().asString()).getString("data.identifier");
         String identifier2 = JsonPath.from(datasetAsJson2.getBody().asString()).getString("data.identifier"); 
@@ -1035,14 +1035,14 @@ public class SearchIT {
                 // TODO: investigate if this is a bug that nothing was found.
                 .body("data.total_count", CoreMatchers.equalTo(0));
 
-        UtilIT.sleepForReindex(String.valueOf(datasetId), apiToken, 5);
+        UtilIT.sleepForDatasetIndex(String.valueOf(datasetId), apiToken);
         Response searchUnpublishedRootSubtreeForDataset = UtilIT.search(identifier.replace("FK2/", ""), apiToken, "&subtree=root");
         searchUnpublishedRootSubtreeForDataset.prettyPrint();
         searchUnpublishedRootSubtreeForDataset.then().assertThat()
                 .statusCode(OK.getStatusCode())
                 .body("data.total_count", CoreMatchers.equalTo(1));
 
-        UtilIT.sleepForReindex(String.valueOf(datasetId), apiToken, 5);
+        UtilIT.sleepForDatasetIndex(String.valueOf(datasetId), apiToken);
         Response searchUnpublishedRootSubtreeForDatasetNoAPI = UtilIT.search(identifier.replace("FK2/", ""), null, "&subtree=root");
         searchUnpublishedRootSubtreeForDatasetNoAPI.prettyPrint();
         searchUnpublishedRootSubtreeForDatasetNoAPI.then().assertThat()
@@ -1050,14 +1050,14 @@ public class SearchIT {
                 // TODO: investigate if this is a bug that nothing was found.
                 .body("data.total_count", CoreMatchers.equalTo(0));
 
-        UtilIT.sleepForReindex(String.valueOf(datasetId), apiToken, 5);
+        UtilIT.sleepForDatasetIndex(String.valueOf(datasetId), apiToken);
         Response searchUnpublishedNoSubtreeForDataset = UtilIT.search(identifier.replace("FK2/", ""), apiToken, "");
         searchUnpublishedNoSubtreeForDataset.prettyPrint();
         searchUnpublishedNoSubtreeForDataset.then().assertThat()
                 .statusCode(OK.getStatusCode())
                 .body("data.total_count", CoreMatchers.equalTo(1));
         
-        UtilIT.sleepForReindex(String.valueOf(datasetId), apiToken, 5);
+        UtilIT.sleepForDatasetIndex(String.valueOf(datasetId), apiToken);
         Response searchUnpublishedNoSubtreeForDatasetNoAPI = UtilIT.search(identifier.replace("FK2/", ""), null, "");
         searchUnpublishedNoSubtreeForDatasetNoAPI.prettyPrint();
         searchUnpublishedNoSubtreeForDatasetNoAPI.then().assertThat()
@@ -1109,14 +1109,14 @@ public class SearchIT {
                 .statusCode(OK.getStatusCode())
                 .body("data.total_count", CoreMatchers.equalTo(2));
         
-        UtilIT.sleepForReindex(String.valueOf(datasetId), apiToken, 5);
+        UtilIT.sleepForDatasetIndex(String.valueOf(datasetId), apiToken);
         Response searchPublishedRootSubtreeForDataset = UtilIT.search(identifier.replace("FK2/", ""), apiToken, "&subtree=root");
         searchPublishedRootSubtreeForDataset.prettyPrint();
         searchPublishedRootSubtreeForDataset.then().assertThat()
                 .statusCode(OK.getStatusCode())
                 .body("data.total_count", CoreMatchers.equalTo(1));
 
-        UtilIT.sleepForReindex(String.valueOf(datasetId), apiToken, 5);
+        UtilIT.sleepForDatasetIndex(String.valueOf(datasetId), apiToken);
         Response searchPublishedRootSubtreeForDatasetNoAPI = UtilIT.search(identifier.replace("FK2/", ""), null, "&subtree=root");
         searchPublishedRootSubtreeForDatasetNoAPI.prettyPrint();
         searchPublishedRootSubtreeForDatasetNoAPI.then().assertThat()
@@ -1672,7 +1672,7 @@ public class SearchIT {
         Response publishDataset = UtilIT.publishDatasetViaNativeApi(datasetPid, "major", apiToken);
         publishDataset.then().assertThat()
                 .statusCode(OK.getStatusCode());
-        UtilIT.sleepForReindex(datasetPid, apiToken, 5);
+        UtilIT.sleepForDatasetIndex(datasetPid, apiToken);
 
         // Wait for reindex of dataverse after publishing
         String searchDataverseWithDatasetQuery = "identifier:" + dataverseAlias + " AND datasetCount:1";
@@ -1918,7 +1918,7 @@ public class SearchIT {
         Response publishGrandchildDataset = UtilIT.publishDatasetViaNativeApi(grandchildDatasetPid, "major", apiToken);
         publishGrandchildDataset.then().assertThat()
                 .statusCode(OK.getStatusCode());
-        UtilIT.sleepForReindex(grandchildDatasetPid, apiToken, 5);
+        UtilIT.sleepForDatasetIndex(grandchildDatasetPid, apiToken);
 
         // Wait for reindex of dataverse after publishing
         String searchDataverseWithGrandchildDatasetQuery = "identifier:" + dataverseAlias4 + " AND datasetCount:1";
@@ -2095,7 +2095,7 @@ public class SearchIT {
 
             // This call forces a wait for dataset indexing to finish and gives time for file uploads to complete
             UtilIT.search("id:dataset_" + datasetId, apiToken);
-            UtilIT.sleepForReindex(datasetId, apiToken, 3);
+            UtilIT.sleepForDatasetIndex(datasetId, apiToken);
         }
 
         // Test Search without show_type_counts
@@ -2314,7 +2314,7 @@ public class SearchIT {
 
         UtilIT.linkDataset(datasetPid, dataverse2Alias, apiToken).then().assertThat().statusCode(OK.getStatusCode());
 
-        UtilIT.sleepForReindex(String.valueOf(datasetId), apiToken, 5);
+        UtilIT.sleepForDatasetIndex(String.valueOf(datasetId), apiToken);
 
         // Test that the Dataverse collection that the dataset was linked to is also returned
         searchResponse = UtilIT.search("*", apiToken, "&subtree=" + dataverseAlias + "&type=dataset&show_collections=true");
@@ -2447,7 +2447,7 @@ public class SearchIT {
         Response publishResponse = UtilIT.publishDatasetViaNativeApi(datasetId, "major", apiToken);
         publishResponse.prettyPrint();
         publishResponse.then().assertThat().statusCode(OK.getStatusCode());
-        UtilIT.sleepForReindex(datasetId.toString(), apiToken, 4);
+        UtilIT.sleepForDatasetIndex(datasetId.toString(), apiToken);
 
         Response search1 = UtilIT.search("id:dataset_" + datasetId, apiToken);
         search1.prettyPrint();

--- a/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
@@ -2674,15 +2674,16 @@ public class UtilIT {
         return requestSpecification.get("/api/search?q=" + query + parameterString);
     }
 
-    private static void sleepForDatasetIndex(String query, String apiToken) {
+    static void sleepForDatasetIndex(String query, String apiToken) {
+        String id = query;
         if (query.contains("id:dataset") || query.contains("id:datafile")) {
             String[] splitted = query.split("_");
             if (splitted.length >= 2) {
-                boolean ok = UtilIT.sleepForReindex(String.valueOf(splitted[1]), apiToken, 5);
-                if (!ok) {
-                    logger.info("Still indexing after 5 seconds");
-                }
+                id = splitted[1];
             }
+        }
+        if (!UtilIT.sleepForReindex(id, apiToken, 10)) {
+            logger.warning("Still indexing after 10 seconds");
         }
     }
 


### PR DESCRIPTION
**What this PR does / why we need it**: SPA not getting image_url through Search API. JSF does get the image_url.

**Which issue(s) this PR closes**: https://github.com/IQSS/dataverse/issues/11588

- Closes #11588
- Closes #11586

**Special notes for your reviewer**:

**Suggestions on how to test this**:

With this PR, the behavior should be the same JSF vs the SPA: a thumbnail for the dataset will be auto-selected when the dataset is published; unless a specific thumbnail has already been picked by the author while it was still in draft, OR auto-selection has been disabled on the instance (such as on qa.dataverse.org).  

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**: included

**Additional documentation**:
