### PR TITLE
Increase the reindex timeout used in many SearchIT tests

### DIFF
--- a/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
@@ -2706,8 +2706,8 @@ public class UtilIT {
                 id = splitted[1];
             }
         }
-        if (!UtilIT.sleepForReindex(id, apiToken, 10)) {
-            logger.warning("Still indexing after 10 seconds");
+        if (!UtilIT.sleepForReindex(id, apiToken, 20)) {
+            logger.warning("Still indexing after 20 seconds");
         }
     }
 


### PR DESCRIPTION
**What this PR does / why we need it**: We're seeing occasional issues in various SearchIT tests (line 1444, line 1631, ...) that appear to be cases where the 10 second max timeout for our sleepForReindex call isn't quite enough. This PR ups the possible maximum to 20 seconds. (Note - the call will return as soon as indexing is complete, so the extra time is only used if needed.)

**Which issue(s) this PR closes**:

- Closes #

**Special notes for your reviewer**:

**Suggestions on how to test this**:

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
