### PR TITLE
Allow Preview User to download files without requiring a Guestbook Re…

### DIFF
--- a/doc/release-notes/12535-download-without-guestbook-response-for-preview-user2.md
+++ b/doc/release-notes/12535-download-without-guestbook-response-for-preview-user2.md
@@ -1,0 +1,2 @@
+## Bug ##
+Preview URL users could not download files from the dataset being previewed if a guestbook was assigned to that dataset. This is now fixed.

--- a/doc/release-notes/12535-download-without-guestbook-response-for-preview-user2.md
+++ b/doc/release-notes/12535-download-without-guestbook-response-for-preview-user2.md
@@ -1,2 +1,2 @@
 ## Bug ##
-Preview URL users could not download files from the dataset being previewed if a guestbook was assigned to that dataset. This is now fixed.
+Preview URL users could not download files from the dataset being previewed if a guestbook was assigned to that dataset. This is now fixed. A similar issue with Locally FAIR content is also fixed.

--- a/src/main/java/edu/harvard/iq/dataverse/api/Access.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Access.java
@@ -2237,7 +2237,7 @@ public class Access extends AbstractApiBean {
         boolean required = ds.hasEnabledGuestbook() && !ds.getEffectiveGuestbookEntryAtRequest() && !(user instanceof PrivateUrlUser);
         boolean wasWrittenInPost = false;
         if (required) {
-            if (user instanceof AuthenticatedUser && permissionService.userOn(user, ds).has(Permission.EditDataset)) {
+            if (permissionService.userOn(user, ds).has(Permission.ViewUnpublishedDataset)) {
                 required = false;
             }
             // Check if we are downloading a thumbnail image which doesn't require a guestbook response

--- a/src/main/java/edu/harvard/iq/dataverse/api/Access.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Access.java
@@ -2237,9 +2237,9 @@ public class Access extends AbstractApiBean {
         boolean required = ds.hasEnabledGuestbook() && !ds.getEffectiveGuestbookEntryAtRequest();
         boolean wasWrittenInPost = false;
         if (required) {
-            checkAuthorization(user, df);
-            // PrivateUrlUsers are exempt from this requirement
-            if (user instanceof PrivateUrlUser) {
+            // PrivateUrlUsers and AuthenticatedUser with ViewUnpublishedDataset are exempt from this requirement
+            if ((user instanceof PrivateUrlUser) ||
+                    (user instanceof AuthenticatedUser && permissionService.userOn(user, ds).has(Permission.ViewUnpublishedDataset))) {
                 return false;
             }
             // Check if we are downloading a thumbnail image which doesn't require a guestbook response

--- a/src/main/java/edu/harvard/iq/dataverse/api/Access.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Access.java
@@ -2232,12 +2232,12 @@ public class Access extends AbstractApiBean {
     }
 
     private boolean checkGuestbookRequiredResponse(User user, UriInfo uriInfo, DataFile df, String gbrids) throws WebApplicationException {
-        // checkAuthorization must be called first to verify the user's permission to download this file
         // Check if guestbook response is required
         Dataset ds = df.getOwner();
         boolean required = ds.hasEnabledGuestbook() && !ds.getEffectiveGuestbookEntryAtRequest();
         boolean wasWrittenInPost = false;
         if (required) {
+            checkAuthorization(user, df);
             // PrivateUrlUsers are exempt from this requirement
             if (user instanceof PrivateUrlUser) {
                 return false;

--- a/src/main/java/edu/harvard/iq/dataverse/api/Access.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Access.java
@@ -12,10 +12,7 @@ import edu.harvard.iq.dataverse.authorization.AuthenticationServiceBean;
 import edu.harvard.iq.dataverse.authorization.DataverseRole;
 import edu.harvard.iq.dataverse.authorization.Permission;
 import edu.harvard.iq.dataverse.authorization.RoleAssignee;
-import edu.harvard.iq.dataverse.authorization.users.ApiToken;
-import edu.harvard.iq.dataverse.authorization.users.AuthenticatedUser;
-import edu.harvard.iq.dataverse.authorization.users.GuestUser;
-import edu.harvard.iq.dataverse.authorization.users.User;
+import edu.harvard.iq.dataverse.authorization.users.*;
 import edu.harvard.iq.dataverse.dataaccess.*;
 import edu.harvard.iq.dataverse.datavariable.DataVariable;
 import edu.harvard.iq.dataverse.datavariable.VariableServiceBean;
@@ -197,7 +194,7 @@ public class Access extends AbstractApiBean {
         
         if (gbrecs != true && df.isReleased()) {
             // Write Guestbook record if not done previously and file is released
-            GuestbookResponse gbr = guestbookResponseService.initAPIGuestbookResponse(df.getOwner(), df, session, getRequestor(req.getUser()));
+            GuestbookResponse gbr = guestbookResponseService.initAPIGuestbookResponse(df.getOwner(), df, session, req.getUser());
             guestbookResponseService.save(gbr);
             MakeDataCountEntry entry = new MakeDataCountEntry(uriInfo, headers, dvRequestService, df);
             mdcLogService.logEntry(entry);
@@ -327,7 +324,7 @@ public class Access extends AbstractApiBean {
 
         if (gbrecs != true && df.isReleased()){
             // Write Guestbook record if not done previously and file is released
-            gbr = guestbookResponseService.initAPIGuestbookResponse(df.getOwner(), df, session, getRequestor(req.getUser()));
+            gbr = guestbookResponseService.initAPIGuestbookResponse(df.getOwner(), df, session, req.getUser());
         }
 
         DownloadInfo dInfo = new DownloadInfo(df);
@@ -1234,7 +1231,7 @@ public class Access extends AbstractApiBean {
         String customZipServiceUrl = settingsService.getValueForKey(SettingsServiceBean.Key.CustomZipDownloadServiceUrl);
         boolean useCustomZipService = customZipServiceUrl != null;
 
-        User user = getRequestor(getRequestUser(crc));
+        User user = getRequestUser(crc);
         DataverseRequest req = createDataverseRequest(user);
 
         Boolean getOrig = false;
@@ -2236,12 +2233,11 @@ public class Access extends AbstractApiBean {
 
     private boolean checkGuestbookRequiredResponse(User user, UriInfo uriInfo, DataFile df, String gbrids) throws WebApplicationException {
         // Check if guestbook response is required
-        Dataset d = df.getOwner();
-        boolean required = df.getOwner().hasEnabledGuestbook() && !d.getEffectiveGuestbookEntryAtRequest();
+        Dataset ds = df.getOwner();
+        boolean required = ds.hasEnabledGuestbook() && !ds.getEffectiveGuestbookEntryAtRequest() && !(user instanceof PrivateUrlUser);
         boolean wasWrittenInPost = false;
         if (required) {
-            User requestor = getRequestor(user);
-            if (requestor instanceof AuthenticatedUser && permissionService.userOn(requestor, df.getOwner()).has(Permission.EditDataset)) {
+            if (user instanceof AuthenticatedUser && permissionService.userOn(user, ds).has(Permission.EditDataset)) {
                 required = false;
             }
             // Check if we are downloading a thumbnail image which doesn't require a guestbook response
@@ -2258,7 +2254,7 @@ public class Access extends AbstractApiBean {
                         throw new NotFoundException("GuestbookResponse Not Found for id:" + gbrids);
                     }
                     Long delta = Instant.now().toEpochMilli() - gbr.getResponseTime().getTime();
-                    wasWrittenInPost = gbr.getDataset().getId().equals(df.getOwner().getId()) && delta <= (GUESTBOOK_RESPONSE_SIGNEDURL_TIMEOUT_MINUTES * 60000L);
+                    wasWrittenInPost = gbr.getDataset().getId().equals(ds.getId()) && delta <= (GUESTBOOK_RESPONSE_SIGNEDURL_TIMEOUT_MINUTES * 60000L);
                 } catch (NumberFormatException | DateTimeParseException ex) {
                     throw new BadRequestException(ex.getMessage());
                 }
@@ -2283,19 +2279,10 @@ public class Access extends AbstractApiBean {
 
     // checkAuthorization is a convenience method; it calls the boolean method
     // isAccessAuthorized(), the actual workhorse, and throws a 403 exception if not.
-    private void checkAuthorization(User initialUser, DataFile df) throws WebApplicationException {
-        User user = getRequestor(initialUser);
-        if (!isAccessAuthorized(user, df)) {
+    private void checkAuthorization(User requestUser, DataFile df) throws WebApplicationException {
+        if (!isAccessAuthorized(requestUser, df)) {
             throw new ForbiddenException();
         }        
-    }
-    private User getRequestor(User user) {
-        // CompoundAuthMechanism should find the user by API Key/Token, Workflow, etc. And for SPA the Bearer Token
-        // For JSF check if CompoundAuthMechanism couldn't find the user then try to get it from the session
-        if (session!=null && user instanceof GuestUser) {
-            user = session.getUser();
-        }
-        return user;
     }
 
     private boolean isAccessAuthorized(User requestUser, DataFile df) {

--- a/src/main/java/edu/harvard/iq/dataverse/api/Access.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Access.java
@@ -2232,21 +2232,23 @@ public class Access extends AbstractApiBean {
     }
 
     private boolean checkGuestbookRequiredResponse(User user, UriInfo uriInfo, DataFile df, String gbrids) throws WebApplicationException {
+        // checkAuthorization must be called first to verify the user's permission to download this file
         // Check if guestbook response is required
         Dataset ds = df.getOwner();
-        boolean required = ds.hasEnabledGuestbook() && !ds.getEffectiveGuestbookEntryAtRequest() && !(user instanceof PrivateUrlUser);
+        boolean required = ds.hasEnabledGuestbook() && !ds.getEffectiveGuestbookEntryAtRequest();
         boolean wasWrittenInPost = false;
         if (required) {
-            if (permissionService.userOn(user, ds).has(Permission.ViewUnpublishedDataset)) {
-                required = false;
+            // PrivateUrlUsers are exempt from this requirement
+            if (user instanceof PrivateUrlUser) {
+                return false;
             }
             // Check if we are downloading a thumbnail image which doesn't require a guestbook response
             boolean imageThumb = uriInfo.getQueryParameters().containsKey("imageThumb");
             if (imageThumb) {
-                required = false;
+                return false;
             }
 
-            if (required && gbrids != null && !gbrids.isEmpty()) {
+            if (gbrids != null && !gbrids.isEmpty()) {
                 try {
                     // verify that this id is good
                     GuestbookResponse gbr = guestbookResponseService.findById(Long.valueOf(gbrids));

--- a/src/main/java/edu/harvard/iq/dataverse/api/auth/SessionCookieAuthMechanism.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/auth/SessionCookieAuthMechanism.java
@@ -21,6 +21,7 @@ public class SessionCookieAuthMechanism implements AuthMechanism {
 
     private boolean isAccessApi(ContainerRequestContext containerRequestContext) {
         return "GET".equalsIgnoreCase(containerRequestContext.getMethod())
-                && containerRequestContext.getUriInfo().getPath().toLowerCase().startsWith("/access/");
+                && containerRequestContext.getUriInfo() != null
+                && containerRequestContext.getUriInfo().getPath().toLowerCase().startsWith("access/");
     }
 }

--- a/src/main/java/edu/harvard/iq/dataverse/api/auth/SessionCookieAuthMechanism.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/auth/SessionCookieAuthMechanism.java
@@ -7,9 +7,6 @@ import edu.harvard.iq.dataverse.settings.FeatureFlags;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.container.ContainerRequestContext;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 public class SessionCookieAuthMechanism implements AuthMechanism {
     @Inject
     DataverseSession session;
@@ -23,11 +20,7 @@ public class SessionCookieAuthMechanism implements AuthMechanism {
     }
 
     private boolean isAccessApi(ContainerRequestContext containerRequestContext) {
-        if (containerRequestContext.getMethod() != null && containerRequestContext.getMethod().equals("GET")) {
-            Pattern pattern = Pattern.compile("/api.*/access/"); // /api/v1/access/ or /api/access/
-            Matcher matcher = pattern.matcher(containerRequestContext.getUriInfo().getAbsolutePath().toString().toLowerCase());
-            return matcher.find();
-        }
-        return false;
+        return "GET".equalsIgnoreCase(containerRequestContext.getMethod())
+                && containerRequestContext.getUriInfo().getPath().toLowerCase().startsWith("/access/");
     }
 }

--- a/src/main/java/edu/harvard/iq/dataverse/api/auth/SessionCookieAuthMechanism.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/auth/SessionCookieAuthMechanism.java
@@ -23,7 +23,7 @@ public class SessionCookieAuthMechanism implements AuthMechanism {
     }
 
     private boolean isAccessApi(ContainerRequestContext containerRequestContext) {
-        if (containerRequestContext.getMethod().equals("GET")) {
+        if (containerRequestContext.getMethod() != null && containerRequestContext.getMethod().equals("GET")) {
             Pattern pattern = Pattern.compile("/api.*/access/"); // /api/v1/access/ or /api/access/
             Matcher matcher = pattern.matcher(containerRequestContext.getUriInfo().getAbsolutePath().toString().toLowerCase());
             return matcher.find();

--- a/src/main/java/edu/harvard/iq/dataverse/api/auth/SessionCookieAuthMechanism.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/auth/SessionCookieAuthMechanism.java
@@ -7,15 +7,27 @@ import edu.harvard.iq.dataverse.settings.FeatureFlags;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.container.ContainerRequestContext;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 public class SessionCookieAuthMechanism implements AuthMechanism {
     @Inject
     DataverseSession session;
 
     @Override
     public User findUserFromRequest(ContainerRequestContext containerRequestContext) throws WrappedAuthErrorResponse {
-        if (FeatureFlags.API_SESSION_AUTH.enabled()) {
+        if (FeatureFlags.API_SESSION_AUTH.enabled() || isAccessApi(containerRequestContext)) {
             return session.getUser();
         }
         return null;
+    }
+
+    private boolean isAccessApi(ContainerRequestContext containerRequestContext) {
+        if (containerRequestContext.getMethod().equals("GET")) {
+            Pattern pattern = Pattern.compile("/api.*/access/"); // /api/v1/access/ or /api/access/
+            Matcher matcher = pattern.matcher(containerRequestContext.getUriInfo().getAbsolutePath().toString().toLowerCase());
+            return matcher.find();
+        }
+        return false;
     }
 }

--- a/src/main/java/edu/harvard/iq/dataverse/api/auth/SessionCookieAuthMechanism.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/auth/SessionCookieAuthMechanism.java
@@ -11,7 +11,7 @@ public class SessionCookieAuthMechanism implements AuthMechanism {
     @Inject
     DataverseSession session;
 
-    public static final String ACCESS_DATAFILE_PATH_PREFIX = "access/datafile/";
+    public static final String ACCESS_PATH_PREFIX = "access/";
 
     @Override
     public User findUserFromRequest(ContainerRequestContext containerRequestContext) throws WrappedAuthErrorResponse {
@@ -24,6 +24,6 @@ public class SessionCookieAuthMechanism implements AuthMechanism {
     private boolean isAccessApi(ContainerRequestContext containerRequestContext) {
         String requestPath = containerRequestContext.getUriInfo() != null ? containerRequestContext.getUriInfo().getPath() : "";
         return ("GET".equalsIgnoreCase(containerRequestContext.getMethod()) &&
-                requestPath.startsWith(ACCESS_DATAFILE_PATH_PREFIX));
+                requestPath.startsWith(ACCESS_PATH_PREFIX));
     }
 }

--- a/src/main/java/edu/harvard/iq/dataverse/api/auth/SessionCookieAuthMechanism.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/auth/SessionCookieAuthMechanism.java
@@ -11,6 +11,8 @@ public class SessionCookieAuthMechanism implements AuthMechanism {
     @Inject
     DataverseSession session;
 
+    public static final String ACCESS_DATAFILE_PATH_PREFIX = "access/datafile/";
+
     @Override
     public User findUserFromRequest(ContainerRequestContext containerRequestContext) throws WrappedAuthErrorResponse {
         if (FeatureFlags.API_SESSION_AUTH.enabled() || isAccessApi(containerRequestContext)) {
@@ -20,8 +22,8 @@ public class SessionCookieAuthMechanism implements AuthMechanism {
     }
 
     private boolean isAccessApi(ContainerRequestContext containerRequestContext) {
-        return "GET".equalsIgnoreCase(containerRequestContext.getMethod())
-                && containerRequestContext.getUriInfo() != null
-                && containerRequestContext.getUriInfo().getPath().toLowerCase().startsWith("access/");
+        String requestPath = containerRequestContext.getUriInfo() != null ? containerRequestContext.getUriInfo().getPath() : "";
+        return ("GET".equalsIgnoreCase(containerRequestContext.getMethod()) &&
+                requestPath.startsWith(ACCESS_DATAFILE_PATH_PREFIX));
     }
 }


### PR DESCRIPTION
The guestbook popup does not appear to collect a response before the download attempt is made. Disabling the guestbook on the dataset resolves the issue and files download normally through the Preview URL. This fix reinstates the behavior of the JSF UI from prior versions of Dataverse.

Which issue(s) this PR closes:https://github.com/IQSS/dataverse/issues/12535

Closes https://github.com/IQSS/dataverse/issues/12535
Closes #12579
Special notes for your reviewer:

Suggestions on how to test this: Create a dataset with a guestbook. Generate a Preview URL. Using the preview url try to download files and dataset zip file. This should work without requiring the guestbook response.

Does this PR introduce a user interface change? If mockups are available, please link/include them here:

Is there a release notes update needed for this change?: Included

Additional documentation: