### PR TITLE
no-op change to trigger CI post 12498 Payara upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1493,3 +1493,4 @@
         </profile>
   </profiles>
 </project>
+


### PR DESCRIPTION
After merging this PR:

- #12498

We've seen API and JSF tests failing in develop (they weren't failing in the PR!):

<img width="2223" height="891" alt="Screenshot 2026-08-28 at 4 10 13 PM" src="https://github.com/user-attachments/assets/3ca84b18-9822-4d4a-9423-6cac5f85a8c0" />

This is just a no-op change to trigger CI.