### PR TITLE
Forbid use of library methods overridden in XMLUtil

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -920,6 +920,9 @@
                     <signaturesFiles>
                         <signaturesFile>${project.basedir}/src/maven/forbiddenapis.txt</signaturesFile>
                     </signaturesFiles>
+                    <excludes>
+                        <exclude>edu/harvard/iq/dataverse/util/xml/XmlUtil.class</exclude>
+                    </excludes>
                     <targetVersion>${target.java.version}</targetVersion>
                 </configuration>
                 <executions>

--- a/src/maven/forbiddenapis.txt
+++ b/src/maven/forbiddenapis.txt
@@ -40,3 +40,17 @@ jakarta.json.Json#createPatchBuilder()
 jakarta.json.Json#createPatchBuilder(jakarta.json.JsonArray)
 jakarta.json.Json#createPointer(java.lang.String)
 jakarta.json.Json#createBuilderFactory(java.util.Map)
+
+@defaultMessage Use edu.harvard.iq.dataverse.util.xml.XmlUtil.getSecureDocumentBuilderFactory() instead
+javax.xml.parsers.DocumentBuilderFactory#newInstance()
+javax.xml.parsers.DocumentBuilderFactory#newInstance(java.lang.String,java.lang.ClassLoader)
+
+@defaultMessage Use edu.harvard.iq.dataverse.util.xml.XmlUtil.getSecureXMLReader() instead
+javax.xml.parsers.SAXParserFactory#newInstance()
+javax.xml.parsers.SAXParserFactory#newInstance(java.lang.String,java.lang.ClassLoader)
+
+@defaultMessage Use edu.harvard.iq.dataverse.util.xml.XmlUtil.getSecureXMLInputFactory() instead
+javax.xml.stream.XMLInputFactory#newInstance()
+javax.xml.stream.XMLInputFactory#newInstance(java.lang.String,java.lang.ClassLoader)
+javax.xml.stream.XMLInputFactory#newFactory()
+javax.xml.stream.XMLInputFactory#newFactory(java.lang.String,java.lang.ClassLoader)


### PR DESCRIPTION
**What this PR does / why we need it**: After the cleanup in #12567, this PR helps to make sure that new code will also use our XMLUtil methods.

**Which issue(s) this PR closes**:

- Closes #

**Special notes for your reviewer**: Leverages the same method as for JsonUtil. The XMLUtil class has to be added to the excludes section because it calls the forbidden methods in its override methods (whereas the JSONUtil class doesn't call the static Json.* methods it replaces since it is calling the methods on the provider class it caches).

**Suggestions on how to test this**: Run the auto-tests. Note that this PR should fail until #12567 is merged and we pick up the changes from it.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**: just dev related, no change for users.

**Additional documentation**:
