### PR TITLE
Stop linking to private installation spreadsheet (deprecated)

### DIFF
--- a/doc/sphinx-guides/source/developers/security.rst
+++ b/doc/sphinx-guides/source/developers/security.rst
@@ -23,12 +23,6 @@ When drafting the security notice, it might be helpful to look at `previous exam
 
 .. _previous examples: https://drive.google.com/drive/folders/0B_qMYwdHFZghaDZIU2hWQnBDZVE?resourcekey=0-SYjuhCohAIM7_pmysVc3Xg&usp=sharing
 
-Gather email addresses from the following sources (these are also described under :ref:`ongoing-security` in the Installation Guide):
-
-- "contact_email" in the `public installation spreadsheet`_
-- "Other Security Contacts" in the `private installation spreadsheet`_
+Gather email addresses from the .. _public installation spreadsheet: https://docs.google.com/spreadsheets/d/1bfsw7gnHlHerLXuk7YprUT68liHfcaMxs1rFciA-mEo/edit#gid=0 (this is also described under :ref:`ongoing-security` in the Installation Guide).
 
 Once you have the emails, include them as bcc.
-
-.. _public installation spreadsheet: https://docs.google.com/spreadsheets/d/1bfsw7gnHlHerLXuk7YprUT68liHfcaMxs1rFciA-mEo/edit#gid=0
-.. _private installation spreadsheet: https://docs.google.com/spreadsheets/d/1EWDwsj6eptQ7nEr-loLvdU7I6Tm2ljAplfNSVWR42i0/edit?usp=sharing


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes link to outdated spreadsheet.

Preview at https://dataverse-guide--12522.org.readthedocs.build/en/12522/developers/security.html#sending-security-notices

**Which issue(s) this PR closes**:
N/A

**Special notes for your reviewer**:
N/A

**Suggestions on how to test this**:
Navigate to the [Security section](https://guides.dataverse.org/en/latest/developers/security.html) in the Dataverse Developer Guide and verify that the link to the public installation spreadsheet works as expected.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
No.

**Is there a release notes update needed for this change?**:
No.

**Additional documentation**:
N/A