### PR TITLE
stop downloading XSDs from sitemaps.org, use local copies #12422

### DIFF
--- a/src/test/java/edu/harvard/iq/dataverse/sitemap/SiteMapUtilTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/sitemap/SiteMapUtilTest.java
@@ -36,8 +36,8 @@ import org.xml.sax.SAXException;
 class SiteMapUtilTest {
 
     // see https://www.sitemaps.org/protocol.html#validating
-    final String xsdSitemap = "https://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd";
-    final String xsdSitemapIndex = "https://www.sitemaps.org/schemas/sitemap/0.9/siteindex.xsd";
+    private static final String XSD_SITEMAP = "xml/xsd/sitemap-0.9/sitemap.xsd";
+    private static final String XSD_SITEINDEX = "xml/xsd/sitemap-0.9/siteindex.xsd";
 
     @TempDir
     Path tempDir;
@@ -112,7 +112,7 @@ class SiteMapUtilTest {
         // then
         String pathToSiteMap = tempDocroot.resolve("sitemap").resolve("sitemap.xml").toString();
         assertDoesNotThrow(() -> XmlValidator.validateXmlWellFormed(pathToSiteMap));
-        assertTrue(XmlValidator.validateXmlSchema(pathToSiteMap, new URL(xsdSitemap)));
+        assertTrue(XmlValidator.validateXmlSchema(pathToSiteMap, getTestResource(XSD_SITEMAP)));
 
         File sitemapFile = new File(pathToSiteMap);
         String sitemapString = XmlPrinter.prettyPrintXml(new String(Files.readAllBytes(Paths.get(sitemapFile.getAbsolutePath()))));
@@ -166,7 +166,7 @@ class SiteMapUtilTest {
 
         // validate sitemap_index.xml file with XSD
         assertDoesNotThrow(() -> XmlValidator.validateXmlWellFormed(pathToSiteMapIndexFile));
-        assertTrue(XmlValidator.validateXmlSchema(pathToSiteMapIndexFile, new URL(xsdSitemapIndex)));
+        assertTrue(XmlValidator.validateXmlSchema(pathToSiteMapIndexFile, getTestResource(XSD_SITEINDEX)));
 
         // verify sitemap_index.xml content
         File sitemapFile = new File(pathToSiteMapIndexFile);
@@ -194,11 +194,11 @@ class SiteMapUtilTest {
 
         // validate sitemap1.xml file with XSD
         assertDoesNotThrow(() -> XmlValidator.validateXmlWellFormed(pathToSiteMap1File));
-        assertTrue(XmlValidator.validateXmlSchema(pathToSiteMap1File, new URL(xsdSitemap)));
+        assertTrue(XmlValidator.validateXmlSchema(pathToSiteMap1File, getTestResource(XSD_SITEMAP)));
 
         // validate sitemap2.xml file with XSD
         assertDoesNotThrow(() -> XmlValidator.validateXmlWellFormed(pathToSiteMap2File));
-        assertTrue(XmlValidator.validateXmlSchema(pathToSiteMap2File, new URL(xsdSitemap)));
+        assertTrue(XmlValidator.validateXmlSchema(pathToSiteMap2File, getTestResource(XSD_SITEMAP)));
 
         // verify sitemap2.xml content
         sitemapFile = new File(pathToSiteMap2File);
@@ -227,4 +227,9 @@ class SiteMapUtilTest {
         assertTrue(isContainsLastmodTag, "Sitemap file must contains <lastmod> tag");
     }
 
+    private URL getTestResource(String resourcePath) {
+        URL resource = SiteMapUtilTest.class.getClassLoader().getResource(resourcePath);
+        assertNotNull(resource, "Missing test resource: " + resourcePath);
+        return resource;
+    }
 }

--- a/src/test/resources/xml/xsd/sitemap-0.9/siteindex.xsd
+++ b/src/test/resources/xml/xsd/sitemap-0.9/siteindex.xsd
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="http://www.sitemaps.org/schemas/sitemap/0.9"
+            xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+            elementFormDefault="qualified">
+  <xsd:annotation>
+    <xsd:documentation>
+      XML Schema for Sitemap index files.
+      Last Modifed 2009-04-08
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:element name="sitemapindex">
+    <xsd:annotation>
+      <xsd:documentation>
+        Container for a set of up to 50,000 sitemap URLs.
+        This is the root element of the XML file.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:any namespace="##other" minOccurs="0" maxOccurs="unbounded" processContents="strict"/>
+        <xsd:element name="sitemap" type="tSitemap" maxOccurs="unbounded"/>
+      </xsd:sequence>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:complexType name="tSitemap">
+    <xsd:annotation>
+      <xsd:documentation>
+        Container for the data needed to describe a sitemap.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="loc" type="tLocSitemap"/>
+      <xsd:element name="lastmod" type="tLastmodSitemap" minOccurs="0"/>
+      <xsd:any namespace="##other" minOccurs="0" maxOccurs="unbounded" processContents="strict"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+  <xsd:simpleType name="tLocSitemap">
+    <xsd:annotation>
+      <xsd:documentation>
+        REQUIRED: The location URI of a sitemap.
+        The URI must conform to RFC 2396 (http://www.ietf.org/rfc/rfc2396.txt).
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:anyURI">
+      <xsd:minLength value="12"/>
+      <xsd:maxLength value="2048"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="tLastmodSitemap">
+    <xsd:annotation>
+      <xsd:documentation>
+        OPTIONAL: The date the document was last modified. The date must conform
+        to the W3C DATETIME format (http://www.w3.org/TR/NOTE-datetime).
+        Example: 2005-05-10
+        Lastmod may also contain a timestamp.
+        Example: 2005-05-10T17:33:30+08:00
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:union>
+      <xsd:simpleType>
+        <xsd:restriction base="xsd:date"/>
+      </xsd:simpleType>
+      <xsd:simpleType>
+        <xsd:restriction base="xsd:dateTime"/>
+      </xsd:simpleType>
+    </xsd:union>
+  </xsd:simpleType>
+
+
+</xsd:schema>

--- a/src/test/resources/xml/xsd/sitemap-0.9/sitemap.xsd
+++ b/src/test/resources/xml/xsd/sitemap-0.9/sitemap.xsd
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="http://www.sitemaps.org/schemas/sitemap/0.9"
+            xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+            elementFormDefault="qualified">
+  <xsd:annotation>
+    <xsd:documentation>
+      XML Schema for Sitemap files.
+      Last Modifed 2008-03-26
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:element name="urlset">
+    <xsd:annotation>
+      <xsd:documentation>
+        Container for a set of up to 50,000 document elements.
+        This is the root element of the XML file.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:any namespace="##other" minOccurs="0" maxOccurs="unbounded" processContents="strict"/>
+        <xsd:element name="url" type="tUrl" maxOccurs="unbounded"/>
+      </xsd:sequence>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:complexType name="tUrl">
+    <xsd:annotation>
+      <xsd:documentation>
+        Container for the data needed to describe a document to crawl.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="loc" type="tLoc"/>
+      <xsd:element name="lastmod" type="tLastmod" minOccurs="0"/>
+      <xsd:element name="changefreq" type="tChangeFreq" minOccurs="0"/>
+      <xsd:element name="priority" type="tPriority" minOccurs="0"/>
+      <xsd:any namespace="##other" minOccurs="0" maxOccurs="unbounded" processContents="strict"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+  <xsd:simpleType name="tLoc">
+    <xsd:annotation>
+      <xsd:documentation>
+        REQUIRED: The location URI of a document.
+        The URI must conform to RFC 2396 (http://www.ietf.org/rfc/rfc2396.txt).
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:anyURI">
+      <xsd:minLength value="12"/>
+      <xsd:maxLength value="2048"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="tLastmod">
+    <xsd:annotation>
+      <xsd:documentation>
+        OPTIONAL: The date the document was last modified. The date must conform
+        to the W3C DATETIME format (http://www.w3.org/TR/NOTE-datetime).
+        Example: 2005-05-10
+        Lastmod may also contain a timestamp.
+        Example: 2005-05-10T17:33:30+08:00
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:union>
+      <xsd:simpleType>
+        <xsd:restriction base="xsd:date"/>
+      </xsd:simpleType>
+      <xsd:simpleType>
+        <xsd:restriction base="xsd:dateTime"/>
+      </xsd:simpleType>
+    </xsd:union>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="tChangeFreq">
+    <xsd:annotation>
+      <xsd:documentation>
+        OPTIONAL: Indicates how frequently the content at a particular URL is
+        likely to change. The value "always" should be used to describe
+        documents that change each time they are accessed. The value "never"
+        should be used to describe archived URLs. Please note that web
+        crawlers may not necessarily crawl pages marked "always" more often.
+        Consider this element as a friendly suggestion and not a command.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="always"/>
+      <xsd:enumeration value="hourly"/>
+      <xsd:enumeration value="daily"/>
+      <xsd:enumeration value="weekly"/>
+      <xsd:enumeration value="monthly"/>
+      <xsd:enumeration value="yearly"/>
+      <xsd:enumeration value="never"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="tPriority">
+    <xsd:annotation>
+      <xsd:documentation>
+        OPTIONAL: The priority of a particular URL relative to other pages
+        on the same site. The value for this element is a number between
+        0.0 and 1.0 where 0.0 identifies the lowest priority page(s).
+        The default priority of a page is 0.5. Priority is used to select
+        between pages on your site. Setting a priority of 1.0 for all URLs
+        will not help you, as the relative priority of pages on your site
+        is what will be considered.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:decimal">
+      <xsd:minInclusive value="0.0"/>
+      <xsd:maxInclusive value="1.0"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+</xsd:schema>


### PR DESCRIPTION
**What this PR does / why we need it**:

sitemaps.org is down, causing tests to fail. In this PR, we switch to local copies for the XSD files, which I got from the Wayback Machine.

**Which issue(s) this PR closes**:

- Closes #12422

**Special notes for your reviewer**:

My chat with Codex:

<img width="695" height="1196" alt="Screenshot 2026-06-03 at 10 09 01 AM" src="https://github.com/user-attachments/assets/8395536f-b4ee-4104-9ded-b1d47b5cfce1" />

**Suggestions on how to test this**:

`mvn test -Dtest=SiteMapUtilTest`

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No.

**Is there a release notes update needed for this change?**:

No.

**Additional documentation**:

None.