### PR TITLE
bump awssdk netty-codec

### DIFF
--- a/modules/dataverse-parent/pom.xml
+++ b/modules/dataverse-parent/pom.xml
@@ -153,7 +153,7 @@
         <postgresql.version>42.7.12</postgresql.version>
         <solr.version>9.8.0</solr.version>
         <postgresql.server.version>16</postgresql.server.version>
-        <aws.version>2.33.0</aws.version>
+        <aws.version>2.49.0</aws.version>
         <google.library.version>26.30.0</google.library.version>
     
         <!-- Basic libs, logging -->

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <auto-service.version>1.1.1</auto-service.version>
         <jhove.version>1.20.1</jhove.version>
         <poi.version>5.4.0</poi.version>
-        <tika.version>3.2.2</tika.version>
+        <tika.version>3.3.2</tika.version>
         <netcdf.version>5.9.1</netcdf.version>
         
         <openapi.infoTitle>Dataverse API</openapi.infoTitle>


### PR DESCRIPTION
**What this PR does / why we need it**:

bump AWSSDK from 2.33.0 to 2.49.0 in order to bump various inclusions of netty-codec

**Which issue(s) this PR closes**:

- Closes https://github.com/IQSS/dataverse-security/issues/135

**Special notes for your reviewer**:

errantly included a commit from a previous PR which is hopefully an easier merge

**Suggestions on how to test this**:

all things AWS

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

no

**Is there a release notes update needed for this change?**:

AWSSDK is a pretty big component of Dataverse, so it might be worth mentioning?

**Additional documentation**:

none