### PR TITLE
Fix: Render multiple metadata values as unordered lists (Issue #12529)

### DIFF
--- a/src/main/webapp/metadataFragment.xhtml
+++ b/src/main/webapp/metadataFragment.xhtml
@@ -95,22 +95,32 @@
                                                 <h:outputText value="#{dsf.getDisplayValue(mdLangCode)}"
                                                     rendered="#{!dsf.datasetFieldType.allowMultiples and !cvocOnDsf}"
                                                     escape="#{dsf.datasetFieldType.isEscapeOutputText()}"/>
-                                                <ui:repeat value="#{dsf.getValues_nondisplay()}" var="value" varStatus="loop" rendered="#{dsf.datasetFieldType.allowMultiples and cvocOnDsf}">
-                                                    <h:outputText value="#{loop.first?'':'; '}"/>
-                                                    <h:outputText value="#{ value }"
-                                                                  escape="#{dsf.datasetFieldType.isEscapeOutputText()}">
-                                                        <f:passThroughAttribute name="lang" value="#{DatasetPage.getFieldLanguage(cvocConf.get(dsf.datasetFieldType.id).getString('languages'))}" />
-                                                        <f:passThroughAttribute name="data-cvoc-service-url" value="#{cvocConf.get(dsf.datasetFieldType.id).getString('cvoc-url','')}" />
-                                                        <f:passThroughAttribute name="data-cvoc-headers" value="#{cvocConf.get(dsf.datasetFieldType.id).containsKey('headers') ? cvocConf.get(dsf.datasetFieldType.id).get('headers').toString() : '{}'}"/>
-                                                        <f:passThroughAttribute name="data-cvoc-protocol" value="#{cvocConf.get(dsf.datasetFieldType.id).getString('protocol','')}" />
-                                                        <f:passThroughAttribute name="data-cvoc-managedfields" value="#{cvocConf.get(dsf.datasetFieldType.id).get('managed-fields').toString()}" />
-                                                    </h:outputText>
-                                                </ui:repeat>
-                                                <ui:repeat value="#{dsf.getValues(mdLangCode)}" var="value" varStatus="loop" rendered="#{dsf.datasetFieldType.allowMultiples and !cvocOnDsf}">
-                                                    <h:outputText value="#{loop.first?'':'; '}#{ value }"
-                                                                  escape="#{dsf.datasetFieldType.isEscapeOutputText()}"/>
-                                                </ui:repeat>
-                                            </ui:fragment>
+                                                <ui:fragment rendered="#{dsf.datasetFieldType.allowMultiples and cvocOnDsf}">
+                                                    <ul class="list-unstyled" style="margin-bottom: 0;">
+                                                        <ui:repeat value="#{dsf.getValues_nondisplay()}" var="value" varStatus="loop">
+                                                            <li>
+                                                                <h:outputText value="#{ value }"
+                                                                              escape="#{dsf.datasetFieldType.isEscapeOutputText()}">
+                                                                    <f:passThroughAttribute name="lang" value="#{DatasetPage.getFieldLanguage(cvocConf.get(dsf.datasetFieldType.id).getString('languages'))}" />
+                                                                    <f:passThroughAttribute name="data-cvoc-service-url" value="#{cvocConf.get(dsf.datasetFieldType.id).getString('cvoc-url','')}" />
+                                                                    <f:passThroughAttribute name="data-cvoc-headers" value="#{cvocConf.get(dsf.datasetFieldType.id).containsKey('headers') ? cvocConf.get(dsf.datasetFieldType.id).get('headers').toString() : '{}'}"/>
+                                                                    <f:passThroughAttribute name="data-cvoc-protocol" value="#{cvocConf.get(dsf.datasetFieldType.id).getString('protocol','')}" />
+                                                                    <f:passThroughAttribute name="data-cvoc-managedfields" value="#{cvocConf.get(dsf.datasetFieldType.id).get('managed-fields').toString()}" />
+                                                                </h:outputText>
+                                                            </li>
+                                                        </ui:repeat>
+                                                    </ul>
+                                                </ui:fragment>
+                                                <ui:fragment rendered="#{dsf.datasetFieldType.allowMultiples and !cvocOnDsf}">
+                                                    <ul class="list-unstyled" style="margin-bottom: 0;">
+                                                        <ui:repeat value="#{dsf.getValues(mdLangCode)}" var="value" varStatus="loop">
+                                                            <li>
+                                                                <h:outputText value="#{ value }"
+                                                                              escape="#{dsf.datasetFieldType.isEscapeOutputText()}"/>
+                                                            </li>
+                                                        </ui:repeat>
+                                                    </ul>
+                                                </ui:fragment>
                                             <!-- Compound datasetFields -->
                                             <ui:fragment rendered="#{dsf.datasetFieldType.compound}">
                                                 <ui:fragment rendered="#{dsf.datasetFieldType.name == 'datasetContact'}">


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR refactors how multiple metadata values are rendered on the dataset page. Previously, multiple values were rendered as a flat string separated by semicolons using a simple `<ui:repeat>`. This updates the UI to render them semantically using `<ul class="list-unstyled">` and `<li>` tags, improving readability and DOM structure.

**Which issue(s) this PR closes**:
- Closes #12529

**Special notes for your reviewer**:
The logic for `cvocOnDsf` remains intact. The `rendered` attributes were carefully maintained to cover both multiple values (with and without CVOC) separately.

**Suggestions on how to test this**:
1. Go to a dataset page that contains metadata fields with multiple values.
2. Verify that the values are displayed cleanly without semicolons.
3. Inspect the element to confirm they are rendered inside `<ul>` and `<li>` tags.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
Yes, minor UI change. Multiple values are no longer separated by `; ` inline, but rendered as an unstyled list.

**Is there a release notes update needed for this change?**:
No.

**Additional documentation**:
None.