### PR TITLE
Expose Collection guestbookRoot setting through API

### DIFF
--- a/doc/release-notes/12450-expose-collection-guestbook-root-setting.md
+++ b/doc/release-notes/12450-expose-collection-guestbook-root-setting.md
@@ -1,0 +1,6 @@
+Added the ability to set and view the guestbookRoot setting of a collection via these APIs
+
+Any GET call that returns a Collection or List of Collections will include "guestbookRoot": true or false
+`Create Dataverse: POST /api/dataverse/{id}`
+`Update Dataverse: PUT /api/dataverse/{id}`
+(by adding "guestbookRoot" the Json body)

--- a/doc/sphinx-guides/source/_static/api/dataverse-complete.json
+++ b/doc/sphinx-guides/source/_static/api/dataverse-complete.json
@@ -11,5 +11,7 @@
   ],
   "affiliation": "Scientific Research University",
   "description": "We do all the science.",
-  "dataverseType": "LABORATORY"
+  "dataverseType": "LABORATORY",
+  "datasetFileCountLimit": 10,
+  "guestbookRoot": false
 }

--- a/doc/sphinx-guides/source/api/native-api.rst
+++ b/doc/sphinx-guides/source/api/native-api.rst
@@ -30,7 +30,11 @@ The steps for creating a Dataverse collection are:
 - Figure out the alias or database id of the "parent" Dataverse collection into which you will be creating your new Dataverse collection.
 - Execute a curl command or equivalent.
 
-Download :download:`dataverse-complete.json <../_static/api/dataverse-complete.json>` file and modify it to suit your needs. The fields ``name``, ``alias``, and ``dataverseContacts`` are required. The controlled vocabulary for ``dataverseType`` is the following:
+Download :download:`dataverse-complete.json <../_static/api/dataverse-complete.json>` file and modify it to suit your needs.
+The fields ``name``, ``alias``, and ``dataverseContacts`` are required.
+The optional field ``datasetFileCountLimit`` can be used to set the maximum number of files a dataset can have.
+The optional field ``guestbookRoot``, when set to true, will allow datasets in this collection to be assigned a Guestbook from a parent collection.
+The controlled vocabulary for ``dataverseType`` is the following:
 
 - ``DEPARTMENT``
 - ``JOURNALS``

--- a/src/main/java/edu/harvard/iq/dataverse/api/dto/DataverseDTO.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/dto/DataverseDTO.java
@@ -71,7 +71,11 @@ public class DataverseDTO {
         this.dataverseType = dataverseType;
     }
 
-    public Boolean getGuestbookRoot() { return guestbookRoot; }
+    public Boolean getGuestbookRoot() {
+        return guestbookRoot;
+    }
 
-    public void setGuestbookRoot(Boolean guestbookRoot) { this.guestbookRoot = guestbookRoot; }
+    public void setGuestbookRoot(Boolean guestbookRoot) {
+        this.guestbookRoot = guestbookRoot;
+    }
 }

--- a/src/main/java/edu/harvard/iq/dataverse/api/dto/DataverseDTO.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/dto/DataverseDTO.java
@@ -13,6 +13,7 @@ public class DataverseDTO {
     private List<DataverseContact> dataverseContacts;
     private Dataverse.DataverseType dataverseType;
     private Integer datasetFileCountLimit;
+    private Boolean guestbookRoot;
 
     public String getAlias() {
         return alias;
@@ -69,4 +70,8 @@ public class DataverseDTO {
     public void setDataverseType(Dataverse.DataverseType dataverseType) {
         this.dataverseType = dataverseType;
     }
+
+    public Boolean getGuestbookRoot() { return guestbookRoot; }
+
+    public void setGuestbookRoot(Boolean guestbookRoot) { this.guestbookRoot = guestbookRoot; }
 }

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/UpdateDataverseCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/UpdateDataverseCommand.java
@@ -133,6 +133,9 @@ public class UpdateDataverseCommand extends AbstractWriteDataverseCommand {
         if (dto.getDatasetFileCountLimit() != null) {
             dataverse.setDatasetFileCountLimit(dto.getDatasetFileCountLimit());
         }
+        if (dto.getGuestbookRoot() != null) {
+            dataverse.setGuestbookRoot(dto.getGuestbookRoot());
+        }
     }
 
     @Override

--- a/src/main/java/edu/harvard/iq/dataverse/util/json/JsonParser.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/json/JsonParser.java
@@ -148,7 +148,6 @@ public class JsonParser {
         }
         if (jobj.containsKey("guestbookRoot")) {
             dv.setGuestbookRoot(jobj.getBoolean("guestbookRoot"));
-            logger.severe("guestbookRoot is " + dv.isGuestbookRoot());
         }
 
         /*  We decided that subject is not user set, but gotten from the subject of the dataverse's

--- a/src/main/java/edu/harvard/iq/dataverse/util/json/JsonParser.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/json/JsonParser.java
@@ -146,6 +146,10 @@ public class JsonParser {
         if (jobj.containsKey("requireFilesToPublishDataset")) {
             dv.setRequireFilesToPublishDataset(jobj.getBoolean("requireFilesToPublishDataset"));
         }
+        if (jobj.containsKey("guestbookRoot")) {
+            dv.setGuestbookRoot(jobj.getBoolean("guestbookRoot"));
+            logger.severe("guestbookRoot is " + dv.isGuestbookRoot());
+        }
 
         /*  We decided that subject is not user set, but gotten from the subject of the dataverse's
             datasets - leavig this code in for now, in case we need to go back to it at some point
@@ -206,6 +210,9 @@ public class JsonParser {
         }
         if (jsonObject.containsKey("datasetFileCountLimit")) {
             dataverseDTO.setDatasetFileCountLimit(Integer.valueOf(jsonObject.getInt("datasetFileCountLimit")));
+        }
+        if (jsonObject.containsKey("guestbookRoot")) {
+            dataverseDTO.setGuestbookRoot(jsonObject.getBoolean("guestbookRoot"));
         }
 
         return dataverseDTO;

--- a/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
@@ -359,6 +359,7 @@ public class JsonPrinter {
         if (dv.getFilePIDsEnabled() != null) {
             bld.add("filePIDsEnabled", dv.getFilePIDsEnabled());
         }
+        bld.add("guestbookRoot", dv.isGuestbookRoot());
         bld.add("effectiveRequiresFilesToPublishDataset", dv.getEffectiveRequiresFilesToPublishDataset());
         bld.add("isReleased", dv.isReleased());
 

--- a/src/test/java/edu/harvard/iq/dataverse/api/DataversesIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/DataversesIT.java
@@ -1955,6 +1955,47 @@ public class DataversesIT {
     }
 
     @Test
+    public void testCreateDataverseWithGuestbookRoot() {
+        Response createUser = UtilIT.createRandomUser();
+        String apiToken = UtilIT.getApiTokenFromResponse(createUser);
+
+        // guestbookRoot not specified on creation should default to false
+        String defaultAlias = UtilIT.getRandomDvAlias();
+        JsonObjectBuilder jsonWithoutGuestbookRoot = JsonUtil.createObjectBuilder()
+                .add("name", defaultAlias)
+                .add("alias", defaultAlias)
+                .add("dataverseContacts", JsonUtil.createArrayBuilder()
+                        .add(JsonUtil.createObjectBuilder()
+                                .add("contactEmail", defaultAlias + "@mailinator.com")
+                        )
+                );
+        Response createDefaultResponse = UtilIT.createDataverse(jsonWithoutGuestbookRoot.build(), apiToken);
+        createDefaultResponse.prettyPrint();
+        createDefaultResponse.then().assertThat()
+                .statusCode(CREATED.getStatusCode())
+                .body("data.alias", equalTo(defaultAlias))
+                .body("data.guestbookRoot", equalTo(false));
+
+        // guestbookRoot explicitly set to true on creation
+        String guestbookRootAlias = UtilIT.getRandomDvAlias();
+        JsonObjectBuilder jsonWithGuestbookRoot = JsonUtil.createObjectBuilder()
+                .add("name", guestbookRootAlias)
+                .add("alias", guestbookRootAlias)
+                .add("dataverseContacts", JsonUtil.createArrayBuilder()
+                        .add(JsonUtil.createObjectBuilder()
+                                .add("contactEmail", guestbookRootAlias + "@mailinator.com")
+                        )
+                )
+                .add("guestbookRoot", true);
+        Response createGuestbookRootResponse = UtilIT.createDataverse(jsonWithGuestbookRoot.build(), apiToken);
+        createGuestbookRootResponse.prettyPrint();
+        createGuestbookRootResponse.then().assertThat()
+                .statusCode(CREATED.getStatusCode())
+                .body("data.alias", equalTo(guestbookRootAlias))
+                .body("data.guestbookRoot", equalTo(true));
+    }
+
+    @Test
     public void testListFacets() {
         Response createUserResponse = UtilIT.createRandomUser();
         String apiToken = UtilIT.getApiTokenFromResponse(createUserResponse);

--- a/src/test/java/edu/harvard/iq/dataverse/api/DataversesIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/DataversesIT.java
@@ -1757,7 +1757,7 @@ public class DataversesIT {
         updateDataverseResponse = UtilIT.updateDataverse(
                 testDataverseAlias, newAlias, newName, newAffiliation, newDataverseType, newContactEmails, newInputLevelNames,
                 null, newMetadataBlockNames, apiToken,
-                Boolean.TRUE, Boolean.TRUE, null
+                Boolean.TRUE, Boolean.TRUE, null, null
         );
         updateDataverseResponse.then().assertThat()
                 .statusCode(BAD_REQUEST.getStatusCode())
@@ -1767,7 +1767,7 @@ public class DataversesIT {
         updateDataverseResponse = UtilIT.updateDataverse(
                 testDataverseAlias, newAlias, newName, newAffiliation, newDataverseType, newContactEmails, newInputLevelNames,
                 newFacetIds, null, apiToken,
-                Boolean.TRUE, Boolean.TRUE, null
+                Boolean.TRUE, Boolean.TRUE, null, null
         );
         updateDataverseResponse.then().assertThat()
                 .statusCode(BAD_REQUEST.getStatusCode())
@@ -1868,6 +1868,7 @@ public class DataversesIT {
 
         // Update the dataverse without setting metadata blocks, facets, or input levels
         // Do NOT ignore the missing data so the metadata blocks, facets, and input levels are deleted and inherited from the parent
+        // Also testing Guestbook Root
         updateDataverseResponse = UtilIT.updateDataverse(
                 newAlias,
                 newAlias,
@@ -1879,9 +1880,10 @@ public class DataversesIT {
                 null,
                 null,
                 apiToken,
-                Boolean.TRUE, Boolean.TRUE, null
+                Boolean.TRUE, Boolean.TRUE, null, Boolean.TRUE
         );
         updateDataverseResponse.then().assertThat().statusCode(OK.getStatusCode());
+        updateDataverseResponse.then().assertThat().body("data.guestbookRoot", equalTo(true));
 
         // Assert that the metadata blocks are inherited from the parent
         listMetadataBlocksResponse = UtilIT.listMetadataBlocks(newAlias, false, false, apiToken);
@@ -2708,7 +2710,7 @@ public class DataversesIT {
                 dataverseAlias, dataverseAlias, newName, newAffiliation, newDataverseType, newContactEmails,
                 newInputLevelNames,
                 null, newMetadataBlockNames, apiToken,
-                Boolean.FALSE, Boolean.FALSE, null);
+                Boolean.FALSE, Boolean.FALSE, null, null);
 
         updateDataverseResponse.then().assertThat()
                 .statusCode(OK.getStatusCode());
@@ -2966,7 +2968,7 @@ public class DataversesIT {
                 dataverseAlias, dataverseAlias, newName, newAffiliation, newDataverseType, newContactEmails,
                 newInputLevelNames,
                 null, newMetadataBlockNames, apiToken,
-                Boolean.FALSE, Boolean.FALSE, null);
+                Boolean.FALSE, Boolean.FALSE, null, null);
 
         updateDataverseResponse.then().assertThat()
                 .statusCode(OK.getStatusCode());

--- a/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
@@ -450,7 +450,7 @@ public class UtilIT {
                                     String apiToken) {
 
         return updateDataverse(alias, newAlias, newName, newAffiliation, newDataverseType, newContactEmails,
-                newInputLevelNames, newFacetIds, newMetadataBlockNames, apiToken, null, null, null);
+                newInputLevelNames, newFacetIds, newMetadataBlockNames, apiToken, null, null, null, null);
     }
 
     static Response updateDataverse(String alias,
@@ -465,7 +465,8 @@ public class UtilIT {
                                     String apiToken,
                                     Boolean inheritMetadataBlocksFromParent,
                                     Boolean inheritFacetsFromParent,
-                                    Integer datasetFileCountLimit) {
+                                    Integer datasetFileCountLimit,
+                                    Boolean guestbookRoot) {
         JsonArrayBuilder contactArrayBuilder = JsonUtil.createArrayBuilder();
         for(String contactEmail : newContactEmails) {
             contactArrayBuilder.add(JsonUtil.createObjectBuilder().add("contactEmail", contactEmail));
@@ -480,6 +481,9 @@ public class UtilIT {
                 ;
         if (datasetFileCountLimit != null) {
             jsonBuilder.add("datasetFileCountLimit", datasetFileCountLimit);
+        }
+        if (guestbookRoot != null) {
+            jsonBuilder.add("guestbookRoot", guestbookRoot);
         }
 
         updateDataverseRequestJsonWithMetadataBlocksConfiguration(newInputLevelNames, newFacetIds, newMetadataBlockNames,
@@ -505,7 +509,8 @@ public class UtilIT {
                 apiToken,
                 null,
                 null,
-                dv.isDatasetFileCountLimitSet(dv.getDatasetFileCountLimit()) ? dv.getDatasetFileCountLimit() : -1);
+                dv.isDatasetFileCountLimitSet(dv.getDatasetFileCountLimit()) ? dv.getDatasetFileCountLimit() : -1,
+                null);
     }
 
     private static void updateDataverseRequestJsonWithMetadataBlocksConfiguration(String[] inputLevelNames,

--- a/src/test/java/edu/harvard/iq/dataverse/api/dto/DataverseDTOTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/dto/DataverseDTOTest.java
@@ -1,0 +1,37 @@
+package edu.harvard.iq.dataverse.api.dto;
+
+import edu.harvard.iq.dataverse.Dataverse;
+import edu.harvard.iq.dataverse.DataverseContact;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class DataverseDTOTest {
+
+    @Test
+    public void testDataverseDTO() {
+        DataverseDTO dv = new DataverseDTO();
+        List<DataverseContact> dataverseContacts = new ArrayList<>();
+        dataverseContacts.add(new DataverseContact());
+        dataverseContacts.add(new DataverseContact());
+        dv.setGuestbookRoot(Boolean.FALSE);
+        dv.setAffiliation("affiliation");
+        dv.setDataverseType(Dataverse.DataverseType.JOURNALS);
+        dv.setDataverseContacts(dataverseContacts);
+        dv.setDescription("description");
+        dv.setName("name");
+        dv.setAlias("alias");
+        dv.setDatasetFileCountLimit(Integer.MAX_VALUE);
+
+        assertEquals(Boolean.FALSE, dv.getGuestbookRoot());
+        assertEquals("affiliation", dv.getAffiliation());
+        assertEquals("description", dv.getDescription());
+        assertEquals("name", dv.getName());
+        assertEquals("alias", dv.getAlias());
+        assertEquals(Integer.MAX_VALUE, dv.getDatasetFileCountLimit());
+        assertEquals(2,dv.getDataverseContacts().size());
+    }
+}

--- a/src/test/java/edu/harvard/iq/dataverse/engine/command/impl/UpdateDataverseCommandTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/engine/command/impl/UpdateDataverseCommandTest.java
@@ -1,0 +1,92 @@
+package edu.harvard.iq.dataverse.engine.command.impl;
+
+import edu.harvard.iq.dataverse.Dataverse;
+import edu.harvard.iq.dataverse.DataverseServiceBean;
+import edu.harvard.iq.dataverse.api.dto.DataverseDTO;
+import edu.harvard.iq.dataverse.engine.TestCommandContext;
+import edu.harvard.iq.dataverse.engine.TestDataverseEngine;
+import edu.harvard.iq.dataverse.engine.command.exception.CommandException;
+import edu.harvard.iq.dataverse.util.SystemConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static edu.harvard.iq.dataverse.mocks.MocksFactory.makeDataverse;
+import static edu.harvard.iq.dataverse.mocks.MocksFactory.makeRequest;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class UpdateDataverseCommandTest {
+
+    Dataverse currentDataverse;
+
+    DataverseServiceBean dataverses = new DataverseServiceBean() {
+        @Override
+        public Dataverse find(Object pk) {
+            return currentDataverse;
+        }
+
+        @Override
+        public Dataverse save(Dataverse dataverse) {
+            return dataverse;
+        }
+
+        @Override
+        public boolean index(Dataverse dataverse) {
+            return true;
+        }
+    };
+
+    SystemConfig systemConfig = new SystemConfig() {
+        @Override
+        public boolean isExternalDataverseValidationEnabled() {
+            return false;
+        }
+    };
+
+    TestDataverseEngine engine;
+
+    @BeforeEach
+    public void setUp() {
+        engine = new TestDataverseEngine(new TestCommandContext() {
+            @Override
+            public DataverseServiceBean dataverses() {
+                return dataverses;
+            }
+
+            @Override
+            public SystemConfig systemConfig() {
+                return systemConfig;
+            }
+        });
+    }
+
+    @Test
+    public void testGuestbookRootIsUpdatedWhenSet() throws CommandException {
+        currentDataverse = makeDataverse();
+        currentDataverse.setDataverseType(Dataverse.DataverseType.UNCATEGORIZED);
+        currentDataverse.setGuestbookRoot(false);
+
+        DataverseDTO dto = new DataverseDTO();
+        dto.setGuestbookRoot(Boolean.TRUE);
+
+        UpdateDataverseCommand sut = new UpdateDataverseCommand(currentDataverse, null, null, makeRequest(), null, null, dto);
+        Dataverse result = engine.submit(sut);
+
+        assertTrue(result.isGuestbookRoot());
+    }
+
+    @Test
+    public void testGuestbookRootIsUnchangedWhenNotSet() throws CommandException {
+        currentDataverse = makeDataverse();
+        currentDataverse.setDataverseType(Dataverse.DataverseType.UNCATEGORIZED);
+        currentDataverse.setGuestbookRoot(true);
+
+        DataverseDTO dto = new DataverseDTO();
+        // guestbookRoot intentionally left unset (null)
+
+        UpdateDataverseCommand sut = new UpdateDataverseCommand(currentDataverse, null, null, makeRequest(), null, null, dto);
+        Dataverse result = engine.submit(sut);
+
+        assertTrue(result.isGuestbookRoot());
+    }
+}

--- a/src/test/java/edu/harvard/iq/dataverse/util/json/JsonParserTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/util/json/JsonParserTest.java
@@ -348,7 +348,17 @@ public class JsonParserTest {
             throw new JsonParseException("Couldn't read test file", ioe);
         }
     }
-    
+
+    @Test
+    public void testParseDataverseDTOWithoutGuestbookRoot() throws JsonParseException {
+        JsonObject dvJson = JsonUtil.createObjectBuilder()
+                .add("alias", "minimal")
+                .add("name", "minimal")
+                .build();
+        DataverseDTO actual = sut.parseDataverseDTO(dvJson);
+        assertNull(actual.getGuestbookRoot());
+    }
+
     @Test
     public void testParseThemeDataverse() throws JsonParseException {
         

--- a/src/test/java/edu/harvard/iq/dataverse/util/json/JsonParserTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/util/json/JsonParserTest.java
@@ -316,6 +316,7 @@ public class JsonParserTest {
              * hard coded to true.
              */
             assertFalse(actual.isPermissionRoot());
+            assertFalse(actual.isGuestbookRoot());
         } catch (IOException ioe) {
             throw new JsonParseException("Couldn't read test file", ioe);
         }
@@ -342,6 +343,7 @@ public class JsonParserTest {
             assertEquals("student@example.edu", actualDataverseContacts.get(1).getContactEmail());
             assertEquals(0, actualDataverseContacts.get(0).getDisplayOrder());
             assertEquals(1, actualDataverseContacts.get(1).getDisplayOrder());
+            assertEquals(Boolean.FALSE, actual.getGuestbookRoot());
         } catch (IOException ioe) {
             throw new JsonParseException("Couldn't read test file", ioe);
         }

--- a/src/test/java/edu/harvard/iq/dataverse/util/json/JsonPrinterTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/util/json/JsonPrinterTest.java
@@ -318,6 +318,7 @@ public class JsonPrinterTest {
         dataverse.setAffiliation("42 Inc.");
         dataverse.setDescription("Description for Dataverse 42.");
         dataverse.setDataverseType(Dataverse.DataverseType.UNCATEGORIZED);
+        dataverse.setGuestbookRoot(true);
         List<DataverseContact> dataverseContacts = new ArrayList<>();
         dataverseContacts.add(new DataverseContact(dataverse, "dv42@mailinator.com"));
         dataverse.setDataverseContacts(dataverseContacts);
@@ -334,6 +335,7 @@ public class JsonPrinterTest {
         assertFalse(jsonObject.getBoolean("permissionRoot"));
         assertEquals("Description for Dataverse 42.", jsonObject.getString("description"));
         assertEquals("UNCATEGORIZED", jsonObject.getString("dataverseType"));
+        assertTrue(jsonObject.getBoolean("guestbookRoot"));
     }
 
     DatasetField constructPrimitive(String datasetFieldTypeName, String value) {


### PR DESCRIPTION
**What this PR does / why we need it**: SPA needs the ability to view and modify the "guestbookRoot" setting of a Collection

**Which issue(s) this PR closes**:https://github.com/IQSS/dataverse/issues/12459

- Closes #12459

**Special notes for your reviewer**:

**Suggestions on how to test this**:See DatasetsIT. Make call to create/update dataverse and verify the setting. 

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:included

**Additional documentation**:

https://dataverse-guide--12611.org.readthedocs.build/en/12611/api/native-api.html#create-a-dataverse-collection