### PR TITLE
Include name in guestbook responses api

### DIFF
--- a/doc/release-notes/12491-include-name-in-guestbook-responces-api.md
+++ b/doc/release-notes/12491-include-name-in-guestbook-responces-api.md
@@ -1,2 +1,3 @@
 ## BUG ##
-Added "name" to response in API GET /api/guestbooks/{guestbookId}/responses
+Changed "userName" in response in API GET /api/guestbooks/{guestbookId}/responses
+"userName" shows either the "Name" entered by the user, or Name of the Auth User, or "Guest". Actual Auth User's username is no longer returned.

--- a/doc/release-notes/12491-include-name-in-guestbook-responces-api.md
+++ b/doc/release-notes/12491-include-name-in-guestbook-responces-api.md
@@ -1,3 +1,2 @@
 ## BUG ##
-Changed "userName" in response in API GET /api/guestbooks/{guestbookId}/responses
-"userName" shows either the "Name" entered by the user, or Name of the Auth User, or "Guest". Actual Auth User's username is no longer returned.
+Changed "userName" in guestbook response to "name" to match the parser in API GET /api/guestbooks/{guestbookId}/responses

--- a/doc/release-notes/12491-include-name-in-guestbook-responces-api.md
+++ b/doc/release-notes/12491-include-name-in-guestbook-responces-api.md
@@ -1,0 +1,2 @@
+## BUG ##
+Added "name" to response in API GET /api/guestbooks/{guestbookId}/responses

--- a/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
@@ -428,9 +428,8 @@ public class JsonPrinter {
                 guestbookResponseObject.add("filePid", gbResponse.getDataFile().getGlobalId().asString());
             }
             String name = gbResponse.getName();
-            String userName = gbResponse.getAuthenticatedUser() != null ? gbResponse.getAuthenticatedUser().getUserIdentifier() : "Guest";
-            guestbookResponseObject.add("name", StringUtil.isEmpty(name) ? userName : name);
-            guestbookResponseObject.add("userName", userName);
+            String userName = gbResponse.getAuthenticatedUser() != null ? gbResponse.getAuthenticatedUser().getName() : "Guest";
+            guestbookResponseObject.add("userName", StringUtil.isEmpty(name) ? userName : name);
             if (gbResponse.getEmail() != null) {
                 guestbookResponseObject.add("email", gbResponse.getEmail());
             }

--- a/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
@@ -31,6 +31,7 @@ import edu.harvard.iq.dataverse.settings.SettingsServiceBean;
 import edu.harvard.iq.dataverse.util.BundleUtil;
 import edu.harvard.iq.dataverse.util.DatasetFieldWalker;
 import edu.harvard.iq.dataverse.util.MailUtil;
+import edu.harvard.iq.dataverse.util.StringUtil;
 import edu.harvard.iq.dataverse.workflow.Workflow;
 import edu.harvard.iq.dataverse.workflow.step.WorkflowStepData;
 import jakarta.ejb.EJB;
@@ -426,7 +427,10 @@ public class JsonPrinter {
             if (gbResponse.getDataFile().getGlobalId() != null) {
                 guestbookResponseObject.add("filePid", gbResponse.getDataFile().getGlobalId().asString());
             }
-            guestbookResponseObject.add("userName", gbResponse.getAuthenticatedUser() != null ? gbResponse.getAuthenticatedUser().getUserIdentifier() : "Guest");
+            String name = gbResponse.getName();
+            String userName = gbResponse.getAuthenticatedUser() != null ? gbResponse.getAuthenticatedUser().getUserIdentifier() : "Guest";
+            guestbookResponseObject.add("name", StringUtil.isEmpty(name) ? userName : name);
+            guestbookResponseObject.add("userName", userName);
             if (gbResponse.getEmail() != null) {
                 guestbookResponseObject.add("email", gbResponse.getEmail());
             }

--- a/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
@@ -428,8 +428,7 @@ public class JsonPrinter {
                 guestbookResponseObject.add("filePid", gbResponse.getDataFile().getGlobalId().asString());
             }
             String name = gbResponse.getName();
-            String userName = gbResponse.getAuthenticatedUser() != null ? gbResponse.getAuthenticatedUser().getName() : "Guest";
-            guestbookResponseObject.add("userName", StringUtil.isEmpty(name) ? userName : name);
+            guestbookResponseObject.add("name", StringUtil.isEmpty(name) ? "Guest" : name);
             if (gbResponse.getEmail() != null) {
                 guestbookResponseObject.add("email", gbResponse.getEmail());
             }

--- a/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
@@ -427,8 +427,9 @@ public class JsonPrinter {
             if (gbResponse.getDataFile().getGlobalId() != null) {
                 guestbookResponseObject.add("filePid", gbResponse.getDataFile().getGlobalId().asString());
             }
-            String name = gbResponse.getName();
-            guestbookResponseObject.add("name", StringUtil.isEmpty(name) ? "Guest" : name);
+            if (!StringUtil.isEmpty(gbResponse.getName())) {
+                guestbookResponseObject.add("name", gbResponse.getName());
+            }
             if (gbResponse.getEmail() != null) {
                 guestbookResponseObject.add("email", gbResponse.getEmail());
             }

--- a/src/test/java/edu/harvard/iq/dataverse/api/FilesIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/FilesIT.java
@@ -4115,9 +4115,7 @@ public class FilesIT {
         JsonPath jsonPath = JsonPath.from(guestbookListResponses.body().asString());
         int totalCount = jsonPath.getList("data.responses").size();
         assertTrue(totalCount > 0);
-        String name = jsonPath.getString("data.responses[0].name");
-        String userName = jsonPath.getString("data.responses[0].userName");
-        assertTrue(name.equals("My Name") || name.contains(userName)); // name defaults to "username username" when a new user is created in this test
+        assertNotNull(jsonPath.getString("data.responses[0].userName"));
 
         // Test Get Responses with pagination
         int pages = 4; // total should be 17. set to 4 pages

--- a/src/test/java/edu/harvard/iq/dataverse/api/FilesIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/FilesIT.java
@@ -4114,6 +4114,10 @@ public class FilesIT {
                 .statusCode(OK.getStatusCode());
         JsonPath jsonPath = JsonPath.from(guestbookListResponses.body().asString());
         int totalCount = jsonPath.getList("data.responses").size();
+        assertTrue(totalCount > 0);
+        String name = jsonPath.getString("data.responses[0].name");
+        String userName = jsonPath.getString("data.responses[0].userName");
+        assertTrue(name.equals("My Name") || name.contains(userName)); // name defaults to "username username" when a new user is created in this test
 
         // Test Get Responses with pagination
         int pages = 4; // total should be 17. set to 4 pages

--- a/src/test/java/edu/harvard/iq/dataverse/api/FilesIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/FilesIT.java
@@ -4115,7 +4115,7 @@ public class FilesIT {
         JsonPath jsonPath = JsonPath.from(guestbookListResponses.body().asString());
         int totalCount = jsonPath.getList("data.responses").size();
         assertTrue(totalCount > 0);
-        assertNotNull(jsonPath.getString("data.responses[0].userName"));
+        assertNotNull(jsonPath.getString("data.responses[0].name"));
 
         // Test Get Responses with pagination
         int pages = 4; // total should be 17. set to 4 pages


### PR DESCRIPTION
**What this PR does / why we need it**:  "name" was missing in JSON response to get Guestbook Responses

**Which issue(s) this PR closes**:https://github.com/IQSS/dataverse/issues/12491

- Closes #12491

**Special notes for your reviewer**:

**Suggestions on how to test this**: See the modified IT test. Check that the "name" field is in the responses list. 

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**: included

**Additional documentation**:
