### PR TITLE
Guides: keeping an installation reachable under rate limiting (static homepage + custom 429 page via the reverse proxy)

### DIFF
--- a/doc/release-notes/rate-limiting-reachability-docs.md
+++ b/doc/release-notes/rate-limiting-reachability-docs.md
@@ -1,0 +1,3 @@
+### New guide: keeping your installation reachable under rate limiting
+
+The Installation Guide's Rate Limiting section now includes field-tested reverse-proxy recipes (Apache) for serving the homepage as a static file and showing a friendly custom "429 Too Many Requests" page, so that heavy anonymous traffic cannot make the installation appear down to guests. See [Keeping Your Installation Reachable Under Rate Limiting](https://guides.dataverse.org/en/latest/installation/config.html#keeping-your-installation-reachable-under-rate-limiting).

--- a/doc/sphinx-guides/source/_static/installation/files/var/www/errorpages/429.html
+++ b/doc/sphinx-guides/source/_static/installation/files/var/www/errorpages/429.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<!--
+  Custom "429 Too Many Requests" page served by the reverse proxy in place of
+  the bare application error. Because ErrorDocument renders this page via an
+  internal redirect at the ORIGINAL request URL, every URL in this document
+  must be absolute - relative paths would break on nested request URLs.
+  Self-contained: no JavaScript required.
+-->
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Too Many Requests - Example Research Data Repository</title>
+    <style>
+        body { margin: 0; font-family: sans-serif; color: #333; }
+        header { background: #1a4c7c; color: #fff; padding: 1rem 2rem; }
+        header h1 { margin: 0; font-size: 1.4rem; }
+        main { max-width: 40rem; margin: 3rem auto; padding: 0 1rem; }
+        .button { display: inline-block; padding: 0.6rem 1.2rem; border-radius: 4px;
+                  background: #1a4c7c; color: #fff; text-decoration: none; }
+    </style>
+</head>
+<body>
+<header>
+    <h1>Example Research Data Repository</h1>
+</header>
+<main>
+    <h2>Too many requests (429)</h2>
+    <p>Our repository is currently receiving a high volume of anonymous traffic, and
+       rate limits are protecting the service. Anonymous browsing is temporarily
+       restricted; logged-in users have a much higher limit and are unlikely
+       to be affected.</p>
+    <p><a class="button" href="/loginpage.xhtml">Log in to continue</a></p>
+    <p>If you prefer not to log in, please try again in a little while.</p>
+</main>
+</body>
+</html>

--- a/doc/sphinx-guides/source/_static/installation/files/var/www/landing/index.html
+++ b/doc/sphinx-guides/source/_static/installation/files/var/www/landing/index.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<!--
+  Minimal static homepage served directly by the reverse proxy.
+  This must be a complete, standalone HTML document (unlike the content-block
+  fragment used with the :HomePageCustomizationFile database setting).
+  All URLs are absolute so they work no matter how the page is reached.
+  No JavaScript is required to render it.
+-->
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Example Research Data Repository</title>
+    <style>
+        body { margin: 0; font-family: sans-serif; color: #333; }
+        header { background: #1a4c7c; color: #fff; padding: 1rem 2rem; }
+        header h1 { margin: 0; font-size: 1.4rem; }
+        main { max-width: 46rem; margin: 3rem auto; padding: 0 1rem; text-align: center; }
+        form { margin: 2rem 0; }
+        input[type="text"] { width: 60%; padding: 0.6rem; font-size: 1rem; border: 1px solid #999; border-radius: 4px 0 0 4px; }
+        button, .button { display: inline-block; padding: 0.6rem 1.2rem; font-size: 1rem; border: 0; border-radius: 4px;
+                 background: #1a4c7c; color: #fff; text-decoration: none; cursor: pointer; }
+        .actions .button { margin: 0 0.5rem; }
+        .announcement { margin-top: 3rem; padding: 1rem; background: #f5f0dc; border: 1px solid #e0d8b0; border-radius: 4px; }
+    </style>
+</head>
+<body>
+<header>
+    <!-- Replace with your installation's name and/or logo, e.g. <img src="/images/logo.svg" alt="..."> -->
+    <h1>Example Research Data Repository</h1>
+</header>
+<main>
+    <p>Find, share, and cite research data.</p>
+    <form action="/dataverse/root/" method="get">
+        <input type="text" name="q" placeholder="Search datasets...">
+        <button type="submit">Search</button>
+    </form>
+    <p class="actions">
+        <a class="button" href="/dataverse/root">Browse Data</a>
+        <a class="button" href="/loginpage.xhtml">Log In</a>
+    </p>
+    <div class="announcement">
+        <!-- Announcements go here; the proxy serves this page with Cache-Control: no-cache
+             so returning visitors see updates immediately. -->
+        Welcome! Log in with your institutional account to deposit data.
+    </div>
+</main>
+</body>
+</html>

--- a/doc/sphinx-guides/source/installation/config.rst
+++ b/doc/sphinx-guides/source/installation/config.rst
@@ -1724,6 +1724,7 @@ A few things to watch:
 - The file must be a complete, standalone HTML document - not the content-block fragment used with the ``:HomePageCustomizationFile`` database setting (see :ref:`Branding Your Installation`). Use absolute URLs for all assets and links, and avoid requiring JavaScript to render.
 - ``:HomePageCustomizationFile`` can stay configured as a harmless fallback (it only affects the root page render if a request ever reaches the application server), or be removed.
 - Keep the login link/button prominent (see the note above) - on this page it doubles as the escape hatch when the rest of the site is rate limited.
+- How the file gets updated is up to you; a cron job that pulls the page from a git repository works well and keeps the content under version control.
 
 Machine-Readable Site Metadata, Always Available
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1743,10 +1744,17 @@ The same pattern is a good home for machine-readable site metadata such as a FAI
   RewriteEngine on
   RewriteRule "^/\.well-known/api-catalog$" "/metadata/api-catalog.json" [PT]
 
+  # a FAIRiCat catalog is a linkset; serve it with the right content type
+  <FilesMatch "api-catalog\.json$">
+      Header set Content-Type "application/linkset+json"
+  </FilesMatch>
+
   # advertise the catalog from the (static) homepage
   <LocationMatch "^/$">
-      Header always set Link "</.well-known/api-catalog>; rel=\"api-catalog\""
+      Header always set Link "</.well-known/api-catalog>; rel=\"api-catalog\"; type=\"application/linkset+json\"; profile=\"https://signposting.org/FAIRiCat/\""
   </LocationMatch>
+
+The catalog file itself is a static linkset pointing at stable service endpoints (OAI-PMH, the native API, robots.txt, and so on): it only needs an update when your services change, so no generation machinery is required.
 
 A Friendly 429 Page from the Proxy
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/sphinx-guides/source/installation/config.rst
+++ b/doc/sphinx-guides/source/installation/config.rst
@@ -1683,7 +1683,13 @@ Keeping Your Installation Reachable Under Rate Limiting
 
 The tier 0 bucket is shared by all guests, so heavy anonymous traffic (search engine bots, AI crawlers) can exhaust it. Every guest then receives "429 Too Many Requests" - including on the homepage, and including on the login page they would need in order to authenticate into a higher tier. To visitors the installation simply looks down.
 
-Two measures at the reverse proxy keep the front door usable while rate limiting protects the application. The examples below are for Apache (the proxy assumed elsewhere in this guide, e.g. under :doc:`shibboleth`); the same pattern works on nginx with ``try_files`` and ``error_page 429``. They pair well with a configuration that limits the page/read commands using the settings above, for example a shared tier 0 limit of 3600 calls per hour and a per-user tier 1 limit of 12000 calls per hour on actions such as ``CheckRateLimitForCollectionPageCommand``, ``CheckRateLimitForDatasetPageCommand``, ``GetDataverseCommand``, ``GetDatasetCommand``, ``GetLatestPublishedDatasetVersionCommand``, ``GetLatestAccessibleDatasetVersionCommand``, and ``GetPrivateUrlCommand``.
+Two measures at the reverse proxy keep the front door usable while rate limiting protects the application.
+
+.. important::
+
+  Whatever design you use, make sure both the homepage and the error page carry a clearly visible link or button to the login page (``/loginpage.xhtml``). Logging in is how users escape the shared guest tier, so the login link is the functional core of these pages, not a nicety: without it, visitors are informed but still cannot reach the authentication step that lifts the limit. The sample pages below include it.
+
+The examples below are for Apache (the proxy assumed elsewhere in this guide, e.g. under :doc:`shibboleth`); the same pattern works on nginx with ``try_files`` and ``error_page 429``. They pair well with a configuration that limits the page/read commands using the settings above, for example a shared tier 0 limit of 3600 calls per hour and a per-user tier 1 limit of 12000 calls per hour on actions such as ``CheckRateLimitForCollectionPageCommand``, ``CheckRateLimitForDatasetPageCommand``, ``GetDataverseCommand``, ``GetDatasetCommand``, ``GetLatestPublishedDatasetVersionCommand``, ``GetLatestAccessibleDatasetVersionCommand``, and ``GetPrivateUrlCommand``.
 
 Serving the Homepage Statically from the Proxy
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1717,6 +1723,7 @@ A few things to watch:
 - The exclusion (``ProxyPassMatch ... "!"``) must come before the catch-all ``ProxyPass``.
 - The file must be a complete, standalone HTML document - not the content-block fragment used with the ``:HomePageCustomizationFile`` database setting (see :ref:`Branding Your Installation`). Use absolute URLs for all assets and links, and avoid requiring JavaScript to render.
 - ``:HomePageCustomizationFile`` can stay configured as a harmless fallback (it only affects the root page render if a request ever reaches the application server), or be removed.
+- Keep the login link/button prominent (see the note above) - on this page it doubles as the escape hatch when the rest of the site is rate limited.
 
 A Friendly 429 Page from the Proxy
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1739,7 +1746,7 @@ When a guest does hit the limit, the bare backend error tells them nothing. A st
 A few things to watch:
 
 - The per-status form ``ProxyErrorOverride On 429`` needs Apache httpd 2.4.47 or newer upstream; RHEL/AlmaLinux 8's 2.4.37 has it backported. ``ErrorDocument`` preserves the original 429 status code.
-- The error page renders at the original request URL (an internal redirect), so all URLs in ``429.html`` must be absolute - relative paths break on nested URLs.
+- The error page renders at the original request URL (an internal redirect), so all URLs in ``429.html`` must be absolute - relative paths break on nested URLs. That includes the login link - the one element this page must have (see the note above).
 - ``ProxyErrorOverride`` applies to the whole virtual host, so API clients also receive the HTML page instead of the JSON error body on 429. Installations that care can exempt the API:
 
   .. code-block:: apacheconf

--- a/doc/sphinx-guides/source/installation/config.rst
+++ b/doc/sphinx-guides/source/installation/config.rst
@@ -1725,6 +1725,29 @@ A few things to watch:
 - ``:HomePageCustomizationFile`` can stay configured as a harmless fallback (it only affects the root page render if a request ever reaches the application server), or be removed.
 - Keep the login link/button prominent (see the note above) - on this page it doubles as the escape hatch when the rest of the site is rate limited.
 
+Machine-Readable Site Metadata, Always Available
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The same pattern is a good home for machine-readable site metadata such as a FAIRiCat catalog: served statically from the proxy, it stays available to harvesters and aggregators regardless of rate limiting or application load. This is also why the homepage uses ``AliasMatch`` above: the request URI stays ``/``, so discovery headers set with ``<LocationMatch "^/$">`` keep firing on the static homepage.
+
+.. code-block:: apacheconf
+
+  # machine-readable site metadata, also served statically
+  Alias /metadata /var/www/metadata
+  <Directory /var/www/metadata>
+      Require all granted
+      Options -Indexes
+  </Directory>
+  ProxyPass /metadata !
+
+  RewriteEngine on
+  RewriteRule "^/\.well-known/api-catalog$" "/metadata/api-catalog.json" [PT]
+
+  # advertise the catalog from the (static) homepage
+  <LocationMatch "^/$">
+      Header always set Link "</.well-known/api-catalog>; rel=\"api-catalog\""
+  </LocationMatch>
+
 A Friendly 429 Page from the Proxy
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/doc/sphinx-guides/source/installation/config.rst
+++ b/doc/sphinx-guides/source/installation/config.rst
@@ -1676,6 +1676,92 @@ Note: If either of these settings exist in the database rate limiting will be en
 
   curl http://localhost:8080/api/admin/settings/:RateLimitingCapacityByTierAndAction -X PUT -d '[{"tier": 0, "limitPerHour": 10, "actions": ["GetLatestPublishedDatasetVersionCommand", "GetPrivateUrlCommand", "GetDatasetCommand", "GetLatestAccessibleDatasetVersionCommand"]}, {"tier": 0, "limitPerHour": 1, "actions": ["CreateGuestbookResponseCommand", "UpdateDatasetVersionCommand", "DestroyDatasetCommand", "DeleteDataFileCommand", "FinalizeDatasetPublicationCommand", "PublishDatasetCommand"]}, {"tier": 1, "limitPerHour": 30, "actions": ["CreateGuestbookResponseCommand", "GetLatestPublishedDatasetVersionCommand", "GetPrivateUrlCommand", "GetDatasetCommand", "GetLatestAccessibleDatasetVersionCommand", "UpdateDatasetVersionCommand", "DestroyDatasetCommand", "DeleteDataFileCommand", "FinalizeDatasetPublicationCommand", "PublishDatasetCommand"]}]'
 
+.. _rate-limiting-reachability:
+
+Keeping Your Installation Reachable Under Rate Limiting
++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+The tier 0 bucket is shared by all guests, so heavy anonymous traffic (search engine bots, AI crawlers) can exhaust it. Every guest then receives "429 Too Many Requests" - including on the homepage, and including on the login page they would need in order to authenticate into a higher tier. To visitors the installation simply looks down.
+
+Two measures at the reverse proxy keep the front door usable while rate limiting protects the application. The examples below are for Apache (the proxy assumed elsewhere in this guide, e.g. under :doc:`shibboleth`); the same pattern works on nginx with ``try_files`` and ``error_page 429``. They pair well with a configuration that limits the page/read commands using the settings above, for example a shared tier 0 limit of 3600 calls per hour and a per-user tier 1 limit of 12000 calls per hour on actions such as ``CheckRateLimitForCollectionPageCommand``, ``CheckRateLimitForDatasetPageCommand``, ``GetDataverseCommand``, ``GetDatasetCommand``, ``GetLatestPublishedDatasetVersionCommand``, ``GetLatestAccessibleDatasetVersionCommand``, and ``GetPrivateUrlCommand``.
+
+Serving the Homepage Statically from the Proxy
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+A homepage served as a static file by the proxy consumes no rate limit budget and stays up even when the application server is saturated. Download :download:`index.html </_static/installation/files/var/www/landing/index.html>` as a starting point, place it at ``/var/www/landing/index.html``, and add the following inside the SSL ``VirtualHost``:
+
+.. code-block:: apacheconf
+
+  # Front page: served statically at the site root.
+  # AliasMatch (rather than DirectoryIndex) keeps the request URI as "/",
+  # so any <LocationMatch ^/$> headers (e.g. Signposting Link headers)
+  # still fire; DirectoryIndex would internally redirect to /index.html
+  # and those headers would be lost.
+  ProxyPassMatch          ^/(index\.html)?$   "!"
+  AliasMatch              "^/(index\.html)?$" "/var/www/landing/index.html"
+
+  # pass everything else to the app server
+  ProxyPass     /         ajp://localhost:8009/
+
+  <Directory /var/www/landing>
+      Require all granted
+      # the front page carries announcements: require revalidation so
+      # returning visitors see updates immediately (cheap 304s otherwise)
+      <IfModule mod_headers.c>
+          Header set Cache-Control "no-cache"
+      </IfModule>
+  </Directory>
+
+A few things to watch:
+
+- The exclusion (``ProxyPassMatch ... "!"``) must come before the catch-all ``ProxyPass``.
+- The file must be a complete, standalone HTML document - not the content-block fragment used with the ``:HomePageCustomizationFile`` database setting (see :ref:`Branding Your Installation`). Use absolute URLs for all assets and links, and avoid requiring JavaScript to render.
+- ``:HomePageCustomizationFile`` can stay configured as a harmless fallback (it only affects the root page render if a request ever reaches the application server), or be removed.
+
+A Friendly 429 Page from the Proxy
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When a guest does hit the limit, the bare backend error tells them nothing. A styled error page served by the proxy can explain what is happening and point them to login. Download :download:`429.html </_static/installation/files/var/www/errorpages/429.html>` as a starting point, place it at ``/var/www/errorpages/429.html``, and add:
+
+.. code-block:: apacheconf
+
+  # local error pages - must be excluded from the proxy
+  Alias /errorpages /var/www/errorpages
+  <Directory /var/www/errorpages>
+      Require all granted
+      Options -Indexes
+  </Directory>
+  ProxyPass /errorpages !
+
+  ProxyErrorOverride On 429
+  ErrorDocument 429 /errorpages/429.html
+
+A few things to watch:
+
+- The per-status form ``ProxyErrorOverride On 429`` needs Apache httpd 2.4.47 or newer upstream; RHEL/AlmaLinux 8's 2.4.37 has it backported. ``ErrorDocument`` preserves the original 429 status code.
+- The error page renders at the original request URL (an internal redirect), so all URLs in ``429.html`` must be absolute - relative paths break on nested URLs.
+- ``ProxyErrorOverride`` applies to the whole virtual host, so API clients also receive the HTML page instead of the JSON error body on 429. Installations that care can exempt the API:
+
+  .. code-block:: apacheconf
+
+    <Location /api>
+        ProxyErrorOverride Off
+    </Location>
+
+Verifying
+^^^^^^^^^
+
+.. code-block:: bash
+
+  # homepage is served by the proxy: 200, even with the app server stopped
+  curl -s -o /dev/null -w "%{http_code}\n" https://demo.example.org/
+
+  # a rate-limited request returns the styled page with the correct status
+  curl -s -o /dev/null -w "%{http_code}\n" https://demo.example.org/dataverse/root
+  curl -s https://demo.example.org/dataverse/root | grep -i "too many requests"
+
+The last two commands only show 429 behavior once the tier 0 bucket is actually exhausted; on a quiet test system you can temporarily set a tier 0 limit of 1 call per hour to trigger it.
+
 .. _Branding Your Installation:
 
 Branding Your Installation
@@ -1814,6 +1900,8 @@ Given this location for the custom homepage HTML file, run this curl command to 
 Note that the ``custom-homepage.html`` file provided has multiple elements that assume your root Dataverse collection still has an alias of "root". While you were branding your root Dataverse collection, you may have changed the alias to "harvard" or "librascholar" or whatever and you should adjust the custom homepage code as needed.
 
 Note: If you prefer to start with less of a blank slate, you can review the custom homepage used by the Harvard Dataverse Repository, which includes branding messaging, action buttons, search input, subject links, and recent dataset links. This page was built to utilize the :doc:`/api/metrics` to deliver dynamic content to the page via Javascript. The files can be found at https://github.com/IQSS/dataverse.harvard.edu
+
+See also :ref:`rate-limiting-reachability` for serving a static homepage directly from a reverse proxy, which keeps the front page up even when the application server is saturated or guests are rate limited.
 
 If you decide you'd like to remove this setting, use the following curl command:
 


### PR DESCRIPTION
**What this PR does / why we need it**:

When anonymous traffic (search-engine and AI crawlers) exhausts the shared tier 0 rate-limit bucket, every guest gets 429s — including on the homepage and the login page they'd need to reach a higher tier, so the installation looks down. This adds a field-tested subsection to the Rate Limiting docs with two reverse-proxy recipes that keep the front door usable: serving the homepage as a static file from Apache (zero rate-limit budget, survives app-server saturation) and a styled 429 error page that explains the situation and points guests to login. Includes downloadable sample pages, an nginx pointer, and curl verification steps. This is operational guidance from a production installation, generalized. Docs-only; no linked issue.
