### PR TITLE
#12692 return DatasetPage as source for dsf

### DIFF
--- a/src/main/webapp/dataset.xhtml
+++ b/src/main/webapp/dataset.xhtml
@@ -755,8 +755,8 @@
                                     <div id="dataset-summary-metadata" class="col-xs-12 col-sm-12 col-md-8 col-lg-9 metadata-container padding-none margin-bottom">
                                         <table class="metadata">
                                             <tbody>
-                                                <ui:repeat value="#{datasetSummaryFields}" var="dsf">
-                                                    <tr id="keywords" jsf:rendered="#{!empty datasetVersionUI.keywordDisplay and dsf.datasetFieldType.id==datasetVersionUI.keyword.datasetFieldType.id}">
+                                                <ui:repeat value="#{DatasetPage.datasetSummaryFields}" var="dsf">
+                                                    <tr id="keywords" jsf:rendered="#{!empty DatasetPage.datasetVersionUI.keywordDisplay and dsf.datasetFieldType.id==datasetVersionUI.keyword.datasetFieldType.id}">
                                                         <th scope="row">
                                                             #{bundle['dataset.keywordDisplay.title']}
                                                             <span class="glyphicon glyphicon-question-sign tooltip-icon"


### PR DESCRIPTION
**What this PR does / why we need it**: Returns Dataset Summary Fields to the dataset ui

**Which issue(s) this PR closes**:

- Closes #12692

**Special notes for your reviewer**: I'd like @qqmyers to weigh in on why the DatasetPage reference was removed and if there's a different approach he would take

**Suggestions on how to test this**: Verify that the Summary Fields appear on the Dataset page UI

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
