### PR TITLE
Scroll to first missing metadata error

### DIFF
--- a/src/main/java/propertyFiles/Bundle.properties
+++ b/src/main/java/propertyFiles/Bundle.properties
@@ -164,7 +164,7 @@ messages.error=Error
 messages.success=Success!
 messages.info=Info
 messages.validation=Validation Error
-messages.validation.msg=Required fields were missed or there was a validation error. Please scroll down to see details.
+messages.validation.msg=Required fields were missed or there was a validation error. See details below.
 
 # contactFormFragment.xhtml
 contact.header=Contact {0}

--- a/src/main/webapp/dataset.xhtml
+++ b/src/main/webapp/dataset.xhtml
@@ -876,12 +876,12 @@
                         <p:commandButton id="saveTop" styleClass="btn btn-default" value="#{bundle.saveChanges}" rendered="#{DatasetPage.editMode == 'METADATA'}"
                                          onclick="PF('blockDatasetForm').show();"
                                          update=":datasetForm,:messagePanel"
-                                         oncomplete="$(document).scrollTop(0);"
+                                         oncomplete="if (args &amp;&amp; !args.validationFailed) {$(document).scrollTop(0);}"
                                          action="#{DatasetPage.save}"
                                          />
                         <p:commandButton id="saveTopTOA" styleClass="btn btn-default" value="#{bundle.saveChanges}" rendered="#{DatasetPage.editMode == 'LICENSE'}"
                                          onclick="testTOADatasetPage();"
-                                         oncomplete="$(document).scrollTop(0);"
+                                         oncomplete="if (args &amp;&amp; !args.validationFailed) {$(document).scrollTop(0);}"
                         />
                         <p:commandButton id="cancelTop" styleClass="btn btn-link" value="#{bundle.cancel}" action="#{DatasetPage.cancel}" process="@this" update="@form">
                             <f:setPropertyActionListener target="#{DatasetPage.selectedTabIndex}" value="#{DatasetPage.editMode == 'METADATA' ? 1 : DatasetPage.selectedTabIndex}"/>
@@ -1051,11 +1051,11 @@
                         <p:commandButton id="saveBottomTerms" styleClass="btn btn-default" rendered="#{DatasetPage.editMode == 'LICENSE'}"
                                          value="#{DatasetPage.editMode == 'CREATE' ? bundle['file.addBtn'] : bundle.saveChanges}" 
                                          onclick="testTOADatasetPage();" 
-                                         oncomplete="$(document).scrollTop(0);"/>
+                                         oncomplete="if (args &amp;&amp; !args.validationFailed) {$(document).scrollTop(0);}" />
                         <p:commandButton id="saveBottom" styleClass="btn btn-default" value="#{DatasetPage.editMode == 'CREATE' ? bundle['file.addBtn'] : bundle.saveChanges}" rendered="#{DatasetPage.editMode == 'CREATE' or DatasetPage.editMode == 'METADATA'}"
                                          onclick="PF('blockDatasetForm').show();"
                                          update=":datasetForm,:messagePanel"
-                                         oncomplete="$(document).scrollTop(0);"
+                                         oncomplete="if (args &amp;&amp; !args.validationFailed) {$(document).scrollTop(0);}"
                                          action="#{DatasetPage.save}"
                                          />
                         <p:commandButton id="cancel" styleClass="btn btn-link" value="#{bundle.cancel}" action="#{DatasetPage.cancel}" process="@this" update="@form" rendered="#{DatasetPage.editMode != 'CREATE'}">

--- a/src/main/webapp/editdatafiles.xhtml
+++ b/src/main/webapp/editdatafiles.xhtml
@@ -91,7 +91,7 @@
                                     <p:commandButton id="savebutton" class="btn btn-default" value="#{bundle.saveChanges}"
                                                      update=":datasetForm,:messagePanel"
                                                      onclick="PF('blockFileForm').show();"
-                                                     oncomplete="$(document).scrollTop(0);"
+                                                     oncomplete="if (args &amp;&amp; !args.validationFailed) {$(document).scrollTop(0);}"
                                                      action="#{EditDatafilesPage.save}"/>
                                     <p:commandButton styleClass="btn btn-link" id="cancelbutton" value="#{bundle.cancel}" action="#{EditDatafilesPage.cancel}" process="@this" update="@form"/>
                                 </div>

--- a/src/main/webapp/resources/js/dv_rebind_bootstrap_ui.js
+++ b/src/main/webapp/resources/js/dv_rebind_bootstrap_ui.js
@@ -407,3 +407,53 @@ function addMenuDelays() {
         });
     });
 }
+
+function scrollToFirstError() {
+    // delay to let other oncomplete scripts finish (like scrollTop(0))
+    setTimeout(function () {
+        // Find all potential error indicators, including PrimeFaces and Bootstrap classes
+        var $errors = $('.ui-message-error, .ui-state-error, .has-error, .ui-message-fatal');
+        
+        // Filter out the main alert at the top if there are field-specific errors
+        var $fieldErrors = $errors.not('.alert-danger .ui-message-error').not('.alert-danger');
+        var $target = $fieldErrors.length > 0 ? $fieldErrors.first() : $errors.first();
+
+        if ($target.length > 0) {
+            // Check if it's inside a collapsed panel
+            var $panel = $target.closest('.collapse:not(.in)');
+            if ($panel.length > 0) {
+                // Find the heading that controls this panel and click it to expand
+                // or just use bootstrap's collapse method
+                $panel.collapse('show');
+                $panel.one('shown.bs.collapse', function () {
+                    $('html, body').animate({
+                        scrollTop: $target.offset().top - 150
+                    }, 500);
+                });
+            } else {
+                $('html, body').animate({
+                    scrollTop: $target.offset().top - 150
+                }, 500);
+            }
+        }
+    }, 250);
+}
+
+$(document).on('pfAjaxComplete', function (e, xhr, settings) {
+    var validationFailed = false;
+    if (xhr && xhr.pfArgs && xhr.pfArgs.validationFailed) {
+        validationFailed = true;
+    } else if (xhr && xhr.responseText && xhr.responseText.indexOf('validationFailed":true') !== -1) {
+        validationFailed = true;
+    }
+
+    if (validationFailed) {
+        scrollToFirstError();
+    }
+});
+
+$(document).ready(function () {
+    if ($('.alert-danger').length > 0 && $('.ui-message-error, .ui-state-error, .has-error').length > 0) {
+        scrollToFirstError();
+    }
+});


### PR DESCRIPTION
**What this PR does / why we need it**:  This PR adds a simple update to scroll to the first missing metadata error when a required field is not filled in.

**Which issue(s) this PR closes**:

- Closes #2190

**Special notes for your reviewer**: Should handle first view of the metadata edit page as well as when 'save' is hit.

**Suggestions on how to test this**: 
- Leave required metadata empty and hit save, e.g. create a dataset w/o entering anything (so missing title), or delete the contact email in an existing dataset.
- Can also create an incomplete dataset via the api (when enabled), go to the dataset page, go to the edit page, and press Save Changes. 

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: just scrolls, changes top message to Required fields were missed or there was a validation error. See details below. since it now auto scrolls.

**Is there a release notes update needed for this change?**:

**Additional documentation**:
