### PR TITLE
Fix license description to use DB shortDescription as fallback instead of name

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/dataset/DatasetUtil.java
+++ b/src/main/java/edu/harvard/iq/dataverse/dataset/DatasetUtil.java
@@ -709,11 +709,15 @@ public class DatasetUtil {
             }
         }
         catch (Exception e) {
-            localizedLicenseValue = licenseName;
+            localizedLicenseValue = null;
         }
 
         if (localizedLicenseValue == null) {
-            localizedLicenseValue = licenseName ;
+            if (LicenseOption.DESCRIPTION.name().equals(keyPart) && license.getShortDescription() != null) {
+                localizedLicenseValue = license.getShortDescription();
+            } else {
+                localizedLicenseValue = licenseName;
+            }
         }
         return localizedLicenseValue;
     }

--- a/src/test/java/edu/harvard/iq/dataverse/dataset/DatasetUtilTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/dataset/DatasetUtilTest.java
@@ -8,7 +8,9 @@ import edu.harvard.iq.dataverse.DatasetVersion;
 import edu.harvard.iq.dataverse.FileMetadata;
 import edu.harvard.iq.dataverse.DatasetFieldType.FieldType;
 import edu.harvard.iq.dataverse.dataaccess.ImageThumbConverter;
+import edu.harvard.iq.dataverse.license.License;
 import edu.harvard.iq.dataverse.mocks.MocksFactory;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -176,5 +178,35 @@ public class DatasetUtilTest {
         String[] expected = testCustomFields.split(",");
 
         assertArrayEquals(expected, actual);
+    }
+
+    @Test
+    public void testGetLocalizedLicenseDetails_descriptionFallsBackToShortDescription() throws Exception {
+        License license = new License("My Custom License", "A short description from DB",
+                new URI("https://example.com/license"), null, true, 0L);
+
+        // When the key is not in License.properties, should return the DB shortDescription
+        String result = DatasetUtil.getLocalizedLicenseDetails(license, "DESCRIPTION");
+        assertEquals("A short description from DB", result);
+    }
+
+    @Test
+    public void testGetLocalizedLicenseDetails_descriptionFallsBackToNameWhenShortDescriptionNull() throws Exception {
+        License license = new License("My Custom License", null,
+                new URI("https://example.com/license"), null, true, 0L);
+
+        // When shortDescription is null, should fall back to the license name
+        String result = DatasetUtil.getLocalizedLicenseDetails(license, "DESCRIPTION");
+        assertEquals("My Custom License", result);
+    }
+
+    @Test
+    public void testGetLocalizedLicenseDetails_nameFallsBackToLicenseName() throws Exception {
+        License license = new License("My Custom License", "A short description from DB",
+                new URI("https://example.com/license"), null, true, 0L);
+
+        // When the key is not in License.properties for NAME, should return the license name
+        String result = DatasetUtil.getLocalizedLicenseDetails(license, "NAME");
+        assertEquals("My Custom License", result);
     }
 }


### PR DESCRIPTION
## Summary

Fixes #9529

When a license's description key is missing from `License.properties`, `getLocalizedLicenseDetails()` was falling back to the **license name** instead of the stored `shortDescription` value in the database. This caused:

- The license icon's `title` attribute to show the license name instead of the description
- A minor accessibility warning in Deque Axe (image title duplicates adjacent text)

## Changes

**`DatasetUtil.getLocalizedLicenseDetails`**:
- When `DESCRIPTION` lookup fails (key absent in `License.properties` or exception), now falls back to `license.getShortDescription()` (the DB-stored value) instead of `license.getName()`
- Falls back further to `licenseName` only if `shortDescription` is also `null`
- `NAME` lookups retain the existing fallback to `licenseName` (no behavior change)

**`DatasetUtilTest`**: Added three regression tests covering:
- DESCRIPTION fallback to `shortDescription` when key is absent from properties
- DESCRIPTION fallback to `licenseName` when `shortDescription` is also null
- NAME fallback to `licenseName` (ensuring existing behavior is preserved)

## Test plan

- [ ] Run `./mvnw test -pl src/test -Dtest=DatasetUtilTest` to verify new unit tests pass
- [ ] Manually add a custom license via the API without a matching entry in `License.properties` and confirm the hover tooltip shows the database description rather than the license name

🤖 Generated with [Claude Code](https://claude.com/claude-code)