### PR TITLE
Fix access to manage permissions menu

### DIFF
--- a/src/main/webapp/dataverse.xhtml
+++ b/src/main/webapp/dataverse.xhtml
@@ -518,7 +518,8 @@
                                     <!-- Edit/Publish Button Group -->
                                     <div class="btn-group" jsf:rendered="#{dataverseSession.user.authenticated and
                                                              (permissionsWrapper.canIssueUpdateDataverseCommand(dataverse)
-                                                             or permissionsWrapper.canIssuePublishDataverseCommand(dataverse))}">
+                                                             or permissionsWrapper.canIssuePublishDataverseCommand(dataverse)
+                                                             or permissionsWrapper.canManagePermissions(dataverse))}">
                                             <!-- Publish Button -->
                                             <ui:fragment rendered="#{permissionsWrapper.canIssuePublishDataverseCommand(dataverse)}">
                                                 <button type="button" class="btn btn-default btn-access" onclick="PF('confirmation').show()"


### PR DESCRIPTION
**What this PR does / why we need it**: On the dataverse.xhtml page, there is another outer div that needed to be updated to allow roles with only the ManageDataversePermissions permission to access the overall menu. This PR fixes that.

**Which issue(s) this PR closes**:

- Closes https://github.com/IQSS/dataverse/issues/12700

**Special notes for your reviewer**:

**Suggestions on how to test this**:

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
