### PR TITLE
chore: Migrate all the hardcoded messages and emails in english to `bundle.properties` for password reset service.

### DIFF
--- a/doc/release-notes/12536-password-reset-internationalization.md
+++ b/doc/release-notes/12536-password-reset-internationalization.md
@@ -1,0 +1,1 @@
+Migrate all the hardcoded message and email strings to properties file for password reset service. See #12536.

--- a/src/main/java/edu/harvard/iq/dataverse/passwordreset/PasswordResetServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/passwordreset/PasswordResetServiceBean.java
@@ -203,22 +203,22 @@ public class PasswordResetServiceBean {
 
     public PasswordChangeAttemptResponse attemptPasswordReset(BuiltinUser user, String newPassword, String token) {
 
-        final String messageSummarySuccess = "Password Reset Successfully";
+        final String messageSummarySuccess = BundleUtil.getStringFromBundle("passwdReset.messageSummarySuccess");
         final String messageDetailSuccess = "";
 
         // optimistic defaults :)
         String messageSummary = messageSummarySuccess;
         String messageDetail = messageDetailSuccess;
 
-        final String messageSummaryFail = "Password Reset Problem";
+        final String messageSummaryFail = BundleUtil.getStringFromBundle("passwdReset.messageSummaryFail");
         if (user == null) {
             messageSummary = messageSummaryFail;
-            messageDetail = "User could not be found.";
+            messageDetail = BundleUtil.getStringFromBundle("passwdReset.failDetail.userNotFound");
             return new PasswordChangeAttemptResponse(false, messageSummary, messageDetail);
         }
         if (newPassword == null) {
             messageSummary = messageSummaryFail;
-            messageDetail = "New password not provided.";
+            messageDetail = BundleUtil.getStringFromBundle("passwdReset.failDetail.passwordNotProvided");
             return new PasswordChangeAttemptResponse(false, messageSummary, messageDetail);
         }
         if (token == null) {
@@ -248,17 +248,17 @@ public class PasswordResetServiceBean {
             }
             AuthenticatedUser authUser = authService.getAuthenticatedUser(user.getUserName());
             
-            String toAddress = authUser.getEmail();
-            String subject = "Dataverse Password Reset Successfully Changed";
+            String pattern = BundleUtil.getStringFromBundle("notification.email.passwordResetCompleted");
+            String[] paramArray = {authUser.getName() };
+            String messageBody = MessageFormat.format(pattern, paramArray);
 
-            String messageBody = "Hi " + authUser.getName() + ",\n\n"
-                    + "Your Dataverse account password was successfully changed.\n\n"
-                    + "Please contact us if you did not request this password reset or need further help.\n\n";
+            String toAddress = authUser.getEmail();
+            String subject = BundleUtil.getStringFromBundle("notification.email.passwordResetCompleted.subject");
             mailService.sendSystemEmail(toAddress, subject, messageBody);
             return new PasswordChangeAttemptResponse(true, messageSummary, messageDetail);
         } else {
             messageSummary = messageSummaryFail;
-            messageDetail = "Your password was not reset. Please contact support.";
+            messageDetail = BundleUtil.getStringFromBundle("passwdReset.failDetail.generic");
             logger.info("Enable to save user " + user.getId());
             return new PasswordChangeAttemptResponse(false, messageSummary, messageDetail);
         }

--- a/src/main/java/propertyFiles/Bundle.properties
+++ b/src/main/java/propertyFiles/Bundle.properties
@@ -404,6 +404,11 @@ passwdReset.newPasswd.details=Please pick a strong password that matches the cri
 passwdReset.newPasswd=New Password
 passwdReset.rePasswd=Retype Password
 passwdReset.resetBtn=Continue
+passwdReset.messageSummarySuccess=Password Reset Successfully
+passwdReset.messageSummaryFail=Password Reset Problem
+passwdReset.failDetail.userNotFound=User could not be found.
+passwdReset.failDetail.passwordNotProvided=New password not provided.
+passwdReset.failDetail.generic=Your password was not reset. Please contact support.
 
 #loginpage.xhtml
 login.System=Login System
@@ -871,6 +876,8 @@ notification.email.revokeRole=One of your roles for the {0} "{1}" has been revok
 notification.email.changeEmail=Hello, {0}.{1}\n\nPlease contact us if you did not intend this change or if you need assistance.
 notification.email.passwordReset=Hi {0},\n\nSomeone, hopefully you, requested a password reset for {1}.\n\nPlease click the link below to reset your Dataverse account password:\n\n {2} \n\n The link above will only work for the next {3} minutes.\n\n Please contact us if you did not request this password reset or need further help.
 notification.email.passwordReset.subject=Dataverse Password Reset Requested
+notification.email.passwordResetCompleted=Hi {0},\n\nYour Dataverse account password was successfully changed.\n\nPlease contact us if you did not request this password reset or need further help.
+notification.email.passwordResetCompleted.subject=Dataverse Password Reset Successfully Changed
 notification.email.datasetWasCreated=Dataset "<a href = "{0}">{1}</a>" was just created by {2} in the {3} collection.
 notification.email.datasetWasMoved=Dataset "<a href = "{0}">{1}</a>" was just moved by {2} to the {3} collection.
 notification.email.requestedFileAccess=You have requested access to a file(s) in dataset "<a href = "{0}">{1}</a>". Your request has been sent to the managers of this dataset who will grant or reject your request. If you have any questions, you may reach the dataset managers using the "Contact" link on the upper right corner of the dataset page.


### PR DESCRIPTION

**What this PR does / why we need it**: Improve internationalization

**Which issue(s) this PR closes**:

- Closes #12536

**Special notes for your reviewer**:

**Suggestions on how to test this**:

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
