### PR TITLE
Cache and bound the collection page link check #12672

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DataversePage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DataversePage.java
@@ -144,6 +144,9 @@ public class DataversePage implements java.io.Serializable {
     private DualListModel<DatasetFieldType> facets = new DualListModel<>(new ArrayList<>(), new ArrayList<>());
     private DualListModel<Dataverse> featuredDataverses = new DualListModel<>(new ArrayList<>(), new ArrayList<>());
     private List<Dataverse> dataversesForLinking;
+    // Depends only on the user's role assignments and on which collection this view is showing, so
+    // it is computed once per view; setDataverse clears it.
+    private Boolean showLinkingPopup;
     private Long linkingDataverseId;
     private List<SelectItem> linkingDVSelectItems;
     private Dataverse linkingDataverse;
@@ -214,7 +217,20 @@ public class DataversePage implements java.io.Serializable {
         this.linkMode = linkMode;
     }
     
+    /**
+     * Rendered from the page (twice), so it is evaluated repeatedly per request: the answer is
+     * cached for the view, and the underlying lookups are bounded. Both matter - computing this
+     * from the full list of permitted collections meant a scan of the dataverse table, and an
+     * entity per row, on every evaluation.
+     */
     public boolean showLinkingPopup() {
+        if (showLinkingPopup == null) {
+            showLinkingPopup = computeShowLinkingPopup();
+        }
+        return showLinkingPopup;
+    }
+
+    private boolean computeShowLinkingPopup() {
         // Must be logged in
         AuthenticatedUser au = getAuthenticatedUser();
         if (au == null) {
@@ -223,23 +239,26 @@ public class DataversePage implements java.io.Serializable {
         if (dataverse == null) {
             return false;
         }
+        var request = dvRequestService.getDataverseRequest();
 
         // If there is an active search query, that's all that matters (plus having permission on ANY collection)
         if (query != null && !query.isEmpty()) {
-            List<Dataverse> permitted = permissionService.findPermittedCollections(dvRequestService.getDataverseRequest(), au, Permission.LinkDataverse);
-            return permitted != null && !permitted.isEmpty();
+            return !permissionService.findSomePermittedCollections(request, au, Permission.LinkDataverse, 1).isEmpty();
         }
 
         // Otherwise (no active search), check if there is at least one OTHER eligible collection
         // Eligible means: not the current collection and not in the parent tree
         // Technically, eligible also means "not already linked", but in that case, we show the Link button anyway and have the Link dialog display a message about all eligible collections already being linked
-        List<Dataverse> dvsWithLinkPermission = permissionService.findPermittedCollections(dvRequestService.getDataverseRequest(), au, Permission.LinkDataverse);
-        if (dvsWithLinkPermission != null && !dvsWithLinkPermission.isEmpty()) {
-            List<Dataverse> eligibleDataverses = dataverseService.removeUnlinkableDataverses(dvsWithLinkPermission, dataverse, false);
-            return !eligibleDataverses.isEmpty();
+        // The current collection and its parent tree are the only collections removeUnlinkableDataverses
+        // can drop here, so one candidate more than that tree is enough to tell whether any eligible
+        // collection exists: if every candidate were dropped, the whole tree would be accounted for and
+        // the extra one could not have been.
+        int candidatesNeeded = 2; // the current collection, plus the one that would make the answer yes
+        for (DvObject owner = dataverse.getOwner(); owner != null; owner = owner.getOwner()) {
+            candidatesNeeded++;
         }
-
-        return false;
+        List<Dataverse> candidates = permissionService.findSomePermittedCollections(request, au, Permission.LinkDataverse, candidatesNeeded);
+        return !dataverseService.removeUnlinkableDataverses(candidates, dataverse, false).isEmpty();
     }
     
     public void setupLinkingPopup (String popupSetting){
@@ -288,6 +307,7 @@ public class DataversePage implements java.io.Serializable {
 
     public void setDataverse(Dataverse dataverse) {
         this.dataverse = dataverse;
+        this.showLinkingPopup = null;
     }
     
     public Long getId() { return this.id; }

--- a/src/main/java/edu/harvard/iq/dataverse/PermissionServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/PermissionServiceBean.java
@@ -970,6 +970,20 @@ public class PermissionServiceBean {
         return null;
     }
 
+    /**
+     * At most {@code limit} of the collections the user has the permission on, in no particular
+     * order. Callers that only need to know whether such a collection exists must use this instead
+     * of {@link #findPermittedCollections(DataverseRequest, AuthenticatedUser, Permission)}, which
+     * materializes an entity per row and, for a superuser, returns the whole dataverse table.
+     */
+    public List<Dataverse> findSomePermittedCollections(DataverseRequest request, AuthenticatedUser user, Permission permission, int limit) {
+        if (user == null || limit < 1) {
+            return new ArrayList<>();
+        }
+        var sqlCode = getBaseQueryForAllPermittedDataverses(request, user, 1 << permission.ordinal()) + " LIMIT " + limit;
+        return em.createNativeQuery(sqlCode, Dataverse.class).getResultList();
+    }
+
     public boolean hasMultiplePermittedCollections(DataverseRequest request, AuthenticatedUser user, int permissionBit) {
         if (user != null) {
             var sqlCode = getBaseQueryForAllPermittedDataverses(request, user, permissionBit) + " LIMIT 2";


### PR DESCRIPTION
**What this PR does / why we need it**:

Makes the collection page's Link button check cheap again. `DataversePage.showLinkingPopup()` is bound to `rendered=` in two places in `dataverse.xhtml`, so it is evaluated repeatedly per request, and it computed its answer from the full list of collections the user may link — for a superuser, `SELECT id, name, alias FROM DATAVERSE` with an entity per row. That is a sequential scan of the dataverse table several times per collection page load, for logged-in users only, which is what made qa.dataverse.org unusable (#12672).

Two changes, no behavior change:

- `showLinkingPopup()` memoizes into a `Boolean` field, cleared by `setDataverse`. Same pattern `DatasetPage` already uses for its own `showLinkingPopup` field and for `hasDataversesToChoose`.
- New `PermissionServiceBean.findSomePermittedCollections(..., limit)` appends `LIMIT n` to the same base SQL, as the existing `hasMultiplePermittedCollections` does with `LIMIT 2`. The existence check asks for 1 row; the eligibility check asks for `2 + ancestorCount`. The current collection and its parent tree are the only collections `removeUnlinkableDataverses` can drop here, so one candidate beyond that tree decides the question: fewer rows than the limit means we have the complete set and filter exactly; a full limit means at least one row falls outside the exclusion set.

**Which issue(s) this PR closes**:

- Closes #12672

**Special notes for your reviewer**:

This is the alternative to reverting #12250 (#12674). If the revert lands first, this needs rebasing onto the re-land rather than onto develop.

Deliberately unchanged: the `query != null` branch is dead code (`DataversePage.query` is never assigned — the collection page's search query lives on `SearchIncludeFragment.query`), but rewiring it would change who sees the Link button, so it is left alone. Worth a follow-up issue.

Also left alone: `updateLinkableDataverses()` still fetches the full list, but it only runs when someone opens the Link dialog and it needs every row for the dropdown. It was unbounded before #12250 too (`findAll()`), so it is not part of this regression.

Two things this does not fix, both worth their own issues: the superuser branch of `findPermittedCollections` is still an unbounded scan for its four remaining callers (all API/action paths, none per-render), and it selects three columns while mapping to `Dataverse.class`, which someone should check in a SQL log for per-row fetches.

**Suggestions on how to test this**:

Log in as a superuser and load a collection page, including the root collection. It should be as fast as it is when logged out. The Link button should still appear when you have `LinkDataverse` on some other collection and not when you do not, and the Link dialog should still list the same collections. `pg_stat_statements` should no longer show `FROM DATAVERSE dv` accumulating calls per page render.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No.

**Is there a release notes update needed for this change?**:

No — #12250 is unreleased, so this is a fix within the same cycle.

**Additional documentation**:

None.
