### PR TITLE
#12464 update code to work with both versions of display value string

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DatasetFieldCompoundValue.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetFieldCompoundValue.java
@@ -177,12 +177,16 @@ public class DatasetFieldCompoundValue implements Serializable {
                 if (StringUtils.isBlank(format)) {
                     format = "#VALUE";
                 }
+                /*
+                if (format.equals("#VALUE,")) {
+                    format = "#VALUE, ";
+                }*/
                 String sanitizedValue = childDatasetField.getDatasetFieldType().isSanitizeHtml() ? MarkupChecker.sanitizeBasicHTML(childDatasetField.getValue()) :  childDatasetField.getValue();
                 if (!childDatasetField.getDatasetFieldType().isSanitizeHtml() && childDatasetField.getDatasetFieldType().isEscapeOutputText()){
                     sanitizedValue = MarkupChecker.stripAllTags(sanitizedValue);
                 }
                 //if a series of child values is comma delimited we want to strip off the final entry's comma
-                if (format.equals("#VALUE, ")) fixTrailingComma = true;
+                if (format.trim().equals("#VALUE,")) fixTrailingComma = true;
                 
                 // replace the special values in the format (note: we replace #VALUE last since we don't
                 // want any issues if the value itself has #NAME in it)
@@ -247,9 +251,17 @@ public class DatasetFieldCompoundValue implements Serializable {
             keyVal = entry.getKey();
             oldValue = entry.getValue();
         }
-
+        
+        String newValue = oldValue; 
+        
         if (keyVal != null && oldValue != null && oldValue.length() >= 2) {
-            String newValue = oldValue.substring(0, oldValue.length() - 2);
+        //To take into account both versions of the tsv for display value
+            if (oldValue.endsWith(", ")) {
+                newValue = oldValue.substring(0, oldValue.length() - 2);
+            } else if (oldValue.endsWith(",")) {
+                newValue = oldValue.substring(0, oldValue.length() - 1);
+            }
+         
             mapIn.replace(keyVal, oldValue, newValue);
         }
 

--- a/src/main/java/edu/harvard/iq/dataverse/DatasetFieldCompoundValue.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetFieldCompoundValue.java
@@ -177,10 +177,7 @@ public class DatasetFieldCompoundValue implements Serializable {
                 if (StringUtils.isBlank(format)) {
                     format = "#VALUE";
                 }
-                /*
-                if (format.equals("#VALUE,")) {
-                    format = "#VALUE, ";
-                }*/
+
                 String sanitizedValue = childDatasetField.getDatasetFieldType().isSanitizeHtml() ? MarkupChecker.sanitizeBasicHTML(childDatasetField.getValue()) :  childDatasetField.getValue();
                 if (!childDatasetField.getDatasetFieldType().isSanitizeHtml() && childDatasetField.getDatasetFieldType().isEscapeOutputText()){
                     sanitizedValue = MarkupChecker.stripAllTags(sanitizedValue);


### PR DESCRIPTION
**What this PR does / why we need it**: Fixes the removal of the trailing comma in a Compound Value field regardless of whether the Display Value string is "VALUE," or "VALUE, ".

**Which issue(s) this PR closes**:

- Closes #12464 

**Special notes for your reviewer**: Probably a more elegant way to do this, but I wanted to make sure it would work for the two display value strings that we know about.

**Suggestions on how to test this**: Remember for the geospatial it will remove the trailing comma for each given group of values (Country, State, City). There are no commas separating the groups - they are put on a new line. So if all your geospatial items are countries then there are no commas at all.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**: no. fixing something introduced by another PR

**Additional documentation**:
