### PR TITLE
Correction in doc: dataverse.files.default-dataset-file-count-limit

### DIFF
--- a/doc/sphinx-guides/source/installation/config.rst
+++ b/doc/sphinx-guides/source/installation/config.rst
@@ -2756,7 +2756,7 @@ Configure a limit to the maximum number of Datafiles that can be uploaded to a D
 Notes:
 
 - This is a default that can be overwritten in any Dataverse/Collection or Dataset.
-- A value less than 1 will be treated as no limit set.
+- A value less than 0 will be treated as no limit set.
 - Changing this value will not delete any existing files. It is only intended for preventing new files from being uploaded.
 - Superusers will not be governed by this rule.
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Corrects an error in the docs

**Which issue(s) this PR closes**:
None

**Special notes for your reviewer**:
None

**Suggestions on how to test this**:
None

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
None

**Is there a release notes update needed for this change?**:
None

**Additional documentation**:
See: https://github.com/IQSS/dataverse/blob/develop/src/main/java/edu/harvard/iq/dataverse/DvObjectContainer.java#L281

`dataverse.files.default-dataset-file-count-limit` of 0 is considered set, since `0 >= 0`