### PR TITLE
get the curation statuses faster: no expensive get calls

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DatasetVersion.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetVersion.java
@@ -198,6 +198,15 @@ public class DatasetVersion implements Serializable {
     private List<CurationStatus> curationStatuses = new ArrayList<>();
 
     @Transient
+    private Map<CurationStatus, Date> keyCache = curationStatuses.stream()
+            .collect(Collectors.toMap(
+                    cs -> cs,
+                    CurationStatus::getCreateTime,
+                    (a, b) -> a,
+                    IdentityHashMap::new
+            ));
+
+    @Transient
     private DatasetVersionDifference dvd;
     
     //The Json version of the archivalCopyLocation string
@@ -2140,31 +2149,55 @@ public class DatasetVersion implements Serializable {
          * The code here assured both the DESC order and NULLS LAST.
          */
         if (curationStatuses != null) {
-            curationStatuses.sort(Comparator.comparing(
-                CurationStatus::getCreateTime,
-                Comparator.nullsLast(Comparator.reverseOrder())
-            ));
+            curationStatuses.sort(
+                    Comparator.comparing(
+                            keyCache::get,
+                            Comparator.nullsLast(Comparator.reverseOrder())
+                    )
+            );
         }
         return curationStatuses;
     }
 
     protected void setCurationStatuses(List<CurationStatus> curationStatuses) {
         this.curationStatuses = curationStatuses;
+        keyCache = curationStatuses.stream()
+                .collect(Collectors.toMap(
+                        cs -> cs,
+                        CurationStatus::getCreateTime,
+                        (a, b) -> a,
+                        IdentityHashMap::new
+                ));
     }
 
     public CurationStatus getCurrentCurationStatus() {
-        return !getCurationStatuses().isEmpty() ? getCurationStatuses().get(0) : null;
+        return !getCurationStatuses().isEmpty() ? getCurationStatuses().getFirst() : null;
     }
 
     
     public void addCurationStatus(CurationStatus status) {
         status.setDatasetVersion(this);
-        curationStatuses.add(0, status); // Add the new status at the beginning of the list
+        curationStatuses.addFirst(status); // Add the new status at the beginning of the list
+        // After that cache the keys
+        keyCache = curationStatuses.stream()
+                .collect(Collectors.toMap(
+                        cs -> cs,
+                        CurationStatus::getCreateTime,
+                        (a, b) -> a,
+                        IdentityHashMap::new
+                ));
     }
 
     public void removeCurationStatus(CurationStatus curationStatus) {
         curationStatuses.remove(curationStatus);
         curationStatus.setDatasetVersion(null);
+        keyCache = curationStatuses.stream()
+                .collect(Collectors.toMap(
+                        cs -> cs,
+                        CurationStatus::getCreateTime,
+                        (a, b) -> a,
+                        IdentityHashMap::new
+                ));
     }
 
     public CurationStatus getCurationStatusAsOfDate(Date date) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Setting a new curation label can take very long and could lead to an internal server error.

**Which issue(s) this PR closes**:
This pull request addresses the following issue: https://github.com/IQSS/dataverse/issues/12399

- Closes #12399

**Special notes for your reviewer**:
It is tested on my dev machine. This machine does not have to handle very high load. It was not possible to test in a real scenario with heavy load on the Payara server.

**Suggestions on how to test this**:

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
No

**Is there a release notes update needed for this change?**:

**Additional documentation**:
This fix has been developed with the help of Claude code. It says: The original approach sorted the list by calling `getCreateTime()` directly inside the comparator. The drawback is that a comparison-based sort calls the comparator roughly `n·log(n)` times for `n` elements, so the getter ends up being invoked far more often than there are actual objects.

The optimization introduces a key cache: before sorting, the code walks the list once and builds a lookup structure that maps each object to its `createTime` value, calling the getter exactly once per element. The sort then reads from this cache instead of calling the getter again, turning each comparison into a cheap lookup rather than a repeated method call.

I assume that the original sorting logic was to expensive and so I co-developed with Claude this fix.