### PR TITLE
a quick experiment adding caching

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DatasetVersionServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetVersionServiceBean.java
@@ -1340,6 +1340,15 @@ w
         return em.createQuery(cq).getSingleResult();
     }
 
+    public boolean hasFiles(Long datasetVersionId) {
+        Query query = em.createNativeQuery("SELECT id FROM fileMetadata WHERE datasetversion_id="+datasetVersionId+" LIMIT 1");
+        try {
+            query.getSingleResult();
+            return true;
+        } catch (NoResultException e) {
+            return false;
+        }
+    }
 
     /**
      * Update the archival copy location for a specific version of a dataset.

--- a/src/main/java/edu/harvard/iq/dataverse/PermissionsWrapper.java
+++ b/src/main/java/edu/harvard/iq/dataverse/PermissionsWrapper.java
@@ -33,6 +33,9 @@ public class PermissionsWrapper implements java.io.Serializable {
     @EJB
     PermissionServiceBean permissionService;
 
+    @EJB
+    DatasetVersionServiceBean  datasetVersionService;
+
     @Inject
     DataverseSession session;
     
@@ -257,15 +260,17 @@ public class PermissionsWrapper implements java.io.Serializable {
     // PUBLISH DATASET
     public boolean canIssuePublishDatasetCommand(DvObject dvo){
         User u = session.getUser();
-        if (u != null && u.isSuperuser()) {
+        if (u == null) {
+            return false; // guests can not publish
+        }
+        if (u.isSuperuser()) {
             return true;
         }
         // Return false if dataset has 0 files and user want to 'publish' or 'submit for review' and 'publish dataset requires files' flag is set
         if (dvo.isInstanceofDataset()) {
             Dataverse dv =((Dataset)dvo).getOwner();
             if (dv != null) {
-                List<FileMetadata> metadataList = ((Dataset) dvo).getLatestVersion().getFileMetadatas();
-                if (metadataList.size() == 0 && dv.getEffectiveRequiresFilesToPublishDataset()) {
+                if (!datasetVersionService.hasFiles(((Dataset) dvo).getLatestVersion().getId()) && dv.getEffectiveRequiresFilesToPublishDataset()) {
                     return false;
                 }
             }
@@ -275,12 +280,15 @@ public class PermissionsWrapper implements java.io.Serializable {
 
     // SUBMIT DATASET FOR REVIEW
     public boolean canIssueSubmitDatasetForReviewCommand(DvObject dvo){
+        User u = session.getUser();
+        if (u == null) {
+            return false; // guests can not submit for review
+        }
         // Return false if dataset has 0 files and user want to 'publish' or 'submit for review' and 'publish dataset requires files' flag is set
         if (dvo.isInstanceofDataset()) {
             Dataverse dv =((Dataset)dvo).getOwner();
             if (dv != null) {
-                List<FileMetadata> metadataList = ((Dataset) dvo).getLatestVersion().getFileMetadatas();
-                if (metadataList.size() == 0 && dv.getEffectiveRequiresFilesToPublishDataset()) {
+                if (!datasetVersionService.hasFiles(((Dataset) dvo).getLatestVersion().getId()) && dv.getEffectiveRequiresFilesToPublishDataset()) {
                     return false;
                 }
             }

--- a/src/main/java/edu/harvard/iq/dataverse/PermissionsWrapper.java
+++ b/src/main/java/edu/harvard/iq/dataverse/PermissionsWrapper.java
@@ -7,6 +7,7 @@ package edu.harvard.iq.dataverse;
 
 import edu.harvard.iq.dataverse.authorization.Permission;
 import edu.harvard.iq.dataverse.authorization.groups.impl.builtin.AuthenticatedUsers;
+import edu.harvard.iq.dataverse.authorization.users.GuestUser;
 import edu.harvard.iq.dataverse.authorization.users.User;
 import edu.harvard.iq.dataverse.engine.command.Command;
 import edu.harvard.iq.dataverse.engine.command.DataverseRequest;
@@ -260,7 +261,7 @@ public class PermissionsWrapper implements java.io.Serializable {
     // PUBLISH DATASET
     public boolean canIssuePublishDatasetCommand(DvObject dvo){
         User u = session.getUser();
-        if (u == null) {
+        if (u == null || u instanceof GuestUser) {
             return false; // guests can not publish
         }
         if (u.isSuperuser()) {
@@ -281,7 +282,7 @@ public class PermissionsWrapper implements java.io.Serializable {
     // SUBMIT DATASET FOR REVIEW
     public boolean canIssueSubmitDatasetForReviewCommand(DvObject dvo){
         User u = session.getUser();
-        if (u == null) {
+        if (u == null || u instanceof GuestUser) {
             return false; // guests can not submit for review
         }
         // Return false if dataset has 0 files and user want to 'publish' or 'submit for review' and 'publish dataset requires files' flag is set

--- a/src/main/java/edu/harvard/iq/dataverse/PermissionsWrapper.java
+++ b/src/main/java/edu/harvard/iq/dataverse/PermissionsWrapper.java
@@ -267,34 +267,51 @@ public class PermissionsWrapper implements java.io.Serializable {
         if (u.isSuperuser()) {
             return true;
         }
-        // Return false if dataset has 0 files and user want to 'publish' or 'submit for review' and 'publish dataset requires files' flag is set
-        if (dvo.isInstanceofDataset()) {
-            Dataverse dv =((Dataset)dvo).getOwner();
-            if (dv != null) {
-                if (!datasetVersionService.hasFiles(((Dataset) dvo).getLatestVersion().getId()) && dv.getEffectiveRequiresFilesToPublishDataset()) {
-                    return false;
+        if (checkDvoCacheForCommandAuthorization(dvo.getId(), PublishDatasetCommand.class, authUsersCommandMap) == null) {
+            // Return false if dataset has 0 files and user want to 'publish' or 'submit for review' and 'publish dataset requires files' flag is set
+            if (dvo.isInstanceofDataset()) {
+                Dataverse dv = ((Dataset) dvo).getOwner();
+                if (dv != null) {
+                    if (!datasetVersionService.hasFiles(((Dataset) dvo).getLatestVersion().getId()) && dv.getEffectiveRequiresFilesToPublishDataset()) {
+                        // it appears (?) to be safe caching the result; if a user
+                        // uploads more files within the same session, that re-renders 
+                        // the page resulting in a new ViewScoped instance of this
+                        // wrapper. 
+                        addCommandAuthorizationToDvoCache(dvo.getId(), PublishDatasetCommand.class, authUsersCommandMap, false);
+                        return false;
+                    }
                 }
             }
+            boolean canPublish = canIssueCommand(dvo, PublishDatasetCommand.class);
+            addCommandAuthorizationToDvoCache(dvo.getId(), PublishDatasetCommand.class, authUsersCommandMap, canPublish);
         }
-        return canIssueCommand(dvo, PublishDatasetCommand.class);
+        return checkDvoCacheForCommandAuthorization(dvo.getId(), PublishDatasetCommand.class, authUsersCommandMap);
     }
 
     // SUBMIT DATASET FOR REVIEW
-    public boolean canIssueSubmitDatasetForReviewCommand(DvObject dvo){
+    public boolean canIssueSubmitDatasetForReviewCommand(DvObject dvo) {
+
         User u = session.getUser();
         if (u == null || u instanceof GuestUser) {
             return false; // guests can not submit for review
         }
-        // Return false if dataset has 0 files and user want to 'publish' or 'submit for review' and 'publish dataset requires files' flag is set
-        if (dvo.isInstanceofDataset()) {
-            Dataverse dv =((Dataset)dvo).getOwner();
-            if (dv != null) {
-                if (!datasetVersionService.hasFiles(((Dataset) dvo).getLatestVersion().getId()) && dv.getEffectiveRequiresFilesToPublishDataset()) {
-                    return false;
+
+        if (checkDvoCacheForCommandAuthorization(dvo.getId(), SubmitDatasetForReviewCommand.class, authUsersCommandMap) == null) {
+            // Return false if dataset has 0 files and user want to 'publish' or 'submit for review' and 'publish dataset requires files' flag is set
+            if (dvo.isInstanceofDataset()) {
+                Dataverse dv = ((Dataset) dvo).getOwner();
+                if (dv != null) {
+                    if (!datasetVersionService.hasFiles(((Dataset) dvo).getLatestVersion().getId()) && dv.getEffectiveRequiresFilesToPublishDataset()) {
+                        // see the comment in canIssuePublishDataset() above
+                        addCommandAuthorizationToDvoCache(dvo.getId(), SubmitDatasetForReviewCommand.class, authUsersCommandMap, false);
+                        return false;
+                    }
                 }
             }
+            boolean canIssueSubmitForReview = canIssueCommand(dvo, SubmitDatasetForReviewCommand.class);
+            addCommandAuthorizationToDvoCache(dvo.getId(), SubmitDatasetForReviewCommand.class, authUsersCommandMap, canIssueSubmitForReview);
         }
-        return canIssueCommand(dvo, SubmitDatasetForReviewCommand.class);
+        return checkDvoCacheForCommandAuthorization(dvo.getId(), SubmitDatasetForReviewCommand.class, authUsersCommandMap);
     }
 
     // For the dataverse_header fragment (and therefore, most of the pages),


### PR DESCRIPTION
caching the results of .canIssuePublishDatasetCommand() and canIssueSubmitDatasetForReview() taking into account a potential "files required" check.

**What this PR does / why we need it**:

this was a quick experiment last night. may or may not be the right way of handling this, idk. 

**Which issue(s) this PR closes**:

- Closes #

**Special notes for your reviewer**:

**Suggestions on how to test this**:

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
