### PR TITLE
IQSS/12679 - fix page refresh

### DIFF
--- a/src/main/webapp/dataset.xhtml
+++ b/src/main/webapp/dataset.xhtml
@@ -955,7 +955,7 @@
                     <!-- View/Tabs infoMode -->
                     <div id="contentTabs" jsf:rendered="#{DatasetPage.editMode != 'INFO'}">
                         <p:fragment id="pageRefreshFragment"> <!-- rendered="_{empty DatasetPage.editMode}" -->
-                            <h:inputHidden value="#{lockedForAnyReason}" id="datasetLockedForAnyReasonVariable" />
+                            <h:inputHidden value="#{DatasetPage.lockedForAnyReason}" id="datasetLockedForAnyReasonVariable" />
                             <h:inputHidden value="#{DatasetPage.stateChanged}" id="datasetStateChangedVariable" />
                             <p:remoteCommand name="refreshAllLocksCommand" process="@this" update=":#{p:resolveClientId('datasetForm:pageRefreshFragment', view)},:messagePanel" actionListener="#{DatasetPage.refreshAllLocks()}"/>
                             <p:remoteCommand name="refreshAllCommand" process="@this" update=":datasetForm:topDatasetBlockFragment,:datasetForm:tabView:filesTable,:messagePanel" action="#{DatasetPage.refresh()}"/>


### PR DESCRIPTION
**What this PR does / why we need it**: Changes in an earlier PR accidentally block the lockedForAnyReason check that is used in determining when the page needs to refresh, i.e. to update once publishing is complete. This PR fixes the issue.

**Which issue(s) this PR closes**:

- Closes #12679

**Special notes for your reviewer**: Wasn't noticed since jsf doesn't complain when something is undefined.

**Suggestions on how to test this**: Per the issue - publish/edit etc and make sure the page refreshes at the end.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
