### PR TITLE
fix: possible locally fair dataset download fix

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/api/Access.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Access.java
@@ -279,6 +279,10 @@ public class Access extends AbstractApiBean {
     private DataFile findDataFileUserCanSeeOrDieWrapper(String fileId, DataverseRequest req){
         
         DataFile df = null;
+
+        if (req.getUser() instanceof GuestUser) {
+            req = dvRequestService.getDataverseRequest();
+        }
         
         try {
             df = findDataFileUserCanSeeOrDie(fileId, req);

--- a/src/main/java/edu/harvard/iq/dataverse/api/Access.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Access.java
@@ -281,6 +281,8 @@ public class Access extends AbstractApiBean {
         DataFile df = null;
 
         if (req.getUser() instanceof GuestUser) {
+            // For JSF/UI requests, the ContainerRequestContext user can be GuestUser even when the session is authenticated.
+            // Locally FAIR visibility checks rely on the DataverseRequest user, so pull the session-backed request here.
             req = dvRequestService.getDataverseRequest();
         }
         


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes the locally FAIR dataset download issue outlined in #12579 that prevents dataset files within a locally FAIR dataverse from being downloaded

**Which issue(s) this PR closes**:

- Closes #12579

**Special notes for your reviewer**:
N/A

**Suggestions on how to test this**:
Spin up a docker container on develop, verify that dataset downloads don't work. Spin up this branch and verify that dataset downloads start working once again

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
N/A

**Is there a release notes update needed for this change?**:
N/A

**Additional documentation**:
N/A