### PR TITLE
update keycloak version 

### DIFF
--- a/conf/keycloak/Dockerfile
+++ b/conf/keycloak/Dockerfile
@@ -14,7 +14,7 @@ RUN mvn clean package
 # ------------------------------------------
 # Stage 2: Build Keycloak Image
 # ------------------------------------------
-FROM quay.io/keycloak/keycloak:26.3.2
+FROM quay.io/keycloak/keycloak:26.7.0
 
 # Add the Oracle JDBC jars
 ARG ORACLE_JDBC_VERSION=23.8.0.25.04

--- a/conf/keycloak/Dockerfile
+++ b/conf/keycloak/Dockerfile
@@ -14,7 +14,7 @@ RUN mvn clean package
 # ------------------------------------------
 # Stage 2: Build Keycloak Image
 # ------------------------------------------
-FROM quay.io/keycloak/keycloak:26.7.0
+FROM quay.io/keycloak/keycloak:26.7.2
 
 # Add the Oracle JDBC jars
 ARG ORACLE_JDBC_VERSION=23.8.0.25.04

--- a/conf/keycloak/builtin-users-spi/pom.xml
+++ b/conf/keycloak/builtin-users-spi/pom.xml
@@ -100,7 +100,7 @@
     </build>
 
     <properties>
-        <keycloak.version>26.6.4</keycloak.version>
+        <keycloak.version>26.7.0</keycloak.version>
         <java.version>17</java.version>
         <jakarta.persistence.version>3.2.0</jakarta.persistence.version>
         <mindrot.jbcrypt.version>0.4</mindrot.jbcrypt.version>

--- a/conf/keycloak/builtin-users-spi/pom.xml
+++ b/conf/keycloak/builtin-users-spi/pom.xml
@@ -100,7 +100,7 @@
     </build>
 
     <properties>
-        <keycloak.version>26.7.0</keycloak.version>
+        <keycloak.version>26.7.2</keycloak.version>
         <java.version>17</java.version>
         <jakarta.persistence.version>3.2.0</jakarta.persistence.version>
         <mindrot.jbcrypt.version>0.4</mindrot.jbcrypt.version>

--- a/conf/keycloak/builtin-users-spi/src/main/resources/META-INF/persistence.xml
+++ b/conf/keycloak/builtin-users-spi/src/main/resources/META-INF/persistence.xml
@@ -24,24 +24,4 @@
         </properties>
     </persistence-unit>
 
-    <persistence-unit name="user-store-qa" transaction-type="JTA">
-        <class>edu.harvard.iq.keycloak.auth.spi.models.DataverseBuiltinUser</class>
-        <class>edu.harvard.iq.keycloak.auth.spi.models.DataverseAuthenticatedUser</class>
-        <properties>
-            <!-- Set the Hibernate dialect for PostgreSQL -->
-            <property name="hibernate.dialect" value="org.hibernate.dialect.PostgreSQLDialect"/>
-
-            <!-- JDBC connection settings -->
-            <property name="hibernate.connection.datasource" value="user-store-qa"/>
-
-            <!-- Transaction management settings -->
-            <property name="jakarta.persistence.transactionType" value="JTA"/>
-
-            <!-- Automatically update database schema -->
-            <property name="hibernate.hbm2ddl.auto" value="none"/>
-
-            <!-- Disable SQL logging -->
-            <property name="hibernate.show_sql" value="false"/>
-        </properties>
-    </persistence-unit>
 </persistence>

--- a/conf/keycloak/docker-compose.yml
+++ b/conf/keycloak/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.9"
 services:
 
   keycloak:
-    image: 'quay.io/keycloak/keycloak:26.7.0'
+    image: 'quay.io/keycloak/keycloak:26.7.2'
     command:
       - "start-dev"
       - "--import-realm"

--- a/conf/keycloak/docker-compose.yml
+++ b/conf/keycloak/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.9"
 services:
 
   keycloak:
-    image: 'quay.io/keycloak/keycloak:26.3.2'
+    image: 'quay.io/keycloak/keycloak:26.7.0'
     command:
       - "start-dev"
       - "--import-realm"

--- a/conf/keycloak/run-keycloak.sh
+++ b/conf/keycloak/run-keycloak.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-DOCKER_IMAGE="quay.io/keycloak/keycloak:26.7.0"
+DOCKER_IMAGE="quay.io/keycloak/keycloak:26.7.2"
 KEYCLOAK_USER="kcadmin"
 KEYCLOAK_PASSWORD="kcpassword"
 KEYCLOAK_PORT=8090

--- a/conf/keycloak/run-keycloak.sh
+++ b/conf/keycloak/run-keycloak.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-DOCKER_IMAGE="quay.io/keycloak/keycloak:26.3.2"
+DOCKER_IMAGE="quay.io/keycloak/keycloak:26.7.0"
 KEYCLOAK_USER="kcadmin"
 KEYCLOAK_PASSWORD="kcpassword"
 KEYCLOAK_PORT=8090

--- a/conf/keycloak/test-realm-include-spi.json
+++ b/conf/keycloak/test-realm-include-spi.json
@@ -2369,7 +2369,7 @@
     "clientSessionMaxLifespan": "0",
     "frontendUrl": ""
   },
-  "keycloakVersion": "26.7.0",
+  "keycloakVersion": "26.7.2",
   "userManagedAccessAllowed": false,
   "organizationsEnabled": false,
   "verifiableCredentialsEnabled": false,

--- a/conf/keycloak/test-realm-include-spi.json
+++ b/conf/keycloak/test-realm-include-spi.json
@@ -2369,7 +2369,7 @@
     "clientSessionMaxLifespan": "0",
     "frontendUrl": ""
   },
-  "keycloakVersion": "26.3.2",
+  "keycloakVersion": "26.7.0",
   "userManagedAccessAllowed": false,
   "organizationsEnabled": false,
   "verifiableCredentialsEnabled": false,

--- a/conf/keycloak/test-realm.json
+++ b/conf/keycloak/test-realm.json
@@ -2052,7 +2052,7 @@
     "clientSessionMaxLifespan" : "0",
     "frontendUrl" : ""
   },
-  "keycloakVersion" : "19.0.3",
+  "keycloakVersion" : "26.7.0",
   "userManagedAccessAllowed" : false,
   "clientProfiles" : {
     "profiles" : [ ]

--- a/conf/keycloak/test-realm.json
+++ b/conf/keycloak/test-realm.json
@@ -2052,7 +2052,7 @@
     "clientSessionMaxLifespan" : "0",
     "frontendUrl" : ""
   },
-  "keycloakVersion" : "26.7.0",
+  "keycloakVersion" : "26.7.2",
   "userManagedAccessAllowed" : false,
   "clientProfiles" : {
     "profiles" : [ ]

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -199,7 +199,7 @@ services:
 
   dev_keycloak:
     container_name: "dev_keycloak"
-    image: 'quay.io/keycloak/keycloak:26.3.2'
+    image: 'quay.io/keycloak/keycloak:26.7.2'
     hostname: keycloak
     environment:
       - KEYCLOAK_ADMIN=kcadmin


### PR DESCRIPTION
update keycloak conf to 26.7.0 and remove user-store-qa from persistence.xml used to create spi jar file.

**What this PR does / why we need it**:

**Which issue(s) this PR closes**:

- Closes #12562

**Special notes for your reviewer**:

**Suggestions on how to test this**:

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
