### PR TITLE
Fix MyData 500 Error when results include files

### DIFF
--- a/doc/release-notes/mydata-bigint-classcastexception.md
+++ b/doc/release-notes/mydata-bigint-classcastexception.md
@@ -1,0 +1,7 @@
+### My Data no longer fails when results include files
+
+On installations whose database was created recently, `dvobject.id` is a `bigint` column, so the
+JDBC driver returns a `Long` for it. My Data read that value as an `Integer`, which made
+`/api/mydata/retrieve` (and the My Data page) fail with a `ClassCastException` and an HTTP 500
+for any request whose results included a file. The value is now read as a `Number`, which is
+correct whether the column is an `integer` (older databases) or a `bigint` (newer ones).

--- a/doc/release-notes/mydata-bigint-classcastexception.md
+++ b/doc/release-notes/mydata-bigint-classcastexception.md
@@ -1,7 +1,0 @@
-### My Data no longer fails when results include files
-
-On installations whose database was created recently, `dvobject.id` is a `bigint` column, so the
-JDBC driver returns a `Long` for it. My Data read that value as an `Integer`, which made
-`/api/mydata/retrieve` (and the My Data page) fail with a `ClassCastException` and an HTTP 500
-for any request whose results included a file. The value is now read as a `Number`, which is
-correct whether the column is an `integer` (older databases) or a `bigint` (newer ones).

--- a/src/main/java/edu/harvard/iq/dataverse/DvObjectServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DvObjectServiceBean.java
@@ -372,9 +372,9 @@ public class DvObjectServiceBean implements java.io.Serializable {
             Long ownerId;
             if (result[0] != null) {
                 try {
-                    objectId = ((Integer) result[0]).longValue();
+                    objectId = ((Number) result[0]).longValue();
                 } catch (Exception ex) {
-                    logger.warning("OBJECT PATH: could not cast result[0] (dvobject id) to Integer!");
+                    logger.warning("OBJECT PATH: could not cast result[0] (dvobject id) to Number!");
                     objectId = null;
                 }
                 if (objectId == null) {

--- a/src/main/java/edu/harvard/iq/dataverse/mydata/RoleTagRetriever.java
+++ b/src/main/java/edu/harvard/iq/dataverse/mydata/RoleTagRetriever.java
@@ -331,19 +331,17 @@ public class RoleTagRetriever {
         // -------------------------------------
         // (3) Process the results -- the parent ID is the Dataverse that we're interested in
         // -------------------------------------
-        Integer dvIdAsInteger;
         Long dvId;
         String dtype;
         Long parentId;
-        
+
         // -------------------------------------
         // Iterate through object list
         // -------------------------------------
         for (Object[] ra : results) {
-            dvIdAsInteger = (Integer)ra[0];     // ?? Why, should be a Long
-            dvId = new Long(dvIdAsInteger);
+            dvId = ((Number)ra[0]).longValue();
             dtype = (String)ra[1];
-            parentId = (Long)ra[2];
+            parentId = ((Number)ra[2]).longValue();
                        
             //msg("result: dvId: " + dvId + " |dtype: " + dtype + " |parentId: " + parentId);
             // Should ALWAYS be a Dataset!


### PR DESCRIPTION
**What this PR does / why we need it**:

Related to https://github.com/IQSS/dataverse/pull/12498  merged
`dvId = ((Number)ra[0]).longValue();` [here](https://github.com/IQSS/dataverse/pull/12498/changes#diff-ed3e02505d87f49cd1bd37f18cff541290df4a8ac5f8828ed5dda6e8eef6c138R520)

On installations whose database was created recently, `dvobject.id` is a `bigint` column, so the JDBC driver returns a `Long` for it. My Data read that value as an `Integer`, which made `/api/mydata/retrieve` (and the My Data page) fail with a `ClassCastException` and an HTTP 500 for any request whose results included a file. The value is now read as a `Number`, which is correct whether the column is an `integer` (older databases) or a `bigint` (newer ones).

**Which issue(s) this PR closes**:

- Closes #

**Special notes for your reviewer**:

**Suggestions on how to test this**:

Requires a freshly created database 

- Log in as a superuser.
- As that user, create a collection, create a dataset in it, and upload a file to the dataset.
- Wait for the dataset and file to be indexed in Solr.
- Open My Data, or call:
`GET /api/v1/mydata/retrieve
  ?role_ids=1&role_ids=2&role_ids=3&role_ids=4&role_ids=5&role_ids=6&role_ids=7&role_ids=8
  &dvobject_types=Dataverse&dvobject_types=Dataset&dvobject_types=DataFile
  &published_states=Draft&published_states=Unpublished`

Before this change that returns a 500; after it, the collection, dataset and file are returned. Requests that exclude `DataFile` succeed either way, which is a useful control:

dvobject_types | before | after
-- | -- | --
Dataverse + Dataset + DataFile | 500 | 3 results
DataFile | 500 | 1 result
Dataverse + Dataset | 2 results | 2 results

<br class="Apple-interchange-newline">

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
