### PR TITLE
Fix File Download API when Guestbook at request is true

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/api/Access.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Access.java
@@ -1982,7 +1982,8 @@ public class Access extends AbstractApiBean {
 
     private boolean checkGuestbookRequiredResponse(User user, UriInfo uriInfo, DataFile df, String gbrids) throws WebApplicationException {
         // Check if guestbook response is required
-        boolean required = df.getOwner().hasEnabledGuestbook();
+        Dataset d = df.getOwner();
+        boolean required = df.getOwner().hasEnabledGuestbook() && !d.getEffectiveGuestbookEntryAtRequest();
         boolean wasWrittenInPost = false;
         if (required) {
             User requestor = getRequestor(user);


### PR DESCRIPTION
**What this PR does / why we need it**: #12110 changed the GET /api/access/datafile/{id} and related to require submission of a guestbook response id when a guestbook is enabled on the dataset. This breaks the API calls when guestbook-at-request is true for a dataset - they return an incorrect 400 response.

**Which issue(s) this PR closes**:

- Closes #

**Special notes for your reviewer**: This PR just adds a check to not require a gbrids check if GB at request is true. One could argue that a gbrids could still be required but
- while /api/access/datafile/{id}/requestAccess now accepts a gb response, it does not return the id
- presumably requestAccess would have failed/access not granted if the gb response doesn't exist
- the time-based check would have to be revised as the access request could have been far in the past

**Suggestions on how to test this**: Manually one can publish a restricted file, in a dataset with a guestbook and gb at request on,  and then try a previewer on it. The separate page preview view will fail with a 400 response on the file access request before this PR.
I would have expected[ this test ](https://github.com/IQSS/dataverse/blob/3e5bba0e7cb6435b37efe6f3bdff19dcd2980346/src/test/java/edu/harvard/iq/dataverse/api/AccessIT.java#L601-L603 )to be for this case, but[ it appears to require another guestbook response to be entered at download as well](https://github.com/IQSS/dataverse/blob/3e5bba0e7cb6435b37efe6f3bdff19dcd2980346/src/test/java/edu/harvard/iq/dataverse/api/AccessIT.java#L697-L704) - seems like accepting a gb response in a download request should also fail when gb at request is true (another bug/aspect of this bug).

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
