### PR TITLE
Guestbook ID over 127 could not be assigned to a Dataset via the API

### DIFF
--- a/doc/release-notes/12556-can-not-set-guestbook-with-id-over-127.md
+++ b/doc/release-notes/12556-can-not-set-guestbook-with-id-over-127.md
@@ -1,0 +1,3 @@
+## Bug ##
+Fixed bug when calling PUT api/datasets/{datsetId}/guestbook body = {id over 127}. Values for Guestbook IDs over 127 are no longer failing.
+

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/UpdateDatasetGuestbookCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/UpdateDatasetGuestbookCommand.java
@@ -32,7 +32,7 @@ public class UpdateDatasetGuestbookCommand extends AbstractCommand<Dataset> {
             // Make sure the requested guestbook is available via the dataset's ancestry
             final List<Guestbook> guestbooks = dataset.getOwner().getAvailableGuestbooks();
             for (Guestbook gb : guestbooks) {
-                if (gb.getId() == guestbook.getId()) {
+                if (gb.getId().equals(guestbook.getId())) {
                     allowedGuestbook = gb;
                     break;
                 }


### PR DESCRIPTION
**What this PR does / why we need it**: Guestbook ID over 127 could not be assigned to a Dataset via the API

**Which issue(s) this PR closes**:https://github.com/IQSS/dataverse/issues/12556

- Closes #12556

**Special notes for your reviewer**:

**Suggestions on how to test this**: See issue for how to reproduce.
Create Datataverse. Create over 200 Guestbooks. Create Dataset under Dataverse. Try to assign a Guestbook with id over 127 to the Dataset.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**: included

**Additional documentation**:
