### PR TITLE
allow tests/verify_mdb_properties.sh to be run in Docker #9176

### DIFF
--- a/tests/Dockerfile.verify_mdb_properties
+++ b/tests/Dockerfile.verify_mdb_properties
@@ -1,0 +1,13 @@
+FROM ghcr.io/graalvm/native-image-community:21
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN microdnf install -y curl findutils git grep sed unzip which \
+    && microdnf clean all
+
+RUN curl -Ls https://sh.jbang.dev | bash -s - app setup
+
+ENV PATH="/root/.jbang/bin:${PATH}"
+
+WORKDIR /workspace
+

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,1 +1,10 @@
 See doc/sphinx-guides/source/developers/testing.rst
+
+To run the metadata block properties verifier in Docker, use:
+
+```bash
+tests/verify_mdb_properties_docker.sh
+```
+
+This builds a local `dataverse-verify-mdb-properties` image with GraalVM native-image
+and JBang, then runs `tests/verify_mdb_properties.sh` inside the container.

--- a/tests/verify_mdb_properties_docker.sh
+++ b/tests/verify_mdb_properties_docker.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# Run verify_mdb_properties.sh in a Linux container with GraalVM native-image and JBang.
+
+set -euo pipefail
+
+if ! command -v docker > /dev/null 2>&1; then
+  echo "Cannot find docker on path. Did you install Docker Desktop or another Docker runtime?" >&2
+  exit 1
+fi
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+IMAGE=${VERIFY_MDB_PROPERTIES_IMAGE:-dataverse-verify-mdb-properties}
+DOCKERFILE="$REPO_ROOT/tests/Dockerfile.verify_mdb_properties"
+
+docker build -f "$DOCKERFILE" -t "$IMAGE" "$REPO_ROOT"
+docker run --rm \
+  -v "$REPO_ROOT:/workspace" \
+  -w /workspace \
+  --entrypoint /bin/bash \
+  "$IMAGE" \
+  -lc 'git config --global --add safe.directory /workspace && tests/verify_mdb_properties.sh'


### PR DESCRIPTION
**What this PR does / why we need it**:

A problem with a properties file was reported here: https://github.com/IQSS/dataverse/actions/runs/26900153259/job/79350005084?pr=12425

I tried to run the script locally on my Mac but I got this error:
```
% tests/verify_mdb_properties.sh              
Cannot find jbang on path. Did you install it?
```

Let's run in it Docker! 🐳 

After using the solution in this PR, I made this fix: https://github.com/IQSS/dataverse/pull/12425/changes/603b87fca396e76096fd1065e4f60d367b858bbd

**Which issue(s) this PR closes**:

None. The script was originally added here:

- #9176

**Special notes for your reviewer**:

Changes were made by Codex.

**Suggestions on how to test this**:

See the README I updated (well, that Codex updated).