### PR TITLE
bump version to 6.11

### DIFF
--- a/doc/sphinx-guides/source/conf.py
+++ b/doc/sphinx-guides/source/conf.py
@@ -75,7 +75,7 @@ copyright = u'%d, The President & Fellows of Harvard College' % datetime.now().y
 # built documents.
 #
 # The short X.Y version.
-version = '6.10.1'
+version = '6.11'
 # The full version, including alpha/beta/rc tags.
 release = version
 

--- a/doc/sphinx-guides/source/versions.rst
+++ b/doc/sphinx-guides/source/versions.rst
@@ -8,6 +8,7 @@ This list provides a way to refer to the documentation for previous and future v
 
 - pre-release `HTML (not final!) <http://preview.guides.gdcc.io/en/develop/>`__ and `PDF (experimental!) <http://preview.guides.gdcc.io/_/downloads/en/develop/pdf/>`__ built from the :doc:`develop </developers/version-control>` branch :doc:`(how to contribute!) </contributor/documentation>`
 - |version|
+- `6.10.1 </en/6.10.1/>`__
 - `6.10 </en/6.10/>`__
 - `6.9 </en/6.9/>`__
 - `6.8 </en/6.8/>`__

--- a/modules/dataverse-parent/pom.xml
+++ b/modules/dataverse-parent/pom.xml
@@ -132,7 +132,7 @@
  
     <properties>
         <!-- This is a special Maven property name, do not change! -->
-        <revision>6.10.1</revision>
+        <revision>6.11</revision>
     
         <target.java.version>21</target.java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -461,8 +461,8 @@
                     Once the release has been made (tag created), change this back to "${parsedVersion.majorVersion}.${parsedVersion.nextMinorVersion}"
                     (These properties are provided by the build-helper plugin below.)
                 -->
-                <base.image.version>${parsedVersion.majorVersion}.${parsedVersion.nextMinorVersion}</base.image.version>
-                <!-- <base.image.version>${revision}</base.image.version> -->
+                <!-- <base.image.version>${parsedVersion.majorVersion}.${parsedVersion.nextMinorVersion}</base.image.version> -->
+                <base.image.version>${revision}</base.image.version>
                 <!-- This is used by the maintenance CI jobs, no need to adapt during releases. -->
                 <app.image.version>${base.image.version}</app.image.version>
             </properties>


### PR DESCRIPTION
**What this PR does / why we need it**:

Our normal version bump.

**Which issue(s) this PR closes**:

- Closes #12289

**Special notes for your reviewer**:

You can compare to the bump to 6.10 (our last non-hotfix release):

- #12230

Here's the official process: https://guides.dataverse.org/en/6.10.1/developers/making-releases.html#prepare-release-branch