### PR TITLE
Allow Preview User to download files without requiring a Guestbook Re…

### DIFF
--- a/doc/release-notes/12535-download-without-guestbook-response-for-preview-user.md
+++ b/doc/release-notes/12535-download-without-guestbook-response-for-preview-user.md
@@ -1,0 +1,2 @@
+## Bug ##
+Preview Users can now download files without the required guestbook response.

--- a/doc/release-notes/12535-download-without-guestbook-response-for-preview-user.md
+++ b/doc/release-notes/12535-download-without-guestbook-response-for-preview-user.md
@@ -1,2 +1,2 @@
 ## Bug ##
-Preview Users can now download files without the required guestbook response.
+Preview URL users could not download files from the dataset being previewed if a guestbook was assigned to that dataset. This is now fixed.

--- a/src/main/java/edu/harvard/iq/dataverse/FileDownloadServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/FileDownloadServiceBean.java
@@ -4,6 +4,7 @@ import edu.harvard.iq.dataverse.authorization.AuthenticationServiceBean;
 import edu.harvard.iq.dataverse.authorization.Permission;
 import edu.harvard.iq.dataverse.authorization.users.ApiToken;
 import edu.harvard.iq.dataverse.authorization.users.AuthenticatedUser;
+import edu.harvard.iq.dataverse.authorization.users.PrivateUrlUser;
 import edu.harvard.iq.dataverse.authorization.users.User;
 import edu.harvard.iq.dataverse.dataaccess.DataAccess;
 import edu.harvard.iq.dataverse.dataaccess.StorageIO;
@@ -14,6 +15,7 @@ import edu.harvard.iq.dataverse.externaltools.ExternalTool;
 import edu.harvard.iq.dataverse.externaltools.ExternalToolHandler;
 import edu.harvard.iq.dataverse.makedatacount.MakeDataCountLoggingServiceBean;
 import edu.harvard.iq.dataverse.makedatacount.MakeDataCountLoggingServiceBean.MakeDataCountEntry;
+import edu.harvard.iq.dataverse.settings.JvmSettings;
 import edu.harvard.iq.dataverse.settings.SettingsServiceBean;
 import edu.harvard.iq.dataverse.util.*;
 import jakarta.ejb.EJB;
@@ -314,6 +316,15 @@ public class FileDownloadServiceBean implements java.io.Serializable {
         } else {
             logger.fine("Redirecting to file download url: " + fileDownloadUrl);
             try {
+                // Sign URL for preview url user
+                User user = session.getUser();
+                if (user != null &&  (user instanceof PrivateUrlUser)) {
+                    PrivateUrlUser privateUrlUser =  (PrivateUrlUser) user;
+                    String key = JvmSettings.API_SIGNING_SECRET.lookupOptional().orElse("") + privateUrlUser.getToken();
+                    // Signing requires the full url path
+                    fileDownloadUrl = fileDownloadUrl.replace("/api/access/", "http://localhost:8080/api/v1/access/");
+                    fileDownloadUrl = UrlSignerUtil.signUrl(fileDownloadUrl, 1, privateUrlUser.getIdentifier(), "GET", key);
+                }
                 FacesContext.getCurrentInstance().getExternalContext().redirect(fileDownloadUrl);
             } catch (IOException ex) {
                 logger.info("Failed to issue a redirect to file download url (" + fileDownloadUrl + "): " + ex);

--- a/src/main/java/edu/harvard/iq/dataverse/FileDownloadServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/FileDownloadServiceBean.java
@@ -20,12 +20,14 @@ import edu.harvard.iq.dataverse.settings.SettingsServiceBean;
 import edu.harvard.iq.dataverse.util.*;
 import jakarta.ejb.EJB;
 import jakarta.ejb.Stateless;
+import jakarta.faces.context.ExternalContext;
 import jakarta.faces.context.FacesContext;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.primefaces.PrimeFaces;
 
@@ -319,11 +321,10 @@ public class FileDownloadServiceBean implements java.io.Serializable {
                 // Sign URL for preview url user
                 User user = session.getUser();
                 if (user != null &&  (user instanceof PrivateUrlUser)) {
-                    PrivateUrlUser privateUrlUser =  (PrivateUrlUser) user;
+                    PrivateUrlUser privateUrlUser = (PrivateUrlUser) user;
                     String key = JvmSettings.API_SIGNING_SECRET.lookupOptional().orElse("") + privateUrlUser.getToken();
                     // Signing requires the full url path
-                    fileDownloadUrl = fileDownloadUrl.replace("/api/access/", "http://localhost:8080/api/v1/access/");
-                    fileDownloadUrl = UrlSignerUtil.signUrl(fileDownloadUrl, 1, privateUrlUser.getIdentifier(), "GET", key);
+                    fileDownloadUrl = UrlSignerUtil.signUrl(getFullUrlForSigning(fileDownloadUrl), 1, privateUrlUser.getIdentifier(), "GET", key);
                 }
                 FacesContext.getCurrentInstance().getExternalContext().redirect(fileDownloadUrl);
             } catch (IOException ex) {
@@ -348,7 +349,23 @@ public class FileDownloadServiceBean implements java.io.Serializable {
             logger.info("Failed to issue a redirect to aux file download url (" + fileDownloadUrl + "): " + ex);
         }
     }
-    
+
+    private String getFullUrlForSigning(String path) {
+        ExternalContext extContext = FacesContext.getCurrentInstance().getExternalContext();
+
+        // Get the base server and port details
+        HttpServletRequest request = (HttpServletRequest) extContext.getRequest();
+        String scheme = request.getScheme();
+        String serverName = request.getServerName();
+        int port = request.getServerPort();
+
+        // Build the full base URL + path and an API version (default is v1)
+        StringBuilder fullUrl = new StringBuilder();
+        fullUrl.append(scheme).append("://").append(serverName).append(":").append(port)
+                .append(path.replace("/api/access/", "/api/v1/access/"));
+
+        return fullUrl.toString();
+    }
     /**
      * Launch an "explore" tool which is a type of ExternalTool such as
      * Data Explorer. This method may be invoked directly from the

--- a/src/main/java/edu/harvard/iq/dataverse/FileDownloadServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/FileDownloadServiceBean.java
@@ -15,19 +15,16 @@ import edu.harvard.iq.dataverse.externaltools.ExternalTool;
 import edu.harvard.iq.dataverse.externaltools.ExternalToolHandler;
 import edu.harvard.iq.dataverse.makedatacount.MakeDataCountLoggingServiceBean;
 import edu.harvard.iq.dataverse.makedatacount.MakeDataCountLoggingServiceBean.MakeDataCountEntry;
-import edu.harvard.iq.dataverse.settings.JvmSettings;
 import edu.harvard.iq.dataverse.settings.SettingsServiceBean;
 import edu.harvard.iq.dataverse.util.*;
 import jakarta.ejb.EJB;
 import jakarta.ejb.Stateless;
-import jakarta.faces.context.ExternalContext;
 import jakarta.faces.context.FacesContext;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import jakarta.servlet.ServletOutputStream;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.primefaces.PrimeFaces;
 
@@ -35,7 +32,6 @@ import java.io.IOException;
 import java.sql.Timestamp;
 import java.util.*;
 import java.util.logging.Logger;
-//import org.primefaces.context.RequestContext;
 
 /**
  *
@@ -318,13 +314,9 @@ public class FileDownloadServiceBean implements java.io.Serializable {
         } else {
             logger.fine("Redirecting to file download url: " + fileDownloadUrl);
             try {
-                // Sign URL for preview url user
                 User user = session.getUser();
                 if (user != null &&  (user instanceof PrivateUrlUser)) {
-                    PrivateUrlUser privateUrlUser = (PrivateUrlUser) user;
-                    String key = JvmSettings.API_SIGNING_SECRET.lookupOptional().orElse("") + privateUrlUser.getToken();
-                    // Signing requires the full url path
-                    fileDownloadUrl = UrlSignerUtil.signUrl(getFullUrlForSigning(fileDownloadUrl), 1, privateUrlUser.getIdentifier(), "GET", key);
+                    fileDownloadUrl = fileDownloadUrl + ((fileDownloadUrl.contains("?")) ? "&" : "?") + "key=" + ((PrivateUrlUser) user).getToken();
                 }
                 FacesContext.getCurrentInstance().getExternalContext().redirect(fileDownloadUrl);
             } catch (IOException ex) {
@@ -350,22 +342,6 @@ public class FileDownloadServiceBean implements java.io.Serializable {
         }
     }
 
-    private String getFullUrlForSigning(String path) {
-        ExternalContext extContext = FacesContext.getCurrentInstance().getExternalContext();
-
-        // Get the base server and port details
-        HttpServletRequest request = (HttpServletRequest) extContext.getRequest();
-        String scheme = request.getScheme();
-        String serverName = request.getServerName();
-        int port = request.getServerPort();
-
-        // Build the full base URL + path and an API version (default is v1)
-        StringBuilder fullUrl = new StringBuilder();
-        fullUrl.append(scheme).append("://").append(serverName).append(":").append(port)
-                .append(path.replace("/api/access/", "/api/v1/access/"));
-
-        return fullUrl.toString();
-    }
     /**
      * Launch an "explore" tool which is a type of ExternalTool such as
      * Data Explorer. This method may be invoked directly from the

--- a/src/main/java/edu/harvard/iq/dataverse/api/Access.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Access.java
@@ -12,10 +12,7 @@ import edu.harvard.iq.dataverse.authorization.AuthenticationServiceBean;
 import edu.harvard.iq.dataverse.authorization.DataverseRole;
 import edu.harvard.iq.dataverse.authorization.Permission;
 import edu.harvard.iq.dataverse.authorization.RoleAssignee;
-import edu.harvard.iq.dataverse.authorization.users.ApiToken;
-import edu.harvard.iq.dataverse.authorization.users.AuthenticatedUser;
-import edu.harvard.iq.dataverse.authorization.users.GuestUser;
-import edu.harvard.iq.dataverse.authorization.users.User;
+import edu.harvard.iq.dataverse.authorization.users.*;
 import edu.harvard.iq.dataverse.dataaccess.*;
 import edu.harvard.iq.dataverse.datavariable.DataVariable;
 import edu.harvard.iq.dataverse.datavariable.VariableServiceBean;
@@ -2237,7 +2234,12 @@ public class Access extends AbstractApiBean {
     private boolean checkGuestbookRequiredResponse(User user, UriInfo uriInfo, DataFile df, String gbrids) throws WebApplicationException {
         // Check if guestbook response is required
         Dataset d = df.getOwner();
-        boolean required = df.getOwner().hasEnabledGuestbook() && !d.getEffectiveGuestbookEntryAtRequest();
+        boolean exempt = false;
+        // PrivateUrlUser access to requested dataset's files must be checked!
+        if (user instanceof PrivateUrlUser) {
+            exempt = (df.getOwner().getId() == ((PrivateUrlUser) user).getDatasetId());
+        }
+        boolean required = !exempt && df.getOwner().hasEnabledGuestbook() && !d.getEffectiveGuestbookEntryAtRequest();
         boolean wasWrittenInPost = false;
         if (required) {
             User requestor = getRequestor(user);

--- a/src/main/java/edu/harvard/iq/dataverse/api/Access.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Access.java
@@ -2235,7 +2235,7 @@ public class Access extends AbstractApiBean {
         // Check if guestbook response is required
         Dataset d = df.getOwner();
         boolean exempt = false;
-        // PrivateUrlUser access to requested dataset's files must be checked!
+        // PrivateUrlUser access to draft files is exempt from guestbook responses in JSF https://github.com/IQSS/dataverse/issues/12535
         if (user instanceof PrivateUrlUser) {
             exempt = (df.getOwner().getId() == ((PrivateUrlUser) user).getDatasetId());
         }

--- a/src/main/java/edu/harvard/iq/dataverse/authorization/users/PrivateUrlUser.java
+++ b/src/main/java/edu/harvard/iq/dataverse/authorization/users/PrivateUrlUser.java
@@ -20,7 +20,8 @@ public class PrivateUrlUser implements User {
      * is a DvObject.
      */
     private final long datasetId;
-    private final boolean anonymizedAccess; 
+    private final boolean anonymizedAccess;
+    private String token = null;
 
     public PrivateUrlUser(long datasetId) {
         this(datasetId, false);
@@ -38,7 +39,14 @@ public class PrivateUrlUser implements User {
     public boolean hasAnonymizedAccess() {
         return anonymizedAccess;
     }
-    
+
+    public String getToken() {
+        return token;
+    }
+    public void setToken(String token) {
+        this.token = token;
+    }
+
     /**
      * By always returning false for isAuthenticated(), we prevent a
      * name from appearing in the corner as well as preventing an account page

--- a/src/main/java/edu/harvard/iq/dataverse/privateurl/PrivateUrlPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/privateurl/PrivateUrlPage.java
@@ -52,7 +52,6 @@ public class PrivateUrlPage implements Serializable {
             }
             if(!sessionUserCanViewUnpublishedDataset){
                 //Only Reset if user cannot view this Draft Version
-                privateUrlUser.setToken(token);
                 session.setUser(privateUrlUser); 
             }
             logger.info("Redirecting PrivateUrlUser '" + privateUrlUser.getIdentifier() + "' to " + draftDatasetPageToBeRedirectedTo);

--- a/src/main/java/edu/harvard/iq/dataverse/privateurl/PrivateUrlPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/privateurl/PrivateUrlPage.java
@@ -52,6 +52,7 @@ public class PrivateUrlPage implements Serializable {
             }
             if(!sessionUserCanViewUnpublishedDataset){
                 //Only Reset if user cannot view this Draft Version
+                privateUrlUser.setToken(token);
                 session.setUser(privateUrlUser); 
             }
             logger.info("Redirecting PrivateUrlUser '" + privateUrlUser.getIdentifier() + "' to " + draftDatasetPageToBeRedirectedTo);

--- a/src/main/java/edu/harvard/iq/dataverse/privateurl/PrivateUrlServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/privateurl/PrivateUrlServiceBean.java
@@ -51,7 +51,11 @@ public class PrivateUrlServiceBean implements Serializable {
      * @return A PrivateUrlUser if one can be found using the token or null.
      */
     public PrivateUrlUser getPrivateUrlUserFromToken(String token) {
-        return PrivateUrlUtil.getPrivateUrlUserFromRoleAssignment(getRoleAssignmentFromPrivateUrlToken(token));
+        PrivateUrlUser user = PrivateUrlUtil.getPrivateUrlUserFromRoleAssignment(getRoleAssignmentFromPrivateUrlToken(token));
+        if (user != null) {
+            user.setToken(token);
+        }
+        return user;
     }
 
     /**

--- a/src/main/java/edu/harvard/iq/dataverse/privateurl/PrivateUrlServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/privateurl/PrivateUrlServiceBean.java
@@ -63,7 +63,11 @@ public class PrivateUrlServiceBean implements Serializable {
      * null.
      */
     public PrivateUrlRedirectData getPrivateUrlRedirectDataFromToken(String token) {
-        return PrivateUrlUtil.getPrivateUrlRedirectData(getRoleAssignmentFromPrivateUrlToken(token));
+        PrivateUrlRedirectData privateUrlRedirectData = PrivateUrlUtil.getPrivateUrlRedirectData(getRoleAssignmentFromPrivateUrlToken(token));
+        if (privateUrlRedirectData != null && privateUrlRedirectData.getPrivateUrlUser() != null) {
+            privateUrlRedirectData.getPrivateUrlUser().setToken(token);
+        }
+        return privateUrlRedirectData;
     }
 
     /**


### PR DESCRIPTION
The guestbook popup does not appear to collect a response before the download attempt is made. Disabling the guestbook on the dataset resolves the issue and files download normally through the Preview URL. This fix reinstates the behavior of the JSF UI from prior versions of Dataverse.

**Which issue(s) this PR closes**:

- Closes #

**Special notes for your reviewer**:

**Suggestions on how to test this**: Create a dataset with a guestbook. Generate a Preview URL. Using the preview url try to download files and dataset zip file. This should work without requiring the guestbook response.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**: Included

**Additional documentation**:
