### PR TITLE
Fix double-escaped directApiCall URL in OAI-PMH metadata

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/harvest/server/xoai/DataverseXoaiItemRepository.java
+++ b/src/main/java/edu/harvard/iq/dataverse/harvest/server/xoai/DataverseXoaiItemRepository.java
@@ -262,7 +262,7 @@ public class DataverseXoaiItemRepository implements ItemRepository {
     
     private String customDataverseJsonApiUri(String identifier) {
         String ret = serverUrl  
-                + "/api/datasets/export?exporter=dataverse_json&amp;persistentId="
+                + "/api/datasets/export?exporter=dataverse_json&persistentId="
                 + identifier;
         
         return ret;

--- a/src/test/java/edu/harvard/iq/dataverse/api/HarvestingServerIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/HarvestingServerIT.java
@@ -574,6 +574,18 @@ public class HarvestingServerIT {
         assertEquals("Darwin's finches (also known as the Galápagos finches) are a group of about fifteen species of passerine birds.", 
                 responseXmlPath.getString("OAI-PMH.GetRecord.record.metadata.dc.description"));
         assertEquals("Medicine, Health and Life Sciences", responseXmlPath.getString("OAI-PMH.GetRecord.record.metadata.dc.subject"));
+
+        Response dataverseJsonRecordResponse =
+                UtilIT.getOaiRecord(singleSetDatasetPersistentId, "dataverse_json");
+        assertEquals(OK.getStatusCode(), dataverseJsonRecordResponse.getStatusCode());
+        responseXmlPath = validateOaiVerbResponse(dataverseJsonRecordResponse, "GetRecord");
+        String directApiCall =
+                responseXmlPath.getString(
+                        "OAI-PMH.GetRecord.record.metadata.dataverse_json.@directApiCall");
+        assertTrue(
+                directApiCall.endsWith(
+                        "/api/datasets/export?exporter=dataverse_json&persistentId="
+                                + singleSetDatasetPersistentId));
         
         // ok, looks legit!
         


### PR DESCRIPTION
Fixes #12670

## Summary
- stop pre-escaping the query separator before XOAI serializes the directApiCall XML attribute
- add integration coverage that parses the OAI-PMH response and verifies the resulting export URL

## Verification
- reproduced the regression on Demo Dataverse 6.11: the raw attribute contains &amp;amp;
- compared with a known-good Dataverse 5 deployment: the raw attribute contains &amp;
- git diff --check passes

The full HarvestingServerIT service-stack test was not run locally; the regression assertion is included for project CI.