### PR TITLE
Switch to Dataverse SPI 2.1.0-M1 release

### DIFF
--- a/modules/dataverse-parent/pom.xml
+++ b/modules/dataverse-parent/pom.xml
@@ -438,7 +438,7 @@
                 <enabled>true</enabled>
             </releases>
             <snapshots>
-                <enabled>true</enabled>
+                <enabled>false</enabled>
             </snapshots>
         </repository>
         <repository>
@@ -450,20 +450,22 @@
             </snapshots>
         </repository>
         <!-- Uncomment when using snapshot releases from Maven Central -->
+        <!--
         <repository>
             <id>central-portal-snapshots</id>
             <name>Central Portal Snapshots</name>
             <url>
                 https://central.sonatype.com/repository/maven-snapshots/
             </url>
-	    <releases>
-	      <enabled>false</enabled>
-	    </releases>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>
         </repository>
-	<!--
+        -->
+	    <!--
         <repository>
             <id>s01-oss-sonatype</id>
             <name>s01-oss-sonatype</name>

--- a/modules/dataverse-parent/pom.xml
+++ b/modules/dataverse-parent/pom.xml
@@ -465,7 +465,7 @@
             </snapshots>
         </repository>
         -->
-	    <!--
+        <!--
         <repository>
             <id>s01-oss-sonatype</id>
             <name>s01-oss-sonatype</name>

--- a/pom.xml
+++ b/pom.xml
@@ -700,7 +700,7 @@
         <dependency>
             <groupId>io.gdcc</groupId>
             <artifactId>dataverse-spi</artifactId>
-            <version>2.1.0-SNAPSHOT</version>
+            <version>2.1.0-M1</version>
         </dependency>
         <dependency>
             <groupId>javax.cache</groupId>


### PR DESCRIPTION
**What this PR does / why we need it**:

- Disabled snapshot artifacts and enabled release artifacts in Maven repository configuration.
- Updated `dataverse-spi` dependency version from `2.1.0-SNAPSHOT` to `2.1.0-M1`.

**Special notes for your reviewer**:
Should be a part of 6.12 to ensure build consistency

**Suggestions on how to test this**:
Just build. It's a noop change, just making sure the 6.12 release uses the fixed release from Central instead of a snapshot

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
Nope

**Is there a release notes update needed for this change?**:
Nope

**Additional documentation**:
None