### PR TITLE
Revert PR #12250 - feat/non-superuser-dataverse-linking

### DIFF
--- a/doc/release-notes/12076-non-superuser-dataverse-linking.md
+++ b/doc/release-notes/12076-non-superuser-dataverse-linking.md
@@ -1,1 +1,0 @@
-Dataverse collection linking and unlinking no longer requires superuser status. Users with the "Link Dataverse" permission on a collection can now perform these actions through the UI and API.

--- a/doc/sphinx-guides/source/admin/dataverses-datasets.rst
+++ b/doc/sphinx-guides/source/admin/dataverses-datasets.rst
@@ -22,14 +22,14 @@ Moves a Dataverse collection whose id is passed to an existing Dataverse collect
 Link a Dataverse Collection
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Creates a link between a Dataverse collection and another Dataverse collection (see the :ref:`dataverse-linking` section of the User Guide for more information). ::
+Creates a link between a Dataverse collection and another Dataverse collection (see the :ref:`dataverse-linking` section of the User Guide for more information). Only accessible to superusers. ::
 
     curl -H "X-Dataverse-key: $API_TOKEN" -X PUT http://$SERVER/api/dataverses/$linked-dataverse-alias/link/$linking-dataverse-alias
 
 Unlink a Dataverse Collection
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Removes a link between a Dataverse collection and another Dataverse collection. Accessible to users with Link Dataverse permission on the linking Dataverse collection.  ::
+Removes a link between a Dataverse collection and another Dataverse collection. Only accessible to superusers. ::
 
     curl -H "X-Dataverse-key: $API_TOKEN" -X DELETE http://$SERVER/api/dataverses/$linked-dataverse-alias/deleteLink/$linking-dataverse-alias
 

--- a/doc/sphinx-guides/source/api/native-api.rst
+++ b/doc/sphinx-guides/source/api/native-api.rst
@@ -3750,66 +3750,6 @@ The fully expanded example above (without environment variables) looks like this
 
   curl -H "X-Dataverse-key: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" -X PUT "https://demo.dataverse.org/api/datasets/24/link/test"
 
-Unlink a Dataset
-~~~~~~~~~~~~~~~~
-
-Removes a link between a dataset and a Dataverse collection (see :ref:`dataset-linking` section of Dataverse Collection Management in the User Guide for more information):
-
-.. code-block:: bash
-
-  export API_TOKEN=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-  export SERVER_URL=https://demo.dataverse.org
-  export DATASET_ID=24
-  export DATAVERSE_ID=test
-
-  curl -H "X-Dataverse-key: $API_TOKEN" -X DELETE "$SERVER_URL/api/datasets/$DATASET_ID/deleteLink/$DATAVERSE_ID"
-
-The fully expanded example above (without environment variables) looks like this:
-
-.. code-block:: bash
-
-  curl -H "X-Dataverse-key: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" -X DELETE "https://demo.dataverse.org/api/datasets/24/deleteLink/test"
-
-Link a Dataverse collection
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Creates a link between one Dataverse collection and another Dataverse collection (see :ref:`dataverse-linking` section of Dataverse Collection Management in the User Guide for more information):
-
-.. code-block:: bash
-
-  export API_TOKEN=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-  export SERVER_URL=https://demo.dataverse.org
-  export LINKED_DATAVERSE_ID=linked-collection
-  export LINKING_DATAVERSE_ID=linking-collection
-
-  curl -H "X-Dataverse-key: $API_TOKEN" -X PUT "$SERVER_URL/api/dataverses/$LINKED_DATAVERSE_ID/link/$LINKING_DATAVERSE_ID"
-
-The fully expanded example above (without environment variables) looks like this:
-
-.. code-block:: bash
-
-  curl -H "X-Dataverse-key: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" -X PUT "https://demo.dataverse.org/api/dataverses/linked-collection/link/linking-collection"
-
-Unlink a Dataverse collection
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Removes a link between one Dataverse collection and another Dataverse collection (see :ref:`dataverse-linking` section of Dataverse Collection Management in the User Guide for more information):
-
-.. code-block:: bash
-
-  export API_TOKEN=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-  export SERVER_URL=https://demo.dataverse.org
-  export LINKED_DATAVERSE_ID=linked-collection
-  export LINKING_DATAVERSE_ID=linking-collection
-
-  curl -H "X-Dataverse-key: $API_TOKEN" -X DELETE "$SERVER_URL/api/dataverses/$LINKED_DATAVERSE_ID/deleteLink/$LINKING_DATAVERSE_ID"
-
-The fully expanded example above (without environment variables) looks like this:
-
-.. code-block:: bash
-
-  curl -H "X-Dataverse-key: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" -X DELETE "https://demo.dataverse.org/api/dataverses/linked-collection/deleteLink/linking-collection"
-
 Dataset Locks
 ~~~~~~~~~~~~~
 

--- a/doc/sphinx-guides/source/user/dataverse-management.rst
+++ b/doc/sphinx-guides/source/user/dataverse-management.rst
@@ -221,18 +221,18 @@ In order to link a dataset, you will need your account to have the "Link Dataset
 
 To link a dataset to your Dataverse collection, you must navigate to that dataset and click the white "Link" button in the upper-right corner of the dataset page. This will open up a window where you can type in the name of the Dataverse collection that you would like to link the dataset to. Select your Dataverse collection and click the save button. This will establish the link, and the dataset will now appear under your Dataverse collection.
 
-To remove an established link, navigate to the linked dataset's page and click the white "Unlink" button in the upper-right corner of the page.
-
 A draft dataset can be linked to other Dataverse collections. It will only become publicly visible in the linked collection(s) after it has been published. To publish the dataset, your account must have the "Publish Dataset" permission for the Dataverse collection in which the dataset was originally created. Permissions in the linked Dataverse collections do not apply.
+
+There is currently no way to remove established links in the UI. If you need to remove a link between a Dataverse collection and a dataset, please contact the support team for the Dataverse installation you are using (see the :ref:`unlink-a-dataset` section of the Admin Guide for more information).
 
 .. _dataverse-linking:
 
 Dataverse Collection Linking
 ============================
 
-Similarly to dataset linking, Dataverse collection linking allows a Dataverse collection owner to "link" their Dataverse collection to another Dataverse collection, so the Dataverse collection being linked will appear in the linking Dataverse collection's list of contents without actually *being* in that Dataverse collection.
+Similarly to dataset linking, Dataverse collection linking allows a Dataverse collection owner to "link" their Dataverse collection to another Dataverse collection, so the Dataverse collection being linked will appear in the linking Dataverse collection's list of contents without actually *being* in that Dataverse collection. Currently, the ability to link a Dataverse collection to another Dataverse collection is a superuser only feature. 
 
-In order to link a collection, you will need your account to have the "Link Dataverse" permission on the linking Dataverse collection.
+If you need to have a Dataverse collection linked to your Dataverse collection, please contact the support team for the Dataverse installation you are using.
 
 Publish Your Dataverse Collection
 =================================

--- a/src/main/java/edu/harvard/iq/dataverse/DataverseLinkingServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DataverseLinkingServiceBean.java
@@ -89,19 +89,19 @@ public class DataverseLinkingServiceBean implements java.io.Serializable {
         }
     }
     
-    public DataverseLinkingDataverse findDataverseLinkingDataverse(Long linkingDataverseId, Long linkedDataverseId) {
+    public DataverseLinkingDataverse findDataverseLinkingDataverse(Long dataverseId, Long linkingDataverseId) {
         try {
             return em.createNamedQuery("DataverseLinkingDataverse.findByDataverseIdAndLinkingDataverseId", DataverseLinkingDataverse.class)
-                .setParameter("dataverseId", linkedDataverseId)
+                .setParameter("dataverseId", dataverseId)
                 .setParameter("linkingDataverseId", linkingDataverseId)
                 .getSingleResult();
         } catch (jakarta.persistence.NoResultException e) {
-            logger.fine("No DataverseLinkingDataverse found for linkingDataverseId " + linkingDataverseId + " and linkedDataverseId " + linkedDataverseId);
+            logger.fine("No DataverseLinkingDataverse found for dataverseId " + dataverseId + " and linkedDataverseId " + linkingDataverseId);        
             return null;
         }
     }
 
-    public boolean alreadyLinked(Dataverse linkingDataverse, Dataverse linkedDataverse) {
-        return findDataverseLinkingDataverse(linkingDataverse.getId(), linkedDataverse.getId()) != null;
+    public boolean alreadyLinked(Dataverse definitionPoint, Dataverse dataverseToLinkTo) {
+        return findDataverseLinkingDataverse(dataverseToLinkTo.getId(), definitionPoint.getId()) != null;
     }
 }

--- a/src/main/java/edu/harvard/iq/dataverse/DataversePage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DataversePage.java
@@ -215,31 +215,18 @@ public class DataversePage implements java.io.Serializable {
     }
     
     public boolean showLinkingPopup() {
-        // Must be logged in
-        AuthenticatedUser au = getAuthenticatedUser();
-        if (au == null) {
+        String testquery = "";
+        if (session.getUser() == null) {
             return false;
         }
         if (dataverse == null) {
             return false;
         }
-
-        // If there is an active search query, that's all that matters (plus having permission on ANY collection)
-        if (query != null && !query.isEmpty()) {
-            List<Dataverse> permitted = permissionService.findPermittedCollections(dvRequestService.getDataverseRequest(), au, Permission.LinkDataverse);
-            return permitted != null && !permitted.isEmpty();
+        if (query != null) {
+            testquery = query;
         }
 
-        // Otherwise (no active search), check if there is at least one OTHER eligible collection
-        // Eligible means: not the current collection and not in the parent tree
-        // Technically, eligible also means "not already linked", but in that case, we show the Link button anyway and have the Link dialog display a message about all eligible collections already being linked
-        List<Dataverse> dvsWithLinkPermission = permissionService.findPermittedCollections(dvRequestService.getDataverseRequest(), au, Permission.LinkDataverse);
-        if (dvsWithLinkPermission != null && !dvsWithLinkPermission.isEmpty()) {
-            List<Dataverse> eligibleDataverses = dataverseService.removeUnlinkableDataverses(dvsWithLinkPermission, dataverse, false);
-            return !eligibleDataverses.isEmpty();
-        }
-
-        return false;
+        return (session.getUser().isSuperuser() && (dataverse.getOwner() != null || !testquery.isEmpty()));
     }
     
     public void setupLinkingPopup (String popupSetting){
@@ -254,18 +241,35 @@ public class DataversePage implements java.io.Serializable {
     public void updateLinkableDataverses() {
         dataversesForLinking = new ArrayList<>();
         linkingDVSelectItems = new ArrayList<>();
-
-
-        List<Dataverse> dvsWithLinkPermission = permissionService.findPermittedCollections(dvRequestService.getDataverseRequest(), getAuthenticatedUser(), Permission.LinkDataverse, "");
-
-        if (dvsWithLinkPermission != null && !dvsWithLinkPermission.isEmpty()) {
-            // for linking - make sure the link hasn't occurred and it's not in the tree
-            if (this.linkMode.equals(LinkMode.LINKDATAVERSE)) {
-                dataversesForLinking = dataverseService.removeUnlinkableDataverses(dvsWithLinkPermission, dataverse);
-            } else {
-                // for saved search, add all
-                dataversesForLinking = dvsWithLinkPermission;
+        
+        //Since only a super user function add all dvs
+        dataversesForLinking = dataverseService.findAll();// permissionService.getDataversesUserHasPermissionOn(session.getUser(), Permission.PublishDataverse);
+        
+        /*
+        List<DataverseRole> roles = dataverseRoleServiceBean.getDataverseRolesByPermission(Permission.PublishDataverse, dataverse.getId());
+        List<String> types = new ArrayList();
+        types.add("Dataverse");
+        for (Long dvIdAsInt : permissionService.getDvObjectIdsUserHasRoleOn(session.getUser(), roles, types, false)) {
+            dataversesForLinking.add(dataverseService.find(dvIdAsInt));
+        }*/
+        
+        //for linking - make sure the link hasn't occurred and its not int the tree
+        if (this.linkMode.equals(LinkMode.LINKDATAVERSE)) {
+        
+            // remove this and it's parent tree
+            dataversesForLinking.remove(dataverse);
+            Dataverse testDV = dataverse;
+            while(testDV.getOwner() != null){
+                dataversesForLinking.remove(testDV.getOwner());
+                testDV = testDV.getOwner();
+            }                
+            
+            for (Dataverse removeLinked : linkingService.findLinkingDataverses(dataverse.getId())) {
+                dataversesForLinking.remove(removeLinked);
             }
+        } else{
+            //for saved search add all
+
         }
 
         for (Dataverse selectDV : dataversesForLinking) {

--- a/src/main/java/edu/harvard/iq/dataverse/DataverseServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DataverseServiceBean.java
@@ -552,30 +552,28 @@ public class DataverseServiceBean implements java.io.Serializable {
         return dataverseList;
     }
 
-    public List<Dataverse> removeUnlinkableDataverses(List<Dataverse> allWithPerms, DvObject dvo, boolean removeAlreadyLinked) {
+    public List<Dataverse> removeUnlinkableDataverses(List<Dataverse> allWithPerms, DvObject dvo) {
         List<Dataverse> dataverseList = new ArrayList<>();
         Dataset linkedDataset = null;
         Dataverse linkedDataverse = null;
+        List<Object> alreadyLinkeddv_ids;
+
+        if ((dvo instanceof Dataset)) {
+            linkedDataset = (Dataset) dvo;
+            alreadyLinkeddv_ids = em.createNativeQuery("SELECT linkingdataverse_id FROM datasetlinkingdataverse WHERE dataset_id = " + linkedDataset.getId()).getResultList();
+        } else {
+            linkedDataverse = (Dataverse) dvo;
+            alreadyLinkeddv_ids = em.createNativeQuery("SELECT linkingdataverse_id FROM dataverselinkingdataverse WHERE dataverse_id = " + linkedDataverse.getId()).getResultList();
+        }
 
         List<Dataverse> remove = new ArrayList<>();
 
-        if (removeAlreadyLinked) {
-            List<Object> alreadyLinkeddv_ids;
-
-            if ((dvo instanceof Dataset)) {
-                linkedDataset = (Dataset) dvo;
-                alreadyLinkeddv_ids = em.createNativeQuery("SELECT linkingdataverse_id FROM datasetlinkingdataverse WHERE dataset_id = " + linkedDataset.getId()).getResultList();
-            } else {
-                linkedDataverse = (Dataverse) dvo;
-                alreadyLinkeddv_ids = em.createNativeQuery("SELECT linkingdataverse_id FROM dataverselinkingdataverse WHERE dataverse_id = " + linkedDataverse.getId()).getResultList();
-            }
-
-            if (alreadyLinkeddv_ids != null && !alreadyLinkeddv_ids.isEmpty()) {
-                alreadyLinkeddv_ids.stream().map((testDVId) -> this.find(testDVId)).forEachOrdered((removeIt) -> {
-                    remove.add(removeIt);
-                });
-            }
+        if (alreadyLinkeddv_ids != null && !alreadyLinkeddv_ids.isEmpty()) {
+            alreadyLinkeddv_ids.stream().map((testDVId) -> this.find(testDVId)).forEachOrdered((removeIt) -> {
+                remove.add(removeIt);
+            });
         }
+        
 
         if (dvo instanceof Dataverse dataverse) {
             remove.add(dataverse);
@@ -599,11 +597,8 @@ public class DataverseServiceBean implements java.io.Serializable {
 
         return dataverseList;
     }
-
-    public List<Dataverse> removeUnlinkableDataverses(List<Dataverse> allWithPerms, DvObject dvo) {
-        return removeUnlinkableDataverses(allWithPerms, dvo, true);
-    }
-
+    
+  
     public List<Dataverse> filterDataversesForUnLinking(String query, DataverseRequest req, Dataset dataset) {
         List<Object> alreadyLinkeddv_ids = em.createNativeQuery("SELECT linkingdataverse_id FROM datasetlinkingdataverse WHERE dataset_id = " + dataset.getId()).getResultList();
         List<Dataverse> dataverseList = new ArrayList<>();

--- a/src/main/java/edu/harvard/iq/dataverse/api/Dataverses.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Dataverses.java
@@ -950,7 +950,7 @@ public class Dataverses extends AbstractApiBean {
 
     @DELETE
     @AuthRequired
-    @Path("{linkedDataverseId}/deleteLink/{linkingDataverseId}")
+    @Path("{linkingDataverseId}/deleteLink/{linkedDataverseId}")
     @Operation(summary = "Remove a dataverse link",
             description = "Deletes a link from one dataverse to another linked dataverse.")
     public Response deleteDataverseLinkingDataverse(@Context ContainerRequestContext crc,

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/CreateSavedSearchCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/CreateSavedSearchCommand.java
@@ -14,7 +14,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import jakarta.json.JsonObjectBuilder;
 
-@RequiredPermissions(Permission.LinkDataverse)
+@RequiredPermissions(Permission.PublishDataverse)
 public class CreateSavedSearchCommand extends AbstractCommand<SavedSearch> {
 
     private static final Logger logger = Logger.getLogger(SavedSearchServiceBean.class.getCanonicalName());

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/DeleteDataverseLinkingDataverseCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/DeleteDataverseLinkingDataverseCommand.java
@@ -26,7 +26,7 @@ import org.apache.solr.client.solrj.SolrServerException;
  * @author sarahferry
  */
 
-@RequiredPermissions( Permission.LinkDataverse )
+@RequiredPermissions( Permission.EditDataverse )
 public class DeleteDataverseLinkingDataverseCommand extends AbstractCommand<Dataverse> {
 
     private final DataverseLinkingDataverse doomed;
@@ -42,6 +42,10 @@ public class DeleteDataverseLinkingDataverseCommand extends AbstractCommand<Data
 
     @Override
     public Dataverse execute(CommandContext ctxt) throws CommandException {
+        if ((!(getUser() instanceof AuthenticatedUser) || !getUser().isSuperuser())) {
+            throw new PermissionException("Delete dataverse linking dataverse can only be called by superusers.",
+                    this, Collections.singleton(Permission.DeleteDataverse), editedDv);
+        }
         Dataverse merged = ctxt.em().merge(editedDv);
         DataverseLinkingDataverse doomedAndMerged = ctxt.em().merge(doomed);
         ctxt.em().remove(doomedAndMerged);

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/LinkDataverseCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/LinkDataverseCommand.java
@@ -45,6 +45,10 @@ public class LinkDataverseCommand extends AbstractCommand<DataverseLinkingDatave
 
     @Override
     public DataverseLinkingDataverse execute(CommandContext ctxt) throws CommandException {
+        if ((!(getUser() instanceof AuthenticatedUser) || !getUser().isSuperuser())) {
+            throw new PermissionException("Link Dataverse can only be called by superusers.",
+                    this, Collections.singleton(Permission.LinkDataverse), linkingDataverse);
+        }
         if (linkedDataverse.equals(linkingDataverse)) {
             throw new IllegalCommandException("Can't link a dataverse to itself", this);
         }

--- a/src/main/java/edu/harvard/iq/dataverse/search/savedsearch/SavedSearchServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/search/savedsearch/SavedSearchServiceBean.java
@@ -277,7 +277,7 @@ public class SavedSearchServiceBean {
 
             if (dvObjectThatDefinitionPointWillLinkTo.isInstanceofDataverse()) {
                 Dataverse linkedDataverse = (Dataverse) dvObjectThatDefinitionPointWillLinkTo;
-                DataverseLinkingDataverse dvld = dvLinkingService.findDataverseLinkingDataverse(linkingDataverse.getId(), linkedDataverse.getId());
+                DataverseLinkingDataverse dvld = dvLinkingService.findDataverseLinkingDataverse(linkedDataverse.getId(), linkingDataverse.getId());
                 if(dvld != null) {
                     Dataverse dv = commandEngine.submitInNewTransaction(new DeleteDataverseLinkingDataverseCommand(dvReq, linkingDataverse, dvld, true));
                 }

--- a/src/main/webapp/dataverse.xhtml
+++ b/src/main/webapp/dataverse.xhtml
@@ -518,8 +518,7 @@
                                     <!-- Edit/Publish Button Group -->
                                     <div class="btn-group" jsf:rendered="#{dataverseSession.user.authenticated and
                                                              (permissionsWrapper.canIssueUpdateDataverseCommand(dataverse)
-                                                             or permissionsWrapper.canIssuePublishDataverseCommand(dataverse)
-                                                             or DataversePage.showLinkingPopup())}">
+                                                             or permissionsWrapper.canIssuePublishDataverseCommand(dataverse))}">
                                             <!-- Publish Button -->
                                             <ui:fragment rendered="#{permissionsWrapper.canIssuePublishDataverseCommand(dataverse)}">
                                                 <button type="button" class="btn btn-default btn-access" onclick="PF('confirmation').show()"
@@ -860,7 +859,7 @@
                                     </div>
                                 </div>
                                 <div class="button-block">
-                                    <p:commandButton styleClass="btn btn-default" value="#{bundle['dataverse.link.save']}" action="#{DataversePage.saveLinkedDataverse}"/>
+                                    <p:commandButton styleClass="btn btn-default" value="#{bundle['dataverse.link.save']}" onclick="PF('linkDataverseForm').hide()" actionListener="#{DataversePage.saveLinkedDataverse()}"/>
                                     <button class="btn btn-link" onclick="PF('linkDataverseForm').hide();" type="button">                              
                                     #{bundle.cancel}
                                     </button>
@@ -868,7 +867,7 @@
                             </ui:fragment>
                             <ui:fragment rendered="#{DataversePage.dataversesForLinking.size() == 0}">
                                 <p class="text-danger">
-                                    <span class="glyphicon glyphicon-exclamation-sign"/> #{bundle['dataverse.link.no.linkable.remaining']}
+                                    <span class="glyphicon glyphicon-exclamation-sign"/> #{bundle['dataverse.link.no.linkable']}
                                 </p>
                                 <div class="button-block">
                                     <button class="btn btn-default" onclick="PF('linkDataverseForm').hide();" type="button">                              

--- a/src/test/java/edu/harvard/iq/dataverse/api/LinkIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/LinkIT.java
@@ -101,82 +101,56 @@ public class LinkIT {
 
     @Test
     public void testCreateDeleteDataverseLink() {
-        // Create user #1 who owns Dataverse collection #1
-        Response createUser1 = UtilIT.createRandomUser();
-        createUser1.prettyPrint();
-        String apiToken1 = UtilIT.getApiTokenFromResponse(createUser1);
-        String username1 = UtilIT.getUsernameFromResponse(createUser1);
+        Response createUser = UtilIT.createRandomUser();
 
-        Response createDataverse1Response = UtilIT.createRandomDataverse(apiToken1);
-        createDataverse1Response.prettyPrint();
-        String dataverse1Alias = UtilIT.getAliasFromResponse(createDataverse1Response);
-        Integer dataverse1Id = UtilIT.getDataverseIdFromResponse(createDataverse1Response);
+        createUser.prettyPrint();
+        String username = UtilIT.getUsernameFromResponse(createUser);
+        String apiToken = UtilIT.getApiTokenFromResponse(createUser);
 
-        // Create user #2 who owns Dataverse collection #2
-        Response createUser2 = UtilIT.createRandomUser();
-        createUser2.prettyPrint();
-        String apiToken2 = UtilIT.getApiTokenFromResponse(createUser2);
+        Response superuserResponse = UtilIT.makeSuperUser(username);
 
-        Response createDataverse2Response = UtilIT.createRandomDataverse(apiToken2);
-        createDataverse2Response.prettyPrint();
-        String dataverse2Alias = UtilIT.getAliasFromResponse(createDataverse2Response);
-        Integer dataverse2Id = UtilIT.getDataverseIdFromResponse(createDataverse2Response);
+        Response createDataverseResponse = UtilIT.createRandomDataverse(apiToken);
+        createDataverseResponse.prettyPrint();
+        String dataverseAlias = UtilIT.getAliasFromResponse(createDataverseResponse);
+        Integer dataverseId = UtilIT.getDataverseIdFromResponse(createDataverseResponse);
 
-        // Let user #1 try to link their collection #1 into collection #2
-        // This should fail, because user #1 has not been granted permission to link into collection #2
-        Response createDataverseLinkWithoutPermissionResponse = UtilIT.createDataverseLink(dataverse1Alias, dataverse2Alias, apiToken1);
-        createDataverseLinkWithoutPermissionResponse.prettyPrint();
-        createDataverseLinkWithoutPermissionResponse.then().assertThat()
-                .statusCode(UNAUTHORIZED.getStatusCode());
+        Response createDataverseResponse2 = UtilIT.createRandomDataverse(apiToken);
+        createDataverseResponse2.prettyPrint();
+        String dataverseAlias2 = UtilIT.getAliasFromResponse(createDataverseResponse2);
+        Integer dataverseId2 = UtilIT.getDataverseIdFromResponse(createDataverseResponse2);
 
-        // Let user #2 grant user #1 admin access for collection #2
-        // (The admin role is the only preconfigured role which includes the "Link Dataverse" permission)
-        Response grantUser2AccessOnDataverse1 = UtilIT.grantRoleOnDataverse(dataverse2Alias, "admin", "@" + username1, apiToken2);
-        grantUser2AccessOnDataverse1.prettyPrint();
-        grantUser2AccessOnDataverse1.then().assertThat()
-                .statusCode(OK.getStatusCode());
+        Response createLinkingDataverseResponse = UtilIT.createDataverseLink(dataverseAlias, dataverseAlias2, apiToken);
+        createLinkingDataverseResponse.prettyPrint();
+        createLinkingDataverseResponse.then().assertThat()
+                .statusCode(OK.getStatusCode())
+                .body("data.message", equalTo("Dataverse " + dataverseAlias + " linked successfully to " + dataverseAlias2));
 
-        // Let user #1 try again
-        // Now that they have access, this should succeed
-        Response tryLinkingAgain = UtilIT.createDataverseLink(dataverse1Alias, dataverse2Alias, apiToken1);
+        Response tryLinkingAgain = UtilIT.createDataverseLink(dataverseAlias, dataverseAlias2, apiToken);
         tryLinkingAgain.prettyPrint();
         tryLinkingAgain.then().assertThat()
-                .statusCode(OK.getStatusCode())
-                .body("data.message", equalTo("Dataverse " + dataverse1Alias + " linked successfully to " + dataverse2Alias));
-
-        // And again, to see if the creation of duplicate links is correctly rejected
-        Response tryLinkingAgainAndAgain = UtilIT.createDataverseLink(dataverse1Alias, dataverse2Alias, apiToken1);
-        tryLinkingAgainAndAgain.prettyPrint();
-        tryLinkingAgainAndAgain.then().assertThat()
                 .statusCode(FORBIDDEN.getStatusCode())
-                .body("message", equalTo(dataverse1Alias + " has already been linked to " + dataverse2Alias + "."));
+                .body("message", equalTo(dataverseAlias + " has already been linked to " + dataverseAlias2 + "."));
 
-        // Make user #1 superuser because it's required to list a collection's links
-        UtilIT.setSuperuserStatus(username1, true);
-
-        Response getLinksResponse = UtilIT.getDataverseLinks(dataverse1Alias, apiToken1);
+        Response getLinksResponse = UtilIT.getDataverseLinks(dataverseAlias, apiToken);
         getLinksResponse.prettyPrint();
         getLinksResponse.then().assertThat()
                 .statusCode(OK.getStatusCode())
-                .body("data.dataversesLinkingToThis[0].id", equalTo(dataverse2Id))
-                .body("data.dataversesLinkingToThis[0].alias", equalTo(dataverse2Alias))
-                .body("data.dataversesLinkingToThis[0].displayName", equalTo(dataverse2Alias));
-        getLinksResponse = UtilIT.getDataverseLinks(dataverse2Alias, apiToken1);
+                .body("data.dataversesLinkingToThis[0].id", equalTo(dataverseId2))
+                .body("data.dataversesLinkingToThis[0].alias", equalTo(dataverseAlias2))
+                .body("data.dataversesLinkingToThis[0].displayName", equalTo(dataverseAlias2));
+        getLinksResponse = UtilIT.getDataverseLinks(dataverseAlias2, apiToken);
         getLinksResponse.prettyPrint();
         getLinksResponse.then().assertThat()
                 .statusCode(OK.getStatusCode())
-                .body("data.linkedDataverses[0].id", equalTo(dataverse1Id))
-                .body("data.linkedDataverses[0].alias", equalTo(dataverse1Alias))
-                .body("data.linkedDataverses[0].displayName", equalTo(dataverse1Alias));
+                .body("data.linkedDataverses[0].id", equalTo(dataverseId))
+                .body("data.linkedDataverses[0].alias", equalTo(dataverseAlias))
+                .body("data.linkedDataverses[0].displayName", equalTo(dataverseAlias));
 
-        // Undo superuser status to test that it's not required for deleting a link
-        UtilIT.setSuperuserStatus(username1, false);
-
-        Response deleteLinkingDataverseResponse = UtilIT.deleteDataverseLink(dataverse1Alias, dataverse2Alias, apiToken1);
+        Response deleteLinkingDataverseResponse = UtilIT.deleteDataverseLink(dataverseAlias, dataverseAlias2, apiToken);
         deleteLinkingDataverseResponse.prettyPrint();
         deleteLinkingDataverseResponse.then().assertThat()
                 .statusCode(OK.getStatusCode())
-                .body("data.message", equalTo("Link from Dataverse " + dataverse2Alias + " to linked Dataverse " + dataverse1Alias + " deleted"));
+                .body("data.message", equalTo("Link from Dataverse " + dataverseAlias + " to linked Dataverse " + dataverseAlias2 + " deleted"));
     }
 
     @Test


### PR DESCRIPTION
**What this PR does / why we need it**:

Collection operations especially are crazy slow. See #12672.

This PR reverts the following PR:

- #12250

**Which issue(s) this PR closes**:

- Closes #12672

**Special notes for your reviewer**:

I wasn't able to use the revert button...

<img width="1403" height="1150" alt="Screenshot 2026-09-09 at 9 48 34 AM" src="https://github.com/user-attachments/assets/7fbcec31-ca36-4c40-a87c-ed6679e93c4a" />

... so I asked Codex/ChatGPT to make a branch for me (I renamed the branch and rebased it):

<img width="838" height="540" alt="Screenshot 2026-09-09 at 10 25 49 AM" src="https://github.com/user-attachments/assets/d316b591-2aeb-49f6-8621-5251c4ee4262" />

Thank you to @youseihuayu-wonderful who suggested looking at this PR! This is what she had to say:

<img width="1023" height="1074" alt="Screenshot 2026-09-09 at 9 53 59 AM" src="https://github.com/user-attachments/assets/095c5af2-c01c-46d6-a3b1-32b3556a0f79" />

**Suggestions on how to test this**:

I have already deployed this PR/branch to the QA server. I would suggest testing the steps in #12672 there.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No, the PR being reverted didn't change the UI so this PR doesn't either.

**Is there a release notes update needed for this change?**:

No, once this is merged, I'll fix the release notes to take this feature out.

**Additional documentation**:

None.