### PR TITLE
Restore Terms of Access rendering in PR #12220

### DIFF
--- a/src/main/webapp/guestbook-terms-popup-fragment.xhtml
+++ b/src/main/webapp/guestbook-terms-popup-fragment.xhtml
@@ -134,9 +134,9 @@
                 </div>
             </ui:fragment>
             <div class="form-group"
-                 jsf:rendered="#{!empty workingVersion.termsOfUseAndAccess.disclaimer}">
+                 jsf:rendered="#{!empty workingVersion.termsOfUseAndAccess.termsOfAccess and (hasRestrictedFile or !empty fileDownloadHelper.filesForRequestAccess)}">
                 <label jsf:for="fdTermsOfAccess" class="col-sm-3 control-label">
-                    #{bundle['file.dataFilesTab.terms.list.termsOfUse.addInfo.termsOfsAccess']}
+                    #{bundle['file.dataFilesTab.terms.list.termsOfAccess.termsOfsAccess']}
                 </label>
                 <h:outputText id="fdTermsOfAccess" class="col-sm-6"
                               value="#{MarkupChecker:sanitizeBasicHTML(workingVersion.termsOfUseAndAccess.termsOfAccess)}"


### PR DESCRIPTION
Restores the two Terms of Access lines reverted in 257febcb.

The row displays `termsOfAccess`, so its render condition should use that field rather than `disclaimer`. The current bundle key does not exist; the restored `file.dataFilesTab.terms.list.termsOfAccess.termsOfsAccess` key does.

The earlier `13-dataset-actions` failure appears unrelated: its fixture has no Terms of Access, disclaimer, guestbook, or restricted file, so this block is not rendered. The trace also shows no `filesTable` `toggleSelect` request after the click and no JSF/EL/bundle error.

Validation:

- Official JSF run: https://github.com/IQSS/dataverse/actions/runs/31662049491
- Direct run on this branch commit: https://github.com/youseihuayu-wonderful/dataverse/actions/runs/31664232079
- Both: **43/43 passed**, including `13-dataset-actions` on Chromium, Firefox, and WebKit
- `xmllint` and `git diff --check`: passed

The production diff from #12220 is limited to these two lines.
