### PR TITLE
Harden dataset storage cleanup

### DIFF
--- a/doc/release-notes/harden-clean-storage.md
+++ b/doc/release-notes/harden-clean-storage.md
@@ -1,0 +1,8 @@
+The dataset storage cleanup call is now `PUT /api/datasets/{id}/cleanStorage`. It was a `GET`, which meant anything that follows links (browser prefetch, link previews in chat and mail clients, crawlers, or revisiting the URL from history) could trigger a deletion.
+
+Two further changes make it safer:
+
+- `dryrun` now defaults to `true`. Omitting it reports what would be removed instead of removing it. Pass `dryrun=false` to actually delete.
+- Storage objects modified more recently than `dataverse.files.clean-storage-min-age-days` (7 by default) are never removed. An upload is written to the dataset's storage location before Dataverse registers it as a file, so without a grace period a completed upload still waiting to be saved was indistinguishable from an abandoned one and could be deleted. Raise the setting if uploads in your installation stay unregistered for longer than a week.
+
+Scripts calling this endpoint need to switch to `PUT` and, if they relied on the old default to delete, to pass `dryrun=false` explicitly.

--- a/doc/sphinx-guides/source/api/native-api.rst
+++ b/doc/sphinx-guides/source/api/native-api.rst
@@ -3462,8 +3462,14 @@ Cleanup Storage of a Dataset
 
 This is an experimental feature and should be tested on your system before using it in production.
 Also, make sure that your backups are up-to-date before using this on production servers.
-It is advised to first call this method with the ``dryrun`` parameter set to ``true`` before actually deleting the files.
-This will allow you to manually inspect the files that would be deleted if that parameter is set to ``false`` or is omitted (a list of the files that would be deleted is provided in the response).
+This call only reports what it would remove unless ``dryrun`` is explicitly set to ``false``. Omitting the parameter is
+the same as setting it to ``true``, so inspecting the reported list is always the default (a list of the files that would
+be deleted is provided in the response).
+
+Storage objects that were modified more recently than ``dataverse.files.clean-storage-min-age-days`` (7 by default) are
+never removed. An upload writes its object to the dataset's storage location before Dataverse registers it as a file, so
+without that grace period a completed upload waiting to be saved would look the same as an abandoned one. Raise the
+setting if your workflows leave uploads unregistered for longer than a week.
 
 If your Dataverse installation has been configured to support direct uploads, or in some other situations,
 you could end up with some files in the storage of a dataset that are not linked to that dataset directly. Most commonly, this could
@@ -3479,13 +3485,13 @@ All the files stored in the Dataset storage location that are not in the file li
   export PERSISTENT_ID=doi:10.5072/FK2/J8SJZB
   export DRYRUN=true
 
-  curl -H "X-Dataverse-key: $API_TOKEN" -X GET "$SERVER_URL/api/datasets/:persistentId/cleanStorage?persistentId=$PERSISTENT_ID&dryrun=$DRYRUN"
+  curl -H "X-Dataverse-key: $API_TOKEN" -X PUT "$SERVER_URL/api/datasets/:persistentId/cleanStorage?persistentId=$PERSISTENT_ID&dryrun=$DRYRUN"
 
 The fully expanded example above (without environment variables) looks like this:
 
 .. code-block:: bash
 
-  curl -H "X-Dataverse-key: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" -X GET "https://demo.dataverse.org/api/datasets/:persistentId/cleanStorage?persistentId=doi:10.5072/FK2/J8SJZB&dryrun=true"
+  curl -H "X-Dataverse-key: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" -X PUT "https://demo.dataverse.org/api/datasets/:persistentId/cleanStorage?persistentId=doi:10.5072/FK2/J8SJZB&dryrun=true"
 
 Adding Files To a Dataset via Other Tools
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/main/java/edu/harvard/iq/dataverse/api/Admin.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Admin.java
@@ -68,6 +68,7 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import static edu.harvard.iq.dataverse.util.json.NullSafeJsonBuilder.jsonObjectBuilder;
 
+import java.time.Duration;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
@@ -2957,7 +2958,8 @@ public class Admin extends AbstractApiBean {
             try {
                 Predicate<String> filter = s -> true;
                 StorageIO<DvObject> datasetIO = DataAccess.getStorageIO(dataset);
-                final List<String> result = datasetIO.cleanUp(filter, true);
+                // Auditing lists everything, so no minimum age applies here.
+                final List<String> result = datasetIO.cleanUp(filter, Duration.ZERO, true);
                 // add files that are in dataset files but not in cleanup result or DataFiles with missing FileMetadata
                 dataset.getFiles().forEach(df -> {
                     try {

--- a/src/main/java/edu/harvard/iq/dataverse/api/Admin.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Admin.java
@@ -2958,8 +2958,9 @@ public class Admin extends AbstractApiBean {
             try {
                 Predicate<String> filter = s -> true;
                 StorageIO<DvObject> datasetIO = DataAccess.getStorageIO(dataset);
-                // Auditing lists everything, so no minimum age applies here.
-                final List<String> result = datasetIO.cleanUp(filter, Duration.ZERO, true);
+                // Auditing lists everything, so no minimum age applies here. The
+                // listing is not used; the call is kept for its existence checks.
+                datasetIO.cleanUp(filter, Duration.ZERO, true);
                 // add files that are in dataset files but not in cleanup result or DataFiles with missing FileMetadata
                 dataset.getFiles().forEach(df -> {
                     try {

--- a/src/main/java/edu/harvard/iq/dataverse/api/Datasets.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Datasets.java
@@ -97,6 +97,7 @@ import java.nio.charset.StandardCharsets;
 import java.sql.Timestamp;
 import java.text.MessageFormat;
 import java.text.SimpleDateFormat;
+import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -3410,11 +3411,14 @@ public class Datasets extends AbstractApiBean {
      * @param idSupplied
      * @return
      */
-    @GET
+    @PUT
     @AuthRequired
     @Path("{id}/cleanStorage")
     @Operation(summary = "Cleans dataset storage",
-            description = "Finds and optionally deletes storage objects that are no longer referenced by files in a dataset.")
+            description = "Finds and optionally deletes storage objects that are no longer referenced by files in a dataset. "
+                    + "Reports without deleting unless dryrun is explicitly set to false. Objects modified more recently than "
+                    + "dataverse.files.clean-storage-min-age-days are never removed, so that an upload which has completed but "
+                    + "has not been registered yet is not mistaken for an abandoned one.")
     public Response cleanStorage(@Context ContainerRequestContext crc, @Parameter(description = "Resource id or persistent identifier.") @PathParam("id") String idSupplied, @Parameter(description = "Whether to validate the request without applying changes.") @QueryParam("dryrun") Boolean dryrun) {
         // get user and dataset
         User authUser = getRequestUser(crc);
@@ -3428,10 +3432,11 @@ public class Datasets extends AbstractApiBean {
 
         // check permissions
         if (!permissionSvc.permissionsFor(req, dataset).contains(Permission.EditDataset)) {
-            return error(Response.Status.INTERNAL_SERVER_ERROR, "Access denied!");
+            return error(Response.Status.FORBIDDEN, "Access denied!");
         }
 
-        boolean doDryRun = dryrun != null && dryrun.booleanValue();
+        // Reporting is the default: deleting requires asking for it explicitly.
+        boolean doDryRun = dryrun == null || dryrun.booleanValue();
 
         // check if no legacy files are present
         Set<String> datasetFilenames = getDatasetFilenames(dataset);
@@ -3443,7 +3448,7 @@ public class Datasets extends AbstractApiBean {
         List<String> deleted;
         try {
             StorageIO<DvObject> datasetIO = DataAccess.getStorageIO(dataset);
-            deleted = datasetIO.cleanUp(filter, doDryRun);
+            deleted = datasetIO.cleanUp(filter, getCleanStorageMinimumAge(), doDryRun);
         } catch (IOException ex) {
             logger.log(Level.SEVERE, null, ex);
             return error(Response.Status.INTERNAL_SERVER_ERROR, "IOException! Serious Error! See administrator!");
@@ -3497,6 +3502,10 @@ public class Datasets extends AbstractApiBean {
                 return wr.getResponse();
             }
         }, getRequestUser(crc));
+    }
+
+    private static Duration getCleanStorageMinimumAge() {
+        return Duration.ofDays(JvmSettings.CLEAN_STORAGE_MIN_AGE_DAYS.lookup(Integer.class));
     }
 
     private static Set<String> getDatasetFilenames(Dataset dataset) {

--- a/src/main/java/edu/harvard/iq/dataverse/dataaccess/AbstractRemoteOverlayAccessIO.java
+++ b/src/main/java/edu/harvard/iq/dataverse/dataaccess/AbstractRemoteOverlayAccessIO.java
@@ -9,6 +9,7 @@ import java.nio.file.Path;
 import java.security.KeyManagementException;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
 import java.util.List;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
@@ -213,8 +214,8 @@ public abstract class AbstractRemoteOverlayAccessIO<T extends DvObject> extends 
     }
 
     @Override
-    public List<String> cleanUp(Predicate<String> filter, boolean dryRun) throws IOException {
-        return baseStore.cleanUp(filter, dryRun);
+    public List<String> cleanUp(Predicate<String> filter, Duration minimumAge, boolean dryRun) throws IOException {
+        return baseStore.cleanUp(filter, minimumAge, dryRun);
     }
     
     @Override

--- a/src/main/java/edu/harvard/iq/dataverse/dataaccess/FileAccessIO.java
+++ b/src/main/java/edu/harvard/iq/dataverse/dataaccess/FileAccessIO.java
@@ -32,7 +32,11 @@ import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -676,7 +680,7 @@ public class FileAccessIO<T extends DvObject> extends StorageIO<T> {
         return true;
     }
 
-    private List<String> listAllFiles() throws IOException {
+    private Map<String, Instant> listAllFiles() throws IOException {
         Dataset dataset = this.getDataset();
         if (dataset == null) {
             throw new IOException("This FileAccessIO object hasn't been properly initialized.");
@@ -689,10 +693,17 @@ public class FileAccessIO<T extends DvObject> extends StorageIO<T> {
 
         DirectoryStream<Path> dirStream = Files.newDirectoryStream(Paths.get(this.getFilesRootDirectory(), datasetDirectoryPath.toString()));
         
-        List<String> res = new ArrayList<>();
+        Map<String, Instant> res = new HashMap<>();
         if (dirStream != null) {
             for (Path filePath : dirStream) {
-                res.add(filePath.getFileName().toString());
+                Instant lastModified;
+                try {
+                    lastModified = Files.getLastModifiedTime(filePath).toInstant();
+                } catch (IOException ex) {
+                    // Unknown age is treated as too recent to remove.
+                    lastModified = null;
+                }
+                res.put(filePath.getFileName().toString(), lastModified);
             }
             dirStream.close();
         }
@@ -716,8 +727,11 @@ public class FileAccessIO<T extends DvObject> extends StorageIO<T> {
     }
 
     @Override
-    public List<String> cleanUp(Predicate<String> filter, boolean dryRun) throws IOException {
-        List<String> toDelete = this.listAllFiles().stream().filter(filter).collect(Collectors.toList());
+    public List<String> cleanUp(Predicate<String> filter, Duration minimumAge, boolean dryRun) throws IOException {
+        List<String> toDelete = this.listAllFiles().entrySet().stream()
+                .filter(e -> filter.test(e.getKey()) && isOlderThan(e.getValue(), minimumAge))
+                .map(Map.Entry::getKey)
+                .collect(Collectors.toList());
         if (dryRun) {
             return toDelete;
         }

--- a/src/main/java/edu/harvard/iq/dataverse/dataaccess/FileAccessIO.java
+++ b/src/main/java/edu/harvard/iq/dataverse/dataaccess/FileAccessIO.java
@@ -39,7 +39,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
 
 // Dataverse imports:
 import edu.harvard.iq.dataverse.DataFile;
@@ -728,10 +727,7 @@ public class FileAccessIO<T extends DvObject> extends StorageIO<T> {
 
     @Override
     public List<String> cleanUp(Predicate<String> filter, Duration minimumAge, boolean dryRun) throws IOException {
-        List<String> toDelete = this.listAllFiles().entrySet().stream()
-                .filter(e -> filter.test(e.getKey()) && isOlderThan(e.getValue(), minimumAge))
-                .map(Map.Entry::getKey)
-                .collect(Collectors.toList());
+        List<String> toDelete = selectForCleanUp(this.listAllFiles(), filter, minimumAge);
         if (dryRun) {
             return toDelete;
         }

--- a/src/main/java/edu/harvard/iq/dataverse/dataaccess/InputStreamIO.java
+++ b/src/main/java/edu/harvard/iq/dataverse/dataaccess/InputStreamIO.java
@@ -13,6 +13,7 @@ import java.nio.channels.Channel;
 import java.nio.channels.Channels;
 import java.nio.channels.WritableByteChannel;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.List;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
@@ -161,7 +162,7 @@ public class InputStreamIO extends StorageIO<DataFile> {
     }
 
     @Override
-    public List<String> cleanUp(Predicate<String> filter, boolean dryRun) throws IOException {
+    public List<String> cleanUp(Predicate<String> filter, Duration minimumAge, boolean dryRun) throws IOException {
         throw new UnsupportedDataAccessOperationException("InputStreamIO: tthis method is not supported in this DataAccess driver.");
     }
 

--- a/src/main/java/edu/harvard/iq/dataverse/dataaccess/S3AccessIO.java
+++ b/src/main/java/edu/harvard/iq/dataverse/dataaccess/S3AccessIO.java
@@ -56,6 +56,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -1517,7 +1519,7 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
         return true;
     }
 
-    private List<String> listAllFiles() throws IOException {
+    private Map<String, Instant> listAllFiles() throws IOException {
         if (!this.canWrite()) {
             open();
         }
@@ -1527,7 +1529,7 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
         }
         String prefix = dataset.getAuthorityForFileStorage() + "/" + dataset.getIdentifierForFileStorage() + "/";
 
-        List<String> ret = new ArrayList<>();
+        Map<String, Instant> ret = new HashMap<>();
         ListObjectsV2Request listObjectsReqManual = ListObjectsV2Request.builder().bucket(bucketName).prefix(prefix)
                 .build();
 
@@ -1571,7 +1573,7 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
 
         for (S3Object item : storedFilesSummary) {
             String fileName = item.key().substring(prefix.length());
-            ret.add(fileName);
+            ret.put(fileName, item.lastModified());
         }
         return ret;
     }
@@ -1623,8 +1625,11 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
     }
 
     @Override
-    public List<String> cleanUp(Predicate<String> filter, boolean dryRun) throws IOException {
-        List<String> toDelete = this.listAllFiles().stream().filter(filter).collect(Collectors.toList());
+    public List<String> cleanUp(Predicate<String> filter, Duration minimumAge, boolean dryRun) throws IOException {
+        List<String> toDelete = this.listAllFiles().entrySet().stream()
+                .filter(e -> filter.test(e.getKey()) && isOlderThan(e.getValue(), minimumAge))
+                .map(Map.Entry::getKey)
+                .collect(Collectors.toList());
         if (dryRun) {
             return toDelete;
         }

--- a/src/main/java/edu/harvard/iq/dataverse/dataaccess/S3AccessIO.java
+++ b/src/main/java/edu/harvard/iq/dataverse/dataaccess/S3AccessIO.java
@@ -1626,10 +1626,7 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
 
     @Override
     public List<String> cleanUp(Predicate<String> filter, Duration minimumAge, boolean dryRun) throws IOException {
-        List<String> toDelete = this.listAllFiles().entrySet().stream()
-                .filter(e -> filter.test(e.getKey()) && isOlderThan(e.getValue(), minimumAge))
-                .map(Map.Entry::getKey)
-                .collect(Collectors.toList());
+        List<String> toDelete = selectForCleanUp(this.listAllFiles(), filter, minimumAge);
         if (dryRun) {
             return toDelete;
         }

--- a/src/main/java/edu/harvard/iq/dataverse/dataaccess/StorageIO.java
+++ b/src/main/java/edu/harvard/iq/dataverse/dataaccess/StorageIO.java
@@ -658,6 +658,21 @@ public abstract class StorageIO<T extends DvObject> {
      * An unknown timestamp is treated as too recent, so that a storage backend which
      * cannot report one never causes a deletion.
      */
+    /**
+     * The stored objects that {@code filter} selects and that are old enough to
+     * remove. Shared by the storage backends so the selection rule has one
+     * definition.
+     *
+     * @param stored object names mapped to their last modification time
+     */
+    protected static List<String> selectForCleanUp(Map<String, Instant> stored, Predicate<String> filter,
+                                                   Duration minimumAge) {
+        return stored.entrySet().stream()
+                .filter(e -> filter.test(e.getKey()) && isOlderThan(e.getValue(), minimumAge))
+                .map(Map.Entry::getKey)
+                .toList();
+    }
+
     protected static boolean isOlderThan(Instant lastModified, Duration minimumAge) {
         if (lastModified == null) {
             return false;

--- a/src/main/java/edu/harvard/iq/dataverse/dataaccess/StorageIO.java
+++ b/src/main/java/edu/harvard/iq/dataverse/dataaccess/StorageIO.java
@@ -654,11 +654,6 @@ public abstract class StorageIO<T extends DvObject> {
     public abstract List<String> cleanUp(Predicate<String> filter, Duration minimumAge, boolean dryRun) throws IOException;
 
     /**
-     * Whether an object last modified at {@code lastModified} is old enough to remove.
-     * An unknown timestamp is treated as too recent, so that a storage backend which
-     * cannot report one never causes a deletion.
-     */
-    /**
      * The stored objects that {@code filter} selects and that are old enough to
      * remove. Shared by the storage backends so the selection rule has one
      * definition.
@@ -673,6 +668,11 @@ public abstract class StorageIO<T extends DvObject> {
                 .toList();
     }
 
+    /**
+     * Whether an object last modified at {@code lastModified} is old enough to remove.
+     * An unknown timestamp is treated as too recent, so that a storage backend which
+     * cannot report one never causes a deletion.
+     */
     protected static boolean isOlderThan(Instant lastModified, Duration minimumAge) {
         if (lastModified == null) {
             return false;

--- a/src/main/java/edu/harvard/iq/dataverse/dataaccess/StorageIO.java
+++ b/src/main/java/edu/harvard/iq/dataverse/dataaccess/StorageIO.java
@@ -36,6 +36,8 @@ import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
 import java.nio.file.Path;
 import java.util.HashMap;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -641,7 +643,27 @@ public abstract class StorageIO<T extends DvObject> {
         return m.find();
     }
 
-    public abstract List<String> cleanUp(Predicate<String> filter, boolean dryRun) throws IOException;
+    /**
+     * Deletes stored objects that {@code filter} selects and that have not been modified
+     * for at least {@code minimumAge}.
+     *
+     * @param filter selects objects by name, typically those no longer referenced by the dataset
+     * @param minimumAge how long an object must have been untouched before it can be removed
+     * @param dryRun when true, report what would be removed without removing anything
+     */
+    public abstract List<String> cleanUp(Predicate<String> filter, Duration minimumAge, boolean dryRun) throws IOException;
+
+    /**
+     * Whether an object last modified at {@code lastModified} is old enough to remove.
+     * An unknown timestamp is treated as too recent, so that a storage backend which
+     * cannot report one never causes a deletion.
+     */
+    protected static boolean isOlderThan(Instant lastModified, Duration minimumAge) {
+        if (lastModified == null) {
+            return false;
+        }
+        return lastModified.isBefore(Instant.now().minus(minimumAge));
+    }
 
     /**
      * A storage-type-specific mechanism for retrieving the size of a file. Intended

--- a/src/main/java/edu/harvard/iq/dataverse/dataaccess/SwiftAccessIO.java
+++ b/src/main/java/edu/harvard/iq/dataverse/dataaccess/SwiftAccessIO.java
@@ -93,7 +93,8 @@ public class SwiftAccessIO<T extends DvObject> extends StorageIO<T> {
 
 	private Account account = null;
     private StoredObject swiftFileObject = null;
-    private Container swiftContainer = null;
+    // Package-private so the cleanup tests can supply a container.
+    Container swiftContainer = null;
     private boolean isPublicContainer = true;
     private String swiftFolderPathSeparator = "_";
     private String swiftDefaultEndpoint = null;

--- a/src/main/java/edu/harvard/iq/dataverse/dataaccess/SwiftAccessIO.java
+++ b/src/main/java/edu/harvard/iq/dataverse/dataaccess/SwiftAccessIO.java
@@ -19,6 +19,10 @@ import java.security.NoSuchAlgorithmException;
 import java.security.SignatureException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Formatter;
 import java.util.List;
 import java.util.Properties;
@@ -912,7 +916,7 @@ public class SwiftAccessIO<T extends DvObject> extends StorageIO<T> {
         return toHexString(mac.doFinal(data.getBytes()));
     }
 
-    private List<String> listAllFiles() throws IOException {
+    private Map<String, Instant> listAllFiles() throws IOException {
         if (!this.canWrite()) {
             open(DataAccessOption.WRITE_ACCESS);
         }
@@ -924,12 +928,19 @@ public class SwiftAccessIO<T extends DvObject> extends StorageIO<T> {
         
         Collection<StoredObject> items; 
         String lastItemName = null; 
-        List<String> ret = new ArrayList<>();
+        Map<String, Instant> ret = new HashMap<>();
 
         while ((items = this.swiftContainer.list(prefix, lastItemName, LIST_PAGE_LIMIT)) != null && items.size() > 0) {
             for (StoredObject item : items) {
                 lastItemName = item.getName().substring(prefix.length());
-                ret.add(lastItemName);
+                Instant lastModified;
+                try {
+                    lastModified = item.getLastModifiedAsDate().toInstant();
+                } catch (RuntimeException ex) {
+                    // Unknown age is treated as too recent to remove.
+                    lastModified = null;
+                }
+                ret.put(lastItemName, lastModified);
             }
         }
 
@@ -956,8 +967,11 @@ public class SwiftAccessIO<T extends DvObject> extends StorageIO<T> {
     }
 
     @Override
-    public List<String> cleanUp(Predicate<String> filter, boolean dryRun) throws IOException {
-        List<String> toDelete = this.listAllFiles().stream().filter(filter).collect(Collectors.toList());
+    public List<String> cleanUp(Predicate<String> filter, Duration minimumAge, boolean dryRun) throws IOException {
+        List<String> toDelete = this.listAllFiles().entrySet().stream()
+                .filter(e -> filter.test(e.getKey()) && isOlderThan(e.getValue(), minimumAge))
+                .map(Map.Entry::getKey)
+                .collect(Collectors.toList());
         if (dryRun) {
             return toDelete;
         }

--- a/src/main/java/edu/harvard/iq/dataverse/dataaccess/SwiftAccessIO.java
+++ b/src/main/java/edu/harvard/iq/dataverse/dataaccess/SwiftAccessIO.java
@@ -93,8 +93,7 @@ public class SwiftAccessIO<T extends DvObject> extends StorageIO<T> {
 
 	private Account account = null;
     private StoredObject swiftFileObject = null;
-    // Package-private so the cleanup tests can supply a container.
-    Container swiftContainer = null;
+    private Container swiftContainer = null;
     private boolean isPublicContainer = true;
     private String swiftFolderPathSeparator = "_";
     private String swiftDefaultEndpoint = null;

--- a/src/main/java/edu/harvard/iq/dataverse/dataaccess/SwiftAccessIO.java
+++ b/src/main/java/edu/harvard/iq/dataverse/dataaccess/SwiftAccessIO.java
@@ -28,7 +28,6 @@ import java.util.List;
 import java.util.Properties;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
 
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
@@ -968,10 +967,7 @@ public class SwiftAccessIO<T extends DvObject> extends StorageIO<T> {
 
     @Override
     public List<String> cleanUp(Predicate<String> filter, Duration minimumAge, boolean dryRun) throws IOException {
-        List<String> toDelete = this.listAllFiles().entrySet().stream()
-                .filter(e -> filter.test(e.getKey()) && isOlderThan(e.getValue(), minimumAge))
-                .map(Map.Entry::getKey)
-                .collect(Collectors.toList());
+        List<String> toDelete = selectForCleanUp(this.listAllFiles(), filter, minimumAge);
         if (dryRun) {
             return toDelete;
         }

--- a/src/main/java/edu/harvard/iq/dataverse/settings/JvmSettings.java
+++ b/src/main/java/edu/harvard/iq/dataverse/settings/JvmSettings.java
@@ -57,6 +57,7 @@ public enum JvmSettings {
     FEATURED_ITEMS_IMAGE_UPLOADS_DIRECTORY(SCOPE_FEATURED_ITEMS, "image-uploads"),
     HIDE_SCHEMA_DOT_ORG_DOWNLOAD_URLS(SCOPE_FILES, "hide-schema-dot-org-download-urls"),
     DEFAULT_DATASET_FILE_COUNT_LIMIT(SCOPE_FILES, "default-dataset-file-count-limit"),
+    CLEAN_STORAGE_MIN_AGE_DAYS(SCOPE_FILES, "clean-storage-min-age-days"),
 
     //STORAGE DRIVER SETTINGS
     SCOPE_DRIVER(SCOPE_FILES),

--- a/src/main/resources/META-INF/microprofile-config.properties
+++ b/src/main/resources/META-INF/microprofile-config.properties
@@ -19,6 +19,9 @@ dataverse.files.directory=${STORAGE_DIR:/tmp/dataverse}
 dataverse.files.uploads=${STORAGE_DIR:${com.sun.aas.instanceRoot}}/uploads
 dataverse.files.docroot=${STORAGE_DIR:${com.sun.aas.instanceRoot}}/docroot
 dataverse.files.globus-cache-maxage=5
+# Storage objects younger than this are left alone by cleanStorage, so that an upload
+# that has finished but has not been registered yet is not mistaken for junk.
+dataverse.files.clean-storage-min-age-days=7
 dataverse.files.featured-items.image-maxsize=1000000
 dataverse.files.featured-items.image-uploads=featuredItems
 

--- a/src/test/java/edu/harvard/iq/dataverse/dataaccess/FileAccessIOTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/dataaccess/FileAccessIOTest.java
@@ -20,6 +20,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.file.Path;
+import java.time.Duration;
+import java.util.function.Predicate;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.commons.io.FileUtils;
@@ -316,5 +318,46 @@ public class FileAccessIOTest {
         System.clearProperty("dataverse.files.filetest.type");
         System.clearProperty("dataverse.files.filetest.label");
         System.clearProperty("dataverse.files.filetest.directory");
+    }
+
+    private File stageOrphan(String name, Duration age) throws IOException {
+        File f = new File("/tmp/files/tmp/dataset/" + name);
+        f.createNewFile();
+        assertTrue(f.setLastModified(System.currentTimeMillis() - age.toMillis()));
+        return f;
+    }
+
+    private static final Predicate<String> ORPHANS = name -> name.startsWith("orphan");
+
+    @Test
+    public void testCleanUp_leavesRecentlyModifiedFilesAlone() throws IOException {
+        File old = stageOrphan("orphan-old", Duration.ofDays(30));
+        File fresh = stageOrphan("orphan-fresh", Duration.ofHours(2));
+
+        List<String> deleted = datasetAccess.cleanUp(ORPHANS, Duration.ofDays(7), false);
+
+        assertEquals(List.of("orphan-old"), deleted);
+        assertFalse(old.exists());
+        assertTrue(fresh.exists(), "an upload that has not been registered yet must survive");
+    }
+
+    @Test
+    public void testCleanUp_dryRunReportsWithoutDeleting() throws IOException {
+        File old = stageOrphan("orphan-old", Duration.ofDays(30));
+
+        List<String> reported = datasetAccess.cleanUp(ORPHANS, Duration.ofDays(7), true);
+
+        assertEquals(List.of("orphan-old"), reported);
+        assertTrue(old.exists(), "a dry run must not delete anything");
+    }
+
+    @Test
+    public void testCleanUp_filterKeepsReferencedFiles() throws IOException {
+        File referenced = stageOrphan("kept-old", Duration.ofDays(30));
+
+        List<String> deleted = datasetAccess.cleanUp(ORPHANS, Duration.ofDays(7), false);
+
+        assertTrue(deleted.isEmpty());
+        assertTrue(referenced.exists());
     }
 }

--- a/src/test/java/edu/harvard/iq/dataverse/dataaccess/S3AccessIOTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/dataaccess/S3AccessIOTest.java
@@ -25,6 +25,15 @@ import static org.mockito.BDDMockito.*;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Predicate;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
+import software.amazon.awssdk.services.s3.model.S3Object;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.STRICT_STUBS)
@@ -128,5 +137,33 @@ public class S3AccessIOTest {
         assertFalse(DataAccess.isValidDirectStorageIdentifier("s3://thebucket:" + FileUtil.generateStorageIdentifier()));
         //bad bucket
         assertFalse(DataAccess.isValidDirectStorageIdentifier("s3test://bucket:" + FileUtil.generateStorageIdentifier()));
+    }
+
+    private static final Predicate<String> ORPHANS = name -> name.startsWith("orphan");
+
+    private S3Object storedObject(String name, Duration age) {
+        String prefix = dataSet.getAuthorityForFileStorage() + "/" + dataSet.getIdentifierForFileStorage() + "/";
+        return S3Object.builder().key(prefix + name).lastModified(Instant.now().minus(age)).build();
+    }
+
+    private void givenBucketContains(S3Object... objects) {
+        given(s3client.listObjectsV2(any(ListObjectsV2Request.class)))
+                .willReturn(CompletableFuture.completedFuture(
+                        ListObjectsV2Response.builder().contents(List.of(objects)).build()));
+    }
+
+    @Test
+    public void testCleanUp_dryRunSkipsRecentlyModifiedObjects() throws IOException {
+        // Skip open(): the injected client is already the one under test.
+        dataSetAccess.isWriteAccess = true;
+        givenBucketContains(
+                storedObject("orphan-old", Duration.ofDays(30)),
+                storedObject("orphan-fresh", Duration.ofHours(2)),
+                storedObject("referenced-old", Duration.ofDays(30)));
+
+        List<String> reported = dataSetAccess.cleanUp(ORPHANS, Duration.ofDays(7), true);
+
+        assertEquals(List.of("orphan-old"), reported);
+        verify(s3client, never()).deleteObject(any(DeleteObjectRequest.class));
     }
 }

--- a/src/test/java/edu/harvard/iq/dataverse/dataaccess/StorageIOCleanUpAgeTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/dataaccess/StorageIOCleanUpAgeTest.java
@@ -4,8 +4,14 @@ import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -49,5 +55,58 @@ class StorageIOCleanUpAgeTest {
     @Test
     void testIsOlderThan_zeroGracePeriodRemovesAnythingWithATimestamp() {
         assertTrue(StorageIO.isOlderThan(Instant.now().minusSeconds(1), Duration.ZERO));
+    }
+
+    private static Map<String, Instant> stored(Object... nameThenAge) {
+        Map<String, Instant> m = new HashMap<>();
+        for (int i = 0; i < nameThenAge.length; i += 2) {
+            Duration age = (Duration) nameThenAge[i + 1];
+            m.put((String) nameThenAge[i], age == null ? null : Instant.now().minus(age));
+        }
+        return m;
+    }
+
+    private static final Predicate<String> ORPHANS = name -> name.startsWith("orphan");
+
+    @Test
+    void testSelectForCleanUp_takesOnlyOldOrphans() {
+        Map<String, Instant> stored = stored(
+                "orphan-old", Duration.ofDays(30),
+                "orphan-fresh", Duration.ofHours(1),
+                "referenced-old", Duration.ofDays(30));
+
+        List<String> selected = StorageIO.selectForCleanUp(stored, ORPHANS, ONE_WEEK);
+
+        assertEquals(List.of("orphan-old"), selected);
+    }
+
+    @Test
+    void testSelectForCleanUp_skipsUnknownTimestamps() {
+        List<String> selected = StorageIO.selectForCleanUp(stored("orphan-a", null), ORPHANS, ONE_WEEK);
+
+        assertTrue(selected.isEmpty());
+    }
+
+    @Test
+    void testSelectForCleanUp_emptyStoreSelectsNothing() {
+        assertTrue(StorageIO.selectForCleanUp(Map.of(), ORPHANS, ONE_WEEK).isEmpty());
+    }
+
+    @Test
+    void testSelectForCleanUp_zeroGraceStillHonoursTheFilter() {
+        Map<String, Instant> stored = stored(
+                "orphan-a", Duration.ofSeconds(5),
+                "referenced-b", Duration.ofSeconds(5));
+
+        List<String> selected = StorageIO.selectForCleanUp(stored, ORPHANS, Duration.ZERO);
+
+        assertEquals(List.of("orphan-a"), selected);
+    }
+
+    @Test
+    void testSelectForCleanUp_resultIsNotMeantToBeModified() {
+        List<String> selected = StorageIO.selectForCleanUp(stored("orphan-a", Duration.ofDays(30)), ORPHANS, ONE_WEEK);
+
+        assertThrows(UnsupportedOperationException.class, () -> selected.add("x"));
     }
 }

--- a/src/test/java/edu/harvard/iq/dataverse/dataaccess/StorageIOCleanUpAgeTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/dataaccess/StorageIOCleanUpAgeTest.java
@@ -1,0 +1,53 @@
+package edu.harvard.iq.dataverse.dataaccess;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The age guard that keeps cleanUp from removing an upload that has finished but has
+ * not been registered as a DataFile yet.
+ */
+class StorageIOCleanUpAgeTest {
+
+    private static final Duration ONE_WEEK = Duration.ofDays(7);
+
+    @Test
+    void testIsOlderThan_unknownTimestampIsNeverRemoved() {
+        assertFalse(StorageIO.isOlderThan(null, ONE_WEEK));
+    }
+
+    @Test
+    void testIsOlderThan_justUploadedIsKept() {
+        assertFalse(StorageIO.isOlderThan(Instant.now(), ONE_WEEK));
+    }
+
+    @Test
+    void testIsOlderThan_withinGracePeriodIsKept() {
+        assertFalse(StorageIO.isOlderThan(Instant.now().minus(Duration.ofDays(6)), ONE_WEEK));
+    }
+
+    @Test
+    void testIsOlderThan_justInsideGracePeriodIsKept() {
+        assertFalse(StorageIO.isOlderThan(Instant.now().minus(Duration.ofDays(7)).plusSeconds(30), ONE_WEEK));
+    }
+
+    @Test
+    void testIsOlderThan_pastGracePeriodIsRemovable() {
+        assertTrue(StorageIO.isOlderThan(Instant.now().minus(Duration.ofDays(8)), ONE_WEEK));
+    }
+
+    @Test
+    void testIsOlderThan_longAbandonedIsRemovable() {
+        assertTrue(StorageIO.isOlderThan(Instant.now().minus(Duration.ofDays(365)), ONE_WEEK));
+    }
+
+    @Test
+    void testIsOlderThan_zeroGracePeriodRemovesAnythingWithATimestamp() {
+        assertTrue(StorageIO.isOlderThan(Instant.now().minusSeconds(1), Duration.ZERO));
+    }
+}

--- a/src/test/java/edu/harvard/iq/dataverse/dataaccess/SwiftAccessIOTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/dataaccess/SwiftAccessIOTest.java
@@ -9,6 +9,18 @@ import edu.harvard.iq.dataverse.DataFile;
 import edu.harvard.iq.dataverse.Dataset;
 import edu.harvard.iq.dataverse.mocks.MocksFactory;
 import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+import java.util.function.Predicate;
+import org.javaswift.joss.model.Container;
+import org.javaswift.joss.model.StoredObject;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.SignatureException;
@@ -22,6 +34,8 @@ import org.junit.jupiter.api.BeforeEach;
  * @author oscardssmith
  */
 public class SwiftAccessIOTest {
+
+    private static final Predicate<String> ORPHANS = name -> name.startsWith("orphan");
 
     private SwiftAccessIO<Dataset> datasetAccess;
     private SwiftAccessIO<DataFile> datafileAccess;
@@ -77,5 +91,36 @@ public class SwiftAccessIOTest {
     @Test
     public void testCalculateRFC2104HMAC() throws SignatureException, NoSuchAlgorithmException, InvalidKeyException {
         assertEquals("104152c5bfdca07bc633eebd46199f0255c9f49d", swiftAccess.calculateRFC2104HMAC("data", "key"));
+    }
+
+    private StoredObject storedObject(String prefix, String name, Duration age) {
+        StoredObject item = mock(StoredObject.class);
+        when(item.getName()).thenReturn(prefix + name);
+        when(item.getLastModifiedAsDate()).thenReturn(Date.from(Instant.now().minus(age)));
+        return item;
+    }
+
+    @Test
+    public void testCleanUp_dryRunSkipsRecentlyModifiedObjects() throws IOException {
+        // datafile is owned by dataset, so both resolve to the same container name.
+        String prefix = datafileAccess.getSwiftContainerName() + "/";
+        // Build the stored objects before stubbing the container, so their own
+        // stubbing does not nest inside the container's.
+        List<StoredObject> stored = List.of(
+                storedObject(prefix, "orphan-old", Duration.ofDays(30)),
+                storedObject(prefix, "orphan-fresh", Duration.ofHours(2)),
+                storedObject(prefix, "referenced-old", Duration.ofDays(30)));
+
+        Container container = mock(Container.class);
+        when(container.list(anyString(), nullable(String.class), anyInt()))
+                .thenReturn(stored)
+                .thenReturn(List.of());
+        datasetAccess.swiftContainer = container;
+        // Skip open(): the container above is the one under test.
+        datasetAccess.isWriteAccess = true;
+
+        List<String> reported = datasetAccess.cleanUp(ORPHANS, Duration.ofDays(7), true);
+
+        assertEquals(List.of("orphan-old"), reported);
     }
 }

--- a/src/test/java/edu/harvard/iq/dataverse/dataaccess/SwiftAccessIOTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/dataaccess/SwiftAccessIOTest.java
@@ -9,18 +9,6 @@ import edu.harvard.iq.dataverse.DataFile;
 import edu.harvard.iq.dataverse.Dataset;
 import edu.harvard.iq.dataverse.mocks.MocksFactory;
 import java.io.IOException;
-import java.time.Duration;
-import java.time.Instant;
-import java.util.Date;
-import java.util.List;
-import java.util.function.Predicate;
-import org.javaswift.joss.model.Container;
-import org.javaswift.joss.model.StoredObject;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.nullable;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.SignatureException;
@@ -34,8 +22,6 @@ import org.junit.jupiter.api.BeforeEach;
  * @author oscardssmith
  */
 public class SwiftAccessIOTest {
-
-    private static final Predicate<String> ORPHANS = name -> name.startsWith("orphan");
 
     private SwiftAccessIO<Dataset> datasetAccess;
     private SwiftAccessIO<DataFile> datafileAccess;
@@ -91,36 +77,5 @@ public class SwiftAccessIOTest {
     @Test
     public void testCalculateRFC2104HMAC() throws SignatureException, NoSuchAlgorithmException, InvalidKeyException {
         assertEquals("104152c5bfdca07bc633eebd46199f0255c9f49d", swiftAccess.calculateRFC2104HMAC("data", "key"));
-    }
-
-    private StoredObject storedObject(String prefix, String name, Duration age) {
-        StoredObject item = mock(StoredObject.class);
-        when(item.getName()).thenReturn(prefix + name);
-        when(item.getLastModifiedAsDate()).thenReturn(Date.from(Instant.now().minus(age)));
-        return item;
-    }
-
-    @Test
-    public void testCleanUp_dryRunSkipsRecentlyModifiedObjects() throws IOException {
-        // datafile is owned by dataset, so both resolve to the same container name.
-        String prefix = datafileAccess.getSwiftContainerName() + "/";
-        // Build the stored objects before stubbing the container, so their own
-        // stubbing does not nest inside the container's.
-        List<StoredObject> stored = List.of(
-                storedObject(prefix, "orphan-old", Duration.ofDays(30)),
-                storedObject(prefix, "orphan-fresh", Duration.ofHours(2)),
-                storedObject(prefix, "referenced-old", Duration.ofDays(30)));
-
-        Container container = mock(Container.class);
-        when(container.list(anyString(), nullable(String.class), anyInt()))
-                .thenReturn(stored)
-                .thenReturn(List.of());
-        datasetAccess.swiftContainer = container;
-        // Skip open(): the container above is the one under test.
-        datasetAccess.isWriteAccess = true;
-
-        List<String> reported = datasetAccess.cleanUp(ORPHANS, Duration.ofDays(7), true);
-
-        assertEquals(List.of("orphan-old"), reported);
     }
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

`cleanStorage` deletes storage objects that are not referenced by any file in the dataset. Three problems with how it does that.

It was a `GET`, so anything that follows a link could trigger a deletion: browser prefetch, link previews in chat and mail clients, crawlers, or opening the URL again from history. It is now a `PUT`.

`dryrun` defaulted to false, so omitting the parameter deleted. It now defaults to true, and deleting requires `dryrun=false`.

It could delete real files. An upload is written to the dataset's storage location before Dataverse registers a `DataFile` for it, so an upload that had finished but was still waiting to be saved looked exactly like an abandoned one and was removed. `cleanUp` now takes a minimum age and skips anything modified more recently. The default is 7 days, configurable with `dataverse.files.clean-storage-min-age-days`.

The permission failure also returned 500 instead of 403.

**Which issue(s) this PR closes**:

- Closes #12689

**Special notes for your reviewer**:

The age check costs no extra calls. The S3 listing already retrieved `lastModified` for each object and discarded it, and the filesystem listing gets it from the directory walk.

An unknown timestamp counts as too recent, so a backend that cannot report one never causes a deletion. That is why the Swift lookup is wrapped.

`getToDeleteFilesFilter` stays a name-only predicate, so its existing test is unchanged. The age check lives in the storage layer, where the timestamps already are.

`InputStreamIO` and `AbstractRemoteOverlayAccessIO` only needed the new signature.

This changes the API. Callers have to switch to `PUT`, and any that relied on the old default to delete have to pass `dryrun=false`.

**Suggestions on how to test this**:

1. Run `StorageIOCleanUpAgeTest` and `DatasetsTest`.
2. Upload a file to a dataset with direct upload and leave it unsaved. Call `PUT /api/datasets/{id}/cleanStorage?dryrun=true` and confirm the unsaved upload is not listed.
3. Call it without `dryrun` and confirm the response reports files without deleting them.
4. Confirm a user without `EditDataset` on the dataset gets 403.
5. With `dataverse.files.clean-storage-min-age-days=0`, confirm orphaned files are reported and then deleted with `dryrun=false`.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

No.

**Is there a release notes update needed for this change?**:

Yes, included: `doc/release-notes/harden-clean-storage.md`.

**Additional documentation**:

Native API guide updated for the new method, the `dryrun` default, and the grace period.
