### PR TITLE
docs: fix code block formatting in Native API Guide (#12457)

### DIFF
--- a/doc/sphinx-guides/source/api/native-api.rst
+++ b/doc/sphinx-guides/source/api/native-api.rst
@@ -3402,6 +3402,8 @@ In order to update the number of files allowed for a Dataset, without causing a 
 
 To delete the existing limit:
 
+.. code-block:: bash
+
   curl -H "X-Dataverse-key:$API_TOKEN" -X DELETE "$SERVER_URL/api/datasets/$ID/files/uploadlimit"
 
 The fully expanded example above (without environment variables) looks like this:
@@ -3411,6 +3413,8 @@ The fully expanded example above (without environment variables) looks like this
   curl -H "X-Dataverse-key:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" -X POST "https://demo.dataverse.org/api/datasets/24/files/uploadlimit/500"
 
 To delete the existing limit:
+
+.. code-block:: bash
 
   curl -H "X-Dataverse-key:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" -X DELETE "https://demo.dataverse.org/api/datasets/24/files/uploadlimit"
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes formatting in the Native API Guide by adding missing ```.. code-block:: bash```

**Which issue(s) this PR closes**:

- Closes #12457

**Special notes for your reviewer**:
No functional changes, documentation-only update.

**Suggestions on how to test this**:
Check the Native API Guide section and verify that the bash code block renders correctly in the documentation preview/build.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
No.

**Is there a release notes update needed for this change?**:
No.

**Additional documentation**:
N/A
