### PR TITLE
Experimental dataset JSON GET API returns multi-valued fields as arrays

### DIFF
--- a/doc/release-notes/9495-return-multi-valued-fields-as-arrays.md
+++ b/doc/release-notes/9495-return-multi-valued-fields-as-arrays.md
@@ -1,0 +1,3 @@
+## Bug ##
+
+API GET /api/datasets/{id}/metadata now returns all multivalued fields as arrays instead of String for 1 entry and Array for more than 1 entry. This consistancy makes parsing the JSON easier for users of the API.

--- a/doc/release-notes/9495-return-multi-valued-fields-as-arrays.md
+++ b/doc/release-notes/9495-return-multi-valued-fields-as-arrays.md
@@ -1,3 +1,1 @@
-## Bug ##
-
-API GET /api/datasets/{id}/metadata now returns all multivalued fields as arrays instead of String for 1 entry and Array for more than 1 entry. This consistancy makes parsing the JSON easier for users of the API.
+When calling (GET) the /api/datasets/{id}/metadata endpoint or requesting JSON-LD (application/ld+json) from the /api/datasets/{id}/versions/{versionId}/metadata endpoint, all multivalued fields as arrays instead of String for 1 entry and Array for more than 1 entry. This consistancy makes parsing the JSON-LD as JSON easier for users of the API.

--- a/src/main/java/edu/harvard/iq/dataverse/util/bagit/OREMap.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/bagit/OREMap.java
@@ -490,9 +490,9 @@ public class OREMap {
                 vals.add(child);
             }
         }
-        // Add metadata value to aggregation, suppress array when only one value
+        // Add metadata value to aggregation, suppress array when multiples not allowed
         JsonArray valArray = vals.build();
-        return (valArray.size() != 1) ? valArray : valArray.get(0);
+        return (dfType.isAllowMultiples()) ? valArray : valArray.get(0);
     }
 
     private static void addCvocValue(String val, JsonArrayBuilder vals, JsonObject cvocEntry,

--- a/src/main/java/edu/harvard/iq/dataverse/util/bagit/OREMap.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/bagit/OREMap.java
@@ -47,7 +47,7 @@ public class OREMap {
     public static final String NAME = "OREMap";
     
     //NOTE: Update this value whenever the output of this class is changed
-    private static final String DATAVERSE_ORE_FORMAT_VERSION = "Dataverse OREMap Format v1.0.3";
+    private static final String DATAVERSE_ORE_FORMAT_VERSION = "Dataverse OREMap Format v1.0.4";
     //v1.0.1 - added versionNote
     private static final String DATAVERSE_SOFTWARE_NAME = "Dataverse";
     private static final String DATAVERSE_SOFTWARE_URL = "https://github.com/iqss/dataverse";

--- a/src/main/java/edu/harvard/iq/dataverse/util/bagit/OREMap.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/bagit/OREMap.java
@@ -48,7 +48,7 @@ public class OREMap {
     public static final String NAME = "OREMap";
     
     //NOTE: Update this value whenever the output of this class is changed
-    private static final String DATAVERSE_ORE_FORMAT_VERSION = "Dataverse OREMap Format v1.0.3";
+    private static final String DATAVERSE_ORE_FORMAT_VERSION = "Dataverse OREMap Format v1.0.4";
     //v1.0.1 - added versionNote
     private static final String DATAVERSE_SOFTWARE_NAME = "Dataverse";
     private static final String DATAVERSE_SOFTWARE_URL = "https://github.com/iqss/dataverse";

--- a/src/main/java/edu/harvard/iq/dataverse/util/bagit/OREMap.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/bagit/OREMap.java
@@ -491,9 +491,9 @@ public class OREMap {
                 vals.add(child);
             }
         }
-        // Add metadata value to aggregation, suppress array when only one value
+        // Add metadata value to aggregation, suppress array when multiples not allowed
         JsonArray valArray = vals.build();
-        return (valArray.size() != 1) ? valArray : valArray.get(0);
+        return (dfType.isAllowMultiples()) ? valArray : valArray.get(0);
     }
 
     private static void addCvocValue(String val, JsonArrayBuilder vals, JsonObject cvocEntry,

--- a/src/test/java/edu/harvard/iq/dataverse/api/DatasetsIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/DatasetsIT.java
@@ -3658,6 +3658,7 @@ createDataset = UtilIT.createRandomDatasetViaNativeApi(dataverse1Alias, apiToken
 
         // Get the metadata with the semantic api
         Response response = UtilIT.getDatasetJsonLDMetadata(datasetId, apiToken);
+        response.prettyPrint();
         response.then().assertThat().statusCode(OK.getStatusCode());
         // Compare the metadata with an expected value - the metadatablock entries
         // should be the same but there will be additional fields with values related to
@@ -3822,6 +3823,7 @@ createDataset = UtilIT.createRandomDatasetViaNativeApi(dataverse1Alias, apiToken
 
         // Get the semantic metadata
         Response response = UtilIT.getDatasetJsonLDMetadata(datasetId, apiToken);
+        response.prettyPrint();
         response.then().assertThat().statusCode(OK.getStatusCode());
         response.prettyPeek();
         String expectedString = getData(response.getBody().asString());

--- a/src/test/java/edu/harvard/iq/dataverse/api/DatasetsIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/DatasetsIT.java
@@ -3655,6 +3655,7 @@ createDataset = UtilIT.createRandomDatasetViaNativeApi(dataverse1Alias, apiToken
 
         // Get the metadata with the semantic api
         Response response = UtilIT.getDatasetJsonLDMetadata(datasetId, apiToken);
+        response.prettyPrint();
         response.then().assertThat().statusCode(OK.getStatusCode());
         // Compare the metadata with an expected value - the metadatablock entries
         // should be the same but there will be additional fields with values related to
@@ -3819,6 +3820,7 @@ createDataset = UtilIT.createRandomDatasetViaNativeApi(dataverse1Alias, apiToken
 
         // Get the semantic metadata
         Response response = UtilIT.getDatasetJsonLDMetadata(datasetId, apiToken);
+        response.prettyPrint();
         response.then().assertThat().statusCode(OK.getStatusCode());
         response.prettyPeek();
         String expectedString = getData(response.getBody().asString());


### PR DESCRIPTION
**What this PR does / why we need it**: For API GET /api/datasets/{id}/metadata multi-valued field values are not returned as arrays if only 1 entry exists. This causes parsing the JSON to be more complex.

**Which issue(s) this PR closes**: https://github.com/IQSS/dataverse/issues/9495

- Closes #9495

**Special notes for your reviewer**: Since the fields are parsed as an array, when more than 1 entry exists, there is no break in backward compatibility.

**Suggestions on how to test this**:  Create a dataset with 1 subject and another with more than 1 subject. Examine the JSON output to see that the "subject": ["Medicine, Health and Life Sciences"] is always surrounded with []. This will happen for all fields that have DatasetFieldType.isAllowMultiples() (for reference "title" does not allow multiples)

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**: Included

**Additional documentation**:
