### PR TITLE
Revise upgrade instructions for request timeout setting

### DIFF
--- a/doc/release-notes/12543-request-timeout.md
+++ b/doc/release-notes/12543-request-timeout.md
@@ -2,7 +2,7 @@
 
 (Put this near the end.)
 
-1. The [Dataverse 6.10 release notes](https://github.com/IQSS/dataverse/releases/tag/v6.10) explained how to upgrade from Payara 6 to 7 but did not originally include the important step of migrating a setting for the number of seconds before a request times out. As described in [the guides](https://guides.dataverse.org/en/6.12/installation/config.html#http-request-timeout-seconds) you might want to shorten or lengthen this value. The default is 900 seconds (15 minutes). If you set it to an hour using the command from the guides (`asadmin set server-config.network-config.protocols.protocol.http-listener-1.http.request-timeout-seconds=3600`) you should see a line like this in your domain.xml file:
+1. The [Dataverse 6.10 release notes](https://github.com/IQSS/dataverse/releases/tag/v6.10) explained how to upgrade from Payara 6 to 7 but and mentioned, in step 7, that any other settings that were customized also need to be migrated. Several examples were given but they did not originally include the commonly edited setting for the number of seconds before a request times out. The 6.10 release notes have been updated to now include this example. As described in [the guides](https://guides.dataverse.org/en/6.12/installation/config.html#http-request-timeout-seconds) you might want to shorten or lengthen this value. The default is 900 seconds (15 minutes). If you set it to an hour using the command from the guides (`asadmin set server-config.network-config.protocols.protocol.http-listener-1.http.request-timeout-seconds=3600`) you should see a line like this in your domain.xml file:
 
    `<http request-timeout-seconds="3600" max-connections="250" default-virtual-server="server">`
 


### PR DESCRIPTION
Updated the release notes for Dataverse 6.10 to include the request timeout setting migration step.

**What this PR does / why we need it**:

**Which issue(s) this PR closes**:

- Closes #

**Special notes for your reviewer**:

**Suggestions on how to test this**:

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
