### PR TITLE
IQSS/12483 gbr req question fix

### DIFF
--- a/doc/release-notes/12483-gbr-req-question-fix.md
+++ b/doc/release-notes/12483-gbr-req-question-fix.md
@@ -1,0 +1,1 @@
+A bug that caused any required custom questions in guestbooks to still be optional has been fixed in the current UI.

--- a/src/main/webapp/guestbook-terms-popup-fragment.xhtml
+++ b/src/main/webapp/guestbook-terms-popup-fragment.xhtml
@@ -232,7 +232,7 @@
                                 <p:inputTextarea id="customQuestionResponseTextArea" rows="8" autoResize="true"
                                              styleClass="form-control"
                                              value="#{customQuestionResponse.response}"
-                                             required="#{param['DO_GB_VALIDATION'] and customQuestionResponse.customQuestion.required}"
+                                             required="#{param[validateThisContext] and customQuestionResponse.customQuestion.required}"
                                              rendered="#{customQuestionResponse.customQuestion.questionType=='textarea'}"
                                              requiredMessage="#{bundle['requiredField']}"/>
                                 <p:message id="cqMessagesTA" for="customQuestionResponseTextArea" display="text"/>


### PR DESCRIPTION
**What this PR does / why we need it**: This PR fixes the bug reported - that custom questions in guestbooks that were marked as required did not have to be answered to submit a response.

**Which issue(s) this PR closes**:

- Closes #12483 

**Special notes for your reviewer**:

**Suggestions on how to test this**: Create a gb with a multiline custom question, confirm you are required to answer it. 

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**: inc.

**Additional documentation**:
