### PR TITLE
Fix for Guestbook Response parsing

### DIFF
--- a/doc/release-notes/12446-fix-guestbook-response-parsing.md
+++ b/doc/release-notes/12446-fix-guestbook-response-parsing.md
@@ -1,0 +1,3 @@
+## Bug ##
+
+Guestbook response parsing now allows a textarea value to be a string along with an array.

--- a/scripts/api/data/guestbook-test-response.json
+++ b/scripts/api/data/guestbook-test-response.json
@@ -11,6 +11,10 @@
         {
             "id": @QID3,
             "value": "Yellow"
+        },
+        {
+            "id": @QID4,
+            "value": "Text area with a string instead of an array"
         }
     ]
   }

--- a/scripts/api/data/guestbook-test.json
+++ b/scripts/api/data/guestbook-test.json
@@ -44,6 +44,13 @@
           "displayOrder": 3
         }
       ]
+    },
+    {
+      "question": "Address",
+      "required": false,
+      "displayOrder": 1,
+      "type": "textarea",
+      "hidden": false
     }
   ]
 }

--- a/scripts/api/data/guestbook-test.json
+++ b/scripts/api/data/guestbook-test.json
@@ -48,7 +48,7 @@
     {
       "question": "Address",
       "required": false,
-      "displayOrder": 1,
+      "displayOrder": 3,
       "type": "textarea",
       "hidden": false
     }

--- a/src/main/java/edu/harvard/iq/dataverse/util/json/JsonParser.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/json/JsonParser.java
@@ -659,8 +659,15 @@ public class JsonParser {
                     throw new JsonParseException(BundleUtil.getStringFromBundle("access.api.requestAccess.failure.guestbookresponseQuestionIdNotFound", List.of(cqId.toString())));
                 } else if (cq.getQuestionType().equalsIgnoreCase("textarea")) {
                     String lineFeed = String.valueOf((char) 10);
-                    JsonArray jsonArray = answer.getJsonArray("value");
-                    List<JsonString> lines = jsonArray.getValuesAs(JsonString.class);
+                    List<JsonString> lines = new ArrayList<>();
+                    try {
+                        // Assume it's an array but fall back to string if it isn't
+                        JsonArray jsonArray = answer.getJsonArray("value");
+                        lines = jsonArray.getValuesAs(JsonString.class);
+                    } catch (Exception ex) {
+                        // if not an array try to get a string and add it to the list
+                        lines.add(answer.getJsonString("value"));
+                    }
                     response = lines.stream().map(JsonString::getString).collect(Collectors.joining(lineFeed));
                 } else if (cq.getQuestionType().equalsIgnoreCase("options")) {
                     String option = answer.getString("value");

--- a/src/test/java/edu/harvard/iq/dataverse/api/FilesIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/FilesIT.java
@@ -3874,7 +3874,6 @@ public class FilesIT {
     @Test
     public void testDownloadFileWithGuestbookResponse() throws IOException, JsonParseException {
         msgt("testDownloadFileWithGuestbookResponse");
-        UtilIT.enableSetting(SettingsServiceBean.Key.FilePIDsEnabled);
         // Create superuser
         Response createUserResponse = UtilIT.createRandomUser();
         assertEquals(200, createUserResponse.getStatusCode());
@@ -3948,6 +3947,8 @@ public class FilesIT {
         uploadResponse.prettyPrint();
         uploadResponse.then().assertThat().statusCode(OK.getStatusCode());
         Integer fileId3 = JsonPath.from(uploadResponse.body().asString()).getInt("data.files[0].dataFile.id");
+
+        UtilIT.enableSetting(SettingsServiceBean.Key.FilePIDsEnabled);
         JsonObjectBuilder json4 = Json.createObjectBuilder().add("description", "my description4").add("directoryLabel", directoryLabel).add("categories", Json.createArrayBuilder().add("Data"));
         uploadResponse = UtilIT.uploadFileViaNative(datasetId.toString(), "src/main/webapp/resources/images/Robot-Icon_2.png", json4.build(), ownerApiToken);
         uploadResponse.then().assertThat().statusCode(OK.getStatusCode());

--- a/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
@@ -5596,6 +5596,7 @@ public class UtilIT {
         gb.getCustomQuestions().get(0).setId(jsonPath.getLong("data.customQuestions[0].id"));
         gb.getCustomQuestions().get(1).setId(jsonPath.getLong("data.customQuestions[1].id"));
         gb.getCustomQuestions().get(2).setId(jsonPath.getLong("data.customQuestions[2].id"));
+        gb.getCustomQuestions().get(3).setId(jsonPath.getLong("data.customQuestions[3].id"));
 
         // Add the Guestbook to the Dataset
         if (persistentId != null) {
@@ -5615,6 +5616,7 @@ public class UtilIT {
         return guestbookAsJson.replace("@ID", gb.getId().toString())
                 .replace("@QID1", cqIDs.get(0).toString())
                 .replace("@QID2", cqIDs.get(1).toString())
-                .replace("@QID3", cqIDs.get(2).toString());
+                .replace("@QID3", cqIDs.get(2).toString())
+                .replace("@QID4", cqIDs.get(3).toString());
     }
 }

--- a/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
@@ -5611,7 +5611,9 @@ public class UtilIT {
         String guestbookAsJson = new String(Files.readAllBytes(Paths.get(guestbookJson.getAbsolutePath())));
 
         List<Long> cqIDs = new ArrayList<>();
-        gb.getCustomQuestions().stream().forEach(cq -> cqIDs.add(cq.getId()));
+        // Try to match the IDs. This is no easy task as the custom questions are not added to the db in order by id.
+        // We will use "displayOrder" to help match them up
+        gb.getCustomQuestions().stream().sorted(Comparator.comparing(CustomQuestion::getDisplayOrder)).forEach(cq -> cqIDs.add(cq.getId()));
 
         return guestbookAsJson.replace("@ID", gb.getId().toString())
                 .replace("@QID1", cqIDs.get(0).toString())

--- a/src/test/java/edu/harvard/iq/dataverse/util/json/JsonParserTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/util/json/JsonParserTest.java
@@ -113,6 +113,13 @@ public class JsonParserTest {
                           "displayOrder": 3
                         }
                       ]
+                    },
+                    {
+                      "question": "Address",
+                      "required": false,
+                      "displayOrder": 3,
+                      "type": "textarea",
+                      "hidden": false
                     }
                   ]
                 }
@@ -792,7 +799,7 @@ public class JsonParserTest {
         Guestbook gb = new Guestbook();
         gb = sut.parseGuestbook(jsonObj, gb);
         assertEquals(true, gb.isEnabled());
-        assertEquals(3, gb.getCustomQuestions().size());
+        assertEquals(4, gb.getCustomQuestions().size());
         assertEquals(4, gb.getCustomQuestions().get(2).getCustomQuestionValues().size());
         assertEquals("Purple", gb.getCustomQuestions().get(2).getCustomQuestionValues().get(3).getValueString());
         assertEquals(3, gb.getCustomQuestions().get(2).getCustomQuestionValues().get(3).getDisplayOrder());
@@ -827,6 +834,10 @@ public class JsonParserTest {
                                 {
                                     "id": 3,
                                     "value": "Yellow"
+                                },
+                                {
+                                    "id": 4,
+                                    "value": "Text area with a string instead of an array"
                                 }
                             ]
                         }
@@ -850,7 +861,7 @@ public class JsonParserTest {
         guestbookResponse.setGuestbook(gb);
         jsonObj = JsonUtil.getJsonObject(guestbookResponseJson);
         GuestbookResponse gbr = sut.parseGuestbookResponse(jsonObj, guestbookResponse);
-        assertTrue(gbr.getCustomQuestionResponses().size() == 3);
+        assertTrue(gbr.getCustomQuestionResponses().size() == 4);
 
         // Test missing required question response
         try {


### PR DESCRIPTION
**What this PR does / why we need it**: allow for better parsing of guestbook response answers

**Which issue(s) this PR closes**:https://github.com/IQSS/dataverse/issues/12446

- Closes #12446

**Special notes for your reviewer**:

**Suggestions on how to test this**: See JsonParserTest. Try passing both "value":["My Value"] and "value":"My Value" as guestbook response answer to a "textarea" typed question.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**: included

**Additional documentation**:
